### PR TITLE
Fix admin cohort page when school cohort present and partnerships missing

### DIFF
--- a/app/components/admin/schools/cohort_component.html.erb
+++ b/app/components/admin/schools/cohort_component.html.erb
@@ -29,7 +29,7 @@
             row.with_value(text: training_programme)
 
             if allow_change_programme?
-              row.with_action(text: "Change", visually_hidden_text: "induction programme",  href: change_programme_href)
+              row.with_action(text: "Change", visually_hidden_text: "training programme",  href: change_programme_href)
             end
           end
         end

--- a/app/components/admin/schools/cohort_component.html.erb
+++ b/app/components/admin/schools/cohort_component.html.erb
@@ -9,16 +9,31 @@
 
   <% elsif fip? %>
 
-    <% partnership_components.each do |pc| %>
-      <%= pc %>
-    <% end %>
-
-    <% if relationship_components.any? %>
-      <h3 class="govuk-heading-m">Additional relationships</h3>
-
-      <% relationship_components.each do |rc| %>
-        <%= rc %>
+    <% if has_partnerships_or_relationships? %>
+      <% partnership_components.each do |pc| %>
+        <%= pc %>
       <% end %>
+
+      <% if relationships.present? %>
+        <h3 class="govuk-heading-m">Additional relationships</h3>
+
+        <% relationship_components.each do |rc| %>
+          <%= rc %>
+        <% end %>
+      <% end %>
+    <% else %>
+      <%=
+        govuk_summary_list do |summary_list|
+          summary_list.with_row do |row|
+            row.with_key(text: "Training programme")
+            row.with_value(text: training_programme)
+
+            if allow_change_programme?
+              row.with_action(text: "Change", visually_hidden_text: "induction programme",  href: change_programme_href)
+            end
+          end
+        end
+      %>
     <% end %>
 
   <% else %>

--- a/app/components/admin/schools/cohort_component.rb
+++ b/app/components/admin/schools/cohort_component.rb
@@ -23,7 +23,9 @@ module Admin
         {
           "core_induction_programme" => "Using DfE-accredited materials",
           "design_our_own"           => "Designing their own training",
+          "full_induction_programme" => "Working with a DfE-funded provider",
           "no_early_career_teachers" => "No ECTs this year",
+          "school_funded_fip"        => "School-funded full induction programme",
         }.fetch(induction_programme_choice, "Not using service")
       end
 
@@ -45,7 +47,7 @@ module Admin
 
       def build_partnerships
         partnerships&.each do |partnership|
-          with_partnership_component(school:, school_cohort:, partnership:)
+          with_partnership_component(school:, school_cohort:, partnership:, training_programme:)
         end
       end
 
@@ -53,6 +55,10 @@ module Admin
         relationships&.each do |relationship|
           with_relationship_component(school:, school_cohort:, relationship:, superuser:)
         end
+      end
+
+      def has_partnerships_or_relationships?
+        partnerships.present? && relationships.present?
       end
 
       def cip?
@@ -78,7 +84,7 @@ module Admin
     private
 
       def induction_programme_choice
-        school_cohort.induction_programme_choice
+        school_cohort&.induction_programme_choice
       end
     end
   end

--- a/app/components/admin/schools/partnership_component.rb
+++ b/app/components/admin/schools/partnership_component.rb
@@ -3,19 +3,13 @@
 module Admin
   module Schools
     class PartnershipComponent < ViewComponent::Base
-      attr_accessor :partnership, :school, :school_cohort
+      attr_accessor :partnership, :school, :school_cohort, :training_programme
 
-      def initialize(partnership:, school:, school_cohort:)
+      def initialize(partnership:, school:, school_cohort:, training_programme:)
         @partnership = partnership
         @school = school
         @school_cohort = school_cohort
-      end
-
-      def training_programme
-        {
-          "full_induction_programme" => "Working with a DfE-funded provider",
-          "school_funded_fip"        => "School-funded full induction programme",
-        }.fetch(induction_programme_choice)
+        @training_programme = training_programme
       end
 
       def heading
@@ -35,10 +29,6 @@ module Admin
       end
 
     private
-
-      def induction_programme_choice
-        school_cohort.induction_programme_choice
-      end
 
       def visually_hidden(text)
         tag.span(text, class: "govuk-visually-hidden")

--- a/spec/components/admin/schools/cohort_component_spec.rb
+++ b/spec/components/admin/schools/cohort_component_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe Admin::Schools::CohortComponent, type: :component do
     end
 
     it "passes the partnership information to the partnership slots" do
