### PR TITLE
[CPDLP-2295] Add authorise for payment button to ECF/NPQ on financial statements

### DIFF
--- a/app/assets/stylesheets/lead_providers/statements.scss
+++ b/app/assets/stylesheets/lead_providers/statements.scss
@@ -84,6 +84,23 @@
   }
 }
 
+.app-application__panel__actions {
+  display: grid;
+  padding: 0px 20px;
+  background-color: #f8f8f8;
+  border: none;
+  margin-bottom: 0 !important;
+
+  .duvet {
+    border-top: 1px solid #b1b4b6;
+    padding-top: 20px;
+  }
+
+  .govuk-grid-column-one-half {
+    padding: 0 !important;
+  }
+}
+
 .app-application__card {
   margin-bottom: 10px;
   border-bottom: 1px solid black;
@@ -168,19 +185,5 @@
     td {
       border-bottom: 0;
     }
-  }
-}
-
-.finance-panel__summary__downloads {
-  display: grid;
-  grid-template-columns: 1fr;
-  grid-template-rows: 1fr;
-  grid-column-gap: 0px;
-  grid-row-gap: 0px;
-  background: #f8f8f8;
-  padding: 0 20px;
-  .duvet {
-    border-top: 1px solid #b1b4b6;
-    padding-top: 20px;
   }
 }

--- a/app/components/finance/statements/ecf_details_table.html.erb
+++ b/app/components/finance/statements/ecf_details_table.html.erb
@@ -1,0 +1,97 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <div class="finance-panel finance-panel__summary">
+      <div class="finance-panel__summary__total-payment-breakdown">
+        <h4 class="govuk-heading-l govuk-!-margin-bottom-2">Total <%= number_to_pounds(@calculator.total(with_vat: true)) %></h4>
+
+        <div>
+          <p class="govuk-body-s govuk-!-margin-bottom-2">
+            Output payment <span><%= number_to_pounds(@calculator.output_fee) %></span>
+          </p>
+
+          <p class="govuk-body-s govuk-!-margin-bottom-2">
+            Service fee <span><%= number_to_pounds(@calculator.service_fee) %></span>
+          </p>
+
+          <p class="govuk-body-s govuk-!-margin-bottom-2">
+            Uplift fees <span><%= number_to_pounds(@calculator.total_for_uplift) %></span>
+          </p>
+
+          <p class="govuk-body-s govuk-!-margin-bottom-2">
+            Clawbacks <span><%= number_to_pounds(@calculator.adjustments_total) %></span>
+          </p>
+
+          <p class="govuk-body-s govuk-!-margin-bottom-2">
+            Additional adjustments <span><%= number_to_pounds(@calculator.additional_adjustments_total) %></span>
+          </p>
+
+          <p class="govuk-body-s govuk-!-margin-bottom-2">
+            VAT <span><%= number_to_pounds(@calculator.vat) %></span>
+          </p>
+        </div>
+      </div>
+
+      <div class="finance-panel__summary__meta">
+        <div class="finance-panel__summary__meta__dates">
+          <div>
+            <div>
+              <strong class="govuk-body-s govuk-!-margin-bottom-0">Milestone cut off date</strong>
+            </div>
+            <div class="govuk-heading-m govuk-!-padding-top-0">
+              <%= @statement.deadline_date.to_fs(:govuk) %>
+            </div>
+          </div>
+
+          <div>
+            <div>
+              <strong class="govuk-body-s govuk-!-margin-bottom-0">Payment date</strong>
+            </div>
+            <div class="govuk-heading-m govuk-!-padding-top-0">
+              <%= @statement.payment_date.to_fs(:govuk) %>
+            </div>
+          </div>
+        </div>
+
+        <div class="finance-panel__summary__meta__counts">
+          <div class="second govuk-list govuk-!-margin-bottom-0">
+            <strong class="govuk-body-s govuk-!-margin-bottom-0">Total starts</strong>
+            <div class="govuk-heading-m govuk-!-padding-top-0">
+              <%= @calculator.started_count %>
+            </div>
+          </div>
+
+          <div>
+            <strong class="govuk-body-s govuk-!-margin-bottom-0">Total retained</strong>
+            <div class="govuk-heading-m govuk-!-padding-top-0">
+              <%= @calculator.retained_count %>
+            </div>
+          </div>
+
+          <div>
+            <strong class="govuk-body-s govuk-!-margin-bottom-0">Total completed</strong>
+            <div class="govuk-heading-m govuk-!-padding-top-0">
+              <%= @calculator.completed_count %>
+            </div>
+          </div>
+
+          <% if @calculator.extended_count.positive? %>
+            <div>
+              <strong class="govuk-body-s govuk-!-margin-bottom-0">Total extended</strong>
+              <div class="govuk-heading-m govuk-!-padding-top-0">
+                <%= @calculator.extended_count %>
+              </div>
+            </div>
+          <% end %>
+
+          <div>
+            <strong class="govuk-body-s govuk-!-margin-bottom-0">Total voided</strong>
+
+            <div class="govuk-heading-m govuk-!-padding-top-0 govuk-!-margin-bottom-0">
+              <%= @calculator.voided_count %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/components/finance/statements/ecf_details_table.rb
+++ b/app/components/finance/statements/ecf_details_table.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Finance
+  module Statements
+    class ECFDetailsTable < BaseComponent
+      include FinanceHelper
+
+      attr_accessor :statement
+
+      def initialize(statement:)
+        @statement = statement
+        @calculator = Finance::ECF::StatementCalculator.new(statement: @statement)
+      end
+    end
+  end
+end

--- a/app/components/finance/statements/npq_details_table.html.erb
+++ b/app/components/finance/statements/npq_details_table.html.erb
@@ -1,14 +1,5 @@
-<% content_for :title, t("finance.npq.payment_breakdown") %>
-<% content_for :before_content, govuk_back_link(text: "Back", href: select_provider_npq_finance_payment_breakdowns_path) %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-xl">National professional qualifications (NPQs)</h1>
-    <span class="govuk-caption-l"><%= @statement.cpd_lead_provider.name %></span>
-    <h2 class="govuk-heading-l"><%= @statement.name %></h2>
-
-    <%= render Finance::Statements::NPQStatementSelector.new(current_statement: @statement, cohorts: Cohort.where(start_year: 2021..)) %>
-
     <div class="app-application__panel__summary">
       <div class="govuk-!-margin-right-4">
         <h4 class="govuk-heading-l govuk-!-margin-bottom-2"><%= t("finance.totals") %></h4>
@@ -110,8 +101,6 @@
               <div class="float tooltip">
                 <div class="float govuk-heading-m govuk-!-margin-bottom-0 govuk-!-padding-top-0">
                   <span><%= @calculator.total_voided %></span>
-                  <br>
-                  <p class="govuk-body-s"><%= govuk_link_to( t("finance.view") , finance_npq_lead_provider_statement_voided_path(@npq_lead_provider.id, @statement)) %></p>
                 </div>
               </div>
             </div>
