### PR TITLE
Add statuscake monitoring to AKS

### DIFF
--- a/.github/actions/deploy-environment-to-aks/action.yml
+++ b/.github/actions/deploy-environment-to-aks/action.yml
@@ -21,6 +21,9 @@ inputs:
   current-commit-sha:
     description: The commit sha for the current commit
     required: true
+  statuscake-api-token:
+    description: The Statuscake token
+    required: false
 
 outputs:
   url:
@@ -48,6 +51,7 @@ runs:
         cd terraform/aks && echo "url=$(terraform output -raw url)" >> $GITHUB_OUTPUT
       env:
         TF_VAR_azure_sp_credentials_json: ${{ inputs.azure-credentials }}
+        TF_VAR_statuscake_api_token: ${{ inputs.statuscake-api-token }}
         DOCKER_IMAGE: ${{ inputs.docker-image }}
         PULL_REQUEST_NUMBER: ${{ inputs.pull-request-number }}
 

--- a/.github/workflows/aks_deploy.yml
+++ b/.github/workflows/aks_deploy.yml
@@ -87,6 +87,7 @@ jobs:
           azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
           pull-request-number: ${{ github.event.pull_request.number }}
           current-commit-sha: ${{ github.event.pull_request.head.sha }}
+          statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}
 
       - name: Post sticky pull request comment
         if: github.event_name == 'pull_request'
@@ -114,6 +115,7 @@ jobs:
           docker-image: ${{ needs.docker.outputs.docker-image }}
           azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
           current-commit-sha: ${{ github.sha }}
+          statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}
 
   deploy_sandbox:
     name: Deploy sandbox
@@ -132,6 +134,7 @@ jobs:
           docker-image: ${{ needs.deploy_staging.outputs.docker-image }}
           azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
           current-commit-sha: ${{ github.sha }}
+          statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}
 
   deploy_production:
     name: Deploy production
@@ -150,3 +153,4 @@ jobs:
           docker-image: ${{ needs.deploy_staging.outputs.docker-image }}
           azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
           current-commit-sha: ${{ github.sha }}
+          statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -166,3 +166,9 @@ install-konduit: ## Install the konduit script, for accessing backend services
 .PHONY: terraform-refresh
 terraform-refresh: terraform-init
 	terraform -chdir=terraform/application refresh -var-file config/$(CONFIG)/variables.tfvars.json
+
+action-group-resources: set-azure-account # make env_aks action-group-resources ACTION_GROUP_EMAIL=notificationemail@domain.com . Must be run before setting enable_monitoring=true for each subscription
+	$(if $(ACTION_GROUP_EMAIL), , $(error Please specify a notification email for the action group))
+	echo ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-mn-rg
+	az group create -l uksouth -g ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-mn-rg --tags "Product=Manage training for early career teachers" "Environment=Test" "Service Offering=Teacher services cloud"
+	az monitor action-group create -n ${AZURE_RESOURCE_PREFIX}-cpd-ecf -g ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-mn-rg --action email ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-email ${ACTION_GROUP_EMAIL}

--- a/terraform/aks/monitoring.tf
+++ b/terraform/aks/monitoring.tf
@@ -1,0 +1,14 @@
+locals {
+  external_url = var.external_hostname != null ? "https://${var.external_hostname}" : null
+}
+
+module "statuscake" {
+  count = var.enable_monitoring ? 1 : 0
+
+  source = "git::https://github.com/DFE-Digital/terraform-modules.git//monitoring/statuscake?ref=stable"
+
+  uptime_urls = compact([module.web_application.probe_url, local.external_url])
+  ssl_urls    = compact([local.external_url])
+
+  contact_groups = [291418]
+}

--- a/terraform/aks/providers.tf
+++ b/terraform/aks/providers.tf
@@ -18,3 +18,7 @@ provider "kubernetes" {
   client_key             = module.cluster_data.kubernetes_client_key
   cluster_ca_certificate = module.cluster_data.kubernetes_cluster_ca_certificate
 }
+
+provider "statuscake" {
+  api_token = var.statuscake_api_token
+}

--- a/terraform/aks/terraform.tf
+++ b/terraform/aks/terraform.tf
@@ -3,5 +3,10 @@ terraform {
 
   backend "azurerm" {}
 
-  required_providers {}
+  required_providers {
+    statuscake = {
+      source  = "StatusCakeDev/statuscake"
+      version = ">= 2.0.5"
+    }
+  }
 }

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -78,3 +78,8 @@ variable "domain" {
   type = string
   default = ""
 }
