### PR TITLE
Swap old PaaS URL for new AKS URL

### DIFF
--- a/docs/source/get-started.html.md
+++ b/docs/source/get-started.html.md
@@ -80,17 +80,17 @@ The sandbox environment is used to test API integrations without affecting real 
 
 ```
 API v1: 
-https://ecf-sandbox.london.cloudapps.digital/api/v1
+https://sb.manage-training-for-early-career-teachers.education.gov.uk/api/v1
 ```
 
 ```
 API v2:
-https://ecf-sandbox.london.cloudapps.digital/api/v2
+https://sb.manage-training-for-early-career-teachers.education.gov.uk/api/v2
 ```
 
 ```
 API v3: 
-https://ecf-sandbox.london.cloudapps.digital/api/v3
+https://sb.manage-training-for-early-career-teachers.education.gov.uk/api/v3
 ```
 
 <div class="govuk-inset-text"> Note, there are some custom API headers that can only be used in sandbox. </div>

--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -185,7 +185,7 @@ Changes to the [API v3 spec](/api-reference/reference-v3.html) have been impleme
 
 ### Test dynamic scenarios
 
-Providers will also be able to [sign into the sandbox environment](https://ecf-sandbox.london.cloudapps.digital/users/sign_in) as school induction tutors. Scenarios, such as transfers, can be simulated. Providers will be contacted shortly with login instructions.
+Providers will also be able to [sign into the sandbox environment](https://sb.manage-training-for-early-career-teachers.education.gov.uk/users/sign_in) as school induction tutors. Scenarios, such as transfers, can be simulated. Providers will be contacted shortly with login instructions.
 
 **Note,** when registering participants in the sandbox environment, providers must use the following dates of birth if they want to the participants to appear as **eligible for funding**:
 

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -11,7 +11,7 @@
   },
   "servers": [
     {
-      "url": "https://ecf-sandbox.london.cloudapps.digital",
+      "url": "https://sb.manage-training-for-early-career-teachers.education.gov.uk",
       "description": "Sandbox"
     },
     {

--- a/swagger/v1/template.yml
+++ b/swagger/v1/template.yml
@@ -8,7 +8,7 @@ info:
     email: continuing-professional-development@digital.education.gov.uk
   description: "The lead provider API for DfE's manage teacher CPD service"
 servers:
-  - url: https://ecf-sandbox.london.cloudapps.digital
+  - url: https://sb.manage-training-for-early-career-teachers.education.gov.uk
     description: "Sandbox"
   - url: /
     description: "Current environment"

--- a/swagger/v2/api_spec.json
+++ b/swagger/v2/api_spec.json
@@ -11,7 +11,7 @@
   },
   "servers": [
     {
-      "url": "https://ecf-sandbox.london.cloudapps.digital",
+      "url": "https://sb.manage-training-for-early-career-teachers.education.gov.uk",
       "description": "Sandbox"
     },
     {

--- a/swagger/v2/template.yml
+++ b/swagger/v2/template.yml
@@ -8,7 +8,7 @@ info:
     email: continuing-professional-development@digital.education.gov.uk
   description: "The lead provider API for DfE's manage teacher CPD service"
 servers:
-  - url: https://ecf-sandbox.london.cloudapps.digital
+  - url: https://sb.manage-training-for-early-career-teachers.education.gov.uk
     description: "Sandbox"
   - url: /
     description: "Current environment"

--- a/swagger/v3/api_spec.json
+++ b/swagger/v3/api_spec.json
@@ -11,7 +11,7 @@
   },
   "servers": [
     {
-      "url": "https://ecf-sandbox.london.cloudapps.digital",
+      "url": "https://sb.manage-training-for-early-career-teachers.education.gov.uk",
       "description": "Sandbox"
     },
     {

--- a/swagger/v3/template.yml
+++ b/swagger/v3/template.yml
@@ -8,7 +8,7 @@ info:
     email: continuing-professional-development@digital.education.gov.uk
   description: "The lead provider API for DfE's manage teacher CPD service."
 servers:
-  - url: https://ecf-sandbox.london.cloudapps.digital
+  - url: https://sb.manage-training-for-early-career-teachers.education.gov.uk
     description: "Sandbox"
   - url: /
     description: "Current environment"


### PR DESCRIPTION
### Context
There are still old sandbox URLs in our API docs

- Ticket: n/a

### Changes proposed in this pull request
Swap out old PaaS sandbox URLs for new AKS URLs

### Guidance to review

