### PR TITLE
Add primary key to habtm join table

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -178,6 +178,7 @@
   - induction_start_date
   - induction_completion_date
   :cohorts_lead_providers:
+  - id
   - lead_provider_id
   - cohort_id
   - created_at

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -16,27 +16,6 @@
   - data
   - created_at
   - updated_at
-  :active_storage_variant_records:
-  - id
-  - blob_id
-  - variation_digest
-  :active_storage_blobs:
-  - id
-  - key
-  - filename
-  - content_type
-  - metadata
-  - service_name
-  - byte_size
-  - checksum
-  - created_at
-  :active_storage_attachments:
-  - id
-  - name
-  - record_type
-  - record_id
-  - blob_id
-  - created_at
   :ecf_duplicates:
   - user_id
   - external_identifier
@@ -75,6 +54,16 @@
   - user_id
   - created_at
   - updated_at
+  :npq_application_eligibility_imports:
+  - id
+  - user_id
+  - filename
+  - status
+  - updated_records
+  - import_errors
+  - processed_at
+  - created_at
+  - updated_at
   :statement_line_items:
   - id
   - statement_id
@@ -105,6 +94,15 @@
   - declaration_type
   - created_at
   - updated_at
+  :schedules:
+  - id
+  - name
+  - created_at
+  - updated_at
+  - schedule_identifier
+  - type
+  - cohort_id
+  - identifier_alias
   :milestones:
   - id
   - name
@@ -360,6 +358,37 @@
   - status
   - delivered_at
   - tags
+  :ecf_participant_validation_data:
+  - id
+  - participant_profile_id
+  - full_name
+  - date_of_birth
+  - trn
+  - nino
+  - api_failure
+  - created_at
+  - updated_at
+  :ecf_participant_eligibilities:
+  - id
+  - participant_profile_id
+  - qts
+  - active_flags
+  - previous_participation
+  - previous_induction
+  - manually_validated
+  - status
+  - created_at
+  - updated_at
+  - reason
+  - different_trn
+  - no_induction
+  - exempt_from_induction
+  :ecf_ineligible_participants:
+  - id
+  - trn
+  - reason
+  - created_at
+  - updated_at
   :district_sparsities:
   - id
   - local_authority_district_id
@@ -458,56 +487,6 @@
   - get_an_identity_id
   - archived_email
   - archived_at
-  :schedules:
-  - id
-  - name
-  - created_at
-  - updated_at
-  - schedule_identifier
-  - type
-  - cohort_id
-  - identifier_alias
-  :npq_application_eligibility_imports:
-  - id
-  - user_id
-  - filename
-  - status
-  - updated_records
-  - import_errors
-  - processed_at
-  - created_at
-  - updated_at
-  :ecf_ineligible_participants:
-  - id
-  - trn
-  - reason
-  - created_at
-  - updated_at
-  :ecf_participant_validation_data:
-  - id
-  - participant_profile_id
-  - full_name
-  - date_of_birth
-  - trn
-  - nino
-  - api_failure
-  - created_at
-  - updated_at
-  :ecf_participant_eligibilities:
-  - id
-  - participant_profile_id
-  - qts
-  - active_flags
-  - previous_participation
-  - previous_induction
-  - manually_validated
-  - status
-  - created_at
-  - updated_at
-  - reason
-  - different_trn
-  - no_induction
-  - exempt_from_induction
   :ecf_school_cohorts:
   - id
   - school_cohort_id

--- a/db/migrate/20230919093921_add_primary_key_to_cohorts_lead_providers.rb
+++ b/db/migrate/20230919093921_add_primary_key_to_cohorts_lead_providers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPrimaryKeyToCohortsLeadProviders < ActiveRecord::Migration[7.0]
+  def change
+    add_column :cohorts_lead_providers, :id, :primary_key
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_13_213845) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_19_093921) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -119,7 +119,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_13_213845) do
     t.index ["start_year"], name: "index_cohorts_on_start_year", unique: true
   end
 
-  create_table "cohorts_lead_providers", id: false, force: :cascade do |t|
+  create_table "cohorts_lead_providers", force: :cascade do |t|
     t.uuid "lead_provider_id", null: false
     t.uuid "cohort_id", null: false
     t.datetime "created_at", null: false


### PR DESCRIPTION
### Context

We have a `has_and_belongs_to_many` table `cohorts_lead_providers`. By default Rails doesn't add a primary key `id` column to this table (as it as a composite of the foreign keys). The `dfe-analytics` gem, however, requires an `id` column that is a primary key on all tables it sends to
BigQuery.

### Changes proposed in this pull request

- Add primary key to HABTM table
- Blocklist active_record_storage_variants

- ### Guidance to review