@@ -119,47 +108,5 @@
         </li>
       </ul>
     </div>
-
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full">
-        <div class="app-application__panel__actions">
-          <div class="duvet">
-            <div class="govuk-grid-column-one-half govuk-!-text-align-left">
-              <% if @statement.mark_as_paid_visible? %>
-                <%= button_to "Authorise for payment", new_finance_statement_payment_authorisation_path(@statement), method: :get, class: "govuk-button govuk-button--primary" %>
-              <% elsif @statement.marked_as_paid? %>
-                <%= govuk_tag(text: "Authorised for payment at #{@statement.marked_as_paid_at.strftime("%-I:%M%P on %-e %b %Y")}") %>
-              <% else %>
-                &nbsp;
-              <% end %>
-            </div>
-            <div class="govuk-grid-column-one-half govuk-!-text-align-right">
-              <p class="govuk-body-s">
-                <%= govuk_link_to "Download declarations (CSV)", finance_npq_statement_assurance_report_path(@statement, format: :csv) %>
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-
   </div>
-</div>
-<br />
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <div class="app-application__panel">
-      <div class="moj-filter-layout__content">
-        <% @npq_contracts.each do |npq_contract| %>
-          <%= render Finance::NPQ::PaymentOverviews::Course.new(statement: @statement, contract: npq_contract) %>
-
-          <br>
-        <% end %>
-      </div>
-    </div>
-  </div>
-
-  <%= render Finance::NPQ::PaymentOverviews::ContractInfo.new(@npq_contracts, @npq_lead_provider) %>
-
-  <%= render partial: "errors/calculation_rounding" %>
 </div>

--- a/app/components/finance/statements/npq_details_table.rb
+++ b/app/components/finance/statements/npq_details_table.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Finance
+  module Statements
+    class NPQDetailsTable < BaseComponent
+      include FinanceHelper
+
+      attr_accessor :statement
+
+      def initialize(statement:)
+        @statement = statement
+        @calculator = Finance::NPQ::StatementCalculator.new(statement: @statement)
+      end
+    end
+  end
+end

--- a/app/controllers/finance/ecf/statements_controller.rb
+++ b/app/controllers/finance/ecf/statements_controller.rb
@@ -7,6 +7,7 @@ module Finance
         @ecf_lead_provider = lead_provider_scope.find(params[:payment_breakdown_id])
         @statement = @ecf_lead_provider.statements.find(params[:id])
         @calculator = StatementCalculator.new(statement: @statement)
+        set_important_message(title: t("finance.statements.payment_authorisations.banner.title"), content: t("finance.statements.payment_authorisations.banner.content", statement_marked_as_paid_at: @statement.marked_as_paid_at.strftime("%-I:%M%P on %-e %b %Y"))) if authorising_for_payment_banner_visible?(@statement)
       end
 
     private

--- a/app/controllers/finance/npq/statements_controller.rb
+++ b/app/controllers/finance/npq/statements_controller.rb
@@ -12,8 +12,8 @@ module Finance
           version: @statement.contract_version,
           cohort: @statement.cohort,
         ).order(course_identifier: :asc)
-
         @calculator = StatementCalculator.new(statement: @statement)
+        set_important_message(title: t("finance.statements.payment_authorisations.banner.title"), content: t("finance.statements.payment_authorisations.banner.content", statement_marked_as_paid_at: @statement.marked_as_paid_at.strftime("%-I:%M%P on %-e %b %Y"))) if authorising_for_payment_banner_visible?(@statement)
       end
 
     private

--- a/app/controllers/finance/payment_authorisations_controller.rb
+++ b/app/controllers/finance/payment_authorisations_controller.rb
@@ -9,7 +9,6 @@ module Finance
 
     def create
       if @payment_authorisation_form.save_form
-        set_important_message(title: "Authorising for payment", content: "Requested at #{@statement.marked_as_paid_at.strftime('%-I:%M%P on %-e %b %Y')}. We'll email you when the payment has been authorised and the statement updated. This may take up to 15 minutes.")
         redirect_to @payment_authorisation_form.back_link
       else
         render :new, status: :unprocessable_entity

--- a/app/controllers/finance/payment_authorisations_controller.rb
+++ b/app/controllers/finance/payment_authorisations_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Finance
+  class PaymentAuthorisationsController < BaseController
+    before_action :set_statement
+    before_action :set_payment_authorisation_form
+
+    def new; end
+
+    def create
+      if @payment_authorisation_form.save_form
+        set_important_message(title: "Authorising for payment", content: "Requested at #{@statement.marked_as_paid_at.strftime('%-I:%M%P on %-e %b %Y')}. We'll email you when the payment has been authorised and the statement updated. This may take up to 15 minutes.")
+        redirect_to @payment_authorisation_form.back_link
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+  private
+
+    def set_payment_authorisation_form
+      @payment_authorisation_form = Finance::CreatePaymentAuthorisationForm.new(finance_payment_authorisation_form_params.merge(statement: @statement))
+    end
+
+    def finance_payment_authorisation_form_params
+      return {} unless params.key?(:finance_payment_authorisation)
+
+      params.require(:finance_payment_authorisation).permit(:checks_done)
+    end
+
+    def set_statement
+      @statement = Finance::Statement.find(params[:statement_id])
+    end
+  end
+end

--- a/app/forms/finance/create_payment_authorisation_form.rb
+++ b/app/forms/finance/create_payment_authorisation_form.rb
@@ -14,13 +14,7 @@ module Finance
     def save_form
       return false unless valid?
 
-      if statement.mark_as_paid!
-        Finance::Statements::MarkAsPaidJob.perform_later(statement_id: statement.id)
-      else
-        false
-      end
-
-      true
+      Finance::Statements::MarkAsPaidJob.perform_later(statement_id: statement.id) if statement.mark_as_paid_at!
     end
 
     def back_link

--- a/app/forms/finance/create_payment_authorisation_form.rb
+++ b/app/forms/finance/create_payment_authorisation_form.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Finance
+  class CreatePaymentAuthorisationForm
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+    include Rails.application.routes.url_helpers
+
+    attribute :statement
+    attribute :checks_done, :boolean
+
+    validates :checks_done, acceptance: { message: I18n.t("finance.statements.payment_authorisations.checks_done.error_message") }
+
+    def save_form
+      return false unless valid?
+
+      if statement.mark_as_paid!
+        Finance::Statements::MarkAsPaidJob.perform_later(statement_id: statement.id)
+      else
+        false
+      end
+
+      true
+    end
+
+    def back_link
+      if statement.ecf?
+        finance_ecf_payment_breakdown_statement_path(statement.lead_provider, statement)
+      elsif statement.npq?
+        finance_npq_lead_provider_statement_path(statement.npq_lead_provider, statement)
+      end
+    end
+  end
+end

--- a/app/helpers/finance_helper.rb
+++ b/app/helpers/finance_helper.rb
@@ -52,7 +52,7 @@ module FinanceHelper
   end
 
   def authorise_for_payment_button_visible?(statement)
