### PR TITLE
[CPDLP-2224] Remove service fees from ECF 2021 contract/cohort statements from October 2023 statement onwards

### DIFF
--- a/app/services/oneoffs/remove_fees_from_ecf_contracts.rb
+++ b/app/services/oneoffs/remove_fees_from_ecf_contracts.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Oneoffs
+  class RemoveFeesFromECFContracts
+    attr_reader :cohort_year, :from_date
+
+    def initialize(cohort_year:, from_date:)
+      @cohort_year = cohort_year
+      @from_date = from_date.to_date
+    end
+
+    def call
+      statements.each do |statement|
+        lead_provider = statement.lead_provider
+        version = statement.contract_version
+
+        old_contract = CallOffContract.where(
+          version:,
+          lead_provider:,
+          cohort:,
+        ).first!
+
+        # Contract already set to zero
+        next if old_contract.monthly_service_fee.to_s == "0.0"
+
+        new_version = increment_version(version)
+
+        new_contract = CallOffContract.find_or_initialize_by(
+          version: new_version,
+          lead_provider:,
+          cohort:,
+        )
+
+        new_contract.uplift_target = old_contract.uplift_target
+        new_contract.uplift_amount = old_contract.uplift_amount
+        new_contract.recruitment_target = old_contract.recruitment_target
+        new_contract.set_up_fee = old_contract.set_up_fee
+        new_contract.revised_target = old_contract.revised_target
+        new_contract.monthly_service_fee = 0.0
+        new_contract.save!
+
+        if new_contract.participant_bands.empty?
+          old_contract.participant_bands.each do |old_band|
+            new_band = old_band.dup
+            new_band.call_off_contract = new_contract
+            new_band.save!
+          end
+        end
+
+        statement.update!(contract_version: new_version)
+      end
+    end
+
+    def cohort
+      @cohort ||= Cohort.find_by!(start_year: cohort_year)
+    end
+
+    def statements
+      @statements ||= Finance::Statement::ECF.where(cohort:).where("payment_date >= ?", from_date)
+    end
+
+    def increment_version(version)
+      n = (version.split(".") || []).last.to_i
+      "0.0.#{n + 1}"
+    end
+  end
+end

