### PR TITLE
[CST-1968] Update the school dashboard filters

### DIFF
--- a/app/models/induction_record.rb
+++ b/app/models/induction_record.rb
@@ -63,7 +63,7 @@ class InductionRecord < ApplicationRecord
   scope :transferred, -> { leaving_induction_status.merge(end_date_in_past) }
 
   scope :current_or_transferring_in, -> { current.or(transferring_in) }
-  scope :school_dashboard_relevant, -> { completed_induction_status.or(current).or(transferring_in).or(transferred) }
+  scope :school_dashboard_relevant, -> { completed_induction_status.or(current).or(transferring_in).or(transferred).or(withdrawn_induction_status) }
 
   scope :ects, -> { joins(:participant_profile).merge(ParticipantProfile.ects) }
   scope :mentors, -> { joins(:participant_profile).merge(ParticipantProfile.mentors) }

--- a/app/services/dashboard/participants.rb
+++ b/app/services/dashboard/participants.rb
@@ -159,8 +159,8 @@ module Dashboard
       end
 
       # Include also the orphan mentors in the @mentors
-      @orphan_mentor_ids = @active_mentors.map(&:participant_profile_id) - @currently_training_ects.map(&:mentor_profile_id)
-      @orphan_mentor_ids.each do |mentor_profile_id|
+      orphan_mentor_ids = @active_mentors.map(&:participant_profile_id) - @currently_training_ects.map(&:mentor_profile_id)
+      orphan_mentor_ids.each do |mentor_profile_id|
         @mentors[dashboard_participant(mentor_profile_id)] = nil
       end
     end

--- a/app/views/schools/participants/_completed_induction.html.erb
+++ b/app/views/schools/participants/_completed_induction.html.erb
@@ -4,7 +4,7 @@
   <% participants.completed_induction.sort_by(&:induction_completion_date).reverse.each do |participant| %>
     <%= govuk_summary_card(title: link_to_participant(participant.participant_profile, school)) do |card|
       card.with_summary_list(rows: [{ key: { text: "Completed", classes: ["xgovuk-!-font-weight-regular"] },
-                                      value: { text: participant.induction_completion_date.to_fs(:govuk) } }])
+                                      value: { text: participant.induction_completion_date&.to_fs(:govuk) } }])
     end %>
   <% end %>
 <% end %>

--- a/app/views/schools/participants/_currently_training_sorted_by_mentor.html.erb
+++ b/app/views/schools/participants/_currently_training_sorted_by_mentor.html.erb
@@ -35,26 +35,27 @@
                    display_description: false))) %>
       <% end %>
     <% end %>
+    <% if participants.ects_mentored_by(mentor) %>
+      <h3 class="govuk-heading-s">
+        ECTs <span class="govuk-visually-hidden">mentored by <%= mentor.full_name %></span>
+      </h3>
 
-    <h3 class="govuk-heading-s">
-      ECTs <span class="govuk-visually-hidden">mentored by <%= mentor.full_name %></span>
-    </h3>
-
-    <%= govuk_summary_list(actions: false, borders: nil) do |list| %>
-      <% participants.ects_mentored_by(mentor).sort_by(&:full_name).each do |ect| %>
-        <% list.with_row do |row| %>
-          <% row.with_key(text: govuk_link_to("#{ect.full_name}",
-                                              school_participant_path(id: ect.participant_profile_id,
-                                                                      school_id: school.slug),
-                                              no_visited_state: true),
-                          classes: ["govuk-!-font-weight-regular", "govuk-\!-padding-bottom-static-0"]) %>
-          <% row.with_value(
-                 text: render(StatusTags::SchoolParticipantStatusTag.new(
-                     participant_profile: ect.participant_profile,
-                     induction_record: ect.induction_record,
-                     display_description: false,
-                     display_induction_start_date: true)),
-                 classes: ["govuk-\!-padding-bottom-static-0"]) %>
+      <%= govuk_summary_list(actions: false, borders: nil) do |list| %>
+        <% participants.ects_mentored_by(mentor).sort_by(&:full_name).each do |ect| %>
+          <% list.with_row do |row| %>
+            <% row.with_key(text: govuk_link_to("#{ect.full_name}",
+                                                school_participant_path(id: ect.participant_profile_id,
+                                                                        school_id: school.slug),
+                                                no_visited_state: true),
+                            classes: ["govuk-!-font-weight-regular", "govuk-\!-padding-bottom-static-0"]) %>
+            <% row.with_value(
+                   text: render(StatusTags::SchoolParticipantStatusTag.new(
+                       participant_profile: ect.participant_profile,
+                       induction_record: ect.induction_record,
+                       display_description: false,
+                       display_induction_start_date: true)),
+                   classes: ["govuk-\!-padding-bottom-static-0"]) %>
+          <% end %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/schools/participants/_no_longer_training.html.erb
+++ b/app/views/schools/participants/_no_longer_training.html.erb
@@ -1,8 +1,8 @@
 <h3 class="govuk-heading-s">Not mentoring or being mentored</h3>
 
-<% if participants.not_mentoring_or_being_mentored.any? %>
+<% if participants.no_longer_training.any? %>
   <%= govuk_summary_list(actions: false, borders: nil) do |list| %>
