### PR TITLE
[Bug-fix] Make validation changes return to validation tab

### DIFF
--- a/app/controllers/admin/participants/validation_data_controller.rb
+++ b/app/controllers/admin/participants/validation_data_controller.rb
@@ -75,7 +75,7 @@ module Admin::Participants
     end
 
     def validation_page
-      admin_participant_path(@participant_profile, anchor: "validation-data")
+      admin_participant_validation_data_path(@participant_profile)
     end
 
     def has_npq_profile?

--- a/spec/requests/admin/participants/change_validation_data_spec.rb
+++ b/spec/requests/admin/participants/change_validation_data_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Admin::Participants::ValidationDataController", type: :request d
     end
 
     it "validates the validation data" do
-      expect(response).to redirect_to("/admin/participants/#{ect_profile.id}#validation-data")
+      expect(response).to redirect_to("/admin/participants/#{ect_profile.id}/validation-data")
     end
 
     it "clears the TRN prior to validation" do


### PR DESCRIPTION
### Context

Originally, changing a participant's validation data item returned you to the validation tab. When the tab component changed to use page paths instead of anchors this was missed.  This PR returns you to the validation data tab after making a change.

### Changes proposed in this pull request
Use the path instead of the anchor for validation data tab.

### Guidance to review
As an admin, select a participant that has not validated (ie. contacted for information status), go to the validation data tab and add/change one of the validation data items. You should be returned to the validation data tab not the details tab.