--- a/spec/services/oneoffs/remove_fees_from_ecf_contracts_spec.rb
+++ b/spec/services/oneoffs/remove_fees_from_ecf_contracts_spec.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+RSpec.describe Oneoffs::RemoveFeesFromECFContracts do
+  let(:cohort) { create(:cohort, start_year: 2021) }
+
+  subject { Oneoffs::RemoveFeesFromECFContracts.new(cohort_year: 2021, from_date: "2023-10-01") }
+
+  describe "#call" do
+    let!(:ecf_statement1) { create(:ecf_statement, cohort:, contract_version: "0.0.1", payment_date: "2023-10-25") }
+    let!(:call_off_contract1) do
+      create(
+        :call_off_contract,
+        lead_provider: ecf_statement1.lead_provider,
+        cohort: ecf_statement1.cohort,
+        version: ecf_statement1.contract_version,
+        monthly_service_fee: 1000.0,
+      )
+    end
+
+    let!(:ecf_statement2) { create(:ecf_statement, cohort:, contract_version: "0.0.4", payment_date: "2023-11-25") }
+    let!(:call_off_contract2) do
+      create(
+        :call_off_contract,
+        lead_provider: ecf_statement2.lead_provider,
+        cohort: ecf_statement2.cohort,
+        version: ecf_statement2.contract_version,
+        monthly_service_fee: nil,
+      )
+    end
+
+    let!(:ecf_statement3) { create(:ecf_statement, cohort:, contract_version: "0.0.7", payment_date: "2023-09-25") }
+    let!(:call_off_contract3) do
+      create(
+        :call_off_contract,
+        lead_provider: ecf_statement3.lead_provider,
+        cohort: ecf_statement3.cohort,
+        version: ecf_statement3.contract_version,
+        monthly_service_fee: 9000.0,
+      )
+    end
+
+    it "should create new contract with zero service fee" do
+      expect(Finance::Statement::ECF.count).to eql(3)
+      expect(ecf_statement1.reload.contract_version).to eql("0.0.1")
+      expect(ecf_statement2.reload.contract_version).to eql("0.0.4")
+      expect(ecf_statement3.reload.contract_version).to eql("0.0.7")
+
+      expect(CallOffContract.count).to eql(3)
+      expect(CallOffContract.where(monthly_service_fee: 1000.0).count).to eql(1)
+      expect(CallOffContract.where(monthly_service_fee: nil).count).to eql(1)
+      expect(CallOffContract.where(monthly_service_fee: 9000.0).count).to eql(1)
+
+      subject.call
+
+      expect(Finance::Statement::ECF.count).to eql(3)
+      expect(ecf_statement1.reload.contract_version).to eql("0.0.2")
+      expect(ecf_statement2.reload.contract_version).to eql("0.0.5")
+      expect(ecf_statement3.reload.contract_version).to eql("0.0.7")
+
+      expect(CallOffContract.count).to eql(3 + 2)
+      expect(CallOffContract.where(monthly_service_fee: 1000.0).count).to eql(1)
+      expect(CallOffContract.where(monthly_service_fee: nil).count).to eql(1)
+      expect(CallOffContract.where(monthly_service_fee: 9000.0).count).to eql(1)
+      expect(CallOffContract.where(monthly_service_fee: 0.0).count).to eql(2)
+    end
+
+    it "should create new contract matching old contract" do
+      # Run twice to check for duplicates
+      subject.call
+      subject.call
+      expect(CallOffContract.count).to eql(3 + 2)
+
+      old_call_off_contract1 = CallOffContract.where(
+        cohort: call_off_contract1.cohort,
+        lead_provider: call_off_contract1.lead_provider,
+        version: "0.0.1",
+      ).first
+      new_call_off_contract1 = CallOffContract.where(
+        cohort: call_off_contract1.cohort,
+        lead_provider: call_off_contract1.lead_provider,
+        version: "0.0.2",
+      ).first
+
+      expect(new_call_off_contract1.uplift_target).to eql(old_call_off_contract1.uplift_target)
+      expect(new_call_off_contract1.uplift_amount).to eql(old_call_off_contract1.uplift_amount)
+      expect(new_call_off_contract1.recruitment_target).to eql(old_call_off_contract1.recruitment_target)
+      expect(new_call_off_contract1.set_up_fee).to eql(old_call_off_contract1.set_up_fee)
+      expect(new_call_off_contract1.revised_target).to eql(old_call_off_contract1.revised_target)
+      expect(new_call_off_contract1.monthly_service_fee).to eql(0.0)
+    end
+
+    it "should create new bands matching old contract bands" do
+      # Run twice to check for duplicates
+      subject.call
+      subject.call
+
+      old_call_off_contract1 = CallOffContract.where(
+        cohort: call_off_contract1.cohort,
+        lead_provider: call_off_contract1.lead_provider,
+        version: "0.0.1",
+      ).first
+      new_call_off_contract1 = CallOffContract.where(
+        cohort: call_off_contract1.cohort,
+        lead_provider: call_off_contract1.lead_provider,
+        version: "0.0.2",
+      ).first
+
+      expect(old_call_off_contract1.participant_bands.count).to eql(3)
+      expect(new_call_off_contract1.participant_bands.count).to eql(3)
+
+      old_call_off_contract1.participant_bands.each_with_index do |old_band, n|
+        new_band = new_call_off_contract1.participant_bands[n]
+        expect(new_band.min).to eql(old_band.min)
+        expect(new_band.max).to eql(old_band.max)
+        expect(new_band.per_participant).to eql(old_band.per_participant)
+        expect(new_band.output_payment_percentage).to eql(old_band.output_payment_percentage)
+        expect(new_band.service_fee_percentage).to eql(old_band.service_fee_percentage)
+      end
+
+      old_call_off_contract2 = CallOffContract.where(
+        cohort: call_off_contract2.cohort,
+        lead_provider: call_off_contract2.lead_provider,
+        version: "0.0.4",
+      ).first
+      new_call_off_contract2 = CallOffContract.where(
+        cohort: call_off_contract2.cohort,
+        lead_provider: call_off_contract2.lead_provider,
+        version: "0.0.5",
+      ).first
+
+      expect(old_call_off_contract2.participant_bands.count).to eql(3)
+      expect(new_call_off_contract2.participant_bands.count).to eql(3)
+
+      old_call_off_contract2.participant_bands.each_with_index do |old_band, n|
+        new_band = new_call_off_contract2.participant_bands[n]
+        expect(new_band.min).to eql(old_band.min)
+        expect(new_band.max).to eql(old_band.max)
+        expect(new_band.per_participant).to eql(old_band.per_participant)
+        expect(new_band.output_payment_percentage).to eql(old_band.output_payment_percentage)
+        expect(new_band.service_fee_percentage).to eql(old_band.service_fee_percentage)
+      end
+    end
+  end
+
+  describe "#increment_version" do
+    it "should increment version" do
+      expect(subject.increment_version("0.0.0")).to eql("0.0.1")
+      expect(subject.increment_version("0.0.1")).to eql("0.0.2")
+      expect(subject.increment_version("0.0.2")).to eql("0.0.3")
+      expect(subject.increment_version("0.0.3")).to eql("0.0.4")
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-2224

### Changes proposed in this pull request

* Created service class `Oneoffs::RemoveFeesFromECFContracts` to execute the changes

### Guidance to review

* Rails console
* Run `Oneoffs::RemoveFeesFromECFContracts.new(cohort_year: 2021, from_date: "2023-10-01").call`

