### PR TITLE
Ignore non utf-8 characters in CSV upload

### DIFF
--- a/app/services/create_partnership_csv_upload.rb
+++ b/app/services/create_partnership_csv_upload.rb
@@ -30,6 +30,6 @@ private
   end
 
   def strip_bom(string)
-    string.force_encoding("UTF-8").gsub(/\xEF\xBB\xBF/, "")
+    string.encode("UTF-8", invalid: :replace, undef: :replace).gsub(/\xEF\xBB\xBF/, "")
   end
 end

--- a/spec/services/create_partnership_csv_upload_spec.rb
+++ b/spec/services/create_partnership_csv_upload_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe CreatePartnershipCsvUpload do
     end
 
     context "with other unicode characters" do
-      let(:urns) { ["\u00A0", "18900\u000f", " 10000\u00A0", "\u2000", "12345\n"] }
+      let(:urns) { ["\u00A0 ", " 18900\u000f", "  10000\u00A0 \255", "\u2000", " 12345\n"] }
 
       it "removes extra characters and keeps the urns" do
         expect(subject.call.uploaded_urns).to eql(%w[18900 10000 12345])


### PR DESCRIPTION
### Context
Error raised when CSV has invalid UTF-8 characters

- Ticket: n/a

### Changes proposed in this pull request

If a urn CSV has invalid characters ignore them when encoding


### Guidance to review

