### PR TITLE
[CPDLP-2387] Prevent provider/user changing cohort for NPQ where there is no contract for the course in the target/new cohort

### DIFF
--- a/app/forms/finance/npq/change_lead_provider_form.rb
+++ b/app/forms/finance/npq/change_lead_provider_form.rb
@@ -10,6 +10,7 @@ module Finance
       attribute :lead_provider_id
 
       validates :lead_provider_id, inclusion: { in: :valid_lead_provider_ids }
+      validates :cohort, npq_contract_for_cohort_and_course: true
 
       def save
         return false unless valid?
@@ -26,7 +27,7 @@ module Finance
 
       def lead_provider_options
         @lead_provider_options ||=
-          NPQLeadProvider.name_order.includes(:cohorts).where(cohorts: { id: npq_application.cohort_id })
+          NPQLeadProvider.name_order.includes(:cohorts).where(cohorts: { id: npq_application.cohort_id }, npq_contracts: { course_identifier: })
       end
 
       def current_lead_provider
@@ -41,10 +42,17 @@ module Finance
         @lead_provider ||= NPQLeadProvider.find(lead_provider_id)
       end
 
+      def course_identifier
+        npq_application.npq_course.identifier
+      end
+
     private
 
-      delegate :participant_identity, :npq_application,
-               to: :participant_profile
+      delegate :participant_identity, :npq_application, to: :participant_profile
+      delegate :cohort, to: :npq_application
+      delegate :cpd_lead_provider, to: :npq_lead_provider
+
+      alias_method :npq_lead_provider, :lead_provider
 
       def valid_lead_provider_ids
         lead_provider_options.pluck(:id)
@@ -52,10 +60,6 @@ module Finance
 
       def external_identifier
         participant_identity.external_identifier
-      end
-
-      def course_identifier
-        npq_application.npq_course.identifier
       end
 
       def lead_provider_unchanged?

--- a/app/forms/finance/npq/change_lead_provider_form.rb
+++ b/app/forms/finance/npq/change_lead_provider_form.rb
@@ -9,8 +9,8 @@ module Finance
       attribute :participant_profile
       attribute :lead_provider_id
 
+      validates :cohort, npq_contract_for_cohort_and_course: true, if: :lead_provider
       validates :lead_provider_id, inclusion: { in: :valid_lead_provider_ids }
-      validates :cohort, npq_contract_for_cohort_and_course: true
 
       def save
         return false unless valid?
@@ -39,7 +39,7 @@ module Finance
       end
 
       def lead_provider
-        @lead_provider ||= NPQLeadProvider.find(lead_provider_id)
+        @lead_provider ||= NPQLeadProvider.find_by(id: lead_provider_id)
       end
 
       def course_identifier

--- a/app/models/participant_declaration/npq.rb
+++ b/app/models/participant_declaration/npq.rb
@@ -10,6 +10,7 @@ class ParticipantDeclaration::NPQ < ParticipantDeclaration
     "npq-headship" => "NPQH",
     "npq-executive-leadership" => "NPQEL",
     "npq-early-years-leadership" => "NPQEYL",
+    "npq-leading-primary-mathematics" => "NPQLPM",
   }.freeze
 
   has_one :npq_application, through: :participant_profile

--- a/app/services/change_schedule.rb
+++ b/app/services/change_schedule.rb
@@ -18,6 +18,7 @@ class ChangeSchedule
   validates :course_identifier, course: true, presence: { message: I18n.t(:missing_course_identifier) }
   validates :cpd_lead_provider, induction_record: true
   validates :schedule_identifier, presence: { message: I18n.t(:invalid_schedule) }
+  validates :cohort, npq_contract_for_cohort_and_course: true
   validate :not_already_withdrawn
   validate :validate_new_schedule_valid_with_existing_declarations
   validate :change_with_a_different_schedule
