### PR TITLE
[CPDLP-2457] Ensure API spec contains all possible schedule-identifier values for ECF and NPQ

### DIFF
--- a/spec/docs/v3/ecf_participants_spec.rb
+++ b/spec/docs/v3/ecf_participants_spec.rb
@@ -395,7 +395,7 @@ describe "API", type: :request, swagger_doc: "v3/api_spec.json" do
             "data": {
               "type": "participant",
               "attributes": {
-                schedule_identifier: "ecf-january-standard-2023",
+                schedule_identifier: "ecf-standard-january",
                 course_identifier: "ecf-induction",
               },
             },
@@ -405,7 +405,7 @@ describe "API", type: :request, swagger_doc: "v3/api_spec.json" do
         schema({ "$ref": "#/components/schemas/ECFParticipantResponse" })
 
         before do
-          create(:schedule, schedule_identifier: "ecf-january-standard-2023", name: "ECF January standard 2023", cohort:)
+          create(:schedule, schedule_identifier: "ecf-standard-january", name: "ECF January standard 2023", cohort:)
         end
 
         run_test!

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -1814,7 +1814,16 @@
             "enum": [
               "ecf-standard-september",
               "ecf-standard-january",
-              "ecf-standard-april"
+              "ecf-standard-april",
+              "ecf-reduced-september",
+              "ecf-reduced-january",
+              "ecf-reduced-april",
+              "ecf-extended-september",
+              "ecf-extended-january",
+              "ecf-extended-april",
+              "ecf-replacement-september",
+              "ecf-replacement-january",
+              "ecf-replacement-april"
             ]
           },
           "updated_at": {
@@ -1862,7 +1871,16 @@
             "enum": [
               "ecf-standard-september",
               "ecf-standard-january",
-              "ecf-standard-april"
+              "ecf-standard-april",
+              "ecf-reduced-september",
+              "ecf-reduced-january",
+              "ecf-reduced-april",
+              "ecf-extended-september",
+              "ecf-extended-january",
+              "ecf-extended-april",
+              "ecf-replacement-september",
+              "ecf-replacement-january",
+              "ecf-replacement-april"
             ],
             "example": "ecf-standard-september"
           },
