### PR TITLE
Maths-npq api spec + release notes updates upto sandbox

### DIFF
--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -7,6 +7,10 @@ weight: 8
 
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
 
+## 13 September 2023
+We’ve added the new NPQ in leading primary mathematics to the sandbox environment.The new course’s identifier is `npq-leading-primary-mathematics`. Providers can access this within the sandbox environment for testing. Functionality will be the same as the other existing NPQ courses.
+
+Providers will be notified ahead of this new NPQ becoming available in the production environment.
 ## 6 September 2023
 
 ### Planned API downtime on 14 September

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -3677,7 +3677,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ]
           },
           "status": {
@@ -3870,7 +3871,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ]
           },
           "status": {
@@ -3981,7 +3983,8 @@
               "npq-senior-leadership",
               "npq-headship",
               "npq-executive-leadership",
-              "npq-early-years-leadership"
+              "npq-early-years-leadership",
+              "npq-leading-primary-mathematics"
             ],
             "example": "npq-leading-teaching"
           },
@@ -4027,7 +4030,8 @@
               "npq-senior-leadership",
               "npq-headship",
               "npq-executive-leadership",
-              "npq-early-years-leadership"
+              "npq-early-years-leadership",
+              "npq-leading-primary-mathematics"
             ],
             "example": "npq-leading-teaching"
           },
@@ -4252,7 +4256,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ],
             "example": "npq-executive-leadership"
           },
@@ -4341,7 +4346,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ],
             "example": "npq-leading-teaching"
           },
@@ -4464,7 +4470,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ],
             "example": "npq-headship"
           },
@@ -4549,7 +4556,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ],
             "example": "npq-headship"
           }
@@ -4605,7 +4613,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ],
             "example": "npq-headship"
           }
@@ -4677,7 +4686,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ],
             "example": "npq-senior-leadership"
           }
@@ -4758,7 +4768,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ],
             "example": "npq-senior-leadership"
           }
@@ -4849,7 +4860,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ],
             "example": "npq-headship"
           }
@@ -4926,7 +4938,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ],
             "example": "npq-headship"
           }
@@ -5004,7 +5017,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ],
             "example": "npq-leading-teaching-development"
           }
@@ -5147,7 +5161,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ],
             "example": "ecf-induction"
           },
@@ -5255,7 +5270,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ],
             "example": "ecf-induction"
           },

--- a/swagger/v1/component_schemas/NPQApplicationAttributes.yml
+++ b/swagger/v1/component_schemas/NPQApplicationAttributes.yml
@@ -109,6 +109,7 @@ properties:
       - npq-early-years-leadership
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
+      - npq-leading-primary-mathematics
   status:
     description: "The current state of the NPQ application"
     type: string

--- a/swagger/v1/component_schemas/NPQApplicationCsvRow.yml
+++ b/swagger/v1/component_schemas/NPQApplicationCsvRow.yml
@@ -97,6 +97,7 @@ properties:
       - npq-early-years-leadership
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
+      - npq-leading-primary-mathematics
   status:
     description: "The current state of the NPQ application"
     type: string

--- a/swagger/v1/component_schemas/NPQOutcomeAttributes.yml
+++ b/swagger/v1/component_schemas/NPQOutcomeAttributes.yml
@@ -26,6 +26,7 @@ properties:
       - npq-headship
       - npq-executive-leadership
       - npq-early-years-leadership
+      - npq-leading-primary-mathematics
     example: npq-leading-teaching
   state:
     description: The state of the outcome (passed, failed or voided)

--- a/swagger/v1/component_schemas/NPQOutcomeAttributesRequest.yml
+++ b/swagger/v1/component_schemas/NPQOutcomeAttributesRequest.yml
@@ -16,6 +16,7 @@ properties:
       - npq-headship
       - npq-executive-leadership
       - npq-early-years-leadership
+      - npq-leading-primary-mathematics
     example: npq-leading-teaching
   state:
     description: The state of the outcome (passed or failed)

