### PR TITLE
Change name hint to use regular hint pattern

### DIFF
--- a/app/views/schools/add_participants/name.html.erb
+++ b/app/views/schools/add_participants/name.html.erb
@@ -14,10 +14,9 @@
     <%= form_with model: @form, url: url_for(action: :update), scope: @wizard.form_scope, method: :put do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_text_field :full_name, width: "three-quarters",
-        label: { text: full_name_label, tag: :h1, size: 'xl', class: "govuk-!-margin-bottom-8" },
-        caption: { text: @school.name, size: 'xl' } do %>
-        <p class="govuk-body">We just need their first name and last name, not titles like Mr, Mrs, Dr.</p>
-      <% end %>
+        label: { text: full_name_label, tag: :h1, size: 'xl' },
+        caption: { text: @school.name, size: 'xl' },
+        hint: { text: "We just need their first name and last name, not titles like Mr, Mrs, Dr." } %>
       <%= f.govuk_submit "Continue" %>
     <% end %>
   </div>


### PR DESCRIPTION
The hint for the name field should use the regular hint pattern, with dark grey text, and a smaller gap.

### Before

<img width="1002" alt="Screenshot 2023-09-26 at 15 01 33" src="https://github.com/DFE-Digital/early-careers-framework/assets/30665/cf2b17af-95ca-454a-95a2-a6ff571e6f10">

### After

<img width="1000" alt="Screenshot 2023-09-26 at 15 02 16" src="https://github.com/DFE-Digital/early-careers-framework/assets/30665/fd01b1a7-66fc-4f86-8ceb-2513c433ca5e">