### PR TITLE
Add database populated checks to the healthcheck and smoke test

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -10,6 +10,7 @@ class HealthcheckController < ApplicationController
       environment: Rails.env,
       database: {
         connected: database_connected?,
+        populated: database_populated?,
         migration_version:,
       },
       sidekiq: {
@@ -33,6 +34,15 @@ private
 
   def database_connected?
     ApplicationRecord.connection.select_value("SELECT 1") == 1
+  rescue StandardError
+    false
+  end
+
+  def database_populated?
+    [
+      ApplicationRecord.connection.select_value("select count(*) from schools"),
+      ApplicationRecord.connection.select_value("select count(*) from schedules"),
+    ].all?(&:positive?)
   rescue StandardError
     false
   end

--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -4,7 +4,7 @@ class HealthcheckController < ApplicationController
   NOTIFY_STATUS_API = "https://stdg40247zwv.statuspage.io/api/v2/status.json"
 
   def check
-    render status: :ok, json: {
+    render status:, json: {
       version: release_version,
       sha:,
       environment: Rails.env,
@@ -27,6 +27,14 @@ class HealthcheckController < ApplicationController
   end
 
 private
+
+  def status
+    if database_connected? && database_populated?
+      :ok
+    else
+      :internal_server_error
+    end
+  end
 
   def sha
     ENV["SHA"].presence || ENV["COMMIT_SHA"].presence || "none"

--- a/bin/smoke
+++ b/bin/smoke
@@ -30,3 +30,21 @@ else
   echo "Fail: healthcheck migration version is $response_migration but latest is $latest_migration"
   exit 1
 fi
+
+database_connected=$(jq ".database.connected" <<< $response)
+
+if [[ $database_connected == 'true' ]]; then
+  echo "✅ Database is connected"
+else
+  echo "Fail: database is not connected"
+  exit 1
+fi
+
+database_poplulated=$(jq ".database.populated" <<< $response)
+
+if [[ $database_poplulated == 'true' ]]; then
+  echo "✅ Database is populated"
+else
+  echo "Fail: database is not populated"
+  exit 1
+fi


### PR DESCRIPTION
### Context

The healthcheck is used by the smoke tests to ensure that the environments are in good shape before continuing the continuous deployment process.

This check provides some extra safety by ensuring if we make changes to resource names in terraform that result in them being deleted (#3992, #4008) and recreated, the emptiness of the tables will cause a failure.

### Changes proposed in this pull request

- Add a database populated check to the healthcheck
- Alter healthcheck status based on db connectivity
- Add connected/populated checks to the smoke test