--- a/swagger/v1/component_schemas/NPQParticipantChangeScheduleAttributes.yml
+++ b/swagger/v1/component_schemas/NPQParticipantChangeScheduleAttributes.yml
@@ -28,6 +28,7 @@ properties:
       - npq-early-years-leadership
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
+      - npq-leading-primary-mathematics
     example: npq-executive-leadership
   cohort:
     description: "Providers may change an NPQ participant's cohort up until the point of submitting a started declaration. The value indicates which call-off contract funds this participant's training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year."

--- a/swagger/v1/component_schemas/NPQParticipantDeferAttributes.yml
+++ b/swagger/v1/component_schemas/NPQParticipantDeferAttributes.yml
@@ -28,6 +28,7 @@ properties:
       - npq-early-years-leadership
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
+      - npq-leading-primary-mathematics
     example: npq-senior-leadership
 example:
   reason: parental-leave

--- a/swagger/v1/component_schemas/NPQParticipantResumeAttributes.yml
+++ b/swagger/v1/component_schemas/NPQParticipantResumeAttributes.yml
@@ -15,6 +15,7 @@ properties:
       - npq-early-years-leadership
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
+      - npq-leading-primary-mathematics
     example: npq-senior-leadership
 required:
   - course_identifier

--- a/swagger/v1/component_schemas/NPQParticipantRetainedDeclarationAttributes.yml
+++ b/swagger/v1/component_schemas/NPQParticipantRetainedDeclarationAttributes.yml
@@ -33,6 +33,7 @@ properties:
       - npq-early-years-leadership
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
+      - npq-leading-primary-mathematics
     example: npq-headship
 required:
   - participant_id

--- a/swagger/v1/component_schemas/NPQParticipantStartedDeclarationAttributes.yml
+++ b/swagger/v1/component_schemas/NPQParticipantStartedDeclarationAttributes.yml
@@ -33,6 +33,7 @@ properties:
       - npq-early-years-leadership
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
+      - npq-leading-primary-mathematics
     example: npq-headship
 required:
   - participant_id

--- a/swagger/v1/component_schemas/NPQParticipantWithdrawAttributes.yml
+++ b/swagger/v1/component_schemas/NPQParticipantWithdrawAttributes.yml
@@ -36,6 +36,7 @@ properties:
       - npq-early-years-leadership
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
+      - npq-leading-primary-mathematics
     example: npq-leading-teaching-development
 required:
   - reason

--- a/swagger/v1/component_schemas/ParticipantDeclarationAttributes.yml
+++ b/swagger/v1/component_schemas/ParticipantDeclarationAttributes.yml
@@ -50,6 +50,7 @@ properties:
       - npq-early-years-leadership
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
+      - npq-leading-primary-mathematics
     example: ecf-induction
   eligible_for_payment:
     description: "[Deprecated - use state instead] Indicates whether this declaration would be eligible for funding from the DfE"

--- a/swagger/v1/component_schemas/ParticipantDeclarationCsvRow.yml
+++ b/swagger/v1/component_schemas/ParticipantDeclarationCsvRow.yml
@@ -52,6 +52,7 @@ properties:
       - npq-early-years-leadership
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
+      - npq-leading-primary-mathematics
     example: ecf-induction
   eligible_for_payment:
     description: "[Deprecated - use state instead] Indicates whether this declaration would be eligible for funding from the DfE"

--- a/swagger/v2/api_spec.json
+++ b/swagger/v2/api_spec.json
@@ -3553,7 +3553,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ]
           },
           "status": {
@@ -3747,7 +3748,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ]
           },
           "status": {
@@ -3824,7 +3826,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ]
           },
           "schedule_identifier": {
@@ -3916,7 +3919,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ]
           },
           "schedule_identifier": {
@@ -4022,7 +4026,8 @@
               "npq-senior-leadership",
               "npq-headship",
               "npq-executive-leadership",
-              "npq-early-years-leadership"
+              "npq-early-years-leadership",
+              "npq-leading-primary-mathematics"
             ],
             "example": "npq-leading-teaching"
           },
@@ -4067,7 +4072,8 @@
               "npq-senior-leadership",
               "npq-headship",
               "npq-executive-leadership",
