### PR TITLE
[CPDLP-2398] Rename participant_bands output_payment_percantage

### DIFF
--- a/app/models/participant_band.rb
+++ b/app/models/participant_band.rb
@@ -47,7 +47,7 @@ class ParticipantBand < ApplicationRecord
   end
 
   def output_payment_per_participant
-    (per_participant * output_payment_percantage) / 100
+    (per_participant * output_payment_percentage) / 100
   end
 
   def service_fee_total

--- a/app/services/importers/create_call_off_contract.rb
+++ b/app/services/importers/create_call_off_contract.rb
@@ -100,7 +100,7 @@ module Importers
         per_participant: band_data[:per_participant],
       }
 
-      attributes.merge!(output_payment_percantage: 100, service_fee_percentage: 0) if band_d
+      attributes.merge!(output_payment_percentage: 100, service_fee_percentage: 0) if band_d
       ParticipantBand.create!(**attributes)
     end
 

--- a/db/migrate/20230911115906_rename_participant_bands_output_payment_percantage.rb
+++ b/db/migrate/20230911115906_rename_participant_bands_output_payment_percantage.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class RenameParticipantBandsOutputPaymentPercantage < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      rename_column :participant_bands, :output_payment_percantage, :output_payment_percentage
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_05_155638) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_11_115906) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -632,7 +632,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_05_155638) do
     t.decimal "per_participant"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "output_payment_percantage", default: 60
+    t.integer "output_payment_percentage", default: 60
     t.integer "service_fee_percentage", default: 40
     t.index ["call_off_contract_id"], name: "index_participant_bands_on_call_off_contract_id"
   end

--- a/spec/services/importers/create_call_off_contract_spec.rb
+++ b/spec/services/importers/create_call_off_contract_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe Importers::CreateCallOffContract do
             min: 0,
             max: 90,
             per_participant: 895,
-            output_payment_percantage: 60,
+            output_payment_percentage: 60,
             service_fee_percentage: 40,
           )
         end
@@ -172,7 +172,7 @@ RSpec.describe Importers::CreateCallOffContract do
             min: 91,
             max: 199,
             per_participant: 700,
-            output_payment_percantage: 60,
+            output_payment_percentage: 60,
             service_fee_percentage: 40,
           )
         end
@@ -183,7 +183,7 @@ RSpec.describe Importers::CreateCallOffContract do
             min: 200,
             max: 299,
             per_participant: 600,
-            output_payment_percantage: 60,
+            output_payment_percentage: 60,
             service_fee_percentage: 40,
           )
         end
@@ -194,7 +194,7 @@ RSpec.describe Importers::CreateCallOffContract do
             min: 300,
             max: 400,
             per_participant: 500,
-            output_payment_percantage: 100,
+            output_payment_percentage: 100,
             service_fee_percentage: 0,
           )
         end


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-2398](https://dfedigital.atlassian.net/browse/CPDLP-2398)

### Changes proposed in this pull request

Rename `participant_bands` `output_payment_percantage` column to `output_payment_percentage`.

[CPDLP-2398]: https://dfedigital.atlassian.net/browse/CPDLP-2398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