### PR TITLE
[CST-2025] Show CIP materials on CIP induction records

### DIFF
--- a/app/views/admin/participants/induction_records/show.html.erb
+++ b/app/views/admin/participants/induction_records/show.html.erb
@@ -75,8 +75,8 @@
           end
         elsif induction_record.enrolled_in_cip?
           sl.with_row do |row|
-            row.with_key(text: "Core materials provider")
-            row.with_value(text: induction_record.core_induction_programme_name || "No materials provider")
+            row.with_key(text: "Materials supplier")
+            row.with_value(text: induction_record.core_induction_programme_name || "No materials supplier")
           end
         end
 

--- a/app/views/admin/participants/induction_records/show.html.erb
+++ b/app/views/admin/participants/induction_records/show.html.erb
@@ -56,20 +56,27 @@
           row.with_value(text: induction_programme_friendly_name(induction_record.training_programme))
         end
 
-        sl.with_row do |row|
-          row.with_key(text: "Lead provider")
-          row.with_value(text: induction_record.lead_provider_name || "No lead provider")
-        end
-
-        sl.with_row do |row|
-          row.with_key(text: "Delivery partner")
-          row.with_value(text: induction_record.delivery_partner_name || "No delivery partner")
-        end
-
-        if induction_record.delivery_partner.present?
+        if induction_record.enrolled_in_fip?
           sl.with_row do |row|
-            row.with_key(text: "Delivery partner record state")
-            row.with_value(text: render(StatusTags::DeliveryPartnerParticipantStatusTag.new(participant_profile: induction_record.participant_profile, induction_record: induction_record)))
+            row.with_key(text: "Lead provider")
+            row.with_value(text: induction_record.lead_provider_name || "No lead provider")
+          end
+
+          sl.with_row do |row|
+            row.with_key(text: "Delivery partner")
+            row.with_value(text: induction_record.delivery_partner_name || "No delivery partner")
+          end
+
+          if induction_record.delivery_partner.present?
+            sl.with_row do |row|
+              row.with_key(text: "Delivery partner record state")
+              row.with_value(text: render(StatusTags::DeliveryPartnerParticipantStatusTag.new(participant_profile: induction_record.participant_profile, induction_record: induction_record)))
+            end
+          end
+        elsif induction_record.enrolled_in_cip?
+          sl.with_row do |row|
+            row.with_key(text: "Core materials provider")
+            row.with_value(text: induction_record.core_induction_programme_name || "No materials provider")
           end
         end
 


### PR DESCRIPTION
### Context

On the admin UI when looking at a participant's induction record the LP/DP is always present and the CIP materials never show even if the induction record is a CIP one.  I've added a condition to only show the LP/DP details when FIP and show CIP materials when CIP instead.

### Changes proposed in this pull request
Show CIP materials on CIP induction records and FIP LP/DP on FIP induction records

### Guidance to review

### Example CIP IR
![image](https://github.com/DFE-Digital/early-careers-framework/assets/333931/6bfea9ad-ac97-4878-b83b-2f252d4e581a)
### Example FIP IR
![image](https://github.com/DFE-Digital/early-careers-framework/assets/333931/4c6d9cff-8a99-4ad2-b32e-4129b87c0803)