-    <% participants.not_mentoring_or_being_mentored.sort_by(&:full_name).each do |participant| %>
+    <% participants.no_longer_training.sort_by(&:full_name).each do |participant| %>
       <% list.with_row do |row| %>
         <% row.with_key(text: govuk_link_to(participant.full_name,
                                        school_participant_path(id: participant.participant_profile_id,

--- a/config/locales/status_tags/school_participant_status.yml
+++ b/config/locales/status_tags/school_participant_status.yml
@@ -127,7 +127,7 @@ en:
       not_yet_mentoring:
         label: "NOT MENTORING"
         description: "The participant is not currently mentoring any ECTs."
-        colour: "turquoise"
+        colour: "purple"
 
       active_mentoring_ero:
         label: "MENTORING"

--- a/spec/features/schools/participant_dashboard/completed_induction_participants_spec.rb
+++ b/spec/features/schools/participant_dashboard/completed_induction_participants_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Manage currently training participants", js: true do
     given_i_am_taken_to_the_induction_dashboard
 
     when_i_navigate_to_participants_dashboard
-    then_i_see_the_participants_filter_with_counts(completed_induction: 2, no_longer_training: 2)
+    then_i_see_the_participants_filter_with_counts(completed_induction: 2, currently_training: 2)
     when_i_filter_by("Completed induction (2)")
     then_i_see_the_participants_filtered_by("Completed Induction")
     and_i_see_ects_with_induction_completed_sorted_by_decreasing_completion_date

--- a/spec/features/schools/participant_dashboard/manage_cip_participants_spec.rb
+++ b/spec/features/schools/participant_dashboard/manage_cip_participants_spec.rb
@@ -184,7 +184,6 @@ RSpec.describe "Manage CIP participants", js: true, with_feature_flags: { eligib
       given_i_am_on_the_cip_induction_dashboard
       and_i_click_on(Cohort.current.description)
       when_i_navigate_to_participants_dashboard
-      when_i_filter_by("No longer training (1)")
       when_i_click_on_the_participants_name "CFI Mentor"
       then_i_am_taken_to_view_details_page
       then_i_can_view_participant_with_status(:request_for_details_delivered)

--- a/spec/features/schools/participant_dashboard/no_longer_training_participants_spec.rb
+++ b/spec/features/schools/participant_dashboard/no_longer_training_participants_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe "Manage currently training participants", js: true do
     given_i_am_taken_to_the_induction_dashboard
 
     when_i_navigate_to_participants_dashboard
-    then_i_see_the_participants_filter_with_counts(currently_training: 2, no_longer_training: 2)
+    then_i_see_the_participants_filter_with_counts(currently_training: 4, no_longer_training: 1)
 
-    when_i_filter_by("No longer training (2)")
+    when_i_filter_by("No longer training (1)")
     then_i_see_the_participants_filtered_by("No Longer Training")
     and_i_see_mentors_not_training_and_ects_not_being_trained_sorted_by_name
 

--- a/spec/features/schools/participants/remove_from_cohort_spec.rb
+++ b/spec/features/schools/participants/remove_from_cohort_spec.rb
@@ -64,5 +64,8 @@ RSpec.describe "SIT removing participants from the cohort", js: true, with_featu
 
     click_on "Return to manage mentors and ECTs"
     expect(page).to have_no_content ineligible_user.full_name
+    when_i_select("No longer training")
+    click_on("Apply")
+    expect(page).to have_content ineligible_user.full_name
   end
 end

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -840,7 +840,7 @@ module ManageTrainingSteps
   alias_method :and_i_see_the_participants_filtered_by, :then_i_see_the_participants_filtered_by
 
   def and_i_see_mentors_not_training_and_ects_not_being_trained_sorted_by_name
-    expect(page).to have_content("Not mentoring or being mentored\nCFI Mentor WAITING FOR TRN\nDeferred participant TRAINING DEFERRED")
+    expect(page).to have_content("Not mentoring or being mentored\nDeferred participant TRAINING DEFERRED")
   end
 
   def and_i_see_ects_with_induction_completed_sorted_by_decreasing_completion_date

--- a/spec/services/dashboard/participants_spec.rb
+++ b/spec/services/dashboard/participants_spec.rb
@@ -59,13 +59,13 @@ RSpec.describe Dashboard::Participants do
     end
   end
 
-  describe "#not_mentoring_or_being_mentored" do
+  describe "#no_longer_training" do
     subject do
-      described_class.new(school: school_1, user:).not_mentoring_or_being_mentored.map(&:induction_record)
+      described_class.new(school: school_1, user:).no_longer_training.map(&:induction_record)
     end
 
     it "returns a unique entry per ect mentor not mentoring or ects not training" do
-      expect(subject).to contain_exactly(deferred_induction_record, not_mentoring_induction_record, transferred_induction_record)
+      expect(subject).to contain_exactly(deferred_induction_record, withdrawn_induction_record, transferred_induction_record)
     end
   end
 end


### PR DESCRIPTION
We need to update the participants dashboard so that:

No longer training:
- Mentors or ECTs who have been withdrawn 
- Mentors or ECTs who have been reported as leaving the school by the CURRENT SIT 
- Mentors or ECTs who have been reported as joining a new school AND the joining date provided by the NEW SIT has passed 

Currently training:
- Mentors without ECTs who do not fit the above "No longer training" criteria 
- If the "Mentor (A-Z)" sort order is selected, then all mentors should be listed alphabetically, even if they don't currently have any ECTs associated with them
- Mentors without ECTs should have a smaller card design, with no "ECTs" header or list, and a "Not mentoring" status label

### Context

- Ticket: CST-1968

### Changes proposed in this pull request
- Update the `InductionRecord.school_dashboard_relevant` scope to also include withdrawn participants
- Update the `Dashboard::Participants` class to:
  -  display the withdrawn ECTs and Mentors to the No longer training
  - move the active Mentors who have no mentees, from the "No longer training" to the "Currently training"
  - remove the redundant methods related to the `orphan_mentors`
  - refactor and reorganise parts of the code to make it more relevant to the new changes and easier to understand 

### Guidance to review
- Ensure the participants are displayed correctly based on the new criteria
- Check the filter counts are correct
- Check all mentors are sorted correctly