-    statement.output_fee && statement.payable? && !statement.marked_as_paid? && statement.deadline_date < Date.current && statement.participant_declarations.any?
+    statement.output_fee && statement.payable? && !statement.marked_as_paid_at? && statement.deadline_date < Date.current && statement.participant_declarations.any?
   end
 
   def authorising_for_payment_banner_visible?(statement)

--- a/app/helpers/finance_helper.rb
+++ b/app/helpers/finance_helper.rb
@@ -50,4 +50,12 @@ module FinanceHelper
 
     induction_record == participant_profile.latest_induction_record_for(cpd_lead_provider:)
   end
+
+  def authorise_for_payment_button_visible?(statement)
+    statement.output_fee && statement.payable? && !statement.marked_as_paid? && statement.deadline_date < Date.current && statement.participant_declarations.any?
+  end
+
+  def authorising_for_payment_banner_visible?(statement)
+    statement.payable? && statement.marked_as_paid_at?
+  end
 end

--- a/app/models/finance/statement.rb
+++ b/app/models/finance/statement.rb
@@ -91,6 +91,18 @@ class Finance::Statement < ApplicationRecord
   def payable?
     false
   end
+
+  def mark_as_paid_visible?
+    output_fee && payable? && !marked_as_paid? && deadline_date < Date.current && participant_declarations.any?
+  end
+
+  def mark_as_paid!
+    update!(marked_as_paid_at: Time.zone.now)
+  end
+
+  def marked_as_paid?
+    marked_as_paid_at.present?
+  end
 end
 
 require "finance/statement/ecf"

--- a/app/models/finance/statement.rb
+++ b/app/models/finance/statement.rb
@@ -92,16 +92,12 @@ class Finance::Statement < ApplicationRecord
     false
   end
 
-  def mark_as_paid_visible?
-    output_fee && payable? && !marked_as_paid? && deadline_date < Date.current && participant_declarations.any?
-  end
-
-  def mark_as_paid!
+  def mark_as_paid_at!
     update!(marked_as_paid_at: Time.zone.now)
   end
 
   def marked_as_paid?
-    marked_as_paid_at.present?
+    marked_as_paid_at.present? && paid?
   end
 end
 

--- a/app/views/errors/_calculation_rounding.html.erb
+++ b/app/views/errors/_calculation_rounding.html.erb
@@ -1,0 +1,10 @@
+<div class="govuk-grid-column-full">
+  <details class="govuk-details" data-module="govuk-details">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text"><%= t("finance.calculation_rounding_error.title") %></span>
+    </summary>
+    <div class="govuk-details__text">
+      <%= t("finance.calculation_rounding_error.message") %>
+    </div>
+  </details>
+</div>

--- a/app/views/finance/ecf/statements/show.html.erb
+++ b/app/views/finance/ecf/statements/show.html.erb
@@ -115,10 +115,10 @@
         <div class="app-application__panel__actions">
           <div class="duvet">
             <div class="govuk-grid-column-one-half govuk-!-text-align-left">
-              <% if @statement.mark_as_paid_visible? %>
-                <%= button_to "Authorise for payment", new_finance_statement_payment_authorisation_path(@statement), method: :get, class: "govuk-button govuk-button--primary" %>
+              <% if authorise_for_payment_button_visible?(@statement) %>
+                <%= button_to t("finance.statements.payment_authorisations.button"), new_finance_statement_payment_authorisation_path(@statement), method: :get, class: "govuk-button govuk-button--primary" %>
               <% elsif @statement.marked_as_paid? %>
-                <%= govuk_tag(text: "Authorised for payment at #{@statement.marked_as_paid_at.strftime("%-I:%M%P on %-e %b %Y")}") %>
+                <%= govuk_tag(text: t("finance.statements.payment_authorisations.tag.content", statement_marked_as_paid_at: @statement.marked_as_paid_at.strftime("%-I:%M%P on %-e %b %Y"))) %>
               <% else %>
                 &nbsp;
               <% end %>
@@ -267,5 +267,5 @@
     <%= render Finance::ECF::Contract.new(contract: @calculator.contract) %>
   </div>
 
-  <%= render partial: "errors/calculation_rounding" %>
+  <%= render partial: "finance/statements/calculation_rounding_message" %>
 </div>

--- a/app/views/finance/ecf/statements/show.html.erb
+++ b/app/views/finance/ecf/statements/show.html.erb
@@ -109,11 +109,27 @@
         </div>
       </div>
     </div>
-    <div class="finance-panel__summary__downloads">
-      <div class="duvet">
-        <p class="govuk-body-s">
-          <%= govuk_link_to "Download declarations (CSV)", finance_ecf_statement_assurance_report_path(@statement, format: :csv) %>
-        </p>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <div class="app-application__panel__actions">
+          <div class="duvet">
+            <div class="govuk-grid-column-one-half govuk-!-text-align-left">
+              <% if @statement.mark_as_paid_visible? %>
+                <%= button_to "Authorise for payment", new_finance_statement_payment_authorisation_path(@statement), method: :get, class: "govuk-button govuk-button--primary" %>
+              <% elsif @statement.marked_as_paid? %>
+                <%= govuk_tag(text: "Authorised for payment at #{@statement.marked_as_paid_at.strftime("%-I:%M%P on %-e %b %Y")}") %>
+              <% else %>
+                &nbsp;
+              <% end %>
+            </div>
+            <div class="govuk-grid-column-one-half govuk-!-text-align-right">
+              <p class="govuk-body-s">
+                <%= govuk_link_to "Download declarations (CSV)", finance_ecf_statement_assurance_report_path(@statement, format: :csv) %>
+              </p>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -250,4 +266,6 @@
 
     <%= render Finance::ECF::Contract.new(contract: @calculator.contract) %>
   </div>
+
+  <%= render partial: "errors/calculation_rounding" %>
 </div>

--- a/app/views/finance/npq/statements/show.html.erb
+++ b/app/views/finance/npq/statements/show.html.erb
@@ -125,10 +125,10 @@
         <div class="app-application__panel__actions">
           <div class="duvet">
             <div class="govuk-grid-column-one-half govuk-!-text-align-left">
-              <% if @statement.mark_as_paid_visible? %>
-                <%= button_to "Authorise for payment", new_finance_statement_payment_authorisation_path(@statement), method: :get, class: "govuk-button govuk-button--primary" %>
+              <% if authorise_for_payment_button_visible?(@statement) %>
+                <%= button_to t("finance.statements.payment_authorisations.button"), new_finance_statement_payment_authorisation_path(@statement), method: :get, class: "govuk-button govuk-button--primary" %>
               <% elsif @statement.marked_as_paid? %>
-                <%= govuk_tag(text: "Authorised for payment at #{@statement.marked_as_paid_at.strftime("%-I:%M%P on %-e %b %Y")}") %>
+                <%= govuk_tag(text: t("finance.statements.payment_authorisations.tag.content", statement_marked_as_paid_at: @statement.marked_as_paid_at.strftime("%-I:%M%P on %-e %b %Y"))) %>
               <% else %>
                 &nbsp;
               <% end %>
