### PR TITLE
Cleanup CSV uploads before persisting uploaded urns

### DIFF
--- a/app/controllers/lead_providers/report_schools/csv_controller.rb
+++ b/app/controllers/lead_providers/report_schools/csv_controller.rb
@@ -14,14 +14,14 @@ module LeadProviders
           render :show and return
         end
 
-        @partnership_csv_upload = PartnershipCsvUpload.new(
+        @partnership_csv_upload = CreatePartnershipCsvUpload.new(
+          csv_file: upload_params[:csv],
           cohort_id: report_schools_form.cohort_id,
           lead_provider_id: current_user.lead_provider_profile.lead_provider.id,
           delivery_partner_id: report_schools_form.delivery_partner_id,
-          uploaded_urns: upload_params[:csv].read.lines(chomp: true),
-        )
+        ).call
 
-        if @partnership_csv_upload.save
+        if @partnership_csv_upload
           session[:partnership_csv_upload_id] = @partnership_csv_upload.id
 
           if @partnership_csv_upload.invalid_schools.empty?

--- a/app/services/create_partnership_csv_upload.rb
+++ b/app/services/create_partnership_csv_upload.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class CreatePartnershipCsvUpload
+  attr_reader :csv_file, :cohort_id, :lead_provider_id, :delivery_partner_id
+
+  def initialize(csv_file:, cohort_id:, lead_provider_id:, delivery_partner_id:)
+    @csv_file = csv_file
+    @cohort_id = cohort_id
+    @lead_provider_id = lead_provider_id
+    @delivery_partner_id = delivery_partner_id
+  end
+
+  def call
+    PartnershipCsvUpload.create!(
+      cohort_id:,
+      lead_provider_id:,
+      delivery_partner_id:,
+      uploaded_urns:,
+    )
+  end
+
+private
+
+  def uploaded_urns
+    clean_uploaded_lines(strip_bom(csv_file.read).scrub.lines(chomp: true))
+  end
+
+  def clean_uploaded_lines(lines)
+    lines.flat_map { |line| line.split(",").reject(&:blank?).map(&:squish) }
+  end
+
+  def strip_bom(string)
+    string.force_encoding("UTF-8").gsub(/\xEF\xBB\xBF/, "")
+  end
+end

--- a/app/services/create_partnership_csv_upload.rb
+++ b/app/services/create_partnership_csv_upload.rb
@@ -26,7 +26,7 @@ private
   end
 
   def clean_uploaded_lines(lines)
-    lines.flat_map { |line| line.split(",").reject(&:blank?).map(&:squish) }
+    lines.flat_map { |line| line.split(",").reject(&:blank?).map { |urn| urn.scan(/\d|,/).join } }
   end
 
   def strip_bom(string)

--- a/spec/services/create_partnership_csv_upload_spec.rb
+++ b/spec/services/create_partnership_csv_upload_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CreatePartnershipCsvUpload do
+  let(:cohort_id) { create(:cohort).id }
+  let(:delivery_partner_id) { create(:delivery_partner).id }
+  let(:lead_provider_id) { create(:lead_provider).id }
+  let(:urns) { %w[111 222] }
+  let(:csv_file) { given_the_csv_contains_urns(urns, insert_bom: true) }
+
+  subject do
+    described_class.new(
+      csv_file:,
+      cohort_id:,
+      lead_provider_id:,
+      delivery_partner_id:,
+    )
+  end
+
+  describe ".call" do
+    it "creates a partnership csv upload with supplied parameters" do
+      expect { subject.call }.to change(PartnershipCsvUpload, :count).by(1)
+    end
+
+    it "sets the correct urns on the partnership csv upload from the file" do
+      expect(subject.call.urns).to eq(urns)
+    end
+
+    it "sets the correct attributes on the partnership csv upload" do
+      expect(subject.call.attributes.symbolize_keys).to include(
+        cohort_id:,
+        lead_provider_id:,
+        delivery_partner_id:,
+      )
+    end
+
+    context "with duplicate urns" do
+      let(:urns) { %w[1 1 2 2 3] }
+
+      it "populates the uploaded_urns field with the CSV contents and maintains duplicates" do
+        expect(subject.call.uploaded_urns).to eq(urns.map(&:to_s))
+      end
+    end
+
+    context "with empty urns" do
+      let(:urns) { ["1", "", "2", " ", "3", "4"] }
+
+      it "removes empty urns from uploaded_urns" do
+        expect(subject.call.uploaded_urns).to eq(%w[1 2 3 4])
+      end
+    end
+
+    context "with urns on one line" do
+      let(:urns) { ["1", "2,3,4", "5", ",,,", "6", "7"] }
+
+      it "flattens multiple urns on one line" do
+        expect(subject.call.uploaded_urns).to eql(%w[1 2 3 4 5 6 7])
+      end
+    end
+
+    context "with whitespaces" do
+      let(:urns) { ["1", "2,3 ,4 ", "5", " ,,,", "6", "7"] }
+
+      it "removes leading or trailing whitespace and condenses internal whitespace" do
+        expect(subject.call.uploaded_urns).to eql(%w[1 2 3 4 5 6 7])
+      end
+    end
+  end
+
+private
+
+  def given_the_csv_contains_urns(urns, insert_bom: false)
+    bom = "\xEF\xBB\xBF"
+
+    file = Tempfile.new
+    file.write(bom) if insert_bom
+    file.write(urns.join("\n"))
+    file.rewind
+
+    file
+  ensure
+    file&.unlink
+  end
+end

--- a/spec/services/create_partnership_csv_upload_spec.rb
+++ b/spec/services/create_partnership_csv_upload_spec.rb
@@ -66,6 +66,14 @@ RSpec.describe CreatePartnershipCsvUpload do
         expect(subject.call.uploaded_urns).to eql(%w[1 2 3 4 5 6 7])
       end
     end
+
+    context "with other unicode characters" do
+      let(:urns) { ["\u00A0", "18900\u000f", " 10000\u00A0", "\u2000", "12345\n"] }
+
+      it "removes extra characters and keeps the urns" do
+        expect(subject.call.uploaded_urns).to eql(%w[18900 10000 12345])
+      end
+    end
   end
 
 private


### PR DESCRIPTION
### Context
An error was raised when attempting to read the csv: https://dfe-teacher-services.sentry.io/issues/4486648382/?alert_rule_id=7310304&alert_type=issue&notification_uuid=bbd2755c-cddc-421d-b5ed-a709d584f020&project=5748989&referrer=slack
- Ticket: n.a

### Changes proposed in this pull request
- Add service which persists partnership upload csvs
- Reinstate cleanup logic for badly formatted csvs

### Guidance to review