-              "npq-early-years-leadership"
+              "npq-early-years-leadership",
+              "npq-leading-primary-mathematics"
             ],
             "example": "npq-leading-teaching"
           },
@@ -4285,7 +4291,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ],
             "example": "npq-executive-leadership"
           },
@@ -4374,7 +4381,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ],
             "example": "npq-leading-teaching"
           },
@@ -4497,7 +4505,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ],
             "example": "npq-headship"
           },
@@ -4582,7 +4591,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ],
             "example": "npq-headship"
           }
@@ -4638,7 +4648,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ],
             "example": "npq-headship"
           }
@@ -4710,7 +4721,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ],
             "example": "npq-senior-leadership"
           }
@@ -4791,7 +4803,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ],
             "example": "npq-senior-leadership"
           }
@@ -4882,7 +4895,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ],
             "example": "npq-headship"
           }
@@ -4959,7 +4973,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ],
             "example": "npq-headship"
           }
@@ -5037,7 +5052,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ],
             "example": "npq-leading-teaching-development"
           }
@@ -5178,7 +5194,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ],
             "example": "ecf-induction"
           },
@@ -5270,7 +5287,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ],
             "example": "ecf-induction"
           },

--- a/swagger/v2/component_schemas/NPQApplicationAttributes.yml
+++ b/swagger/v2/component_schemas/NPQApplicationAttributes.yml
@@ -105,6 +105,7 @@ properties:
       - npq-early-years-leadership
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
+      - npq-leading-primary-mathematics
   status:
     description: "The current state of the NPQ application"
     type: string

--- a/swagger/v2/component_schemas/NPQApplicationCsvRow.yml
+++ b/swagger/v2/component_schemas/NPQApplicationCsvRow.yml
@@ -97,6 +97,7 @@ properties:
       - npq-early-years-leadership
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
+      - npq-leading-primary-mathematics
   status:
     description: "The current state of the NPQ application"
     type: string

--- a/swagger/v2/component_schemas/NPQEnrolment.yml
+++ b/swagger/v2/component_schemas/NPQEnrolment.yml
@@ -23,6 +23,7 @@ properties:
       - npq-early-years-leadership
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
+      - npq-leading-primary-mathematics
   schedule_identifier:
     description: "The schedule the participant is enrolled in"
     type: string

--- a/swagger/v2/component_schemas/NPQEnrolmentCsvRow.yml
+++ b/swagger/v2/component_schemas/NPQEnrolmentCsvRow.yml
@@ -30,6 +30,7 @@ properties:
       - npq-early-years-leadership
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
+      - npq-leading-primary-mathematics
   schedule_identifier:
     description: "The schedule currently applied to this enrolment"
     type: string

--- a/swagger/v2/component_schemas/NPQOutcomeAttributes.yml
+++ b/swagger/v2/component_schemas/NPQOutcomeAttributes.yml
@@ -26,6 +26,7 @@ properties:
       - npq-headship
       - npq-executive-leadership
       - npq-early-years-leadership
+      - npq-leading-primary-mathematics
     example: npq-leading-teaching
   state:
     description: The state of the outcome (passed or failed)

--- a/swagger/v2/component_schemas/NPQOutcomeAttributesRequest.yml
+++ b/swagger/v2/component_schemas/NPQOutcomeAttributesRequest.yml
@@ -16,6 +16,7 @@ properties:
       - npq-headship
       - npq-executive-leadership
       - npq-early-years-leadership
+      - npq-leading-primary-mathematics
     example: npq-leading-teaching
   state:
     description: The state of the outcome (passed or failed)

--- a/swagger/v2/component_schemas/NPQParticipantChangeScheduleAttributes.yml
+++ b/swagger/v2/component_schemas/NPQParticipantChangeScheduleAttributes.yml
@@ -28,6 +28,7 @@ properties:
       - npq-early-years-leadership
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
+      - npq-leading-primary-mathematics
     example: npq-executive-leadership
   cohort:
     description: "Providers may change an NPQ participant's cohort up until the point of submitting a started declaration. The value indicates which call-off contract funds this participant's training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year."