@@ -161,5 +161,5 @@
 
   <%= render Finance::NPQ::PaymentOverviews::ContractInfo.new(@npq_contracts, @npq_lead_provider) %>
 
-  <%= render partial: "errors/calculation_rounding" %>
+  <%= render partial: "finance/statements/calculation_rounding_message" %>
 </div>

--- a/app/views/finance/payment_authorisations/new.html.erb
+++ b/app/views/finance/payment_authorisations/new.html.erb
@@ -20,8 +20,8 @@
       </p>
 
       <br>
-      <%= f.govuk_submit "Authorise for payment" %>
-      <%= govuk_link_to "Cancel", @payment_authorisation_form.back_link, class: "govuk-!-margin-left-6", style: "display: inline-block; margin-top: 8px;" %>
+      <%= f.govuk_submit t("finance.statements.payment_authorisations.button") %>
+      <%= govuk_link_to t("finance.statements.payment_authorisations.cancel"), @payment_authorisation_form.back_link, class: "govuk-!-margin-left-6", style: "display: inline-block; margin-top: 8px;" %>
     <% end %>
   </div>
 </div>

--- a/app/views/finance/payment_authorisations/new.html.erb
+++ b/app/views/finance/payment_authorisations/new.html.erb
@@ -1,0 +1,27 @@
+<% content_for :before_content, govuk_back_link(text: "Back", href: @payment_authorisation_form.back_link) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl"><%= I18n.t("finance.statements.payment_authorisations.title", statement_name: @statement.name) %></h1>
+
+    <%= form_for @payment_authorisation_form, url: finance_statement_payment_authorisations_path(@statement), as: :finance_payment_authorisation do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <% if @statement.ecf? %>
+        <%= render Finance::Statements::ECFDetailsTable.new(statement: @statement) %>
+      <% elsif @statement.npq? %>
+        <%= render Finance::Statements::NPQDetailsTable.new(statement: @statement) %>
+      <% end %>
+
+      <p class="govuk-body">
+        <%= f.govuk_check_boxes_fieldset :checks_done, multiple: false, legend: { text: govuk_warning_text(text: I18n.t("finance.statements.payment_authorisations.checks_done.legend")) } do %>
+          <%= f.govuk_check_box :checks_done, 1, 0, multiple: false, link_errors: true, label: { text: I18n.t("finance.statements.payment_authorisations.checks_done.label") } %>
+        <% end %>
+      </p>
+
+      <br>
+      <%= f.govuk_submit "Authorise for payment" %>
+      <%= govuk_link_to "Cancel", @payment_authorisation_form.back_link, class: "govuk-!-margin-left-6", style: "display: inline-block; margin-top: 8px;" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/finance/statements/_calculation_rounding_message.html.erb
+++ b/app/views/finance/statements/_calculation_rounding_message.html.erb
@@ -1,10 +1,10 @@
 <div class="govuk-grid-column-full">
   <details class="govuk-details" data-module="govuk-details">
     <summary class="govuk-details__summary">
-      <span class="govuk-details__summary-text"><%= t("finance.calculation_rounding_error.title") %></span>
+      <span class="govuk-details__summary-text"><%= t("finance.calculation_rounding_message.title") %></span>
     </summary>
     <div class="govuk-details__text">
-      <%= t("finance.calculation_rounding_error.message") %>
+      <%= t("finance.calculation_rounding_message.content") %>
     </div>
   </details>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -640,6 +640,9 @@ en:
     cohort: Cohort
     course_total: Course total
     contract_information: Contract Information
+    calculation_rounding_error:
+      title: Calculation rounding errors
+      message: Due to the way payments per participant are made, there may be rounding errors in some of the individual sub-calculations. The total output fees displayed are correct. Contact your contract manager if you have any queries.
     spring: Spring 2022
     recruitment_target_total: Recruitment target total
     total_completed: Total completed
@@ -734,6 +737,13 @@ en:
       providers:
         show:
           title: "Banding tracker for %{provider_name}"
+    statements:
+      payment_authorisations:
+        title: "Check %{statement_name} statement details before authorising for payment"
+        checks_done:
+          label: "Yes, I'm ready to authorise this for payment"
+          legend: "Have all necessary assurance checks been done?"
+          error_message: "Confirm all necessary assurance checks have been done before authorising this statement for payment"
 
   admin:
     npq:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -640,9 +640,9 @@ en:
     cohort: Cohort
     course_total: Course total
     contract_information: Contract Information
-    calculation_rounding_error:
+    calculation_rounding_message:
       title: Calculation rounding errors
-      message: Due to the way payments per participant are made, there may be rounding errors in some of the individual sub-calculations. The total output fees displayed are correct. Contact your contract manager if you have any queries.
+      content: Due to the way payments per participant are made, there may be rounding errors in some of the individual sub-calculations. The total output fees displayed are correct. Contact your contract manager if you have any queries.
     spring: Spring 2022
     recruitment_target_total: Recruitment target total
     total_completed: Total completed
@@ -740,6 +740,13 @@ en:
     statements:
       payment_authorisations:
         title: "Check %{statement_name} statement details before authorising for payment"
+        button: "Authorise for payment"
+        cancel: "Cancel"
+        tag:
+          content: "Authorised for payment at %{statement_marked_as_paid_at}"
+        banner:
+          title: "Authorising for payment"
+          content: "Requested at %{statement_marked_as_paid_at}. This may take up to 15 minutes. Refresh to see the updated statement."
         checks_done:
           label: "Yes, I'm ready to authorise this for payment"
           legend: "Have all necessary assurance checks been done?"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -583,6 +583,7 @@ Rails.application.routes.draw do
           get :delete
         end
       end
+      resources :payment_authorisations, only: %i[new create]
     end
   end
 

--- a/spec/components/finance/statements/ecf_details_table_spec.rb
+++ b/spec/components/finance/statements/ecf_details_table_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Finance::Statements::ECFDetailsTable, type: :component do
+  let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
+  let(:lead_provider) { cpd_lead_provider.lead_provider }
+  let!(:contract) { create(:call_off_contract, :with_minimal_bands, lead_provider:) }
+
+  let(:participant_declaration) do
+    create(
+      :ect_participant_declaration,
+      :eligible,
+      cpd_lead_provider:,
+    )
+  end
+
+  let!(:statement) { participant_declaration.statements.first }
+
+  let(:rendered) { render_inline(described_class.new(statement:)) }
+
+  it "has the correct text" do
+    expect(rendered).to have_text("Total starts")
+    expect(rendered).to have_text(1)
+    expect(rendered).to have_text("Total")
+    expect(rendered).to have_text("£6,101.75")
+  end
+end

