### PR TITLE
Add back missing variables, these are required for sending emails

### DIFF
--- a/terraform/aks/application.tf
+++ b/terraform/aks/application.tf
@@ -25,6 +25,10 @@ module "application_configuration" {
     GIAS_API_SCHEMA     = "https://ea-edubase-api-prod.azurewebsites.net/edubase/schema/service.wsdl"
     GIAS_EXTRACT_ID     = 13904
     GIAS_API_USER       = "ecftech"
+    DOMAIN              = var.domain
+    GOVUK_WEBSITE_ROOT  = var.domain
+    GOVUK_APP_DOMAIN    = var.domain
+    SEND_EMAILS_TO      = "cpd-test@digital.education.gov.uk"
   }
 
   secret_key_vault_short = "app"

--- a/terraform/aks/application.tf
+++ b/terraform/aks/application.tf
@@ -1,6 +1,7 @@
 locals {
   environment  = "${var.app_environment}${var.app_suffix}"
   service_name = "cpd-ecf"
+  domain       = var.app_environment == "review" ? "cpd-ecf-${local.environment}-web.test.teacherservices.cloud" : var.domain
 }
 
 module "application_configuration" {
@@ -25,9 +26,9 @@ module "application_configuration" {
     GIAS_API_SCHEMA     = "https://ea-edubase-api-prod.azurewebsites.net/edubase/schema/service.wsdl"
     GIAS_EXTRACT_ID     = 13904
     GIAS_API_USER       = "ecftech"
-    DOMAIN              = var.domain
-    GOVUK_WEBSITE_ROOT  = var.domain
-    GOVUK_APP_DOMAIN    = var.domain
+    DOMAIN              = local.domain
+    GOVUK_WEBSITE_ROOT  = local.domain
+    GOVUK_APP_DOMAIN    = local.domain
     SEND_EMAILS_TO      = "cpd-test@digital.education.gov.uk"
   }
 

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -73,3 +73,7 @@ variable "redis_queue_family" {
 variable "redis_queue_sku_name" {
   default = "Standard"
 }
+
+variable "domain" {
+  type = string
+}

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -76,4 +76,5 @@ variable "redis_queue_sku_name" {
 
 variable "domain" {
   type = string
+  default = ""
 }

--- a/terraform/aks/workspace_variables/production_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/production_aks.tfvars.json
@@ -9,5 +9,6 @@
   "namespace": "cpd-production",
   "redis_queue_family": "P",
   "redis_queue_capacity": 1,
-  "redis_queue_sku_name": "Premium"
+  "redis_queue_sku_name": "Premium",
+  "domain": "manage-training-for-early-career-teachers.education.gov.uk"
 }

--- a/terraform/aks/workspace_variables/sandbox_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/sandbox_aks.tfvars.json
@@ -4,5 +4,6 @@
   "cluster": "production",
   "deploy_azure_backing_services": true,
   "enable_monitoring": false,
-  "namespace": "cpd-production"
+  "namespace": "cpd-production",
+  "domain": "sb.manage-training-for-early-career-teachers.education.gov.uk"
 }

--- a/terraform/aks/workspace_variables/staging_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/staging_aks.tfvars.json
@@ -3,5 +3,6 @@
   "cluster": "test",
   "deploy_azure_backing_services": true,
   "enable_monitoring": false,
-  "namespace": "cpd-development"
+  "namespace": "cpd-development",
+  "domain": "st.manage-training-for-early-career-teachers.education.gov.uk"
 }


### PR DESCRIPTION
### Context
We are getting errors in sandbox when attempting to send emails:
```
`full_url_for': Missing host to link to! Please provide the :host parameter, set default_url_options[:host], or set :only_path to true (ArgumentError)
```
We set the domain in environment config, this is required for sending emails.

- Ticket: n/a

### Changes proposed in this pull request
- Add send email to ENV to allow redirect in non prod/test envs (needs amending for the vcap attribute later)
- Add domain variable and set in application to allow emails to be sent

### Guidance to review

There is a bit of cleanup still required after the migration