### PR TITLE
Drop 'please' from error messages

### DIFF
--- a/app/forms/appropriate_body_selection_form.rb
+++ b/app/forms/appropriate_body_selection_form.rb
@@ -15,14 +15,14 @@ class AppropriateBodySelectionForm
 
   validates :body_appointed,
             inclusion: { in: %w[yes no],
-                         message: "Please select whether you have appointed an appropriate body or not" },
+                         message: "Select whether you have appointed an appropriate body or not" },
             on: :body_appointed
   validates :body_type,
-            presence: { message: "Please select an appropriate body type" },
+            presence: { message: "Select an appropriate body type" },
             on: :body_type,
             inclusion: { in: %w[local_authority national teaching_school_hub unknown],
-                         message: "Please select an appropriate body type" }
-  validates :body_id, presence: { message: "Please select an appropriate body" }, on: :body
+                         message: "Select an appropriate body type" }
+  validates :body_id, presence: { message: "Select an appropriate body" }, on: :body
 
   def attributes
     {

--- a/app/forms/appropriate_body_selection_form.rb
+++ b/app/forms/appropriate_body_selection_form.rb
@@ -15,7 +15,7 @@ class AppropriateBodySelectionForm
 
   validates :body_appointed,
             inclusion: { in: %w[yes no],
-                         message: "Select whether you have appointed an appropriate body or not" },
+                         message: "Select whether you’ve appointed an appropriate body or not" },
             on: :body_appointed
   validates :body_type,
             presence: { message: "Select an appropriate body type" },

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -31,7 +31,7 @@ en:
       failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
       success: "Successfully authenticated from %{kind} account."
     passwords:
-      no_token: "You can’t access this page without coming from a password reset email. If you do come from a password reset email, make sure you used the full URL provided."
+      no_token: "You cannot access this page unless you received a password reset email. If you did receive a password reset email, make sure you used the full URL provided."
       send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
       send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
       updated: "Your password has been changed successfully. You are now signed in."

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -13,7 +13,7 @@ en:
       locked: "Your account is locked."
       last_attempt: "You have one more attempt before your account is locked."
       not_found_in_database: "Invalid %{authentication_keys}."
-      timeout: "Your session expired. Please sign in again to continue."
+      timeout: "Your session expired. Sign in again to continue."
       unauthenticated: "You need to sign in or sign up before continuing."
       unconfirmed: "You have to confirm your email address before continuing."
     mailer:
@@ -31,7 +31,7 @@ en:
       failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
       success: "Successfully authenticated from %{kind} account."
     passwords:
-      no_token: "You can’t access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+      no_token: "You can’t access this page without coming from a password reset email. If you do come from a password reset email, make sure you used the full URL provided."
       send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
       send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
       updated: "Your password has been changed successfully. You are now signed in."
@@ -41,8 +41,8 @@ en:
       signed_up: "Welcome! You have signed up successfully."
       signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
       signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
-      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
-      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirmation link to confirm your new email address."
+      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Follow the link to activate your account."
+      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Check your email and follow the confirmation link to confirm your new email address."
       updated: "Your account has been updated successfully."
       updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again"
     sessions:
@@ -52,7 +52,7 @@ en:
     unlocks:
       send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
       send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
-      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+      unlocked: "Your account has been unlocked successfully. Sign in to continue."
   errors:
     messages:
       already_confirmed: "was already confirmed, please try signing in"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -146,7 +146,7 @@ en:
       invalid: The property '#/participant_id' must have a valid UUID format
     cpd_lead_provider: &cpd_lead_provider_error_messages
       blank: The lead provider must be present
-    select_file: "Please select a CSV file to upload."
+    select_file: "Select a CSV file to upload."
     supplier:
       blank: "Select one"
     mentor:
@@ -193,9 +193,9 @@ en:
       blank: "Not registered"
       not_active: "Not active"
     programme:
-      blank: "Please select programme type"
+      blank: "Select programme type"
     provider:
-      blank: "Please select a provider"
+      blank: "Select a provider"
     national_insurance_number:
       blank: Enter the national insurance number (NINo)
       invalid: Enter a National Insurance number in the correct format
@@ -277,8 +277,8 @@ en:
             transfer_choice:
               blank: "Select which programme the participant will join"
             start_date:
