### PR TITLE
Switch `f.submit` over to `f.govuk_submit` for consistent HTML

### DIFF
--- a/app/components/banners/maintenance_component.html.erb
+++ b/app/components/banners/maintenance_component.html.erb
@@ -14,7 +14,7 @@
       </p>
 
       <%= form_with url: maintenance_banner_dismissal_path, method: :patch do |f| %>
-        <%= f.submit "Dismiss", class: "govuk-button govuk-button--secondary govuk-!-margin-0" %>
+        <%= f.govuk_submit("Dismiss", secondary: true, class: "govuk-!-margin-0") %>
       <% end %>
     </div>
   </div>

--- a/app/views/admin/notes/edit.html.erb
+++ b/app/views/admin/notes/edit.html.erb
@@ -15,7 +15,7 @@
             hint: { text: "Give details about any changes made to this participant. Notes are for internal use only" }
             ) %>
 
-      <%= f.submit "Save", class: "govuk-button" %>
+      <%= f.govuk_submit("Save") %>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/npq/applications/notes/edit.html.erb
+++ b/app/views/admin/npq/applications/notes/edit.html.erb
@@ -16,7 +16,7 @@
             hint: { text: "Give details about any changes made to this NPQ Application. Notes are for internal use only" }
             ) %>
 
-      <%= f.submit "Save", class: "govuk-button" %>
+      <%= f.govuk_submit("Save") %>
     <% end %>
   </div>
 </div>

--- a/app/views/lead_providers/report_schools/confirm/show.html.erb
+++ b/app/views/lead_providers/report_schools/confirm/show.html.erb
@@ -30,7 +30,7 @@
         <td class="govuk-table__cell">
           <%= form_for :remove, url: { action: :remove_school } do |form| %>
             <%= form.hidden_field :school_id, value: school.id, id: "remove-school-#{school.id}" %>
-            <%= form.submit "Remove", class: "govuk-button govuk-button--secondary govuk-!-margin-0", data: { module: "govuk-button" } %>
+            <%= form.govuk_submit("Remove", secondary: true, class: "govuk-!-margin-0") %>
           <% end %>
         </td>
       </tr>

--- a/app/views/privacy_policies/show.html.erb
+++ b/app/views/privacy_policies/show.html.erb
@@ -12,9 +12,10 @@
         <%= sanitize(@policy.html) %>
 
         <% if @policy.acceptance_required?(current_user) %>
-            <%= form_tag({action: :update}, method: :put) do %>
-                <%= hidden_field_tag :policy_id, @policy.id %>
-            <%= submit_tag "Continue", class: "govuk-button govuk-!-margin-top-4" %>
+            <%= form_with(url: privacy_policy_path, method: :put) do |f| %>
+              <%= hidden_field_tag :policy_id, @policy.id %>
+
+              <%= f.govuk_submit %>
             <% end %>
         <% end %>
 

--- a/app/views/users/sessions/redirect_from_magic_link.html.erb
+++ b/app/views/users/sessions/redirect_from_magic_link.html.erb
@@ -2,11 +2,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">You’re now signed in</h1>
-    <%= form_tag(users_sign_in_with_token_path) do %>
+    <%= form_with(url: users_sign_in_with_token_path) do |f| %>
       <div class="field">
         <%= hidden_field_tag :login_token, @login_token %>
       </div>
-      <%= submit_tag "Continue", class: "govuk-button" %>
+      <%= f.govuk_submit %>
     <% end %>
   </div>
 </div>

--- a/spec/cypress/support/commands.js
+++ b/spec/cypress/support/commands.js
@@ -9,7 +9,7 @@ Cypress.Commands.add("loginCreated", (factory) => {
       OnRails.getCreatedRecord(factory).login_token
     }`
   );
-  cy.get('[action="/users/sign_in_with_token"] [name="commit"]').click();
+  cy.get(".govuk-main-wrapper .govuk-button").contains("Continue").click();
 });
 
 Cypress.Commands.add("login", (...traits) => {
@@ -19,7 +19,7 @@ Cypress.Commands.add("login", (...traits) => {
       cy.visit(`/users/confirm_sign_in?login_token=${user.login_token}`);
     });
 
-  cy.get('[action="/users/sign_in_with_token"] [name="commit"]').click();
+  cy.get(".govuk-main-wrapper .govuk-button").contains("Continue").click();
 });
 
 Cypress.Commands.add("logout", () => {

--- a/spec/cypress/support/step_definitions/common-interaction.js
+++ b/spec/cypress/support/step_definitions/common-interaction.js
@@ -41,7 +41,7 @@ const buttons = {
   "search button": "[data-test=search-button]",
   "impersonate button": "[data-test=impersonate-button]",
   "stop impersonating button": "[data-test=stop-impersonating-button]",
-  "remove button": ".govuk-button[value=Remove]",
+  "remove button": '.govuk-button:contains("Remove")',
 };
 
 const links = {

--- a/spec/cypress/support/step_definitions/database.js
+++ b/spec/cypress/support/step_definitions/database.js
@@ -59,7 +59,7 @@ const login = (traits, args) => {
       cy.visit(`/users/confirm_sign_in?login_token=${user.login_token}`);
     });
 
-  cy.get('[action="/users/sign_in_with_token"] [name="commit"]').click();
+  cy.get(".govuk-main-wrapper .govuk-button").contains("Continue").click();
 };
 
 Given("I am logged in as {string}", (traits) => login(traits));
@@ -81,7 +81,7 @@ Given("I am logged in as existing user with {}", (argsStr) => {
   );
   cy.visit(`/users/confirm_sign_in?login_token=abcdefghij`);
 
-  cy.get('[action="/users/sign_in_with_token"] [name="commit"]').click();
+  cy.get(".govuk-main-wrapper .govuk-button").contains("Continue").click();
 });
 
 const setFeature = (feature, isActive) => {


### PR DESCRIPTION
The `govuk_submit` form helper ensures the relevant `data-module` attributes are set and double-click prevention is enabled too.