--- a/spec/components/finance/statements/npq_details_table_spec.rb
+++ b/spec/components/finance/statements/npq_details_table_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Finance::Statements::NPQDetailsTable, type: :component do
+  let(:cohort)              { Cohort.current || create(:cohort, :current) }
+  let(:cpd_lead_provider)   { create(:cpd_lead_provider, :with_npq_lead_provider) }
+  let(:npq_lead_provider)   { cpd_lead_provider.npq_lead_provider }
+  let(:statement)           { create(:npq_statement, cpd_lead_provider:) }
+  let(:participant_profile) { create(:npq_application, :accepted, :eligible_for_funding, npq_course:, npq_lead_provider:).profile }
+  let!(:npq_course)              { create(:npq_leadership_course, identifier: "npq-leading-teaching") }
+  let!(:contract)                { create(:npq_contract, npq_lead_provider:, cohort:, monthly_service_fee: nil) }
+
+  let!(:participant_declaration) do
+    travel_to statement.deadline_date do
+      create(:npq_participant_declaration, :eligible, cpd_lead_provider:, participant_profile:)
+    end
+  end
+
+  let(:rendered) { render_inline(described_class.new(statement:)) }
+
+  it "has the correct text" do
+    expect(rendered).to have_text("Total starts")
+    expect(rendered).to have_text(1)
+    expect(rendered).to have_text("Total net VAT")
+    expect(rendered).to have_text("£1,372.63")
+  end
+end

--- a/spec/factories/finance/statements.rb
+++ b/spec/factories/finance/statements.rb
@@ -16,6 +16,7 @@ FactoryBot.define do
 
       factory :npq_paid_statement, class: "Finance::Statement::NPQ::Paid" do
         paid
+        marked_as_paid_at { Time.zone.now }
       end
     end
 
@@ -24,9 +25,10 @@ FactoryBot.define do
 
       factory :ecf_paid_statement, class: "Finance::Statement::ECF::Paid" do
         paid
+        marked_as_paid_at { Time.zone.now }
       end
 
-      factory :ecf_payable_statement, class: "Finance::Statement::NPQ::Payable" do
+      factory :ecf_payable_statement, class: "Finance::Statement::ECF::Payable" do
         payable
       end
     end

--- a/spec/features/finance/ecf/statement_spec.rb
+++ b/spec/features/finance/ecf/statement_spec.rb
@@ -31,7 +31,36 @@ RSpec.describe "Show ECF statement", :js do
   end
 
   context "Statement authorise for payment" do
-    scenario "successfully authorised" do
+    scenario "successfully authorising" do
+      given_i_am_logged_in_as_a_finance_user
+      and_multiple_declarations_exist
+
+      when_i_visit_the_ecf_financial_statements_page
+
+      then_i_see("Early career framework (ECF)")
+
+      and_i_see_authorise_for_payment_button
+      when_i_click_the_authorise_for_payment_button
+
+      then_i_see("Check #{statement.name} statement details before authorising for payment")
+
+      when_i_do_all_assurance_checks
+
+      expect {
+        when_i_click_the_authorise_for_payment_button
+      }.to have_enqueued_job(
+        Finance::Statements::MarkAsPaidJob,
+      ).with(statement_id: statement.id).on_queue("default")
+
+      then_i_see("Authorising for payment")
+      then_i_see("Requested at #{statement.reload.marked_as_paid_at.strftime('%-I:%M%P on %-e %b %Y')}. This may take up to 15 minutes. Refresh to see the updated statement.")
+
+      when_i_visit_the_ecf_financial_statements_page
+
+      then_i_do_not_see("Authorised for payment at #{statement.marked_as_paid_at.strftime('%-I:%M%P on %-e %b %Y')}".upcase)
+    end
+
+    scenario "successfully authorised", perform_jobs: true do
       given_i_am_logged_in_as_a_finance_user
       and_multiple_declarations_exist
 
@@ -47,13 +76,11 @@ RSpec.describe "Show ECF statement", :js do
       when_i_do_all_assurance_checks
       when_i_click_the_authorise_for_payment_button
 
-      then_i_see("Authorising for payment")
-      then_i_see("Requested at #{statement.reload.marked_as_paid_at.strftime('%-I:%M%P on %-e %b %Y')}. We'll email you when the payment has been authorised and the statement updated. This may take up to 15 minutes.")
+      then_i_do_not_see("Authorising for payment")
 
       when_i_visit_the_ecf_financial_statements_page
 
-      then_i_do_not_see("Authorising for payment")
-      then_i_see("Authorised for payment at #{statement.marked_as_paid_at.strftime('%-I:%M%P on %-e %b %Y')}".upcase)
+      then_i_see("Authorised for payment at #{Finance::Statement.find(statement.id).marked_as_paid_at.strftime('%-I:%M%P on %-e %b %Y')}".upcase)
     end
 
     scenario "missing doing assurance checks" do

--- a/spec/features/finance/ecf/statement_spec.rb
+++ b/spec/features/finance/ecf/statement_spec.rb
@@ -3,9 +3,21 @@
 require "rails_helper"
 
 RSpec.describe "Show ECF statement", :js do
-  let(:statement) { create :ecf_statement }
-  let(:lead_provider) { statement.lead_provider }
-  let!(:contract) { create(:call_off_contract, lead_provider:, version: statement.contract_version, cohort: Cohort.current) }
+  let!(:cpd_lead_provider) do
+    create(:cpd_lead_provider, :with_lead_provider, name: "Lead provider name").tap do |cpd_lead_provider|
+      create(:call_off_contract, lead_provider: cpd_lead_provider.lead_provider, revised_target: 65).tap do |call_off_contract|
+        band_a, band_b, band_c, band_d = call_off_contract.bands
+        band_a.update!(min: nil, max: 2)
+        band_b.update!(min: 3,  max: 5)
+        band_c.update!(min: 6,  max: 8)
+        band_d.update!(min: 9,  max: 15)
+      end
+    end
+  end
+  let(:cohort) { Cohort.current || create(:cohort, :current) }
+  let(:statement) { create(:ecf_payable_statement, cpd_lead_provider:, cohort:) }
+  let(:lead_provider) { cpd_lead_provider.lead_provider }
+  let(:schedule) { Finance::Schedule.find_by(schedule_identifier: "ecf-standard-september", cohort:) }
 
   scenario "Statement includes additional adjustments" do
     given_i_am_logged_in_as_a_finance_user
@@ -16,6 +28,52 @@ RSpec.describe "Show ECF statement", :js do
     then_i_see("Early career framework (ECF)")
     and_i_see_additional_adjustments_table
     and_i_see_additional_adjustments_total
