### PR TITLE
Update mailer to take a school param

### DIFF
--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -63,6 +63,8 @@ class SchoolMailer < ApplicationMailer
 
   def remind_sit_to_add_ects_and_mentors_email
     induction_coordinator = params[:induction_coordinator]
+    school = params[:school]
+    school_name = school.name
     email_address = induction_coordinator.user.email
     name = induction_coordinator.user.full_name
 
@@ -74,6 +76,7 @@ class SchoolMailer < ApplicationMailer
       personalisation: {
         name:,
         email_address:,
+        school_name:,
       },
     ).tag(:remind_sits_to_add_ects_and_mentors).associate_with(induction_coordinator, as: :induction_coordinator_profile)
   end

--- a/spec/mailers/school_mailer_spec.rb
+++ b/spec/mailers/school_mailer_spec.rb
@@ -34,9 +34,10 @@ RSpec.describe SchoolMailer, type: :mailer do
 
   describe "#remind_sit_to_add_ects_and_mentors_email" do
     let(:induction_coordinator) { create(:seed_induction_coordinator_profile, :with_user) }
+    let(:school) { create(:seed_school) }
 
     let(:email) do
-      SchoolMailer.with(induction_coordinator:).remind_sit_to_add_ects_and_mentors_email.deliver_now
+      SchoolMailer.with(induction_coordinator:, school:).remind_sit_to_add_ects_and_mentors_email.deliver_now
     end
 
     it "renders the right headers" do


### PR DESCRIPTION

### Context

We want to include the school details in the Notify template for future comms.

- Ticket: 

### Changes proposed in this pull request
Pass a `School` as a param to the mailer
Provide a `school_name` param to the template

### Guidance to review

