### PR TITLE
[CST-1924] Fix the unregistered users mailer

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -47,6 +47,6 @@ class UserMailer < ApplicationMailer
         sign_in: new_user_session_url,
         request_access: resend_email_request_nomination_invite_url,
       },
-    ).tag(:access_info_email).associate_with(recipient)
+    ).tag(:access_info_email)
   end
 end

--- a/lib/devise/strategies/passwordless_authenticatable.rb
+++ b/lib/devise/strategies/passwordless_authenticatable.rb
@@ -40,7 +40,7 @@ module Devise
             UserMailer.with(email: email.downcase, full_name: user.full_name, url:, token_expiry: token_expiry.localtime.to_fs(:govuk)).sign_in_email.deliver_later(queue: "priority_mailers")
             raise LoginIncompleteError
           else
-            # UserMailer.with(recipient: email.downcase).access_info_email.deliver_later(queue: "priority_mailers")
+            UserMailer.with(recipient: email.downcase).access_info_email.deliver_later(queue: "priority_mailers")
             raise EmailNotFoundError
           end
         end


### PR DESCRIPTION
### Context

- Ticket: CST-1924

This PR fixes the issue introduced in the #3939 and re-enables the email.

The issue:
Calling the `. associate_with (recipient) ` in the mailer with a String param raised an exception after Notify sent the email, which failed and re-queued the job. That created a loop that was sending the emails multiple times to the unregistered users who were trying to login.

### Changes proposed in this pull request
- There's no real need to associate the email with the recipient's email, so I'm removing the`.associate_with(recipient)` call
- Re-enabling the mailer

### Guidance to review

- Try to sign-in with a random email address
- Verify on `Notify -> API integration` page that the email was sent only once
- Check the mailer job in not re-queued on sidekiq