+
+variable "external_hostname" {
+  type    = string
+  default = null
+}

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -83,3 +83,6 @@ variable "external_hostname" {
   type    = string
   default = null
 }
+
+variable "statuscake_api_token" {
+}

--- a/terraform/aks/workspace_variables/production_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/production_aks.tfvars.json
@@ -11,5 +11,5 @@
   "redis_queue_capacity": 1,
   "redis_queue_sku_name": "Premium",
   "domain": "manage-training-for-early-career-teachers.education.gov.uk",
-  "external_hostname": "https://manage-training-for-early-career-teachers.education.gov.uk/"
+  "external_hostname": "manage-training-for-early-career-teachers.education.gov.uk/"
 }

--- a/terraform/aks/workspace_variables/production_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/production_aks.tfvars.json
@@ -10,5 +10,6 @@
   "redis_queue_family": "P",
   "redis_queue_capacity": 1,
   "redis_queue_sku_name": "Premium",
-  "domain": "manage-training-for-early-career-teachers.education.gov.uk"
+  "domain": "manage-training-for-early-career-teachers.education.gov.uk",
+  "external_hostname": "https://manage-training-for-early-career-teachers.education.gov.uk/"
 }

--- a/terraform/aks/workspace_variables/production_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/production_aks.tfvars.json
@@ -5,7 +5,7 @@
   "app_environment": "production",
   "cluster": "production",
   "deploy_azure_backing_services": true,
-  "enable_monitoring": false,
+  "enable_monitoring": true,
   "namespace": "cpd-production",
   "redis_queue_family": "P",
   "redis_queue_capacity": 1,

--- a/terraform/aks/workspace_variables/sandbox_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/sandbox_aks.tfvars.json
@@ -5,5 +5,6 @@
   "deploy_azure_backing_services": true,
   "enable_monitoring": false,
   "namespace": "cpd-production",
-  "domain": "sb.manage-training-for-early-career-teachers.education.gov.uk"
+  "domain": "sb.manage-training-for-early-career-teachers.education.gov.uk",
+  "external_hostname": "https://sb.manage-training-for-early-career-teachers.education.gov.uk/"
 }

--- a/terraform/aks/workspace_variables/sandbox_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/sandbox_aks.tfvars.json
@@ -6,5 +6,5 @@
   "enable_monitoring": false,
   "namespace": "cpd-production",
   "domain": "sb.manage-training-for-early-career-teachers.education.gov.uk",
-  "external_hostname": "https://sb.manage-training-for-early-career-teachers.education.gov.uk/"
+  "external_hostname": "sb.manage-training-for-early-career-teachers.education.gov.uk/"
 }

--- a/terraform/aks/workspace_variables/staging_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/staging_aks.tfvars.json
@@ -5,5 +5,5 @@
   "enable_monitoring": false,
   "namespace": "cpd-development",
   "domain": "st.manage-training-for-early-career-teachers.education.gov.uk",
-  "external_hostname": "https://st.manage-training-for-early-career-teachers.education.gov.uk/"
+  "external_hostname": "st.manage-training-for-early-career-teachers.education.gov.uk/"
 }

--- a/terraform/aks/workspace_variables/staging_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/staging_aks.tfvars.json
@@ -4,5 +4,6 @@
   "deploy_azure_backing_services": true,
   "enable_monitoring": false,
   "namespace": "cpd-development",
-  "domain": "st.manage-training-for-early-career-teachers.education.gov.uk"
+  "domain": "st.manage-training-for-early-career-teachers.education.gov.uk",
+  "external_hostname": "https://st.manage-training-for-early-career-teachers.education.gov.uk/"
 }


### PR DESCRIPTION
### Context
Terraform statuscake module: https://github.com/DFE-Digital/terraform-modules/tree/main/monitoring/statuscake

- Ticket: n/a
We have statuscake monitoring in PaaS, add it to Azure since we are migrating soon

### Changes proposed in this pull request
- Add external hostname variable and set in all envs 
- Amend monitoring to true in production as this is used in both db setup and statuscake
- Add monitoring and set our contact group
- Add statuscake to providers and set token in action

### Guidance to review
Did I miss anything?