-      expect(subject).to have_received(:with_partnership_component).with(school:, school_cohort:, partnership:)
+      expect(subject).to have_received(:with_partnership_component).with(school:, school_cohort:, partnership:, training_programme: "Working with a DfE-funded provider")
     end
 
     it "passes the relationship information to the relationship slots" do

--- a/spec/components/admin/schools/cohort_component_spec.rb
+++ b/spec/components/admin/schools/cohort_component_spec.rb
@@ -21,38 +21,60 @@ RSpec.describe Admin::Schools::CohortComponent, type: :component do
       expect(rendered_content).to have_css("h2", text: "#{cohort.start_year} programme")
     end
 
-    context "when partnerships are present" do
-      it("renders the partnerships") { expect(rendered_content).to have_css(partnership_matcher, text: "Challenge") }
-    end
-
-    context "when no partnerships are present" do
-      let(:partnership) { nil }
-
-      it("renders no partnerships") { expect(rendered_content).not_to have_css(partnership_matcher) }
-    end
-
-    context "when relationships are present" do
-      it("renders the relationships") { expect(rendered_content).to have_css(relationship_matcher) }
-    end
-
-    context "when no relationships are present" do
-      let(:relationships) { nil }
-
-      it("renders no relationships") { expect(rendered_content).not_to have_css(relationship_matcher) }
-    end
-
-    context "when no school cohort, partnerships or relationships are present" do
-      let(:partnership) { nil }
-      let(:relationships) { nil }
-      let(:school_cohort) { nil }
-
-      it("shows an message explaining there is no programme") do
-        expect(page).to have_content("No induction programme chosen for #{school.name} in #{cohort.academic_year}")
+    context "when school is FIP" do
+      context "when partnerships are present" do
+        it("renders the partnerships") { expect(rendered_content).to have_css(partnership_matcher, text: "Challenge") }
       end
 
-      it "renders a link styled as a secondary button so admins can set one up" do
-        expect(page).to have_link("Choose an induction programme", href: admin_school_change_programme_path(id: cohort.start_year, school_id: school.slug), class: "govuk-button--secondary")
+      context "when no partnerships are present" do
+        let(:partnership) { nil }
+
+        it("renders no partnerships") { expect(rendered_content).not_to have_css(partnership_matcher) }
       end
+
+      context "when relationships are present" do
+        it("renders the relationships") { expect(rendered_content).to have_css(relationship_matcher) }
+      end
+
+      context "when no relationships are present" do
+        let(:relationships) { nil }
+
+        it("renders no relationships") { expect(rendered_content).not_to have_css(relationship_matcher) }
+      end
+
+      context "when no school cohort, partnerships or relationships are present" do
+        let(:partnership) { nil }
+        let(:relationships) { nil }
+        let(:school_cohort) { nil }
+
+        it("shows an message explaining there is no programme") do
+          expect(page).to have_content("No induction programme chosen for #{school.name} in #{cohort.academic_year}")
+        end
+
+        it "renders a link styled as a secondary button so admins can set one up" do
+          expect(page).to have_link("Choose an induction programme", href: admin_school_change_programme_path(id: cohort.start_year, school_id: school.slug), class: "govuk-button--secondary")
+        end
+      end
+
+      context "when there is a school cohort but there is not partnership or relationships" do
+        let(:partnership) { nil }
+        let(:relationships) { nil }
+
+        it "displays the training programme" do
+          expect(page).to have_content("Training programme")
+          expect(page).to have_content("Working with a DfE-funded provider")
+        end
+
+        it "contains a link that allows the induction programme to be changed" do
+          expect(page).to have_link("Change induction programme", href: admin_school_change_programme_path(id: cohort.start_year, school_id: school.slug))
+        end
+      end
+    end
+
+    context "when school is CIP" do
+      let(:induction_programme_choice) { "core_induction_programme" }
+
+      it("renders the correct description") { expect(page).to have_content("Using DfE-accredited materials") }
     end
   end
 
@@ -104,6 +126,28 @@ RSpec.describe Admin::Schools::CohortComponent, type: :component do
       it "returns the default induction programme's core induction programme name" do
         expected = school_cohort.default_induction_programme.core_induction_programme.name
         expect(subject.materials).to eql(expected)
