### PR TITLE
Fix school cohort rendering bug

### DIFF
--- a/app/components/admin/schools/cohort_component.rb
+++ b/app/components/admin/schools/cohort_component.rb
@@ -58,7 +58,7 @@ module Admin
       end
 
       def has_partnerships_or_relationships?
-        partnerships.present? && relationships.present?
+        partnerships.present? || relationships.present?
       end
 
       def cip?

--- a/spec/components/admin/schools/cohort_component_spec.rb
+++ b/spec/components/admin/schools/cohort_component_spec.rb
@@ -136,12 +136,12 @@ RSpec.describe Admin::Schools::CohortComponent, type: :component do
 
       context "when there is a partnership but no relationships" do
         let(:relationships) { nil }
-        it { is_expected.not_to have_partnerships_or_relationships }
+        it { is_expected.to have_partnerships_or_relationships }
       end
 
       context "when there are relationships but no partnership" do
         let(:partnership) { nil }
-        it { is_expected.not_to have_partnerships_or_relationships }
+        it { is_expected.to have_partnerships_or_relationships }
       end
 
       context "when there is no partnership and there are no relationships" do


### PR DESCRIPTION
### Context

The `#has_partnerships_or_relationships?` method incorrectly required both parnerships and relationships to be present but should return true when either is 🤦
