### PR TITLE
Allow GIAS importer to do more automatically

### DIFF
--- a/app/models/concerns/gias_types.rb
+++ b/app/models/concerns/gias_types.rb
@@ -17,10 +17,6 @@ module GiasTypes
   MAJOR_CHANGE_ATTRIBUTES = %w[
     school_status_code
     school_status_name
-    school_type_code
-    school_type_name
-    section_41_approved
-    ukprn
   ].freeze
 
   def open_status_code?(status_code)

--- a/app/services/data_stage/update_staged_schools.rb
+++ b/app/services/data_stage/update_staged_schools.rb
@@ -62,6 +62,8 @@ module DataStage
         if school.counterpart.present?
           school.counterpart.update!(extract_values_from(simple_changes)) if simple_changes.any?
           school.school_changes.create!(attribute_changes: major_changes, status: :changed) if major_changes.any?
+        elsif school.open? && school.school_links.none?
+          school.create_or_sync_counterpart!
         end
       end
     end

--- a/spec/factories/staged_school_change.rb
+++ b/spec/factories/staged_school_change.rb
@@ -25,16 +25,6 @@ FactoryBot.define do
       end
     end
 
-    trait :with_unhandled_changes do
-      attribute_changes do
-        {
-          school_status_code: [4, 1],
-          school_status_name: %w[proposed_to_open open],
-          ukprn: %w[12345678 98765421],
-        }
-      end
-    end
-
     trait :handled do
       handled { true }
     end


### PR DESCRIPTION
### Context

Currently some simple changes are not processed automatically such as new schools without links or "unhandled" attributes which don't need to be handled in any special way. This PR removes the unhandled attribute checks and also allows the addition of new schools where possible.