+  end
+
+  context "Statement authorise for payment" do
+    scenario "successfully authorised" do
+      given_i_am_logged_in_as_a_finance_user
+      and_multiple_declarations_exist
+
+      when_i_visit_the_ecf_financial_statements_page
+
+      then_i_see("Early career framework (ECF)")
+
+      and_i_see_authorise_for_payment_button
+      when_i_click_the_authorise_for_payment_button
+
+      then_i_see("Check #{statement.name} statement details before authorising for payment")
+
+      when_i_do_all_assurance_checks
+      when_i_click_the_authorise_for_payment_button
+
+      then_i_see("Authorising for payment")
+      then_i_see("Requested at #{statement.reload.marked_as_paid_at.strftime('%-I:%M%P on %-e %b %Y')}. We'll email you when the payment has been authorised and the statement updated. This may take up to 15 minutes.")
+
+      when_i_visit_the_ecf_financial_statements_page
+
+      then_i_do_not_see("Authorising for payment")
+      then_i_see("Authorised for payment at #{statement.marked_as_paid_at.strftime('%-I:%M%P on %-e %b %Y')}".upcase)
+    end
+
+    scenario "missing doing assurance checks" do
+      given_i_am_logged_in_as_a_finance_user
+      and_multiple_declarations_exist
+
+      when_i_visit_the_ecf_financial_statements_page
+
+      then_i_see("Early career framework (ECF)")
+
+      and_i_see_authorise_for_payment_button
+      when_i_click_the_authorise_for_payment_button
+
+      then_i_see("Check #{statement.name} statement details before authorising for payment")
+
+      when_i_click_the_authorise_for_payment_button
+
+      then_i_do_not_see("Authorising for payment")
+      then_i_see("Confirm all necessary assurance checks have been done before authorising this statement for payment")
+    end
   end
 
   def when_i_visit_the_ecf_financial_statements_page
@@ -32,6 +90,10 @@ RSpec.describe "Show ECF statement", :js do
     expect(page).to have_content(string)
   end
 
+  def then_i_do_not_see(string)
+    expect(page).not_to have_content(string)
+  end
+
   def and_i_see_additional_adjustments_table
     expect(page).to have_content("Additional adjustments")
     expect(page).to have_content("Big amount")
@@ -41,5 +103,51 @@ RSpec.describe "Show ECF statement", :js do
 
   def and_i_see_additional_adjustments_total
     expect(page).to have_css(".finance-panel .finance-panel__summary__total-payment-breakdown p:nth-child(5)", text: "Additional adjustments\n£799.99")
+  end
+
+  def and_multiple_declarations_exist
+    milestone = schedule.milestones.find_by(declaration_type: "started")
+    travel_to(milestone.milestone_date) do
+      declaration = create(:ect_participant_declaration, :payable, declaration_type: "started", cpd_lead_provider:, cohort:)
+      declaration.statement_line_items.first.update!(statement:, state: declaration.state)
+    end
+
+    milestone = schedule.milestones.find_by(declaration_type: "retained-1")
+    travel_to milestone.milestone_date do
+      declaration = create(:ect_participant_declaration, :payable, declaration_type: "retained-1", cpd_lead_provider:, cohort:)
+      declaration.statement_line_items.first.update!(statement:, state: declaration.state)
+    end
+
+    travel_to schedule.milestones.find_by(declaration_type: "retained-2").milestone_date do
+      declaration = create(:ect_participant_declaration, :payable, declaration_type: "retained-2", cpd_lead_provider:, cohort:)
+      declaration.statement_line_items.first.update!(statement:, state: declaration.state)
+    end
+
+    travel_to schedule.milestones.find_by(declaration_type: "retained-3").milestone_date do
+      declaration = create(:ect_participant_declaration, :payable, declaration_type: "retained-3", cpd_lead_provider:, cohort:)
+      declaration.statement_line_items.first.update!(statement:, state: declaration.state)
+    end
+
+    travel_to schedule.milestones.find_by(declaration_type: "retained-4").milestone_date do
+      declaration = create(:ect_participant_declaration, :payable, declaration_type: "retained-4", cpd_lead_provider:, cohort:)
+      declaration.statement_line_items.first.update!(statement:, state: declaration.state)
+    end
+
+    travel_to schedule.milestones.find_by(declaration_type: "completed").milestone_date do
+      declaration = create(:ect_participant_declaration, :payable, declaration_type: "completed", cpd_lead_provider:, cohort:)
+      declaration.statement_line_items.first.update!(statement:, state: declaration.state)
+    end
+  end
+
+  def and_i_see_authorise_for_payment_button
+    expect(page).to have_button("Authorise for payment")
+  end
+
+  def when_i_click_the_authorise_for_payment_button
+    click_button "Authorise for payment", class: "govuk-button", type: "submit"
+  end
+
+  def when_i_do_all_assurance_checks
+    check("Yes, I'm ready to authorise this for payment", allow_label_click: true)
   end
 end

--- a/spec/features/finance/npq/statement_spec.rb
+++ b/spec/features/finance/npq/statement_spec.rb
@@ -13,7 +13,36 @@ RSpec.describe "Show NPQ statement", :js do
   let!(:contract)           { create(:npq_contract, npq_lead_provider:, cohort:, monthly_service_fee: nil) }
 
   context "Statement authorise for payment" do
-    scenario "successfully authorised" do
+    scenario "successfully authorising" do
+      given_i_am_logged_in_as_a_finance_user
+      and_multiple_declarations_exist
+
+      when_i_visit_the_npq_financial_statements_page
+
+      then_i_see("National professional qualifications (NPQs)")
+
+      and_i_see_authorise_for_payment_button
+      when_i_click_the_authorise_for_payment_button
+
+      then_i_see("Check #{statement.name} statement details before authorising for payment")
+
+      when_i_do_all_assurance_checks
+
+      expect {
+        when_i_click_the_authorise_for_payment_button
+      }.to have_enqueued_job(
+        Finance::Statements::MarkAsPaidJob,
+      ).with(statement_id: statement.id).on_queue("default")
+
+      then_i_see("Authorising for payment")
+      then_i_see("Requested at #{statement.reload.marked_as_paid_at.strftime('%-I:%M%P on %-e %b %Y')}. This may take up to 15 minutes. Refresh to see the updated statement.")
+
+      when_i_visit_the_npq_financial_statements_page
+
+      then_i_do_not_see("Authorised for payment at #{statement.marked_as_paid_at.strftime('%-I:%M%P on %-e %b %Y')}".upcase)
+    end
+
+    scenario "successfully authorised", perform_jobs: true do
       given_i_am_logged_in_as_a_finance_user
       and_multiple_declarations_exist
 
@@ -29,13 +58,11 @@ RSpec.describe "Show NPQ statement", :js do
       when_i_do_all_assurance_checks
       when_i_click_the_authorise_for_payment_button
 
-      then_i_see("Authorising for payment")
-      then_i_see("Requested at #{statement.reload.marked_as_paid_at.strftime('%-I:%M%P on %-e %b %Y')}. We'll email you when the payment has been authorised and the statement updated. This may take up to 15 minutes.")
+      then_i_do_not_see("Authorising for payment")
 
       when_i_visit_the_npq_financial_statements_page
 
-      then_i_do_not_see("Authorising for payment")
-      then_i_see("Authorised for payment at #{statement.marked_as_paid_at.strftime('%-I:%M%P on %-e %b %Y')}".upcase)
+      then_i_see("Authorised for payment at #{Finance::Statement.find(statement.id).marked_as_paid_at.strftime('%-I:%M%P on %-e %b %Y')}".upcase)
     end
 
     scenario "missing doing assurance checks" do