@@ -73,14 +74,14 @@ class ChangeSchedule
     @schedule ||= participant_profile&.schedule_for(cpd_lead_provider:)
   end
 
+  def cohort
+    @cohort ||= super ? Cohort.find_by(start_year: super) : fallback_cohort
+  end
+
 private
 
   def user
     @user ||= participant_identity&.user
-  end
-
-  def cohort
-    @cohort ||= super ? Cohort.find_by(start_year: super) : fallback_cohort
   end
 
   def fallback_cohort

--- a/app/services/record_declaration.rb
+++ b/app/services/record_declaration.rb
@@ -31,6 +31,7 @@ class RecordDeclaration
   validate :validates_billable_slot_available
   validates :course_identifier, course: true
   validates :cpd_lead_provider, induction_record: true
+  validates :cohort, npq_contract_for_cohort_and_course: { message: I18n.t(:missing_npq_contract_for_cohort_and_course_new_declaration) }
 
   attr_reader :raw_declaration_date
 
@@ -81,13 +82,12 @@ class RecordDeclaration
     schedule.milestones.find_by(declaration_type:)
   end
 
-  def schedule
-    participant_profile&.schedule
-  end
-
 private
 
   attr_writer :raw_declaration_date
+
+  delegate :schedule, to: :participant_profile, allow_nil: true
+  delegate :cohort, to: :schedule
 
   def participant_profile_for_course_identifier
     return unless participant_identity

--- a/app/validators/npq_contract_for_cohort_and_course_validator.rb
+++ b/app/validators/npq_contract_for_cohort_and_course_validator.rb
@@ -5,7 +5,7 @@ class NPQContractForCohortAndCourseValidator < ActiveModel::Validator
     return if record.errors.any?
     return unless npq_contract_for_cohort_and_course_missing?(record)
 
-    record.errors.add(:cohort, I18n.t(:missing_npq_contract_for_cohort_and_course))
+    record.errors.add(:cohort, options[:message] || I18n.t(:missing_npq_contract_for_cohort_and_course))
   end
 
 private

--- a/app/validators/npq_contract_for_cohort_and_course_validator.rb
+++ b/app/validators/npq_contract_for_cohort_and_course_validator.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class NPQContractForCohortAndCourseValidator < ActiveModel::Validator
+  def validate(record)
+    return if record.errors.any?
+    return unless npq_contract_for_cohort_and_course_missing?(record)
+
+    record.errors.add(:cohort, I18n.t(:missing_npq_contract_for_cohort_and_course))
+  end
+
+private
+
+  def npq_contract_for_cohort_and_course_missing?(record)
+    return unless npq_course?(record)
+
+    npq_contract_for_cohort_and_course(record).empty?
+  end
+
+  def npq_contract_for_cohort_and_course(record)
+    NPQContract.where(
+      cohort: record.cohort,
+      npq_lead_provider: record.cpd_lead_provider.npq_lead_provider,
+      course_identifier: record.course_identifier,
+    )
+  end
+
+  def npq_course?(record)
+    ParticipantProfile::NPQ::COURSE_IDENTIFIERS.include?(record.course_identifier)
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -83,6 +83,7 @@ en:
   schedule_invalid_for_course: Selected schedule is not valid for the course
   missing_school_cohort_default_partnership: You cannot change a participant to this cohort as you do not have a partnership with the school for the cohort. Contact the DfE for assistance.
   missing_npq_contract_for_cohort_and_course: You cannot change a participant to this cohort as you do not have a contract for the cohort and course. Contact the DfE for assistance.
+  missing_npq_contract_for_cohort_and_course_new_declaration: You cannot submit a declaration for this participant as you do not have a contract for the cohort and course. Contact the DfE for assistance.
   withdrawn_participant: Cannot perform actions on a withdrawn participant
   declaration_already_voided: "This declaration has already been voided."
   declaration_not_voidable: "This declaration cannot be voided. Contact the DfE if you have any questions about why you cannot void it."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,6 +82,7 @@ en:
   schedule_invalidates_declaration: Changing schedule would invalidate existing declarations. Please void them first.
   schedule_invalid_for_course: Selected schedule is not valid for the course
   missing_school_cohort_default_partnership: You cannot change a participant to this cohort as you do not have a partnership with the school for the cohort. Contact the DfE for assistance.
