### PR TITLE
Add statuscake token to review app destroy

### DIFF
--- a/.github/workflows/aks_destroy_review.yml
+++ b/.github/workflows/aks_destroy_review.yml
@@ -50,6 +50,7 @@ jobs:
         run: make ci review terraform-destroy
         env:
           TF_VAR_azure_sp_credentials_json: ${{ secrets.AZURE_CREDENTIALS }}
+          TF_VAR_statuscake_api_token: ${{ secrets.STATUSCAKE_API_TOKEN }}
           DOCKER_IMAGE: "ghcr.io/dfe-digital/early-careers-framework:no-tag"
           PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
 


### PR DESCRIPTION
### Context

Review app deletion is failing. Add statuscake token as its now required

- Ticket: n/a

### Changes proposed in this pull request
Add statuscake token read from Github secrets to delete review app

### Guidance to review
We need to fix this generally where not every terraform init/plan/apply/destroy needs the token, cleanup will be a bit later