--- a/spec/features/finance/npq/statement_spec.rb
+++ b/spec/features/finance/npq/statement_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Show NPQ statement", :js do
+  let(:cohort)              { Cohort.current || create(:cohort, :current) }
+  let(:cpd_lead_provider)   { create(:cpd_lead_provider, :with_npq_lead_provider) }
+  let(:npq_lead_provider)   { cpd_lead_provider.npq_lead_provider }
+  let(:statement)           { create(:npq_payable_statement, cpd_lead_provider:) }
+  let(:participant_profile) { create(:npq_application, :accepted, :eligible_for_funding, npq_course:, npq_lead_provider:).profile }
+  let(:another_participant_profile) { create(:npq_application, :accepted, :eligible_for_funding, npq_course:, npq_lead_provider:).profile }
+  let!(:npq_course)         { create(:npq_leadership_course, identifier: "npq-leading-teaching") }
+  let!(:contract)           { create(:npq_contract, npq_lead_provider:, cohort:, monthly_service_fee: nil) }
+
+  context "Statement authorise for payment" do
+    scenario "successfully authorised" do
+      given_i_am_logged_in_as_a_finance_user
+      and_multiple_declarations_exist
+
+      when_i_visit_the_npq_financial_statements_page
+
+      then_i_see("National professional qualifications (NPQs)")
+
+      and_i_see_authorise_for_payment_button
+      when_i_click_the_authorise_for_payment_button
+
+      then_i_see("Check #{statement.name} statement details before authorising for payment")
+
+      when_i_do_all_assurance_checks
+      when_i_click_the_authorise_for_payment_button
+
+      then_i_see("Authorising for payment")
+      then_i_see("Requested at #{statement.reload.marked_as_paid_at.strftime('%-I:%M%P on %-e %b %Y')}. We'll email you when the payment has been authorised and the statement updated. This may take up to 15 minutes.")
+
+      when_i_visit_the_npq_financial_statements_page
+
+      then_i_do_not_see("Authorising for payment")
+      then_i_see("Authorised for payment at #{statement.marked_as_paid_at.strftime('%-I:%M%P on %-e %b %Y')}".upcase)
+    end
+
+    scenario "missing doing assurance checks" do
+      given_i_am_logged_in_as_a_finance_user
+      and_multiple_declarations_exist
+
+      when_i_visit_the_npq_financial_statements_page
+
+      then_i_see("National professional qualifications (NPQs)")
+
+      and_i_see_authorise_for_payment_button
+      when_i_click_the_authorise_for_payment_button
+
+      then_i_see("Check #{statement.name} statement details before authorising for payment")
+
+      when_i_click_the_authorise_for_payment_button
+
+      then_i_do_not_see("Authorising for payment")
+      then_i_see("Confirm all necessary assurance checks have been done before authorising this statement for payment")
+    end
+  end
+
+  def when_i_visit_the_npq_financial_statements_page
+    visit("/finance/npq/payment-overviews/#{npq_lead_provider.id}/statements/#{statement.id}")
+  end
+
+  def then_i_see(string)
+    expect(page).to have_content(string)
+  end
+
+  def then_i_do_not_see(string)
+    expect(page).not_to have_content(string)
+  end
+
+  def and_multiple_declarations_exist
+    travel_to statement.deadline_date do
+      declaration = create(:npq_participant_declaration, :eligible, cpd_lead_provider:, participant_profile:)
+      declaration.statement_line_items.first.update!(statement:, state: declaration.state)
+
+      declaration = create(:npq_participant_declaration, :eligible, cpd_lead_provider:, participant_profile: another_participant_profile)
+      declaration.statement_line_items.first.update!(statement:, state: declaration.state)
+    end
+  end
+
+  def and_i_see_authorise_for_payment_button
+    expect(page).to have_button("Authorise for payment")
+  end
+
+  def when_i_click_the_authorise_for_payment_button
+    click_button "Authorise for payment", class: "govuk-button", type: "submit"
+  end
+
+  def when_i_do_all_assurance_checks
+    check("Yes, I'm ready to authorise this for payment", allow_label_click: true)
+  end
+end

--- a/spec/forms/finance/create_payment_authorisation_form_spec.rb
+++ b/spec/forms/finance/create_payment_authorisation_form_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+RSpec.describe Finance::CreatePaymentAuthorisationForm, type: :model do
+  let(:statement) { create :ecf_statement }
+  let(:params) { { statement:, checks_done: true } }
+
+  subject(:form) { described_class.new(params) }
+
+  describe "#valid?" do
+    context "checks done true" do
+      let(:params) { { statement:, checks_done: true } }
+
+      it "is valid" do
+        expect(form.valid?).to eql(true)
+      end
+    end
+
+    context "checks done false" do
+      let(:params) { { statement:, checks_done: false } }
+
+      it "is valid" do
+        expect(form.valid?).to eql(false)
+      end
+    end
+  end
+
+  describe "#save_form" do
+    it "marks statement as paid" do
+      expect { form.save_form }.to change { statement.reload.marked_as_paid_at }
+    end
+
+    it "calls the correct service class" do
+      expect(Finance::Statements::MarkAsPaidJob).to receive(:perform_later).with(statement_id: statement.id)
+
+      form.save_form
+    end
+  end
+
+  describe "#back_link" do
+    context "ECF statement" do
+      it "redirects to ECF statement page" do
+        expect(form.back_link).to eql(finance_ecf_payment_breakdown_statement_path(statement.lead_provider, statement))
+      end
+    end
+
+    context "NPQ statement" do
+      let(:statement) { create :npq_statement }
+
+      it "redirects to NPQ statement page" do
+        expect(form.back_link).to eql(finance_npq_lead_provider_statement_path(statement.npq_lead_provider, statement))
+      end
+    end
+  end
+end

--- a/spec/helpers/finance_helper_spec.rb
+++ b/spec/helpers/finance_helper_spec.rb
@@ -136,6 +136,14 @@ RSpec.describe FinanceHelper, type: :helper do
         end
       end
 
+      context "marked as to be paid statement" do
+        let(:statement) { create(:ecf_payable_statement, marked_as_paid_at: Time.zone.now) }
+
+        it "returns false" do
+          expect(authorise_for_payment_button_visible?(statement)).to eq(false)
+        end
+      end
+
       context "deadline date in the future statement" do
         let(:statement) { create(:ecf_payable_statement, deadline_date: Date.tomorrow) }
 

--- a/spec/helpers/finance_helper_spec.rb
+++ b/spec/helpers/finance_helper_spec.rb
@@ -92,4 +92,95 @@ RSpec.describe FinanceHelper, type: :helper do
       end
     end
   end