+  missing_npq_contract_for_cohort_and_course: You cannot change a participant to this cohort as you do not have a contract for the cohort and course. Contact the DfE for assistance.
   withdrawn_participant: Cannot perform actions on a withdrawn participant
   declaration_already_voided: "This declaration has already been voided."
   declaration_not_voidable: "This declaration cannot be voided. Contact the DfE if you have any questions about why you cannot void it."

--- a/spec/components/finance/statements/npq_details_table_spec.rb
+++ b/spec/components/finance/statements/npq_details_table_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe Finance::Statements::NPQDetailsTable, type: :component do
 
   it "has the correct text" do
     expect(rendered).to have_text("Total starts")
-    expect(rendered).to have_text(1)
+    expect(rendered).to have_text(2)
     expect(rendered).to have_text("Total net VAT")
-    expect(rendered).to have_text("£1,372.63")
+    expect(rendered).to have_text("£1,532.63")
   end
 end

--- a/spec/components/finance/statements/npq_details_table_spec.rb
+++ b/spec/components/finance/statements/npq_details_table_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe Finance::Statements::NPQDetailsTable, type: :component do
   let(:npq_lead_provider)   { cpd_lead_provider.npq_lead_provider }
   let(:statement)           { create(:npq_statement, cpd_lead_provider:) }
   let(:participant_profile) { create(:npq_application, :accepted, :eligible_for_funding, npq_course:, npq_lead_provider:).profile }
-  let!(:npq_course)              { create(:npq_leadership_course, identifier: "npq-leading-teaching") }
-  let!(:contract)                { create(:npq_contract, npq_lead_provider:, cohort:, monthly_service_fee: nil) }
+  let!(:npq_course)         { create(:npq_leadership_course, identifier: "npq-leading-teaching") }
 
   let!(:participant_declaration) do
     travel_to statement.deadline_date do
@@ -19,10 +18,13 @@ RSpec.describe Finance::Statements::NPQDetailsTable, type: :component do
 
   let(:rendered) { render_inline(described_class.new(statement:)) }
 
+  before do
+    npq_contract = NPQContract.find_by(npq_lead_provider:, cohort:, npq_course:)
+    npq_contract.update!(monthly_service_fee: nil)
+  end
+
   it "has the correct text" do
-    expect(rendered).to have_text("Total starts")
-    expect(rendered).to have_text(2)
-    expect(rendered).to have_text("Total net VAT")
-    expect(rendered).to have_text("£1,532.63")
+    expect(rendered).to have_text("Total starts\n          \n            \n              \n                \n                  1")
+    expect(rendered).to have_text("Total net VAT\n          £1,372.63")
   end
 end

--- a/spec/docs/v1/npq_participants_spec.rb
+++ b/spec/docs/v1/npq_participants_spec.rb
@@ -95,6 +95,7 @@ describe "API", type: :request, swagger_doc: "v1/api_spec.json" do
                   "NPQ Participant" do
     let(:participant) { npq_application }
     let(:profile)     { npq_application.profile }