+      end
+    end
+
+    describe "#has_partnerships_or_relationships?" do
+      context "when there is a partnership and some relationships" do
+        it { is_expected.to have_partnerships_or_relationships }
+      end
+
+      context "when there is a partnership but no relationships" do
+        let(:relationships) { nil }
+        it { is_expected.not_to have_partnerships_or_relationships }
+      end
+
+      context "when there are relationships but no partnership" do
+        let(:partnership) { nil }
+        it { is_expected.not_to have_partnerships_or_relationships }
+      end
+
+      context "when there is no partnership and there are no relationships" do
+        let(:partnership) { nil }
+        let(:relationships) { nil }
+        it { is_expected.not_to have_partnerships_or_relationships }
       end
     end
 

--- a/spec/components/admin/schools/cohort_component_spec.rb
+++ b/spec/components/admin/schools/cohort_component_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Admin::Schools::CohortComponent, type: :component do
         end
 
         it "contains a link that allows the induction programme to be changed" do
-          expect(page).to have_link("Change induction programme", href: admin_school_change_programme_path(id: cohort.start_year, school_id: school.slug))
+          expect(page).to have_link("Change training programme", href: admin_school_change_programme_path(id: cohort.start_year, school_id: school.slug))
         end
       end
     end

--- a/spec/components/admin/schools/partnership_component_spec.rb
+++ b/spec/components/admin/schools/partnership_component_spec.rb
@@ -2,10 +2,11 @@
 
 RSpec.describe Admin::Schools::PartnershipComponent, type: :component do
   let(:induction_programme_choice) { "full_induction_programme" }
+  let(:training_programme) { "A training programme" }
   let(:school) { FactoryBot.create(:seed_school) }
   let(:school_cohort) { FactoryBot.create(:seed_school_cohort, :with_cohort, :with_appropriate_body, school:, induction_programme_choice:) }
   let(:partnership) { FactoryBot.create(:seed_partnership, :valid, school:, cohort: school_cohort.cohort) }
-  let(:kwargs) { { school:, school_cohort:, partnership: } }
+  let(:kwargs) { { school:, school_cohort:, partnership:, training_programme: } }
   subject { Admin::Schools::PartnershipComponent.new(**kwargs) }
 
   describe "rendering" do
@@ -15,13 +16,9 @@ RSpec.describe Admin::Schools::PartnershipComponent, type: :component do
       expect(rendered_content).to have_css("dl.govuk-summary-list")
     end
 
-    it "renders a 'training programme' row" do
+    it "renders a 'training programme' row without a change link" do
       expect(rendered_content).to have_css("dt", text: "Training programme")
-    end
-
-    it "renders the training programme with a change link" do
-      expect(rendered_content).to have_css("dt", text: "Training programme")
-      expect(rendered_content).to have_css("dd", text: "Working with a DfE-funded provider")
+      expect(rendered_content).to have_css("dd", text: "A training programme")
       expect(rendered_content).not_to have_content("Change induction programme")
     end
 
@@ -47,19 +44,6 @@ RSpec.describe Admin::Schools::PartnershipComponent, type: :component do
   end
 
   describe "methods" do
-    describe "#training_programme" do
-      {
-        "full_induction_programme" => "Working with a DfE-funded provider",
-        "school_funded_fip"        => "School-funded full induction programme",
-      }.each do |training_programme, description|
-        describe "training programme '#{training_programme}" do
-          let(:school_cohort) { FactoryBot.create(:seed_school_cohort, :with_cohort, induction_programme_choice: training_programme, school:) }
-
-          it("has description #{description}") { expect(subject.training_programme).to eql(description) }
-        end
-      end
-    end
-
     describe "#lead_provider_name" do
       it "is the lead provider's name" do
         expect(subject.lead_provider_name).to eql(school_cohort.lead_provider.name)


### PR DESCRIPTION
### Context

This is an attempt to fix a bug in the admin console's cohorts tab where:

* a school is FIP
* the school has no partnerships/relationships
* the school does have a `school_cohort`

Previously this circumstance (which sounds invalid to me!) left a gap on the page. Now that gap is filed with a summary list that has a change link:

| Before | After |
|-----|-----|
| ![Screenshot from 2023-09-18 16-57-05](https://github.com/DFE-Digital/early-careers-framework/assets/128088/e9e80da0-aa20-486e-afa2-3c14aa552636) | ![Screenshot from 2023-09-18 16-57-18](https://github.com/DFE-Digital/early-careers-framework/assets/128088/a0c126d2-4c8a-4b7b-9eb5-0b6d6a79db29) |

Because we're now displaying FIP details in multiple context I've moved the FIP entries from `#training_programme` up into the `CohortComponent` and just pass the text into the `PartnershipComponent` .

Also added a few extra tests for better coverage of odd situations.