--- a/swagger/v2/component_schemas/NPQParticipantDeferAttributes.yml
+++ b/swagger/v2/component_schemas/NPQParticipantDeferAttributes.yml
@@ -28,6 +28,7 @@ properties:
       - npq-early-years-leadership
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
+      - npq-leading-primary-mathematics
     example: npq-senior-leadership
 example:
   reason: parental-leave

--- a/swagger/v2/component_schemas/NPQParticipantResumeAttributes.yml
+++ b/swagger/v2/component_schemas/NPQParticipantResumeAttributes.yml
@@ -15,6 +15,7 @@ properties:
       - npq-early-years-leadership
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
+      - npq-leading-primary-mathematics
     example: npq-senior-leadership
 required:
   - course_identifier

--- a/swagger/v2/component_schemas/NPQParticipantRetainedDeclarationAttributes.yml
+++ b/swagger/v2/component_schemas/NPQParticipantRetainedDeclarationAttributes.yml
@@ -33,6 +33,7 @@ properties:
       - npq-early-years-leadership
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
+      - npq-leading-primary-mathematics
     example: npq-headship
 required:
   - participant_id

--- a/swagger/v2/component_schemas/NPQParticipantStartedDeclarationAttributes.yml
+++ b/swagger/v2/component_schemas/NPQParticipantStartedDeclarationAttributes.yml
@@ -33,6 +33,7 @@ properties:
       - npq-early-years-leadership
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
+      - npq-leading-primary-mathematics
     example: npq-headship
 required:
   - participant_id

--- a/swagger/v2/component_schemas/NPQParticipantWithdrawAttributes.yml
+++ b/swagger/v2/component_schemas/NPQParticipantWithdrawAttributes.yml
@@ -36,6 +36,7 @@ properties:
       - npq-early-years-leadership
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
+      - npq-leading-primary-mathematics
     example: npq-leading-teaching-development
 required:
   - reason

--- a/swagger/v2/component_schemas/ParticipantDeclarationAttributes.yml
+++ b/swagger/v2/component_schemas/ParticipantDeclarationAttributes.yml
@@ -48,6 +48,7 @@ properties:
       - npq-early-years-leadership
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
+      - npq-leading-primary-mathematics
     example: ecf-induction
   state:
     description: "Indicates the state of this payment declaration"

--- a/swagger/v2/component_schemas/ParticipantDeclarationCsvRow.yml
+++ b/swagger/v2/component_schemas/ParticipantDeclarationCsvRow.yml
@@ -50,6 +50,7 @@ properties:
       - npq-early-years-leadership
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
+      - npq-leading-primary-mathematics
     example: ecf-induction
   state:
     description: "Indicates the state of this payment declaration"

--- a/swagger/v3/api_spec.json
+++ b/swagger/v3/api_spec.json
@@ -5007,7 +5007,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ]
           },
           "status": {
@@ -5225,7 +5226,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ]
           },
           "schedule_identifier": {
@@ -5387,7 +5389,8 @@
               "npq-senior-leadership",
               "npq-headship",
               "npq-executive-leadership",
-              "npq-early-years-leadership"
+              "npq-early-years-leadership",
+              "npq-leading-primary-mathematics"
             ],
             "example": "npq-leading-teaching"
           },
@@ -5438,7 +5441,8 @@
               "npq-senior-leadership",
               "npq-headship",
               "npq-executive-leadership",
-              "npq-early-years-leadership"
+              "npq-early-years-leadership",
+              "npq-leading-primary-mathematics"
             ],
             "example": "npq-leading-teaching"
           },
@@ -5649,7 +5653,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ],
             "example": "npq-executive-leadership"
           },
@@ -5739,7 +5744,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ],
             "example": "npq-leading-teaching"
           },
@@ -5889,7 +5895,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ],
             "example": "npq-headship"
           },
@@ -5974,7 +5981,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ],
             "example": "npq-headship"
           }
@@ -6030,7 +6038,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ],
             "example": "npq-headship"
           }