+
+  describe "#authorise_for_payment_button_visible?" do
+    let!(:participant_declaration) do
+      create(
+        :ect_participant_declaration,
+        :eligible,
+      )
+    end
+
+    before { participant_declaration.statement_line_items.first.update!(statement:) }
+
+    context "when mark as paid is allowed" do
+      let(:statement) { create(:ecf_payable_statement) }
+
+      it "returns true" do
+        expect(authorise_for_payment_button_visible?(statement)).to eq(true)
+      end
+    end
+
+    context "when mark as paid is not allowed" do
+      context "already paid statement" do
+        let(:statement) { create(:ecf_paid_statement) }
+
+        it "returns false" do
+          expect(authorise_for_payment_button_visible?(statement)).to eq(false)
+        end
+      end
+
+      context "no output fee statement" do
+        let(:statement) { create(:ecf_payable_statement, output_fee: false) }
+
+        it "returns false" do
+          expect(authorise_for_payment_button_visible?(statement)).to eq(false)
+        end
+      end
+
+      context "marked as paid statement" do
+        let(:statement) { create(:ecf_paid_statement) }
+
+        it "returns false" do
+          expect(authorise_for_payment_button_visible?(statement)).to eq(false)
+        end
+      end
+
+      context "deadline date in the future statement" do
+        let(:statement) { create(:ecf_payable_statement, deadline_date: Date.tomorrow) }
+
+        it "returns false" do
+          expect(authorise_for_payment_button_visible?(statement)).to eq(false)
+        end
+      end
+
+      context "no participant declarations statement" do
+        let(:statement) { create(:ecf_payable_statement) }
+
+        before { participant_declaration.statement_line_items.destroy_all }
+
+        it "returns false" do
+          expect(authorise_for_payment_button_visible?(statement)).to eq(false)
+        end
+      end
+    end
+  end
+
+  describe "#authorising_for_payment_banner_visible?" do
+    context "when statement is payable" do
+      context "when mark as paid is set" do
+        let(:statement) { create(:ecf_payable_statement, marked_as_paid_at: Time.zone.now) }
+
+        it "returns true" do
+          expect(authorising_for_payment_banner_visible?(statement)).to eq(true)
+        end
+      end
+
+      context "when mark as paid is not set" do
+        let(:statement) { create(:ecf_payable_statement) }
+
+        it "returns false" do
+          expect(authorising_for_payment_banner_visible?(statement)).to eq(false)
+        end
+      end
+    end
+
+    context "when statement is not payable" do
+      let(:statement) { create(:ecf_paid_statement) }
+
+      it "returns false" do
+        expect(authorising_for_payment_banner_visible?(statement)).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/models/finance/statement_spec.rb
+++ b/spec/models/finance/statement_spec.rb
@@ -102,4 +102,64 @@ RSpec.describe Finance::Statement do
       it { is_expected.not_to be_payable }
     end
   end
+
+  context "#mark_as_paid!" do
+    let(:participant_declaration) do
+      create(
+        :ect_participant_declaration,
+        :eligible,
+      )
+    end
+
+    subject { participant_declaration.statements.first }
+
+    it "sets marked_as_paid_at" do
+      expect { subject.mark_as_paid! }.to change { subject.reload.marked_as_paid_at }
+    end
+  end
+
+  context "#marked_as_paid?" do
+    context "marked as paid statement" do
+      subject { create(:ecf_paid_statement) }
+
+      it "returns true" do
+        expect(subject.marked_as_paid?).to eq(true)
+      end
+    end
+
+    context "non marked as paid statement" do
+      subject { create(:ecf_statement) }
+
+      it "returns false" do
+        expect(subject.marked_as_paid?).to eq(false)
+      end
+    end
+  end
+
+  context "#mark_as_paid_visible?" do
+    context "when mark as paid is allowed" do
+      let(:participant_declaration) do
+        create(
+          :ect_participant_declaration,
+          :eligible,
+        )
+      end
+
+      subject { create(:ecf_payable_statement) }
+
+      before { participant_declaration.statement_line_items.first.update!(statement: subject) }
+
+      it "returns true" do
+        expect(subject.mark_as_paid_visible?).to eq(true)
+      end
+    end
+
+    context "when mark as paid is not allowed" do
+      subject { create(:ecf_paid_statement) }
+
+      it "returns false" do
+        expect(subject.mark_as_paid_visible?).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/models/finance/statement_spec.rb
+++ b/spec/models/finance/statement_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Finance::Statement do
     end
   end
 
-  context "#mark_as_paid!" do
+  context "#mark_as_paid_at!" do
     let(:participant_declaration) do
       create(
         :ect_participant_declaration,
@@ -114,7 +114,7 @@ RSpec.describe Finance::Statement do
     subject { participant_declaration.statements.first }
 
     it "sets marked_as_paid_at" do
-      expect { subject.mark_as_paid! }.to change { subject.reload.marked_as_paid_at }
+      expect { subject.mark_as_paid_at! }.to change { subject.reload.marked_as_paid_at }
     end
   end
 
@@ -132,33 +132,6 @@ RSpec.describe Finance::Statement do
 
       it "returns false" do
         expect(subject.marked_as_paid?).to eq(false)
-      end
-    end
-  end
-
-  context "#mark_as_paid_visible?" do
-    context "when mark as paid is allowed" do
-      let(:participant_declaration) do
-        create(
-          :ect_participant_declaration,
-          :eligible,
-        )
-      end
-
-      subject { create(:ecf_payable_statement) }
-
-      before { participant_declaration.statement_line_items.first.update!(statement: subject) }
-
-      it "returns true" do
-        expect(subject.mark_as_paid_visible?).to eq(true)
-      end
-    end
-
-    context "when mark as paid is not allowed" do
-      subject { create(:ecf_paid_statement) }
-
-      it "returns false" do
-        expect(subject.mark_as_paid_visible?).to eq(false)
       end
     end
   end

--- a/spec/support/perform_jobs.rb
+++ b/spec/support/perform_jobs.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "sidekiq/testing"
+
+RSpec.configure do |config|
+  Sidekiq::Testing.fake!
+
+  config.around(:each, perform_jobs: true) do |example|
+    Sidekiq::Testing.inline! do
+      queue_adapter = ActiveJob::Base.queue_adapter
+      old_perform_enqueued_jobs = queue_adapter.perform_enqueued_jobs
+      old_perform_enqueued_at_jobs = queue_adapter.perform_enqueued_at_jobs
+      old_queue = queue_adapter.queue
+      queue_adapter.perform_enqueued_jobs = true
+      queue_adapter.perform_enqueued_at_jobs = true
+      queue_adapter.queue = begin
+        queue_name
+      rescue StandardError
+        :default
+      end
+      example.run
+    ensure
+      queue_adapter.perform_enqueued_jobs = old_perform_enqueued_jobs
+      queue_adapter.perform_enqueued_at_jobs = old_perform_enqueued_at_jobs
+      queue_adapter.queue = old_queue
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-2295](https://dfedigital.atlassian.net/browse/CPDLP-2295)

### Changes proposed in this pull request

Add authorise for payment button to ECF/NPQ on financial statements.

[CPDLP-2295]: https://dfedigital.atlassian.net/browse/CPDLP-2295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