-              blank: "Please enter a start date"
-              invalid: "Please enter a valid start date"
+              blank: "Enter a start date"
+              invalid: "Enter a valid start date"
               before_start: "Start date cannot be before the current induction record start (%{date})"
             email:
               <<: *email_error_messages
@@ -293,13 +293,13 @@ en:
         admin/application_exports_form:
           attributes:
             start_date:
-              blank: "Please enter a start date"
-              invalid: "Please enter a valid start date"
+              blank: "Enter a start date"
+              invalid: "Enter a valid start date"
               in_future: "Start date cannot be in the future"
               before_relaunch_date: "Start date must be after 6th June 2022"
             end_date:
-              blank: "Please enter an end date"
-              invalid: "Please enter a valid end date"
+              blank: "Enter an end date"
+              invalid: "Enter a valid end date"
               in_future: "End date cannot be in the future"
               before_start_date: "End date must be after start date"
         induction/amend_participant_cohort:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -193,7 +193,7 @@ en:
       blank: "Not registered"
       not_active: "Not active"
     programme:
-      blank: "Select programme type"
+      blank: "Select a programme type"
     provider:
       blank: "Select a provider"
     national_insurance_number:

--- a/spec/features/admin/npq_applications/export_spec.rb
+++ b/spec/features/admin/npq_applications/export_spec.rb
@@ -63,8 +63,8 @@ RSpec.feature "Admin NPQ Application export system", js: true, rutabaga: false d
     then_i_should_be_on the_npq_applications_exports_page
     and_the_page_should_be_accessible
 
-    then_i_see_an_error_message("Please enter a valid start date")
-    then_i_see_an_error_message("Please enter a valid end date")
+    then_i_see_an_error_message("Enter a valid start date")
+    then_i_see_an_error_message("Enter a valid end date")
   end
 
   scenario "Admin enters no dates" do
@@ -82,8 +82,8 @@ RSpec.feature "Admin NPQ Application export system", js: true, rutabaga: false d
     then_i_should_be_on the_npq_applications_exports_page
     and_the_page_should_be_accessible
 
-    then_i_see_an_error_message("Please enter a start date")
-    then_i_see_an_error_message("Please enter an end date")
+    then_i_see_an_error_message("Enter a start date")
+    then_i_see_an_error_message("Enter an end date")
   end
 
   scenario "Admin enters an end date before start date" do

--- a/spec/features/finance/banding_tracker_spec.rb
+++ b/spec/features/finance/banding_tracker_spec.rb
@@ -72,7 +72,7 @@ RSpec.feature "Banding tracker", type: :feature, js: true do
     click_on "Continue"
 
     within "ul.govuk-error-summary__list" do
-      expect(page).to have_link("Please select a provider", href: "#finance-banding-tracker-choose-provider-id-field-error")
+      expect(page).to have_link("Select a provider", href: "#finance-banding-tracker-choose-provider-id-field-error")
     end
 
     choose "Lead provider name"

--- a/spec/requests/lead_providers/report_schools/csv_spec.rb
+++ b/spec/requests/lead_providers/report_schools/csv_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Lead Provider school reporting: uploading csv", type: :request d
         post "/lead-providers/report-schools/csv", params: {}
 
         expect(response).to render_template :show
-        expect(response.body).to include("Please select a CSV file to upload")
+        expect(response.body).to include("Select a CSV file to upload")
       end
     end
 

--- a/spec/requests/lead_providers/report_schools/csv_spec.rb
+++ b/spec/requests/lead_providers/report_schools/csv_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Lead Provider school reporting: uploading csv", type: :request d
   describe "POST /lead-providers/report-schools/csv" do
     context "with no file selected" do
       it "renders :new with error message" do
-        expect_any_instance_of(AnalyticsDataLayer).to receive(:add).with(csv_file_errors: %w[please_select_a_csv_file_to_upload])
+        expect_any_instance_of(AnalyticsDataLayer).to receive(:add).with(csv_file_errors: %w[select_a_csv_file_to_upload])
 
         post "/lead-providers/report-schools/csv", params: {}
 


### PR DESCRIPTION
The [GOV.UK Design System guidance for error messages](https://design-system.service.gov.uk/components/error-message/) is:

> Be clear and concise
> Do not use ‘please’ because it implies a choice