@@ -6102,7 +6111,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ],
             "example": "npq-senior-leadership"
           }
@@ -6183,7 +6193,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ],
             "example": "npq-senior-leadership"
           }
@@ -6262,7 +6273,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ],
             "example": "npq-leading-teaching"
           },
@@ -6400,7 +6412,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ],
             "example": "npq-leading-teaching"
           },
@@ -6565,7 +6578,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ],
             "example": "npq-leading-teaching-development"
           }
@@ -6852,7 +6866,8 @@
               "npq-executive-leadership",
               "npq-early-years-leadership",
               "npq-additional-support-offer",
-              "npq-early-headship-coaching-offer"
+              "npq-early-headship-coaching-offer",
+              "npq-leading-primary-mathematics"
             ],
             "example": "ecf-induction"
           },

--- a/swagger/v3/component_schemas/NPQApplicationAttributes.yml
+++ b/swagger/v3/component_schemas/NPQApplicationAttributes.yml
@@ -105,6 +105,7 @@ properties:
       - npq-early-years-leadership
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
+      - npq-leading-primary-mathematics
   status:
     description: "The current state of the NPQ application"
     type: string

--- a/swagger/v3/component_schemas/NPQEnrolment.yml
+++ b/swagger/v3/component_schemas/NPQEnrolment.yml
@@ -29,6 +29,7 @@ properties:
       - npq-early-years-leadership
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
+      - npq-leading-primary-mathematics
   schedule_identifier:
     description: "The schedule the participant is enrolled in"
     type: string

--- a/swagger/v3/component_schemas/NPQOutcomeAttributes.yml
+++ b/swagger/v3/component_schemas/NPQOutcomeAttributes.yml
@@ -27,6 +27,7 @@ properties:
       - npq-headship
       - npq-executive-leadership
       - npq-early-years-leadership
+      - npq-leading-primary-mathematics
     example: npq-leading-teaching
   state:
     description: The state of the outcome (passed, failed or voided)

--- a/swagger/v3/component_schemas/NPQOutcomeAttributesRequest.yml
+++ b/swagger/v3/component_schemas/NPQOutcomeAttributesRequest.yml
@@ -16,6 +16,7 @@ properties:
       - npq-headship
       - npq-executive-leadership
       - npq-early-years-leadership
+      - npq-leading-primary-mathematics
     example: npq-leading-teaching
   state:
     description: The state of the outcome (passed or failed)

--- a/swagger/v3/component_schemas/NPQParticipantChangeScheduleAttributes.yml
+++ b/swagger/v3/component_schemas/NPQParticipantChangeScheduleAttributes.yml
@@ -28,6 +28,7 @@ properties:
       - npq-early-years-leadership
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
+      - npq-leading-primary-mathematics
     example: npq-executive-leadership
   cohort:
     description: "Providers may change an NPQ participant's cohort up until the point of submitting a started declaration. The value indicates which call-off contract funds this participant's training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year."

--- a/swagger/v3/component_schemas/NPQParticipantCompletedDeclarationAttributes.yml
+++ b/swagger/v3/component_schemas/NPQParticipantCompletedDeclarationAttributes.yml
@@ -39,6 +39,7 @@ properties:
       - npq-early-years-leadership
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
+      - npq-leading-primary-mathematics
     example: npq-leading-teaching
   state:
     description: "Indicates the state of this payment declaration"

--- a/swagger/v3/component_schemas/NPQParticipantDeclarationCompletedAttributesRequest.yml
+++ b/swagger/v3/component_schemas/NPQParticipantDeclarationCompletedAttributesRequest.yml
@@ -38,6 +38,7 @@ properties:
       - npq-early-years-leadership
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
+      - npq-leading-primary-mathematics
     example: npq-headship
   has_passed:
     description: Whether the participant has failed or passed

--- a/swagger/v3/component_schemas/NPQParticipantDeclarationRetainedAttributesRequest.yml
+++ b/swagger/v3/component_schemas/NPQParticipantDeclarationRetainedAttributesRequest.yml
@@ -33,6 +33,7 @@ properties:
       - npq-early-years-leadership
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
+      - npq-leading-primary-mathematics
     example: npq-headship
 required:
   - participant_id