@@ -2037,7 +2055,17 @@
             "example": "ecf-standard-january",
             "enum": [
               "ecf-standard-september",
-              "ecf-standard-january"
+              "ecf-standard-january",
+              "ecf-standard-april",
+              "ecf-reduced-september",
+              "ecf-reduced-january",
+              "ecf-reduced-april",
+              "ecf-extended-september",
+              "ecf-extended-january",
+              "ecf-extended-april",
+              "ecf-replacement-september",
+              "ecf-replacement-january",
+              "ecf-replacement-april"
             ]
           },
           "updated_at": {
@@ -2407,7 +2435,16 @@
             "enum": [
               "ecf-standard-september",
               "ecf-standard-january",
-              "ecf-standard-april"
+              "ecf-standard-april",
+              "ecf-reduced-september",
+              "ecf-reduced-january",
+              "ecf-reduced-april",
+              "ecf-extended-september",
+              "ecf-extended-january",
+              "ecf-extended-april",
+              "ecf-replacement-september",
+              "ecf-replacement-january",
+              "ecf-replacement-april"
             ]
           },
           "updated_at": {
@@ -2634,7 +2671,16 @@
             "enum": [
               "ecf-standard-september",
               "ecf-standard-january",
-              "ecf-standard-april"
+              "ecf-standard-april",
+              "ecf-reduced-september",
+              "ecf-reduced-january",
+              "ecf-reduced-april",
+              "ecf-extended-september",
+              "ecf-extended-january",
+              "ecf-extended-april",
+              "ecf-replacement-september",
+              "ecf-replacement-january",
+              "ecf-replacement-april"
             ]
           },
           "updated_at": {
@@ -3010,7 +3056,16 @@
             "enum": [
               "ecf-standard-september",
               "ecf-standard-january",
-              "ecf-standard-april"
+              "ecf-standard-april",
+              "ecf-reduced-september",
+              "ecf-reduced-january",
+              "ecf-reduced-april",
+              "ecf-extended-september",
+              "ecf-extended-january",
+              "ecf-extended-april",
+              "ecf-replacement-september",
+              "ecf-replacement-january",
+              "ecf-replacement-april"
             ]
           },
           "updated_at": {
@@ -4101,12 +4156,16 @@
             "description": "The new schedule of the participant",
             "type": "string",
             "enum": [
-              "npq-aso-november",
-              "npq-aso-december",
               "npq-aso-march",
               "npq-aso-june",
-              "npq-leadership-spring",
+              "npq-aso-november",
+              "npq-aso-december",
+              "npq-ehco-march",
+              "npq-ehco-june",
+              "npq-ehco-november",
+              "npq-ehco-december",
               "npq-leadership-autumn",
+              "npq-leadership-spring",
               "npq-specialist-autumn",
               "npq-specialist-spring"
             ],

--- a/swagger/v1/component_schemas/ECFParticipantAttributes.yml
+++ b/swagger/v1/component_schemas/ECFParticipantAttributes.yml
@@ -94,6 +94,15 @@ properties:
       - ecf-standard-september
       - ecf-standard-january
       - ecf-standard-april
+      - ecf-reduced-september
+      - ecf-reduced-january
+      - ecf-reduced-april
+      - ecf-extended-september
+      - ecf-extended-january
+      - ecf-extended-april
+      - ecf-replacement-september
+      - ecf-replacement-january
+      - ecf-replacement-april
   updated_at:
     description: "The date the ECF participant was last updated"
     type: string

--- a/swagger/v1/component_schemas/ECFParticipantChangeScheduleAttributes.yml
+++ b/swagger/v1/component_schemas/ECFParticipantChangeScheduleAttributes.yml
@@ -8,6 +8,15 @@ properties:
       - ecf-standard-september
       - ecf-standard-january
       - ecf-standard-april
+      - ecf-reduced-september
+      - ecf-reduced-january
+      - ecf-reduced-april
+      - ecf-extended-september
+      - ecf-extended-january
+      - ecf-extended-april
+      - ecf-replacement-september
+      - ecf-replacement-january
+      - ecf-replacement-april
     example: ecf-standard-september
   course_identifier:
     description: "The type of course the participant is enrolled in"

--- a/swagger/v1/component_schemas/ECFParticipantCsvRow.yml
+++ b/swagger/v1/component_schemas/ECFParticipantCsvRow.yml
@@ -101,6 +101,16 @@ properties:
     enum:
       - ecf-standard-september
       - ecf-standard-january
+      - ecf-standard-april
+      - ecf-reduced-september
+      - ecf-reduced-january
+      - ecf-reduced-april
+      - ecf-extended-september
+      - ecf-extended-january
+      - ecf-extended-april
+      - ecf-replacement-september
+      - ecf-replacement-january
+      - ecf-replacement-april
   updated_at:
     description: "The date the ECF participant was last updated"
     type: string

--- a/swagger/v1/component_schemas/ECFParticipantDeferAttributesResponse.yml
+++ b/swagger/v1/component_schemas/ECFParticipantDeferAttributesResponse.yml
@@ -85,6 +85,15 @@ properties:
       - ecf-standard-september
       - ecf-standard-january
       - ecf-standard-april
+      - ecf-reduced-september
+      - ecf-reduced-january
+      - ecf-reduced-april
+      - ecf-extended-september
+      - ecf-extended-january
+      - ecf-extended-april
+      - ecf-replacement-september
+      - ecf-replacement-january
+      - ecf-replacement-april
   updated_at:
     description: "The date the ECF participant was last updated"
     type: string

--- a/swagger/v1/component_schemas/ECFParticipantResumeAttributesResponse.yml
+++ b/swagger/v1/component_schemas/ECFParticipantResumeAttributesResponse.yml
@@ -85,6 +85,15 @@ properties:
       - ecf-standard-september
       - ecf-standard-january
       - ecf-standard-april
+      - ecf-reduced-september
+      - ecf-reduced-january
+      - ecf-reduced-april
+      - ecf-extended-september
+      - ecf-extended-january
+      - ecf-extended-april
+      - ecf-replacement-september
+      - ecf-replacement-january
+      - ecf-replacement-april
   updated_at:
     description: "The date the ECF participant was last updated"
     type: string

--- a/swagger/v1/component_schemas/ECFParticipantWithdrawAttributesResponse.yml
+++ b/swagger/v1/component_schemas/ECFParticipantWithdrawAttributesResponse.yml
@@ -85,6 +85,15 @@ properties:
       - ecf-standard-september
       - ecf-standard-january
       - ecf-standard-april
+      - ecf-reduced-september
+      - ecf-reduced-january
+      - ecf-reduced-april
+      - ecf-extended-september
+      - ecf-extended-january
+      - ecf-extended-april
+      - ecf-replacement-september
+      - ecf-replacement-january
+      - ecf-replacement-april
   updated_at:
     description: "The date the ECF participant was last updated"
     type: string

--- a/swagger/v1/component_schemas/NPQParticipantChangeScheduleAttributes.yml
+++ b/swagger/v1/component_schemas/NPQParticipantChangeScheduleAttributes.yml
@@ -5,12 +5,16 @@ properties:
     description: "The new schedule of the participant"
     type: string
     enum:
-      - npq-aso-november
-      - npq-aso-december
       - npq-aso-march
       - npq-aso-june
-      - npq-leadership-spring
+      - npq-aso-november
+      - npq-aso-december
+      - npq-ehco-march
+      - npq-ehco-june
+      - npq-ehco-november
+      - npq-ehco-december
       - npq-leadership-autumn
+      - npq-leadership-spring
       - npq-specialist-autumn
       - npq-specialist-spring
     example: npq-leadership-autumn

--- a/swagger/v2/api_spec.json
+++ b/swagger/v2/api_spec.json
@@ -1666,7 +1666,16 @@
             "enum": [
               "ecf-standard-september",
               "ecf-standard-january",
-              "ecf-standard-april"
+              "ecf-standard-april",
+              "ecf-reduced-september",
+              "ecf-reduced-january",
+              "ecf-reduced-april",
+              "ecf-extended-september",
+              "ecf-extended-january",
+              "ecf-extended-april",
+              "ecf-replacement-september",
+              "ecf-replacement-january",
+              "ecf-replacement-april"
             ]
           },
           "updated_at": {
@@ -1714,7 +1723,16 @@
             "enum": [
               "ecf-standard-september",
               "ecf-standard-january",
-              "ecf-standard-april"
+              "ecf-standard-april",
+              "ecf-reduced-september",
+              "ecf-reduced-january",
+              "ecf-reduced-april",
+              "ecf-extended-september",
+              "ecf-extended-january",
+              "ecf-extended-april",
+              "ecf-replacement-september",
+              "ecf-replacement-january",
+              "ecf-replacement-april"
             ],
             "example": "ecf-standard-september"
           },
