### PR TITLE
[CST-1981] Remove NTA from 2023 AB options list

### DIFF
--- a/app/forms/appropriate_body_selection_form.rb
+++ b/app/forms/appropriate_body_selection_form.rb
@@ -46,7 +46,7 @@ class AppropriateBodySelectionForm
 
   def self.body_type_choices_for_year(cohort_start_year)
     if cohort_start_year.present?
-      TYPES.select { |ab_type| ab_type.disable_from_year.nil? || ab_type.disable_from_year > cohort_start_year }
+      TYPES.select { |ab_type| ab_type.disable_from_year.nil? || cohort_start_year < ab_type.disable_from_year }
     else
       TYPES
     end

--- a/app/forms/schools/cohorts/wizard_steps/appropriate_body_step.rb
+++ b/app/forms/schools/cohorts/wizard_steps/appropriate_body_step.rb
@@ -13,7 +13,7 @@ module Schools
         end
 
         def choices
-          @choices ||= AppropriateBody.where(body_type: wizard.appropriate_body_type)
+          @choices ||= AppropriateBody.where(body_type: wizard.appropriate_body_type).active_in_year(wizard.cohort.start_year)
         end
 
         def complete?

--- a/app/services/importers/appropriate_bodies.rb
+++ b/app/services/importers/appropriate_bodies.rb
@@ -11,6 +11,9 @@ module Importers
 
         AppropriateBody.find_or_create_by!(name:, body_type:)
       end
+
+      # remove NTA from 2023 onwards
+      AppropriateBody.find_by(body_type: "national", name: "National Teacher Accreditation (NTA)")&.update!(disable_from_year: 2023)
     end
   end
 end

--- a/spec/forms/edit_induction_tutor_form_spec.rb
+++ b/spec/forms/edit_induction_tutor_form_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 RSpec.describe EditInductionTutorForm, type: :model do
-  let(:induction_tutor) { NewSeeds::Scenarios::Schools::School.new.build.with_an_induction_tutor.induction_tutor }
-  let(:full_name) { Faker::Name.name }
+  let(:induction_tutor) { NewSeeds::Scenarios::Schools::School.new.build.with_an_induction_tutor(full_name: "Helen Bach").induction_tutor }
+  let(:full_name) { "Bert Pancakes" }
   let(:email) { Faker::Internet.email }
 
   describe "validations" do


### PR DESCRIPTION
### Context

- Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-1981)
Remove NTA from the list of options of National ABs from 2023

### Changes proposed in this pull request
Make cohort setup form respect the `AppropriateBody.disable_from_year` attribute when providing the options for selection
Set the disable_from_year to 2023 in the AB importer for NTA.

### Guidance to review
As a SIT when setting up the 2023 cohort, when choosing an AB select "National" and then the only AB option presented should be IStip. NTA should not be an option.