--- a/swagger/v3/component_schemas/NPQParticipantDeclarationStartedAttributesRequest.yml
+++ b/swagger/v3/component_schemas/NPQParticipantDeclarationStartedAttributesRequest.yml
@@ -32,6 +32,7 @@ properties:
       - npq-early-years-leadership
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
+      - npq-leading-primary-mathematics
     example: npq-headship
 required:
   - participant_id

--- a/swagger/v3/component_schemas/NPQParticipantDeferAttributes.yml
+++ b/swagger/v3/component_schemas/NPQParticipantDeferAttributes.yml
@@ -28,6 +28,7 @@ properties:
       - npq-early-years-leadership
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
+      - npq-leading-primary-mathematics
     example: npq-senior-leadership
 example:
   reason: parental-leave

--- a/swagger/v3/component_schemas/NPQParticipantResumeAttributes.yml
+++ b/swagger/v3/component_schemas/NPQParticipantResumeAttributes.yml
@@ -15,6 +15,7 @@ properties:
       - npq-early-years-leadership
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
+      - npq-leading-primary-mathematics
     example: npq-senior-leadership
 required:
   - course_identifier

--- a/swagger/v3/component_schemas/NPQParticipantRetainedDeclarationAttributes.yml
+++ b/swagger/v3/component_schemas/NPQParticipantRetainedDeclarationAttributes.yml
@@ -40,6 +40,7 @@ properties:
       - npq-early-years-leadership
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
+      - npq-leading-primary-mathematics
     example: npq-leading-teaching
   state:
     description: "Indicates the state of this payment declaration"

--- a/swagger/v3/component_schemas/NPQParticipantStartedDeclarationAttributes.yml
+++ b/swagger/v3/component_schemas/NPQParticipantStartedDeclarationAttributes.yml
@@ -39,6 +39,7 @@ properties:
       - npq-early-years-leadership
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
+      - npq-leading-primary-mathematics
     example: npq-leading-teaching
   state:
     description: "Indicates the state of this payment declaration"

--- a/swagger/v3/component_schemas/NPQParticipantWithdrawAttributes.yml
+++ b/swagger/v3/component_schemas/NPQParticipantWithdrawAttributes.yml
@@ -36,6 +36,7 @@ properties:
       - npq-early-years-leadership
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
+      - npq-leading-primary-mathematics
     example: npq-leading-teaching-development
 required:
   - reason

--- a/swagger/v3/component_schemas/ParticipantDeclarationAttributes.yml
+++ b/swagger/v3/component_schemas/ParticipantDeclarationAttributes.yml
@@ -48,6 +48,7 @@ properties:
       - npq-early-years-leadership
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
+      - npq-leading-primary-mathematics
     example: ecf-induction
   state:
     description: "Indicates the state of this payment declaration"


### PR DESCRIPTION
### Context
Update api documentation for maths npq course
### Ticket
https://dfedigital.atlassian.net/browse/CPDNPQ-1314 

### Changes proposed in this pull request
Swagger directory now contains the maths_npq identifier. Identifiers have been added to the files NPQApplicationAttributes.yml and api_spec.json in the directories v1, v2, and v3.
### Description:

 **New Course Identifier:** We have introduced a new course with identifier `leading-primary-mathematics`, which is now available for use by lead providers. This identifier facilitates the retrieval of applications specifically for the primary mathematics course.

 **Sandbox Environment Testing:** To support our development and testing processes, this new course identifier is now accessible within the sandbox environment for testing.
 **Contract Updates:** Lead providers can now provide and update contracts for the `leading-primary-mathematics course`.

 **Application Generation and Contract Sync:** Lead providers have the capability to generate applications for the `leading-primary-mathematics` course. Once an application is generated, the associated contract is automatically updated to reflect the changes. This streamlined process ensures that contracts are always in sync with the latest application data.
**Note:** This is being released up to sandbox for now.

