### PR TITLE
[Bug-Fix] Prevent job from rechecking/updating ECTs with a completion date

### DIFF
--- a/app/jobs/set_participant_completion_date_job.rb
+++ b/app/jobs/set_participant_completion_date_job.rb
@@ -12,6 +12,7 @@ class SetParticipantCompletionDateJob < ApplicationJob
       .includes(:teacher_profile)
       .where.not(teacher_profile: { trn: nil })
       .where.not(induction_start_date: nil)
+      .where(induction_completion_date: nil)
       .where(created_at: ...Cohort.find_by(start_year: 2023).registration_start_date)
       .order(:updated_at)
       .limit(200)


### PR DESCRIPTION
### Context

The participant induction completion date job had an issue where it was re-updating participants that already had an `induction_completion_date` set causing additional induction records to be created.

### Changes proposed in this pull request
Prevent job from re-checking and updating participants with an `induction_completion_date`

### Guidance to review

