### PR TITLE
Update _no_ects_cohort_details.html.erb

### DIFF
--- a/app/views/schools/dashboard/_no_ects_cohort_details.html.erb
+++ b/app/views/schools/dashboard/_no_ects_cohort_details.html.erb
@@ -1,2 +1,2 @@
-<p class="govuk-body">Your school has told us you do not expect any ECTs to join you in the <%= school_cohort.description %> academic year.</p>
+<p class="govuk-body">Your school has told us you do not expect any ECTs pr mentors to join you in the <%= school_cohort.description %> academic year.</p>
 <%= govuk_link_to 'Tell us if this has changed', schools_cohort_setup_start_path(cohort_id: school_cohort.cohort), class: "govuk-link govuk-link--no-visited-state" %>

--- a/app/views/schools/dashboard/_no_ects_cohort_details.html.erb
+++ b/app/views/schools/dashboard/_no_ects_cohort_details.html.erb
@@ -1,2 +1,2 @@
-<p class="govuk-body">Your school has told us you do not expect any ECTs pr mentors to join you in the <%= school_cohort.description %> academic year.</p>
+<p class="govuk-body">Your school has told us you do not expect any ECTs or mentors to join you in the <%= school_cohort.description %> academic year.</p>
 <%= govuk_link_to 'Tell us if this has changed', schools_cohort_setup_start_path(cohort_id: school_cohort.cohort), class: "govuk-link govuk-link--no-visited-state" %>


### PR DESCRIPTION
Mentors are now referenced too. This is because induction tutors need to set up training for 23/24 if they expect new mentors to begin training, even if they do not expect any new ECTs.

See https://dfedigital.atlassian.net/browse/CST-2004 for more information.