@@ -1888,7 +1906,17 @@
             "example": "ecf-standard-january",
             "enum": [
               "ecf-standard-september",
-              "ecf-standard-january"
+              "ecf-standard-january",
+              "ecf-standard-april",
+              "ecf-reduced-september",
+              "ecf-reduced-january",
+              "ecf-reduced-april",
+              "ecf-extended-september",
+              "ecf-extended-january",
+              "ecf-extended-april",
+              "ecf-replacement-september",
+              "ecf-replacement-january",
+              "ecf-replacement-april"
             ]
           },
           "updated_at": {
@@ -2261,7 +2289,16 @@
             "enum": [
               "ecf-standard-september",
               "ecf-standard-january",
-              "ecf-standard-april"
+              "ecf-standard-april",
+              "ecf-reduced-september",
+              "ecf-reduced-january",
+              "ecf-reduced-april",
+              "ecf-extended-september",
+              "ecf-extended-january",
+              "ecf-extended-april",
+              "ecf-replacement-september",
+              "ecf-replacement-january",
+              "ecf-replacement-april"
             ]
           },
           "updated_at": {
@@ -2487,7 +2524,16 @@
             "enum": [
               "ecf-standard-september",
               "ecf-standard-january",
-              "ecf-standard-april"
+              "ecf-standard-april",
+              "ecf-reduced-september",
+              "ecf-reduced-january",
+              "ecf-reduced-april",
+              "ecf-extended-september",
+              "ecf-extended-january",
+              "ecf-extended-april",
+              "ecf-replacement-september",
+              "ecf-replacement-january",
+              "ecf-replacement-april"
             ]
           },
           "updated_at": {
@@ -2867,7 +2913,16 @@
             "enum": [
               "ecf-standard-september",
               "ecf-standard-january",
-              "ecf-standard-april"
+              "ecf-standard-april",
+              "ecf-reduced-september",
+              "ecf-reduced-january",
+              "ecf-reduced-april",
+              "ecf-extended-september",
+              "ecf-extended-january",
+              "ecf-extended-april",
+              "ecf-replacement-september",
+              "ecf-replacement-january",
+              "ecf-replacement-april"
             ]
           },
           "updated_at": {
@@ -3688,14 +3743,18 @@
             "type": "string",
             "example": "npq-leadership-autumn",
             "enum": [
+              "npq-aso-march",
+              "npq-aso-june",
+              "npq-aso-november",
+              "npq-aso-december",
+              "npq-ehco-march",
+              "npq-ehco-june",
+              "npq-ehco-november",
+              "npq-ehco-december",
               "npq-leadership-autumn",
               "npq-leadership-spring",
               "npq-specialist-autumn",
-              "npq-specialist-spring",
-              "npq-aso-november",
-              "npq-aso-december",
-              "npq-aso-march",
-              "npq-aso-june"
+              "npq-specialist-spring"
             ]
           },
           "cohort": {
@@ -3781,14 +3840,18 @@
             "type": "string",
             "example": "npq-specialist-autumn",
             "enum": [
-              "npq-specialist-autumn",
-              "npq-specialist-spring",
+              "npq-aso-march",
+              "npq-aso-june",
+              "npq-aso-november",
+              "npq-aso-december",
+              "npq-ehco-march",
+              "npq-ehco-june",
+              "npq-ehco-november",
+              "npq-ehco-december",
               "npq-leadership-autumn",
               "npq-leadership-spring",
-              "npq-aso-december",
-              "npq-aso-november",
-              "npq-aso-march",
-              "npq-aso-june"
+              "npq-specialist-autumn",
+              "npq-specialist-spring"
             ]
           },
           "cohort": {
@@ -4131,12 +4194,16 @@
             "description": "The new schedule of the participant",
             "type": "string",
             "enum": [
-              "npq-aso-november",
-              "npq-aso-december",
               "npq-aso-march",
               "npq-aso-june",
-              "npq-leadership-spring",
+              "npq-aso-november",
+              "npq-aso-december",
+              "npq-ehco-march",
+              "npq-ehco-june",
+              "npq-ehco-november",
+              "npq-ehco-december",
               "npq-leadership-autumn",
+              "npq-leadership-spring",
               "npq-specialist-autumn",
               "npq-specialist-spring"
             ],

--- a/swagger/v2/component_schemas/ECFParticipantAttributes.yml
+++ b/swagger/v2/component_schemas/ECFParticipantAttributes.yml
@@ -94,6 +94,15 @@ properties:
       - ecf-standard-september
       - ecf-standard-january
       - ecf-standard-april
+      - ecf-reduced-september
+      - ecf-reduced-january
+      - ecf-reduced-april
+      - ecf-extended-september
+      - ecf-extended-january
+      - ecf-extended-april
+      - ecf-replacement-september
+      - ecf-replacement-january
+      - ecf-replacement-april
   updated_at:
     description: "The date the ECF participant was last updated"
     type: string

--- a/swagger/v2/component_schemas/ECFParticipantChangeScheduleAttributes.yml
+++ b/swagger/v2/component_schemas/ECFParticipantChangeScheduleAttributes.yml
@@ -8,6 +8,15 @@ properties:
       - ecf-standard-september
       - ecf-standard-january
       - ecf-standard-april
+      - ecf-reduced-september
+      - ecf-reduced-january
+      - ecf-reduced-april
+      - ecf-extended-september
+      - ecf-extended-january
+      - ecf-extended-april
+      - ecf-replacement-september
+      - ecf-replacement-january
+      - ecf-replacement-april
     example: ecf-standard-september
   course_identifier:
     description: "The type of course the participant is enrolled in"

--- a/swagger/v2/component_schemas/ECFParticipantCsvRow.yml
+++ b/swagger/v2/component_schemas/ECFParticipantCsvRow.yml
@@ -100,6 +100,16 @@ properties:
     enum:
       - ecf-standard-september
       - ecf-standard-january
+      - ecf-standard-april
+      - ecf-reduced-september
+      - ecf-reduced-january
+      - ecf-reduced-april
+      - ecf-extended-september
+      - ecf-extended-january
+      - ecf-extended-april
+      - ecf-replacement-september
+      - ecf-replacement-january
+      - ecf-replacement-april
   updated_at:
     description: "The date the ECF participant was last updated"
     type: string

--- a/swagger/v2/component_schemas/ECFParticipantDeferAttributesResponse.yml
+++ b/swagger/v2/component_schemas/ECFParticipantDeferAttributesResponse.yml
@@ -88,6 +88,15 @@ properties:
       - ecf-standard-september
       - ecf-standard-january
       - ecf-standard-april
+      - ecf-reduced-september
+      - ecf-reduced-january
+      - ecf-reduced-april
+      - ecf-extended-september
+      - ecf-extended-january
+      - ecf-extended-april
+      - ecf-replacement-september
+      - ecf-replacement-january
+      - ecf-replacement-april
   updated_at:
     description: "The date the ECF participant was last updated"
     type: string

--- a/swagger/v2/component_schemas/ECFParticipantResumeAttributesResponse.yml
+++ b/swagger/v2/component_schemas/ECFParticipantResumeAttributesResponse.yml
@@ -84,6 +84,15 @@ properties:
       - ecf-standard-september
       - ecf-standard-january
       - ecf-standard-april
+      - ecf-reduced-september
+      - ecf-reduced-january
+      - ecf-reduced-april
+      - ecf-extended-september
+      - ecf-extended-january
+      - ecf-extended-april
+      - ecf-replacement-september
+      - ecf-replacement-january
+      - ecf-replacement-april
   updated_at:
     description: "The date the ECF participant was last updated"
     type: string

--- a/swagger/v2/component_schemas/ECFParticipantWithdrawAttributesResponse.yml
+++ b/swagger/v2/component_schemas/ECFParticipantWithdrawAttributesResponse.yml
@@ -89,6 +89,15 @@ properties:
       - ecf-standard-september
       - ecf-standard-january
       - ecf-standard-april
+      - ecf-reduced-september
+      - ecf-reduced-january
+      - ecf-reduced-april
+      - ecf-extended-september
+      - ecf-extended-january
+      - ecf-extended-april
+      - ecf-replacement-september
+      - ecf-replacement-january
+      - ecf-replacement-april
   updated_at:
     description: "The date the ECF participant was last updated"
     type: string

--- a/swagger/v2/component_schemas/NPQEnrolment.yml
+++ b/swagger/v2/component_schemas/NPQEnrolment.yml
@@ -29,14 +29,18 @@ properties:
     type: string
     example: "npq-leadership-autumn"
     enum:
+      - npq-aso-march
+      - npq-aso-june
+      - npq-aso-november
+      - npq-aso-december
+      - npq-ehco-march
+      - npq-ehco-june
+      - npq-ehco-november
+      - npq-ehco-december
       - npq-leadership-autumn
       - npq-leadership-spring
       - npq-specialist-autumn
       - npq-specialist-spring
-      - npq-aso-november
-      - npq-aso-december
-      - npq-aso-march
-      - npq-aso-june
   cohort:
     description: "The value indicates which call-off contract funds this participant's training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year. Providers may change an NPQ participant's cohort up until the point of submitting a started declaration."
     type: string

--- a/swagger/v2/component_schemas/NPQEnrolmentCsvRow.yml
+++ b/swagger/v2/component_schemas/NPQEnrolmentCsvRow.yml
@@ -36,14 +36,18 @@ properties:
     type: string
     example: "npq-specialist-autumn"
     enum:
-      - npq-specialist-autumn
-      - npq-specialist-spring
-      - npq-leadership-autumn
-      - npq-leadership-spring
-      - npq-aso-december
-      - npq-aso-november
       - npq-aso-march
       - npq-aso-june
+      - npq-aso-november
+      - npq-aso-december
+      - npq-ehco-march
+      - npq-ehco-june
+      - npq-ehco-november
+      - npq-ehco-december
+      - npq-leadership-autumn
+      - npq-leadership-spring
+      - npq-specialist-autumn
+      - npq-specialist-spring
   cohort:
     description: "The value indicates which call-off contract funds this participant's training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year. Providers may change an NPQ participant's cohort up until the point of submitting a started declaration."
     type: string

--- a/swagger/v2/component_schemas/NPQParticipantChangeScheduleAttributes.yml
+++ b/swagger/v2/component_schemas/NPQParticipantChangeScheduleAttributes.yml
@@ -5,12 +5,16 @@ properties:
     description: "The new schedule of the participant"
     type: string
     enum:
-      - npq-aso-november
-      - npq-aso-december
       - npq-aso-march
       - npq-aso-june
-      - npq-leadership-spring
+      - npq-aso-november
+      - npq-aso-december
+      - npq-ehco-march
+      - npq-ehco-june
+      - npq-ehco-november
+      - npq-ehco-december
       - npq-leadership-autumn
+      - npq-leadership-spring
       - npq-specialist-autumn
       - npq-specialist-spring
     example: npq-leadership-autumn

--- a/swagger/v3/api_spec.json
+++ b/swagger/v3/api_spec.json
@@ -3187,6 +3187,20 @@
           "schedule_identifier": {
             "description": "The schedule of the ECF participant. For the possible values please refer to the <a href=\"/api-reference/ecf/schedules-and-milestone-dates.html#schedules-and-milestone-dates\" class=\"govuk-link\">ECF schedules and milestone dates guidance</a>.",
             "type": "string",
+            "enum": [
+              "ecf-standard-september",
+              "ecf-standard-january",
+              "ecf-standard-april",
+              "ecf-reduced-september",
+              "ecf-reduced-january",
+              "ecf-reduced-april",
+              "ecf-extended-september",
+              "ecf-extended-january",
+              "ecf-extended-april",
+              "ecf-replacement-september",
+              "ecf-replacement-january",
+              "ecf-replacement-april"
+            ],
             "example": "ecf-standard-january"
           },
           "delivery_partner_id": {
@@ -5248,6 +5262,20 @@
           "schedule_identifier": {
             "description": "The schedule the participant is enrolled in. For the possible values please refer to the <a href=\"/api-reference/npq/schedules-and-milestone-dates.html#schedules-and-milestone-dates\" class=\"govuk-link\">NPQ schedules and milestone dates guidance</a>.",
             "type": "string",
+            "enum": [
+              "npq-aso-march",
+              "npq-aso-june",
+              "npq-aso-november",
+              "npq-aso-december",
+              "npq-ehco-march",
+              "npq-ehco-june",
+              "npq-ehco-november",
+              "npq-ehco-december",
+              "npq-leadership-autumn",
+              "npq-leadership-spring",
+              "npq-specialist-autumn",
+              "npq-specialist-spring"
+            ],
             "example": "npq-leadership-autumn"
           },
           "cohort": {

--- a/swagger/v3/api_spec.json
+++ b/swagger/v3/api_spec.json
@@ -3185,7 +3185,7 @@
             "example": true
           },
           "schedule_identifier": {
-            "description": "The schedule of the ECF participant. For the possible values please refer to the <a href=\"/ecf-usage.html#notifying-of-schedule-change\" class=\"govuk-link\">ECF change schedule guidance</a>.",
+            "description": "The schedule of the ECF participant. For the possible values please refer to the <a href=\"/api-reference/ecf/schedules-and-milestone-dates.html#schedules-and-milestone-dates\" class=\"govuk-link\">ECF schedules and milestone dates guidance</a>.",
             "type": "string",
             "example": "ecf-standard-january"
           },
@@ -3311,7 +3311,16 @@
             "enum": [
               "ecf-standard-september",
               "ecf-standard-january",
-              "ecf-standard-april"
+              "ecf-standard-april",
+              "ecf-reduced-september",
+              "ecf-reduced-january",
+              "ecf-reduced-april",
+              "ecf-extended-september",
+              "ecf-extended-january",
+              "ecf-extended-april",
+              "ecf-replacement-september",
+              "ecf-replacement-january",
+              "ecf-replacement-april"
             ],
             "example": "ecf-standard-september"
           },
@@ -5237,19 +5246,9 @@
             ]
           },
           "schedule_identifier": {
-            "description": "The schedule the participant is enrolled in",
+            "description": "The schedule the participant is enrolled in. For the possible values please refer to the <a href=\"/api-reference/npq/schedules-and-milestone-dates.html#schedules-and-milestone-dates\" class=\"govuk-link\">NPQ schedules and milestone dates guidance</a>.",
             "type": "string",
-            "example": "npq-leadership-autumn",
-            "enum": [
-              "npq-leadership-autumn",
-              "npq-leadership-spring",
-              "npq-specialist-autumn",
-              "npq-specialist-spring",
-              "npq-aso-november",
-              "npq-aso-december",
-              "npq-aso-march",
-              "npq-aso-june"
-            ]
+            "example": "npq-leadership-autumn"
           },
           "cohort": {
             "description": "The value indicates which call-off contract funds this participant's training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year. Providers may change an NPQ participant's cohort up until the point of submitting a started declaration.",
@@ -5635,12 +5634,16 @@
             "description": "The new schedule of the participant",
             "type": "string",
             "enum": [
-              "npq-aso-november",
-              "npq-aso-december",
               "npq-aso-march",
               "npq-aso-june",
-              "npq-leadership-spring",
+              "npq-aso-november",
+              "npq-aso-december",
+              "npq-ehco-march",
+              "npq-ehco-june",
+              "npq-ehco-november",
+              "npq-ehco-december",
               "npq-leadership-autumn",
+              "npq-leadership-spring",
               "npq-specialist-autumn",
               "npq-specialist-spring"
             ],

--- a/swagger/v3/component_schemas/ECFEnrolment.yml
+++ b/swagger/v3/component_schemas/ECFEnrolment.yml
@@ -82,7 +82,7 @@ properties:
     type: boolean
     example: true
   schedule_identifier:
-    description: "The schedule of the ECF participant. For the possible values please refer to the <a href=\"/ecf-usage.html#notifying-of-schedule-change\" class=\"govuk-link\">ECF change schedule guidance</a>."
+    description: "The schedule of the ECF participant. For the possible values please refer to the <a href=\"/api-reference/ecf/schedules-and-milestone-dates.html#schedules-and-milestone-dates\" class=\"govuk-link\">ECF schedules and milestone dates guidance</a>."
     type: string
     example: ecf-standard-january
   delivery_partner_id:

--- a/swagger/v3/component_schemas/ECFEnrolment.yml
+++ b/swagger/v3/component_schemas/ECFEnrolment.yml
@@ -84,6 +84,19 @@ properties:
   schedule_identifier:
     description: "The schedule of the ECF participant. For the possible values please refer to the <a href=\"/api-reference/ecf/schedules-and-milestone-dates.html#schedules-and-milestone-dates\" class=\"govuk-link\">ECF schedules and milestone dates guidance</a>."
     type: string
+    enum:
+      - ecf-standard-september
+      - ecf-standard-january
+      - ecf-standard-april
+      - ecf-reduced-september
+      - ecf-reduced-january
+      - ecf-reduced-april
+      - ecf-extended-september
+      - ecf-extended-january
+      - ecf-extended-april
+      - ecf-replacement-september
+      - ecf-replacement-january
+      - ecf-replacement-april
     example: ecf-standard-january
   delivery_partner_id:
     description: Unique ID of the delivery partner associated with the participant

--- a/swagger/v3/component_schemas/ECFParticipantChangeScheduleAttributes.yml
+++ b/swagger/v3/component_schemas/ECFParticipantChangeScheduleAttributes.yml
@@ -8,6 +8,15 @@ properties:
       - ecf-standard-september
       - ecf-standard-january
       - ecf-standard-april
+      - ecf-reduced-september
+      - ecf-reduced-january
+      - ecf-reduced-april
+      - ecf-extended-september
+      - ecf-extended-january
+      - ecf-extended-april
+      - ecf-replacement-september
+      - ecf-replacement-january
+      - ecf-replacement-april
     example: ecf-standard-september
   course_identifier:
     description: "The type of course the participant is enrolled in"

--- a/swagger/v3/component_schemas/NPQEnrolment.yml
+++ b/swagger/v3/component_schemas/NPQEnrolment.yml
@@ -31,18 +31,9 @@ properties:
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
   schedule_identifier:
-    description: "The schedule the participant is enrolled in"
+    description: "The schedule the participant is enrolled in. For the possible values please refer to the <a href=\"/api-reference/npq/schedules-and-milestone-dates.html#schedules-and-milestone-dates\" class=\"govuk-link\">NPQ schedules and milestone dates guidance</a>."
     type: string
     example: "npq-leadership-autumn"
-    enum:
-      - npq-leadership-autumn
-      - npq-leadership-spring
-      - npq-specialist-autumn
-      - npq-specialist-spring
-      - npq-aso-november
-      - npq-aso-december
-      - npq-aso-march
-      - npq-aso-june
   cohort:
     description: "The value indicates which call-off contract funds this participant's training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year. Providers may change an NPQ participant's cohort up until the point of submitting a started declaration."
     type: string

--- a/swagger/v3/component_schemas/NPQEnrolment.yml
+++ b/swagger/v3/component_schemas/NPQEnrolment.yml
@@ -33,6 +33,19 @@ properties:
   schedule_identifier:
     description: "The schedule the participant is enrolled in. For the possible values please refer to the <a href=\"/api-reference/npq/schedules-and-milestone-dates.html#schedules-and-milestone-dates\" class=\"govuk-link\">NPQ schedules and milestone dates guidance</a>."
     type: string
+    enum:
+      - npq-aso-march
+      - npq-aso-june
+      - npq-aso-november
+      - npq-aso-december
+      - npq-ehco-march
+      - npq-ehco-june
+      - npq-ehco-november
+      - npq-ehco-december
+      - npq-leadership-autumn
+      - npq-leadership-spring
+      - npq-specialist-autumn
+      - npq-specialist-spring
     example: "npq-leadership-autumn"
   cohort:
     description: "The value indicates which call-off contract funds this participant's training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year. Providers may change an NPQ participant's cohort up until the point of submitting a started declaration."

--- a/swagger/v3/component_schemas/NPQParticipantChangeScheduleAttributes.yml
+++ b/swagger/v3/component_schemas/NPQParticipantChangeScheduleAttributes.yml
@@ -5,12 +5,16 @@ properties:
     description: "The new schedule of the participant"
     type: string
     enum:
-      - npq-aso-november
-      - npq-aso-december
       - npq-aso-march
       - npq-aso-june
-      - npq-leadership-spring
+      - npq-aso-november
+      - npq-aso-december
+      - npq-ehco-march
+      - npq-ehco-june
+      - npq-ehco-november
+      - npq-ehco-december
       - npq-leadership-autumn
+      - npq-leadership-spring
       - npq-specialist-autumn
       - npq-specialist-spring
     example: npq-leadership-autumn


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-2457

We’re missing some schedule-identifier values from the API spec.

### Changes proposed in this pull request

Ensure API spec contains all possible schedule-identifier values for ECF and NPQ.