### PR TITLE
Add 'NotYetCompleted' to the possible values of induction status to d…

### DIFF
--- a/app/presenters/dqt_record_presenter.rb
+++ b/app/presenters/dqt_record_presenter.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class DQTRecordPresenter < SimpleDelegator
+  INDUCTION_IN_PROGRESS = ["InProgress", "In Progress", "NotYetCompleted", "Not Yet Completed"].freeze
+
   def name
     dqt_record["name"]
   end
@@ -42,7 +44,7 @@ class DQTRecordPresenter < SimpleDelegator
   end
 
   def induction_in_progress?
-    dqt_record.dig("induction", "status") == "InProgress"
+    INDUCTION_IN_PROGRESS.include?(dqt_record.dig("induction", "status"))
   end
 
 private

--- a/spec/services/participant_validation_service_spec.rb
+++ b/spec/services/participant_validation_service_spec.rb
@@ -284,6 +284,31 @@ RSpec.describe ParticipantValidationService do
         end
       end
 
+      context "when the participant's induction status is Not Yet Completed" do
+        let(:induction) do
+          {
+            "start_date" => induction_start_date,
+            "status" => "Not Yet Completed",
+          }
+        end
+
+        it "does not raise an error" do
+          expect { validation_result }.not_to raise_error
+        end
+
+        it "returns previous_induction as false" do
+          expect(validation_result[:previous_induction]).to eq false
+        end
+
+        it "returns no_induction as false" do
+          expect(validation_result[:no_induction]).to eq false
+        end
+
+        it "returns induction_start_date" do
+          expect(validation_result[:induction_start_date]).to eq(induction_start_date)
+        end
+      end
+
       context "when the participant has previously had an induction and participation" do
         let!(:eligibility) { create(:ineligible_participant, trn:, reason: :previous_participation) }
         let(:induction) do


### PR DESCRIPTION
Add 'NotYetCompleted' to the possible values of induction status to not set eligibility of a participant as previous _induction. 

### Context

When the induction of a participant is not completed yet, DQT records can have values "InProgress" or "NotCompletedYet" in their 'status' field. 
Our code currently checks the value to be  only "InProgress". 

### Changes proposed in this pull request
Check the status value of a DQT record can be "NotCompletedYet" when defining if a participant induction is still in progress. 

### Guidance to review

