### PR TITLE
Make it clearer you're adding ECT or mentor

### DIFF
--- a/app/views/schools/add_participants/what_we_need.html.erb
+++ b/app/views/schools/add_participants/what_we_need.html.erb
@@ -5,7 +5,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-xl"><%= @school.name %></span>
-    <h1 class="govuk-heading-xl">What we need from you</h1>
+    <h1 class="govuk-heading-xl">Add <%= @wizard.ect_participant? ? "an ECT" : "a mentor" %></h1>
 
     <p class="govuk-body">You must tell us their:</p>
     <ul class="govuk-list govuk-list--bullet">
@@ -31,7 +31,7 @@
       </p>
     <% end %>
 
-    <%= govuk_details(summary_text: "Tell your ECTs and mentors about this use of their data", classes: "govuk-!-margin-top-7 govuk-!-margin-bottom-7") do %>
+    <%= govuk_details(summary_text: "Tell your #{@wizard.ect_participant? ? "ECT" : "mentor"} about this use of their data", classes: "govuk-!-margin-top-7 govuk-!-margin-bottom-7") do %>
       <p>You should let them know that we:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>use their personal data to arrange DfE funding</li>

--- a/app/views/schools/add_participants/what_we_need.html.erb
+++ b/app/views/schools/add_participants/what_we_need.html.erb
@@ -1,11 +1,12 @@
-<% content_for :title, "What we need from you" %>
+<% @title = "What we need to know about this #{@wizard.ect_participant? ? "ECT" : "mentor"}" %>
+<% content_for :title, @title %>
 
 <% content_for :before_content, govuk_back_link(text: "Back", href: wizard_back_link_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-xl"><%= @school.name %></span>
-    <h1 class="govuk-heading-xl">Add <%= @wizard.ect_participant? ? "an ECT" : "a mentor" %></h1>
+    <h1 class="govuk-heading-xl"><%= @title %></h1>
 
     <p class="govuk-body">You must tell us their:</p>
     <ul class="govuk-list govuk-list--bullet">

--- a/spec/features/schools/participants/add_participants/add_ect_as_mentor_spec.rb
+++ b/spec/features/schools/participants/add_participants/add_ect_as_mentor_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Add ECT as mentor", js: true do
 
     when_i_select_to_add_a "Mentor"
     when_i_click_on_continue
-    then_i_am_taken_to_the_what_we_need_from_you_page
+    then_i_am_taken_to_the_what_we_need_to_know_about_this_mentor_page
 
     when_i_click_on_continue
     then_i_am_taken_to_add_mentor_full_name_page

--- a/spec/features/schools/participants/add_participants/add_ect_with_appropriate_body_spec.rb
+++ b/spec/features/schools/participants/add_participants/add_ect_with_appropriate_body_spec.rb
@@ -119,7 +119,7 @@ private
   end
 
   def and_i_go_through_the_what_we_need_from_you_page
-    expect(page).to have_selector("h1", text: "What we need from you")
+    expect(page).to have_selector("h1", text: "What we need to know about this ECT")
     click_on "Continue"
   end
 

--- a/spec/features/schools/participants/add_participants/unhappy_path_already_on_ecf_training_spec.rb
+++ b/spec/features/schools/participants/add_participants/unhappy_path_already_on_ecf_training_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Add participants", js: true do
 
       when_i_select_to_add_a "ECT"
       when_i_click_on_continue
-      then_i_am_taken_to_the_what_we_need_from_you_page
+      then_i_am_taken_to_the_what_we_need_to_know_about_this_ect_page
 
       when_i_click_on_continue
       then_i_am_taken_to_add_ect_name_page
@@ -59,7 +59,7 @@ RSpec.describe "Add participants", js: true do
 
       when_i_select_to_add_a "ECT"
       when_i_click_on_continue
-      then_i_am_taken_to_the_what_we_need_from_you_page
+      then_i_am_taken_to_the_what_we_need_to_know_about_this_ect_page
 
       when_i_click_on_continue
       then_i_am_taken_to_add_ect_name_page
@@ -107,7 +107,7 @@ RSpec.describe "Add participants", js: true do
 
       when_i_select_to_add_a "ECT"
       when_i_click_on_continue
-      then_i_am_taken_to_the_what_we_need_from_you_page
+      then_i_am_taken_to_the_what_we_need_to_know_about_this_ect_page
 
       when_i_click_on_continue
       then_i_am_taken_to_add_ect_name_page

--- a/spec/features/schools/participants/add_participants/unhappy_path_email_taken_spec.rb
+++ b/spec/features/schools/participants/add_participants/unhappy_path_email_taken_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Add participants", js: true do
 
     when_i_select_to_add_a "ECT"
     when_i_click_on_continue
-    then_i_am_taken_to_the_what_we_need_from_you_page
+    then_i_am_taken_to_the_what_we_need_to_know_about_this_ect_page
 
     when_i_click_on_continue
     then_i_am_taken_to_add_ect_name_page

--- a/spec/features/schools/participants/add_participants/unhappy_path_sit_error_entering_validation_info_spec.rb
+++ b/spec/features/schools/participants/add_participants/unhappy_path_sit_error_entering_validation_info_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Add participants", js: true do
 
     when_i_select_to_add_a "ECT"
     when_i_click_on_continue
-    then_i_am_taken_to_the_what_we_need_from_you_page
+    then_i_am_taken_to_the_what_we_need_to_know_about_this_ect_page
 
     when_i_click_on_continue
     then_i_am_taken_to_add_ect_name_page

--- a/spec/features/schools/participants/transferring_participants/already_enrolled_at_school_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/already_enrolled_at_school_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe "Transferring participants", type: :feature, js: true, rutabaga: 
   end
 
   def then_i_should_be_on_what_we_need_page
-    expect(page).to have_selector("h1", text: "What we need from you")
+    expect(page).to have_selector("h1", text: "What we need to know about this ECT")
   end
 
   def then_i_am_taken_to_add_ect_name_page

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/allow_withdrawn_participant_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/allow_withdrawn_participant_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe "transferring a withdrawn participant", type: :feature, js: true 
   end
 
   def then_i_should_be_on_what_we_need_page
-    expect(page).to have_selector("h1", text: "What we need from you")
+    expect(page).to have_selector("h1", text: "What we need to know about this ECT")
   end
 
   def then_i_should_be_on_full_name_page

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_different_partner_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_different_partner_spec.rb
@@ -213,7 +213,7 @@ RSpec.describe "Transferring ECT is with a different lead provider", type: :feat
   end
 
   def then_i_should_be_on_what_we_need_page
-    expect(page).to have_selector("h1", text: "What we need from you")
+    expect(page).to have_selector("h1", text: "What we need to know about this ECT")
   end
 
   def then_i_should_be_on_full_name_page

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_no_change_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_no_change_spec.rb
@@ -219,7 +219,7 @@ RSpec.describe "ECT has matching lead provider and delivery partner", type: :fea
   end
 
   def then_i_should_be_on_what_we_need_page
-    expect(page).to have_selector("h1", text: "What we need from you")
+    expect(page).to have_selector("h1", text: "What we need to know about this ECT")
   end
 
   def then_i_should_be_on_full_name_page

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_different_partner_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_different_partner_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe "Transferring a mentor with a different provider", type: :feature
   end
 
   def then_i_should_be_on_what_we_need_page
-    expect(page).to have_selector("h1", text: "What we need from you")
+    expect(page).to have_selector("h1", text: "What we need to know about this mentor")
   end
 
   def then_i_should_be_on_full_name_page

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_no_change_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_no_change_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe "Transferring a mentor weith matching lead provider and delivery 
   end
 
   def then_i_should_be_on_what_we_need_page
-    expect(page).to have_selector("h1", text: "What we need from you")
+    expect(page).to have_selector("h1", text: "What we need to know about this mentor")
   end
 
   def then_i_should_be_on_full_name_page

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/unhappy_path_cannot_validate_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/unhappy_path_cannot_validate_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe "transferring participants", type: :feature, js: true do
       end
 
       def then_i_should_be_on_what_we_need_page
-        expect(page).to have_selector("h1", text: "What we need from you")
+        expect(page).to have_selector("h1", text: "What we need to know about this ECT")
       end
 
       def then_i_should_be_on_full_name_page

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -888,7 +888,7 @@ module ManageTrainingSteps
   end
 
   def then_i_should_be_on_the_what_we_need_from_you_page
-    expect(page).to have_selector("h1", text: "What we need from you")
+    expect(page).to have_selector("h1", text: "What we need to know about this ECT")
   end
 
   def then_i_am_taken_to_add_ect_name_page
@@ -1197,8 +1197,12 @@ module ManageTrainingSteps
     expect(page).to have_text("Tell us if any new ECTs or mentors will start training at your school in the 2022 to 2023 academic year")
   end
 
-  def then_i_am_taken_to_the_what_we_need_from_you_page
-    expect(page).to have_content("What we need from you")
+  def then_i_am_taken_to_the_what_we_need_to_know_about_this_mentor_page
+    expect(page).to have_content("What we need to know about this mentor")
+  end
+
+  def then_i_am_taken_to_the_what_we_need_to_know_about_this_ect_page
+    expect(page).to have_content("What we need to know about this ECT")
   end
 
   def then_i_am_taken_to_the_appropriate_body_type_page


### PR DESCRIPTION
🗂️ [Jira card](https://dfedigital.atlassian.net/browse/CST-1966)

We had some people contact support because they'd accidentally added an ECT as a mentor or vice versa.

We think this is partly because the page after selector "ECT" or "Mentor" is generic to both.  By updating this page to be more specific (in the page title and the note about privacy), we hope to make it more obvious to users when they’ve mis-clicked, so that they can quickly go back and select the right option.

### Before

<img width="1012" alt="Screenshot 2023-09-11 at 17 58 58" src="https://github.com/DFE-Digital/early-careers-framework/assets/30665/9afb80be-5bd2-4180-94e7-01b6dd86265c">

### After

| ECTs | Mentors |
|------|---------|
| <img width="1044" alt="Screenshot 2023-09-11 at 17 59 35" src="https://github.com/DFE-Digital/early-careers-framework/assets/30665/91cfbf54-b559-40e3-b381-cadf34584b41"> | <img width="1004" alt="Screenshot 2023-09-11 at 17 59 51" src="https://github.com/DFE-Digital/early-careers-framework/assets/30665/68421376-3005-44ca-a6c3-19b75c530a72"> |