+    let!(:contract)   { create(:npq_contract, npq_course: npq_application.npq_course, npq_lead_provider: npq_application.npq_lead_provider) }
 
     let(:attributes) do
       {

--- a/spec/docs/v2/npq_participants_spec.rb
+++ b/spec/docs/v2/npq_participants_spec.rb
@@ -95,6 +95,7 @@ describe "API", type: :request, swagger_doc: "v2/api_spec.json" do
                   "NPQ Participant" do
     let(:participant) { npq_application }
     let(:profile)     { npq_application.profile }
+    let!(:contract)   { create(:npq_contract, npq_course: npq_application.npq_course, npq_lead_provider: npq_application.npq_lead_provider) }
 
     let(:attributes) do
       {

--- a/spec/docs/v3/npq_participants_spec.rb
+++ b/spec/docs/v3/npq_participants_spec.rb
@@ -118,7 +118,8 @@ describe "API", type: :request, swagger_doc: "v3/api_spec.json" do
                   "NPQ Participant" do
     let(:participant) { npq_application }
     let(:profile)     { npq_application.profile }
-    let(:schedule) { create(:npq_leadership_schedule, schedule_identifier: "npq-aso-june", name: "NPQ ASO June") }
+    let(:schedule)    { create(:npq_leadership_schedule, schedule_identifier: "npq-aso-june", name: "NPQ ASO June") }
+    let!(:contract)   { create(:npq_contract, npq_course: npq_application.npq_course, npq_lead_provider: npq_application.npq_lead_provider) }
 
     let(:attributes) do
       {

--- a/spec/factories/participant_declaration.rb
+++ b/spec/factories/participant_declaration.rb
@@ -53,6 +53,13 @@ FactoryBot.define do
 
       params[:evidence_held] = "other" if declaration_type != "started"
 
+      if participant_profile.is_a?(ParticipantProfile::NPQ)
+        create(:npq_contract,
+               npq_lead_provider: cpd_lead_provider.npq_lead_provider,
+               cohort: participant_profile.npq_application.cohort,
+               npq_course: participant_profile.npq_application.npq_course)
+      end
+
       service = RecordDeclaration.new(params)
       raise ArgumentError, service.errors.full_messages unless service.valid?
 

--- a/spec/features/finance/change_lead_provider_spec.rb
+++ b/spec/features/finance/change_lead_provider_spec.rb
@@ -6,8 +6,9 @@ RSpec.feature "Finance users participant change lead provider", type: :feature d
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider, :with_npq_lead_provider) }
 
   describe "NPQ" do
-    let(:participant_profile)     { create(:npq_participant_profile, npq_lead_provider: cpd_lead_provider.npq_lead_provider) }
-    let(:participant_declaration) { create(:npq_participant_declaration, :submitted, participant_profile:, cpd_lead_provider:) }
+    let(:participant_profile) { create(:npq_participant_profile, npq_lead_provider: cpd_lead_provider.npq_lead_provider) }
+    let(:npq_course) { create(:npq_leadership_course, identifier: "npq-senior-leadership") }
+    let(:participant_declaration) { create(:npq_participant_declaration, :submitted, participant_profile:, cpd_lead_provider:, npq_course:) }
     let(:voided_participant_declaration) { create(:npq_participant_declaration, :voided, participant_profile:, cpd_lead_provider:) }
     let(:npq_lead_provider) { create(:npq_lead_provider) }
 
@@ -123,9 +124,7 @@ RSpec.feature "Finance users participant change lead provider", type: :feature d
 
   def and_a_npq_lead_provider_exists
     npq_lead_provider
-    cohort = participant_profile.npq_application.cohort
-    create(:npq_leadership_course, identifier: "npq-senior-leadership")
-    create(:npq_contract, :npq_senior_leadership, cohort:, npq_lead_provider:)
+    create(:npq_contract, npq_course: participant_profile.npq_application.npq_course, npq_lead_provider:)
   end
 
   def then_i_should_not_see_change_lead_provider_link

--- a/spec/features/participant_declarations/participant_declaration_steps.rb
+++ b/spec/features/participant_declarations/participant_declaration_steps.rb
@@ -46,6 +46,7 @@ module ParticipantDeclarationSteps
     NPQ::Application::Accept.new(npq_application: @npq_application).call
     @declaration_date = @npq_application.reload.profile.schedule.milestones.first.start_date + 1.day
     @submission_date = @npq_application.profile.schedule.milestones.first.start_date + 2.days
+    create(:npq_contract, cohort:, npq_course:, npq_lead_provider:)
   end
 
   def when_the_participant_details_are_passed_to_the_lead_provider

--- a/spec/forms/finance/npq/change_lead_provider_form_spec.rb
+++ b/spec/forms/finance/npq/change_lead_provider_form_spec.rb
@@ -5,13 +5,11 @@ RSpec.describe Finance::NPQ::ChangeLeadProviderForm, type: :model do
 
   describe "NPQ" do
     let!(:lead_provider) { create(:npq_lead_provider) }
-    let(:participant_profile) { create(:npq_participant_profile) }
+    let(:npq_course) { create(:npq_leadership_course, identifier: "npq-senior-leadership") }
+    let(:participant_profile) { create(:npq_participant_profile, npq_course:) }
     let(:params) { { participant_profile:, lead_provider_id: lead_provider.id } }
     let(:cohort) { participant_profile.npq_application.cohort }
-    let!(:npq_leadership_course) { create(:npq_leadership_course, identifier: "npq-senior-leadership") }
     let!(:npq_contract) { create(:npq_contract, :npq_senior_leadership, cohort:, npq_lead_provider: lead_provider) }
-
-    it { is_expected.to validate_inclusion_of(:lead_provider_id).in_array([lead_provider.id]) }
 
     describe ".save" do
       context "valid params" do
@@ -29,6 +27,19 @@ RSpec.describe Finance::NPQ::ChangeLeadProviderForm, type: :model do
           expect(form.save).to be false
           expect(participant_profile.npq_application.reload.npq_lead_provider).to eql(old_lead_provider)
           expect(participant_profile.npq_application.reload.npq_lead_provider).not_to eql(lead_provider)
+        end
+      end
+    end
+
+    describe "validations" do
+      it { is_expected.to validate_inclusion_of(:lead_provider_id).in_array([lead_provider.id]) }
+
+      context "when lead provider has no contract for the cohort and course" do
+        before { npq_contract.update!(npq_course: create(:npq_specialist_course)) }
+
+        it "is invalid and returns an error message" do
+          expect(form).to be_invalid
+          expect(form.errors.messages_for(:cohort)).to include("You cannot change a participant to this cohort as you do not have a contract for the cohort and course. Contact the DfE for assistance.")
         end
       end
     end

--- a/spec/forms/finance/npq/change_lead_provider_form_spec.rb
+++ b/spec/forms/finance/npq/change_lead_provider_form_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Finance::NPQ::ChangeLeadProviderForm, type: :model do
         it "does not change lead provider" do
           old_lead_provider = participant_profile.npq_application.npq_lead_provider
           expect(form.save).to be false
+
           expect(participant_profile.npq_application.reload.npq_lead_provider).to eql(old_lead_provider)
           expect(participant_profile.npq_application.reload.npq_lead_provider).not_to eql(lead_provider)
         end

--- a/spec/requests/api/v1/npq_participants_spec.rb
+++ b/spec/requests/api/v1/npq_participants_spec.rb
@@ -246,6 +246,7 @@ RSpec.describe "NPQ Participants API", type: :request do
         create(:npq_aso_schedule, schedule_identifier: SecureRandom.alphanumeric)
       end
     end
+    let!(:contract) { create(:npq_contract, npq_course: npq_application.npq_course, npq_lead_provider: npq_application.npq_lead_provider) }
 
     it "changes the schedules of the specified profile", :aggregate_failures do
       put "/api/v1/participants/npq/#{npq_application.profile.user_id}/change-schedule", params: {

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -583,6 +583,7 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
         let(:course_identifier) { npq_course.identifier }
         let(:declaration_type)  { "completed" }
         let(:has_passed) { nil }
+        let!(:contract) { create(:npq_contract, npq_course:, npq_lead_provider: cpd_lead_provider.npq_lead_provider) }
         let(:params) do
           {
             data: {

--- a/spec/requests/api/v2/npq_participants_spec.rb
+++ b/spec/requests/api/v2/npq_participants_spec.rb
@@ -254,6 +254,7 @@ RSpec.describe "NPQ Participants API", type: :request do
         create(:npq_aso_schedule, schedule_identifier: SecureRandom.alphanumeric)
       end
     end
+    let!(:contract) { create(:npq_contract, npq_course: npq_application.npq_course, npq_lead_provider: npq_application.npq_lead_provider) }
 
     it "changes the schedules of the specified profile", :aggregate_failures do
       put "/api/v2/participants/npq/#{npq_application.profile.user_id}/change-schedule", params: {

--- a/spec/requests/api/v2/participant_declarations_spec.rb
+++ b/spec/requests/api/v2/participant_declarations_spec.rb
@@ -279,6 +279,7 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
         let(:course_identifier) { npq_course.identifier }
         let(:declaration_type)  { "completed" }
         let(:has_passed) { nil }
+        let!(:contract) { create(:npq_contract, npq_course:, npq_lead_provider: cpd_lead_provider.npq_lead_provider) }
         let(:params) do
           {
             data: {

--- a/spec/requests/api/v3/npq_participants_spec.rb
+++ b/spec/requests/api/v3/npq_participants_spec.rb
@@ -252,6 +252,7 @@ RSpec.describe "NPQ Participants API", type: :request do
         create(:npq_aso_schedule, schedule_identifier: SecureRandom.alphanumeric)
       end
     end
+    let!(:contract) { create(:npq_contract, npq_course: npq_application.npq_course, npq_lead_provider: npq_application.npq_lead_provider) }
 
     it "changes the schedules of the specified profile", :aggregate_failures do
       put "/api/v3/participants/npq/#{npq_application.profile.user_id}/change-schedule", params: {

--- a/spec/requests/api/v3/participant_declarations_spec.rb
+++ b/spec/requests/api/v3/participant_declarations_spec.rb
@@ -501,6 +501,7 @@ RSpec.describe "API Participant Declarations", type: :request do
         let(:course_identifier) { npq_course.identifier }
         let(:declaration_type)  { "completed" }
         let(:has_passed) { nil }
+        let!(:contract) { create(:npq_contract, npq_course:, npq_lead_provider: cpd_lead_provider.npq_lead_provider) }
         let(:params) do
           {
             data: {

--- a/spec/services/finance/npq/statement_calculator_spec.rb
+++ b/spec/services/finance/npq/statement_calculator_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe Finance::NPQ::StatementCalculator do
   let!(:npq_leadership_schedule) { create(:npq_leadership_schedule, cohort:) }
   let!(:npq_specialist_schedule) { create(:npq_specialist_schedule, cohort:) }
   let!(:npq_course)              { create(:npq_leadership_course, identifier: "npq-leading-teaching") }
-  let!(:contract)                { create(:npq_contract, npq_lead_provider:, cohort:, monthly_service_fee: nil) }
 
   subject { described_class.new(statement:) }
 
   describe "#total_payment" do
+    let!(:contract) { create(:npq_contract, npq_lead_provider:, cohort:, monthly_service_fee: nil) }
     let(:default_total) { BigDecimal("0.1212631578947368421052631578947368421064e4") }
 
     context "when there is a positive reconcile_amount" do

--- a/spec/services/npq/amend_participant_cohort_spec.rb
+++ b/spec/services/npq/amend_participant_cohort_spec.rb
@@ -3,8 +3,9 @@
 require "rails_helper"
 
 RSpec.describe NPQ::AmendParticipantCohort, type: :model do
-  let(:npq_application) { create(:npq_application, cohort: cohort_previous) }
+  let(:npq_application) { create(:npq_application, :accepted, cohort: cohort_previous) }
   let(:npq_application_id) { npq_application.id }
+  let!(:npq_contract) { create(:npq_contract, :npq_senior_leadership, cohort: cohort_previous, npq_lead_provider: npq_application.npq_lead_provider, npq_course: npq_application.npq_course) }
 
   let!(:cohort_current) { Cohort.current }
   let(:cohort_previous) { Cohort.previous }
@@ -54,6 +55,15 @@ RSpec.describe NPQ::AmendParticipantCohort, type: :model do
       it "returns an error message" do
         expect(subject).to be_invalid
         expect(subject.errors.messages_for(:target_cohort_start_year)).to include("Invalid value. Must be different to 2021")
+      end
+    end
+
+    context "when lead provider has no contract for the cohort and course" do
+      before { npq_contract.update!(npq_course: create(:npq_specialist_course)) }
+
+      it "is invalid and returns an error message" do
+        expect(subject).to be_invalid
+        expect(subject.errors.messages_for(:cohort)).to include("You cannot change a participant to this cohort as you do not have a contract for the cohort and course. Contact the DfE for assistance.")
       end
     end
   end

--- a/spec/validators/npq_contract_for_cohort_and_course_validator_spec.rb
+++ b/spec/validators/npq_contract_for_cohort_and_course_validator_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe NPQContractForCohortAndCourseValidator do
+  let(:klass) do
+    Class.new do
+      include ActiveModel::Model
+      include ActiveModel::Validations
+
+      validates :cohort, npq_contract_for_cohort_and_course: true
+
+      attr_reader :cohort, :cpd_lead_provider, :course_identifier
+
+      def self.model_name
+        ActiveModel::Name.new(self, nil, "temp")
+      end
+
+      def initialize(cohort:, cpd_lead_provider:, course_identifier:)
+        @cohort = cohort
+        @cpd_lead_provider = cpd_lead_provider
+        @course_identifier = course_identifier
+      end
+    end
+  end
+
+  describe "#validate" do
+    subject { klass.new(**params) }
+
+    let(:params) { { cohort:, cpd_lead_provider:, course_identifier: } }
+
+    let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_npq_lead_provider) }
+    let(:npq_lead_provider) { cpd_lead_provider.npq_lead_provider }
+    let(:npq_course) { create(:npq_leadership_course, identifier: "npq-senior-leadership") }
+    let(:participant_profile) { create(:npq_participant_profile, npq_course:) }
+    let(:cohort) { participant_profile.npq_application.cohort }
+    let!(:npq_contract) { create(:npq_contract, :npq_senior_leadership, cohort:, npq_lead_provider:) }
+
+    context "NPQ course" do
+      let(:course_identifier) { npq_course.identifier }
+
+      it "is valid" do
+        expect(subject).to be_valid
+      end
+
+      context "when lead provider has no contract for the cohort and course" do
+        before { npq_contract.update!(npq_course: create(:npq_specialist_course)) }
+
+        it "is invalid" do
+          expect(subject).to be_invalid
+        end
+
+        it "has a meaningfull error", :aggregate_failures do
+          expect(subject).to be_invalid
+          expect(subject.errors.messages_for(:cohort))
+            .to eq(["You cannot change a participant to this cohort as you do not have a contract for the cohort and course. Contact the DfE for assistance."])
+        end
+      end
+    end
+
+    context "non NPQ course" do
+      let(:course_identifier) { "ecf-induction" }
+
+      it "returns no errors" do
+        expect(subject).to be_valid
+        expect(subject.errors).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-2387](https://dfedigital.atlassian.net/browse/CPDLP-2387)

### Changes proposed in this pull request

Add validation to all entry points and changes for NPQ applications and profiles to prevent provider/user changing cohort for NPQ where there is no contract for the course in the target/new cohort.

[CPDLP-2387]: https://dfedigital.atlassian.net/browse/CPDLP-2387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