### PR TITLE
Update mailer to take a school param and supply a school_name to template

### DIFF
--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -46,6 +46,8 @@ class SchoolMailer < ApplicationMailer
 
   def remind_sit_to_assign_mentors_to_ects_email
     induction_coordinator = params[:induction_coordinator]
+    school = params[:school]
+    school_name = school.name
     email_address = induction_coordinator.user.email
     name = induction_coordinator.user.full_name
 
@@ -57,6 +59,7 @@ class SchoolMailer < ApplicationMailer
       personalisation: {
         name:,
         email_address:,
+        school_name:,
       },
     ).tag(:remind_sits_to_assign_mentors_to_ects).associate_with(induction_coordinator, as: :induction_coordinator_profile)
   end

--- a/spec/mailers/school_mailer_spec.rb
+++ b/spec/mailers/school_mailer_spec.rb
@@ -21,9 +21,10 @@ RSpec.describe SchoolMailer, type: :mailer do
 
   describe "#remind_sit_to_assign_mentors_to_ects_email" do
     let(:induction_coordinator) { create(:seed_induction_coordinator_profile, :with_user) }
+    let(:school) { create(:seed_school) }
 
     let(:email) do
-      SchoolMailer.with(induction_coordinator:).remind_sit_to_assign_mentors_to_ects_email.deliver_now
+      SchoolMailer.with(induction_coordinator:, school:).remind_sit_to_assign_mentors_to_ects_email.deliver_now
     end
 
     it "renders the right headers" do


### PR DESCRIPTION
### Context
Update the reminder to add mentors to ECTs mailer to include the school name.

### Changes proposed in this pull request
Add school as a parameter to the mailer
Add school_name as an additional personalisation to the template

### Guidance to review
