### PR TITLE
Update mentees when deduplicating

### DIFF
--- a/lib/participant_profile_deduplicator.rb
+++ b/lib/participant_profile_deduplicator.rb
@@ -105,10 +105,11 @@ private
   def update_mentored_ects!
     return unless [primary_profile, duplicate_profile].all?(&:mentor?)
 
-    duplicate_profile.mentee_profiles.each do |mentee|
-      mentee.update!(mentor_profile_id: primary_profile.id)
-      mentee.induction_records.each { |induction_record| induction_record.update!(mentor_profile_id: primary_profile.id) }
-    end
+    duplicate_profile.mentee_profiles.update_all(mentor_profile_id: primary_profile.id)
+
+    InductionRecord
+      .where(mentor_profile_id: duplicate_profile.id)
+      .update_all(mentor_profile_id: primary_profile.id)
   end
 
   def update_primary_profile_schedule(new_schedule)

--- a/lib/participant_profile_deduplicator.rb
+++ b/lib/participant_profile_deduplicator.rb
@@ -31,6 +31,7 @@ class ParticipantProfileDeduplicator
         transfer_validation_data!
         transfer_participant_eligibility!
         handle_school_change!
+        update_mentored_ects!
         reconcile_remaining_induction_records!
       end
 
@@ -83,7 +84,7 @@ private
   end
 
   def warning_ect_mentor_duplicate
-    return unless duplicate_profile.is_a?(ParticipantProfile::ECT) && primary_profile.is_a?(ParticipantProfile::Mentor)
+    return unless duplicate_profile.ect? && primary_profile.mentor?
 
     log_info("WARNING: transition from ECT to Mentor may not indicate a duplication.")
   end
@@ -99,6 +100,15 @@ private
     return if primary_profile == profile_with_correct_schedule
 
     update_primary_profile_schedule(profile_with_correct_schedule.latest_induction_record.schedule)
+  end
+
+  def update_mentored_ects!
+    return unless [primary_profile, duplicate_profile].all?(&:mentor?)
+
+    duplicate_profile.mentee_profiles.each do |mentee|
+      mentee.update!(mentor_profile_id: primary_profile.id)
+      mentee.induction_records.each { |induction_record| induction_record.update!(mentor_profile_id: primary_profile.id) }
+    end
   end
 
   def update_primary_profile_schedule(new_schedule)
@@ -120,7 +130,7 @@ private
   end
 
   def determine_course_identifier(participant_profile)
-    participant_profile.is_a?(ParticipantProfile::ECF::Mentor) ? "ecf-mentor" : "ecf-induction"
+    participant_profile.mentor? ? "ecf-mentor" : "ecf-induction"
   end
 
   def earliest_voidable_declaration

--- a/spec/lib/participant_profile_deduplicator_spec.rb
+++ b/spec/lib/participant_profile_deduplicator_spec.rb
@@ -68,6 +68,21 @@ describe ParticipantProfileDeduplicator do
       end
     end
 
+    context "when deduplicating Mentor profiles" do
+      let(:primary_profile) { create(:mentor) }
+      let(:duplicate_profile) { create(:mentor) }
+      let!(:duplicate_mentee) { create(:ect, mentor_profile: duplicate_profile) }
+
+      before { 3.times { create(:induction_record, participant_profile: duplicate_mentee, mentor_profile: duplicate_profile) } }
+
+      it "transfers the duplicate profile mentees to the primary profile" do
+        dedup!
+
+        expect(duplicate_mentee.induction_records).to all(have_attributes({ mentor_profile_id: primary_profile.id }))
+        expect(primary_profile.mentee_profiles).to include(duplicate_mentee)
+      end
+    end
+
     context "when duplicate profile is ECT and primary profile is Mentor" do
       let(:primary_profile) { create(:mentor) }
 

--- a/spec/lib/participant_profile_deduplicator_spec.rb
+++ b/spec/lib/participant_profile_deduplicator_spec.rb
@@ -71,15 +71,29 @@ describe ParticipantProfileDeduplicator do
     context "when deduplicating Mentor profiles" do
       let(:primary_profile) { create(:mentor) }
       let(:duplicate_profile) { create(:mentor) }
-      let!(:duplicate_mentee) { create(:ect, mentor_profile: duplicate_profile) }
+      let(:other_mentor) { create(:mentor) }
 
-      before { 3.times { create(:induction_record, participant_profile: duplicate_mentee, mentor_profile: duplicate_profile) } }
+      let!(:duplicate_mentee) { create(:ect, mentor_profile: duplicate_profile) }
+      let!(:relevant_historical_induction_record) { travel_to(1.day.ago) { create(:induction_record, participant_profile: duplicate_mentee, mentor_profile: duplicate_profile) } }
+      let!(:irrelevant_historical_induction_record) { travel_to(2.days.ago) { create(:induction_record, participant_profile: duplicate_mentee, mentor_profile: other_mentor) } }
+      let!(:other_mentee_relevant_historical_induction_record) { create(:induction_record, mentor_profile: duplicate_profile) }
 
       it "transfers the duplicate profile mentees to the primary profile" do
         dedup!
 
-        expect(duplicate_mentee.induction_records).to all(have_attributes({ mentor_profile_id: primary_profile.id }))
+        # Transfer mentee to the primary profile
         expect(primary_profile.mentee_profiles).to include(duplicate_mentee)
+
+        # Update relevant induction records on the mentee to point to the primary
+        expect(duplicate_mentee.latest_induction_record.reload).to have_attributes({ mentor_profile_id: primary_profile.id })
+        expect(relevant_historical_induction_record.reload).to have_attributes({ mentor_profile_id: primary_profile.id })
+        # Don't update induction records pointing to another mentor
+        expect(irrelevant_historical_induction_record.reload).to have_attributes({ mentor_profile_id: other_mentor.id })
+
+        # Don't transfer mentees that are not currently with the duplicate mentor
+        expect(primary_profile.mentee_profiles).not_to include(other_mentee_relevant_historical_induction_record.participant_profile)
+        # But do update relevant induction records on these mentees
+        expect(other_mentee_relevant_historical_induction_record.reload).to have_attributes({ mentor_profile_id: primary_profile.id })
       end
     end
 


### PR DESCRIPTION
[Jira-2455](https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-2455)

### Context

Currently when we deduplicate two mentor profiles we are neglecting to assign the `mentee_profiles` from the duplicate to the primary, so we end up with mentees that have no mentor.

### Changes proposed in this pull request

- Update mentees when deduplicating

### Guidance to review

