### PR TITLE
Spike - Convert training state to Ruby (centralised query)

### DIFF
--- a/app/controllers/admin/npq/applications/eligibility_status_controller.rb
+++ b/app/controllers/admin/npq/applications/eligibility_status_controller.rb
@@ -26,7 +26,7 @@ module Admin
 
             flash[:success] = {
               title: "#{name} updated",
-              content: "#{name} has been marked '#{@npq_application.funding_eligiblity_status_code.humanize.downcase}'",
+              content: "#{name} has been marked '#{@npq_application.funding_eligiblity_status_code.to_s.humanize.downcase}'",
             }
           else
             flash[:alert] = "Failed to save new status"

--- a/app/controllers/admin/npq/applications/eligible_for_funding_controller.rb
+++ b/app/controllers/admin/npq/applications/eligible_for_funding_controller.rb
@@ -27,7 +27,7 @@ module Admin
             update_admin_signatures if @npq_application.saved_change_to_eligible_for_funding?
             flash[:success] = {
               title: "#{name} updated",
-              content: "#{name} has been marked '#{@npq_application.funding_eligiblity_status_code.humanize.downcase}'",
+              content: "#{name} has been marked '#{@npq_application.funding_eligiblity_status_code.to_s.humanize.downcase}'",
             }
           else
             flash[:alert] = "Failed to save new elgibility"

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -29,6 +29,10 @@ class Email < ApplicationRecord
     status == "delivered"
   end
 
+  def submitted?
+    status == "submitted"
+  end
+
   def failed?
     status.in? FAILED_STATUSES
   end

--- a/app/services/determine_training_record_state.rb
+++ b/app/services/determine_training_record_state.rb
@@ -1,558 +1,75 @@
 # frozen_string_literal: true
 
-# noinspection RubyTooManyMethodsInspection, RubyTooManyInstanceVariablesInspection, RubyInstanceMethodNamingConvention
-
-# DetermineTrainingRecordState returns a DetermineTrainingRecordState::Record for a given participant that
-# contains the provided IDs along with the following states which can have the nested values:
-#
-# validation_state:
-#   different_trn
-#   internal_error
-#   request_for_details_delivered
-#   request_for_details_failed
-#   request_for_details_submitted
-#   tra_record_not_found
-#   valid
-#   validation_not_started
-#
-# training_eligibility_state:
-#   active_flags
-#   checks_not_complete
-#   duplicate_profile
-#   eligible_for_induction_training
-#   eligible_for_mentor_training
-#   exempt_from_induction
-#   not_allowed
-#   not_qualified
-#   not_yet_mentoring
-#   previous_induction
-#   tra_record_not_found
-#
-# fip_funding_eligibility_state:
-#   active_flags
-#   checks_not_complete
-#   duplicate_profile
-#   eligible_for_fip_funding
-#   eligible_for_mentor_funding
-#   eligible_for_mentor_funding_primary
-#   exempt_from_induction
-#   ineligible_ero
-#   ineligible_ero_primary
-#   ineligible_ero_secondary
-#   ineligible_secondary
-#   no_induction_start
-#   not_allowed
-#   not_qualified
-#   previous_induction
-#   tra_record_not_found
-#
-# mentoring_state:
-#   active_mentoring
-#   active_mentoring_ero
-#   not_a_mentor
-#   not_yet_mentoring
-#   not_yet_mentoring_ero
-#
-# training_state:
-#   active_cip_training
-#   active_diy_training
-#   active_fip_training
-#   completed_training
-#   deferred_training
-#   joining
-#   leaving
-#   left
-#   no_longer_involved
-#   not_registered_for_training
-#   registered_for_cip_training
-#   registered_for_diy_training
-#   registered_for_fip_no_partner
-#   registered_for_fip_training
-#   withdrawn_programme
-#   withdrawn_training
-#
-# record_state:
-#   active_cip_training
-#   active_diy_training
-#   active_fip_training
-#   active_flags
-#   active_mentoring
-#   active_mentoring_ero
-#   checks_not_complete
-#   completed_training
-#   deferred_training
-#   different_trn
-#   duplicate_profile
-#   exempt_from_induction
-#   internal_error
-#   joining
-#   leaving
-#   left
-#   no_induction_start
-#   no_longer_involved
-#   not_allowed
-#   not_qualified
-#   not_registered_for_training
-#   not_yet_mentoring
-#   not_yet_mentoring_ero
-#   previous_induction
-#   registered_for_cip_training
-#   registered_for_diy_training
-#   registered_for_fip_no_partner
-#   registered_for_fip_training
-#   request_for_details_delivered
-#   request_for_details_failed
-#   request_for_details_submitted
-#   tra_record_not_found
-#   validation_not_started
-#   withdrawn_programme
-#   withdrawn_training
 class DetermineTrainingRecordState < BaseService
-  attr_reader :participant_profile, :induction_record, :latest_request_for_details
-
-  RECORD_STATES = %w[
-    different_trn
-    request_for_details_delivered
-    request_for_details_failed
-    request_for_details_submitted
-    validation_not_started
-    internal_error
-    tra_record_not_found
-    checks_not_complete
-    active_flags
-    not_allowed
-    duplicate_profile
-    not_qualified
-    exempt_from_induction
-    previous_induction
-    no_induction_start
-    active_mentoring_ero
-    active_mentoring
-    not_yet_mentoring_ero
-    not_yet_mentoring
-    no_longer_involved
-    leaving
-    left
-    joining
-    withdrawn_programme
-    withdrawn_training
-    deferred_training
-    completed_training
-    registered_for_fip_no_partner
-    active_fip_training
-    registered_for_fip_training
-    registered_for_cip_training
-    active_cip_training
-    active_diy_training
-    registered_for_diy_training
-    not_registered_for_training
-  ].each_with_object({}) { |v, h| h[v] = v }.freeze
-
-  Record = Struct.new(
-    :validation_state,
-    :training_eligibility_state,
-    :fip_funding_eligibility_state,
-    :mentoring_state,
-    :training_state,
-    :record_state,
-    keyword_init: true,
-  ) do
-    def validation_status_valid?
-      validation_state == :valid
-    end
-  end
+  attr_reader :participant_profiles, :induction_records, :delivery_partner, :appropriate_body, :school
 
   def call
-    Record.new(
-      validation_state:,
-      mentoring_state:,
-      training_eligibility_state:,
-      fip_funding_eligibility_state:,
-      training_state:,
-      record_state:,
-    )
+    participant_profiles.reduce({}) do |hash, participant_profile|
+      induction_record = induction_records.find { |ir| ir.participant_profile_id = participant_profile.id }
+      hash[participant_profile.id] = TrainingRecordState.new(participant_profile:, induction_record:)
+    end
   end
 
 private
 
-  def initialize(participant_profile:, induction_record: nil, delivery_partner: nil, appropriate_body: nil, school: nil)
-    unless participant_profile.is_a? ParticipantProfile
-      raise ArgumentError, "Expected a ParticipantProfile, got #{participant_profile.class}"
+  def initialize(participant_profiles:, induction_records: nil, delivery_partner: nil, appropriate_body: nil, school: nil)
+    @participant_profiles = participant_profiles
+      .joins("LEFT JOIN email_associations ON email_associations.object_id = participant_profiles.id")
+      .joins("LEFT JOIN emails ON emails.id = email_associations.email_id AND 'request_for_details' = ANY (tags)")
+      .select(
+        "participant_profiles.*",
+        "emails.status AS transient_request_for_details_status",
+        "EXISTS (
+          SELECT 1 FROM induction_records as mir
+            WHERE mir.mentor_profile_id = participant_profiles.id
+          ) AS transient_mentees",
+        "EXISTS (
+          SELECT 1 FROM induction_records as cmir
+            WHERE cmir.mentor_profile_id = participant_profiles.id
+              AND (cmir.induction_status = 'active' OR cmir.induction_status = 'leaving')
+          ) AS transient_current_mentees",
+      )
+    @delivery_partner = delivery_partner
+    @appropriate_body = appropriate_body
+    @school = school
+    @induction_records = induction_records || query_latest_induction_records
+  end
+
+  def query_latest_induction_records
+    query = InductionRecord
+      .joins("JOIN (#{latest_induction_records_join.to_sql}) AS latest_induction_records ON latest_induction_records.latest_id = induction_records.id")
+
+    if school.present? || appropriate_body.present?
+      school_cohorts = {
+        school:,
+        appropriate_body:,
+      }.compact_blank
+
+      query.joins(induction_programme: :school_cohort).where(induction_programme: { school_cohorts: })
     end
 
-    @participant_profile = participant_profile
-
-    if participant_profile.ecf?
-      unless induction_record.nil? || induction_record.is_a?(InductionRecord)
-        raise ArgumentError, "Expected an InductionRecord, got #{induction_record.class}"
-      end
-
-      unless delivery_partner.nil? || delivery_partner.is_a?(DeliveryPartner)
-        raise ArgumentError, "Expected a DeliveryPartner, got #{delivery_partner.class}"
-      end
-
-      unless appropriate_body.nil? || appropriate_body.is_a?(AppropriateBody)
-        raise ArgumentError, "Expected a AppropriateBody, got #{appropriate_body.class}"
-      end
-
-      unless school.nil? || school.is_a?(School)
-        raise ArgumentError, "Expected a School, got #{school.class}"
-      end
-
-      @induction_record = induction_record || Induction::FindBy.call(participant_profile:, delivery_partner:, appropriate_body:, school:)
-      @latest_request_for_details = Email.associated_with(participant_profile).tagged_with(:request_for_details).select(:status).latest
+    if delivery_partner.present?
+      query.joins(induction_programme: :partnership).where(induction_programme: { partnerships: { delivery_partner: } })
     end
+
+    query
   end
 
-  def record_state
-    return training_state if withdrawn_participant? || (transitioning_or_not_currently_training? && !mentor?)
-    return validation_state unless validation_status_valid?
-    return training_eligibility_state unless eligible_for_training?
-    return fip_funding_eligibility_state if on_fip? && !applicable_funding_state?
-    return mentoring_state if mentor?
-
-    training_state
+  def latest_induction_records_join
+    InductionRecord
+      .select(Arel.sql("DISTINCT FIRST_VALUE(induction_records.id) OVER (#{latest_induction_record_order}) AS latest_id"))
   end
 
-  def validation_state
-    @validation_state ||= begin
-      return :different_trn if manual_check_different_trn?
-
-      return :request_for_details_delivered if request_for_details_delivered?
-      return :request_for_details_failed if request_for_details_failed?
-      return :request_for_details_submitted if request_for_details_submitted?
-
-      return :validation_not_started if awaiting_validation_data?
-
-      return :internal_error if validation_api_failed?
-      return :tra_record_not_found if no_tra_record_found?
-
-      :valid
-    end
-  end
-
-  def training_eligibility_state
-    @training_eligibility_state ||= begin
-      return :checks_not_complete if eligibility_not_checked?
-
-      return :active_flags if manual_check_active_flags?
-      return :not_allowed if ineligible_active_flags?
-
-      return :eligible_for_mentor_training if mentored?
-      return :not_yet_mentoring if mentor?
-
-      return :duplicate_profile if ineligible_duplicate_profile?
-      return :not_qualified if manual_check_no_qts?
-
-      return :exempt_from_induction if ineligible_exempt_from_induction?
-      return :previous_induction if ineligible_previous_induction?
-
-      return :tra_record_not_found if no_tra_record_found?
-
-      :eligible_for_induction_training
-    end
-  end
-
-  def fip_funding_eligibility_state
-    @fip_funding_eligibility_state ||= begin
-      return :checks_not_complete if eligibility_not_checked?
-
-      return :eligible_for_fip_funding if eligible? && !mentor?
-
-      unless eligible? && mentor?
-        return :active_flags if manual_check_active_flags?
-        return :not_allowed if ineligible_active_flags?
-      end
-
-      if mentor?
-        if ineligible_previous_participation?
-          return :ineligible_ero_secondary if secondary_profile? || ineligible_duplicate_profile?
-          return :ineligible_ero_primary if primary_profile?
-
-          return :ineligible_ero
-        end
-
-        return :ineligible_secondary if secondary_profile? || ineligible_duplicate_profile?
-        return :eligible_for_mentor_funding_primary if primary_profile?
-
-        return :eligible_for_mentor_funding
-      end
-
-      return :duplicate_profile if ineligible_duplicate_profile?
-      return :no_induction_start if manual_check_no_induction?
-      return :not_qualified if manual_check_no_qts?
-
-      return :exempt_from_induction if ineligible_exempt_from_induction?
-      return :previous_induction if ineligible_previous_induction?
-
-      return :tra_record_not_found if no_tra_record_found?
-
-      :eligible_for_fip_funding
-    end
-  end
-
-  def training_state
-    @training_state ||= begin
-      return :no_longer_involved if changed_training?
-      return :leaving if is_leaving_school?
-      return :left if has_left_school?
-      return :joining if is_joining_school?
-
-      return :withdrawn_programme if withdrawn_participant?
-      return :withdrawn_training if withdrawn_training?
-      return :deferred_training if deferred_training?
-      return :completed_training if completed_training?
-
-      ect_training_state
-    end
-  end
-
-  def mentoring_state
-    @mentoring_state ||= begin
-      return :not_a_mentor unless mentor?
-
-      if mentoring?
-        return :active_mentoring_ero if previous_participation?
-
-        :active_mentoring
-      else
-        return :not_yet_mentoring_ero if previous_participation?
-
-        :not_yet_mentoring
-      end
-    end
-  end
-
-  def ect_training_state
-    @ect_training_state ||= begin
-      if on_fip?
-        return :registered_for_fip_no_partner if no_partnership?
-        return :registered_for_fip_training unless induction_start_date_in_past?
-
-        return :active_fip_training
-      end
-
-      if on_cip?
-        return :registered_for_cip_training unless induction_start_date_in_past?
-
-        return :active_cip_training
-      end
-
-      if on_design_our_own?
-        return :registered_for_diy_training unless induction_start_date_in_past?
-
-        return :active_diy_training
-      end
-
-      :not_registered_for_training
-    end
-  end
-
-  def transitioning_or_not_currently_training?
-    %i[
-      withdrawn_training
-      deferred_training
-      completed_training
-      joining
-      leaving
-      left
-    ].include?(training_state)
-  end
-
-  def validation_status_valid?
-    validation_state == :valid
-  end
-
-  def eligible_for_training?
-    %i[
-      eligible_for_mentor_training
-      eligible_for_induction_training
-    ].include?(training_eligibility_state)
-  end
-
-  def applicable_funding_state?
-    %i[
-      eligible_for_mentor_funding
-      eligible_for_mentor_funding_primary
-      eligible_for_fip_funding
-      ineligible_secondary
-      ineligible_ero
-      ineligible_ero_primary
-      ineligible_ero_secondary
-    ].include?(fip_funding_eligibility_state)
-  end
-
-  def on_fip?
-    relevant_induction_programme&.full_induction_programme?
-  end
-
-  def on_cip?
-    relevant_induction_programme&.core_induction_programme?
-  end
-
-  def on_design_our_own?
-    relevant_induction_programme&.design_our_own?
-  end
-
-  def mentor?
-    participant_profile.mentor?
-  end
-
-  def mentoring?
-    @mentoring ||= mentor? && InductionRecord.current.where(mentor_profile_id: participant_profile.id).exists?
-  end
-
-  def mentored?
-    @mentored ||= mentor? && InductionRecord.where(mentor_profile_id: participant_profile.id).exists?
-  end
-
-  def primary_profile?
-    participant_profile.primary_profile?
-  end
-
-  def secondary_profile?
-    participant_profile.secondary_profile?
-  end
-
-  def sparsity_uplift?
-    participant_profile.sparsity_uplift
-  end
-
-  def pupil_premium_uplift?
-    participant_profile.pupil_premium_uplift
-  end
-
-  def uplift?
-    sparsity_uplift? || pupil_premium_uplift?
-  end
-
-  def eligibility_not_checked?
-    participant_profile.ecf_participant_eligibility.blank? && (participant_profile.ect? || participant_profile.teacher_profile&.trn.present?)
-  end
-
-  def eligible?
-    participant_profile.ecf_participant_eligibility&.eligible_status?
-  end
-
-  def eligible_no_qts?
-    eligible? && participant_profile.ecf_participant_eligibility&.no_qts_reason?
-  end
-
-  def ineligible?
-    participant_profile.ecf_participant_eligibility&.ineligible_status?
-  end
-
-  def ineligible_active_flags?
-    ineligible? && participant_profile.ecf_participant_eligibility&.active_flags_reason?
-  end
-
-  def ineligible_exempt_from_induction?
-    ineligible? && participant_profile.ecf_participant_eligibility&.exempt_from_induction_reason?
-  end
-
-  def ineligible_duplicate_profile?
-    ineligible? && participant_profile.ecf_participant_eligibility&.duplicate_profile_reason?
-  end
-
-  def ineligible_previous_induction?
-    ineligible? && participant_profile.ecf_participant_eligibility&.previous_induction_reason?
-  end
-
-  def ineligible_previous_participation?
-    ineligible? && participant_profile.ecf_participant_eligibility&.previous_participation_reason?
-  end
-
-  def previous_participation?
-    participant_profile.ecf_participant_eligibility&.previous_participation_reason?
-  end
-
-  def manual_checks?
-    participant_profile.ecf_participant_eligibility&.manual_check_status?
-  end
-
-  def manual_check_active_flags?
-    manual_checks? && participant_profile.ecf_participant_eligibility&.active_flags_reason?
-  end
-
-  def manual_check_different_trn?
-    manual_checks? && participant_profile.ecf_participant_eligibility&.different_trn_reason?
-  end
-
-  def manual_check_no_induction?
-    manual_checks? && participant_profile.ecf_participant_eligibility&.no_induction_reason?
-  end
-
-  def manual_check_no_qts?
-    manual_checks? && participant_profile.ecf_participant_eligibility&.no_qts_reason?
-  end
-
-  def induction_start_date_in_past?
-    participant_profile.induction_start_date&.past?
-  end
-
-  def awaiting_validation_data?
-    participant_profile.teacher_profile&.trn.nil? && participant_profile.ecf_participant_validation_data.blank?
-  end
-
-  def request_for_details_submitted?
-    awaiting_validation_data? && latest_request_for_details&.submitted?
-  end
-
-  def request_for_details_failed?
-    awaiting_validation_data? && latest_request_for_details&.failed?
-  end
-
-  def request_for_details_delivered?
-    awaiting_validation_data? && latest_request_for_details&.delivered?
-  end
-
-  def validation_api_failed?
-    participant_profile.ecf_participant_validation_data&.api_failure || false
-  end
-
-  def no_tra_record_found?
-    return participant_profile.teacher_profile&.trn.nil? unless mentor?
-
-    participant_profile.ecf_participant_validation_data&.trn.present? && participant_profile.teacher_profile&.trn.nil?
-  end
-
-  def no_partnership?
-    relevant_induction_programme&.partnership&.lead_provider.nil?
-  end
-
-  def relevant_induction_programme
-    @relevant_induction_programme ||= induction_record&.induction_programme || participant_profile.school_cohort&.default_induction_programme
-  end
-
-  def withdrawn_training?
-    induction_record.present? ? induction_record.training_status_withdrawn? : participant_profile.training_status_withdrawn?
-  end
-
-  def deferred_training?
-    induction_record.present? ? induction_record.training_status_deferred? : participant_profile.training_status_deferred?
-  end
-
-  def withdrawn_participant?
-    induction_record.present? ? induction_record.withdrawn_induction_status? : participant_profile.withdrawn_record?
-  end
-
-  def completed_training?
-    induction_record&.completed_induction_status?
-  end
-
-  def changed_training?
-    induction_record&.changed_induction_status?
-  end
-
-  def is_leaving_school?
-    induction_record&.leaving_induction_status? && induction_record&.end_date&.future?
-  end
-
-  def has_left_school?
-    induction_record&.leaving_induction_status? && induction_record&.end_date&.past?
-  end
-
-  def is_joining_school?
-    induction_record&.active_induction_status? && induction_record&.school_transfer && induction_record&.start_date&.future?
+  def latest_induction_record_order
+    <<~SQL
+      PARTITION BY induction_records.participant_profile_id ORDER BY
+        CASE
+          WHEN induction_records.end_date IS NULL
+            THEN 1
+          ELSE 2
+        END,
+        induction_records.start_date DESC,
+        induction_records.created_at DESC
+    SQL
   end
 end

--- a/app/services/induction/find_by.rb
+++ b/app/services/induction/find_by.rb
@@ -8,6 +8,7 @@
 # optional params:
 #   lead_provider: restricts search to a LeadProvider
 #   delivery_partner: restricts search to a DeliveryPartner
+#   appropriate_body: restricts search to an AppropriateBody
 #   schedule: restricts search to a Schedule
 #   school: restricts search to a School
 #   date_range: restrict search to a date range e.g. Date.new(2022, 9, 1)..Date.new(2022, 11, 1)
@@ -19,6 +20,7 @@ class Induction::FindBy < BaseService
     query = participant_profile.induction_records
 
     query = add_provider_to(query:) if lead_provider.present? || delivery_partner.present?
+    query = add_appropriate_body_to(query:) if appropriate_body.present?
     query = add_schedule_to(query:) if schedule.present?
     query = add_school_to(query:) if school.present?
     query = add_date_range_to(query:) if date_range.present?
@@ -29,12 +31,13 @@ class Induction::FindBy < BaseService
 
 private
 
-  attr_reader :participant_profile, :lead_provider, :delivery_partner, :schedule, :school, :date_range, :current_not_latest_record, :only_active_partnerships
+  attr_reader :participant_profile, :lead_provider, :delivery_partner, :appropriate_body, :schedule, :school, :date_range, :current_not_latest_record, :only_active_partnerships
 
-  def initialize(participant_profile:, lead_provider: nil, delivery_partner: nil, schedule: nil, school: nil, date_range: nil, current_not_latest_record: false, only_active_partnerships: false)
+  def initialize(participant_profile:, lead_provider: nil, delivery_partner: nil, appropriate_body: nil, schedule: nil, school: nil, date_range: nil, current_not_latest_record: false, only_active_partnerships: false)
     @participant_profile = participant_profile
     @lead_provider = lead_provider
     @delivery_partner = delivery_partner
+    @appropriate_body = appropriate_body
     @schedule = schedule
     @school = school
     @date_range = date_range
@@ -57,6 +60,10 @@ private
     end
 
     query.joins(induction_programme: :partnership).where(induction_programme: { partnerships: })
+  end
+
+  def add_appropriate_body_to(query:)
+    query.where(appropriate_body:)
   end
 
   def add_schedule_to(query:)

--- a/app/services/training_record_state.rb
+++ b/app/services/training_record_state.rb
@@ -1,0 +1,514 @@
+# frozen_string_literal: true
+
+# validation_state:
+#   different_trn
+#   internal_error
+#   request_for_details_delivered
+#   request_for_details_failed
+#   request_for_details_submitted
+#   tra_record_not_found
+#   valid
+#   validation_not_started
+#
+# training_eligibility_state:
+#   active_flags
+#   checks_not_complete
+#   duplicate_profile
+#   eligible_for_induction_training
+#   eligible_for_mentor_training
+#   exempt_from_induction
+#   not_allowed
+#   not_qualified
+#   not_yet_mentoring
+#   previous_induction
+#   tra_record_not_found
+#
+# fip_funding_eligibility_state:
+#   active_flags
+#   checks_not_complete
+#   duplicate_profile
+#   eligible_for_fip_funding
+#   eligible_for_mentor_funding
+#   eligible_for_mentor_funding_primary
+#   exempt_from_induction
+#   ineligible_ero
+#   ineligible_ero_primary
+#   ineligible_ero_secondary
+#   ineligible_secondary
+#   no_induction_start
+#   not_allowed
+#   not_qualified
+#   previous_induction
+#   tra_record_not_found
+#
+# mentoring_state:
+#   active_mentoring
+#   active_mentoring_ero
+#   not_a_mentor
+#   not_yet_mentoring
+#   not_yet_mentoring_ero
+#
+# training_state:
+#   active_cip_training
+#   active_diy_training
+#   active_fip_training
+#   completed_training
+#   deferred_training
+#   joining
+#   leaving
+#   left
+#   no_longer_involved
+#   not_registered_for_training
+#   registered_for_cip_training
+#   registered_for_diy_training
+#   registered_for_fip_no_partner
+#   registered_for_fip_training
+#   withdrawn_programme
+#   withdrawn_training
+#
+# record_state:
+#   active_cip_training
+#   active_diy_training
+#   active_fip_training
+#   active_flags
+#   active_mentoring
+#   active_mentoring_ero
+#   checks_not_complete
+#   completed_training
+#   deferred_training
+#   different_trn
+#   duplicate_profile
+#   exempt_from_induction
+#   internal_error
+#   joining
+#   leaving
+#   left
+#   no_induction_start
+#   no_longer_involved
+#   not_allowed
+#   not_qualified
+#   not_registered_for_training
+#   not_yet_mentoring
+#   not_yet_mentoring_ero
+#   previous_induction
+#   registered_for_cip_training
+#   registered_for_diy_training
+#   registered_for_fip_no_partner
+#   registered_for_fip_training
+#   request_for_details_delivered
+#   request_for_details_failed
+#   request_for_details_submitted
+#   tra_record_not_found
+#   validation_not_started
+#   withdrawn_programme
+#   withdrawn_training
+class TrainingRecordState
+  RECORD_STATES = %w[
+    different_trn
+    request_for_details_delivered
+    request_for_details_failed
+    request_for_details_submitted
+    validation_not_started
+    internal_error
+    tra_record_not_found
+    checks_not_complete
+    active_flags
+    not_allowed
+    duplicate_profile
+    not_qualified
+    exempt_from_induction
+    previous_induction
+    no_induction_start
+    active_mentoring_ero
+    active_mentoring
+    not_yet_mentoring_ero
+    not_yet_mentoring
+    no_longer_involved
+    leaving
+    left
+    joining
+    withdrawn_programme
+    withdrawn_training
+    deferred_training
+    completed_training
+    registered_for_fip_no_partner
+    active_fip_training
+    registered_for_fip_training
+    registered_for_cip_training
+    active_cip_training
+    active_diy_training
+    registered_for_diy_training
+    not_registered_for_training
+  ].each_with_object({}) { |v, h| h[v] = v }.freeze
+
+  attr_reader :induction_record, :participant_profile
+
+  delegate :id, to: :participant_profile, prefix: true
+
+  def initialize(participant_profile:, induction_record:)
+    @participant_profile = participant_profile
+    @induction_record = induction_record
+  end
+
+  def validation_state
+    @validation_state ||= begin
+      return :different_trn if manual_check_different_trn?
+
+      return :request_for_details_delivered if request_for_details_delivered?
+      return :request_for_details_failed if request_for_details_failed?
+      return :request_for_details_submitted if request_for_details_submitted?
+
+      return :validation_not_started if awaiting_validation_data?
+
+      return :internal_error if validation_api_failed?
+      return :tra_record_not_found if no_tra_record_found?
+
+      :valid
+    end
+  end
+
+  def training_eligibility_state
+    @training_eligibility_state ||= begin
+      return :checks_not_complete if eligibility_not_checked?
+
+      return :active_flags if manual_check_active_flags?
+      return :not_allowed if ineligible_active_flags?
+
+      return :eligible_for_mentor_training if mentored?
+      return :not_yet_mentoring if mentor?
+
+      return :duplicate_profile if ineligible_duplicate_profile?
+      return :not_qualified if manual_check_no_qts?
+
+      return :exempt_from_induction if ineligible_exempt_from_induction?
+      return :previous_induction if ineligible_previous_induction?
+
+      return :tra_record_not_found if no_tra_record_found?
+
+      :eligible_for_induction_training
+    end
+  end
+
+  def fip_funding_eligibility_state
+    @fip_funding_eligibility_state ||= begin
+      return :checks_not_complete if eligibility_not_checked?
+
+      return :eligible_for_fip_funding if eligible? && !mentor?
+
+      unless eligible? && mentor?
+        return :active_flags if manual_check_active_flags?
+        return :not_allowed if ineligible_active_flags?
+      end
+
+      if mentor?
+        if ineligible_previous_participation?
+          return :ineligible_ero_secondary if secondary_profile? || ineligible_duplicate_profile?
+          return :ineligible_ero_primary if primary_profile?
+
+          return :ineligible_ero
+        end
+
+        return :ineligible_secondary if secondary_profile? || ineligible_duplicate_profile?
+        return :eligible_for_mentor_funding_primary if primary_profile?
+
+        return :eligible_for_mentor_funding
+      end
+
+      return :duplicate_profile if ineligible_duplicate_profile?
+      return :no_induction_start if manual_check_no_induction?
+      return :not_qualified if manual_check_no_qts?
+
+      return :exempt_from_induction if ineligible_exempt_from_induction?
+      return :previous_induction if ineligible_previous_induction?
+
+      return :tra_record_not_found if no_tra_record_found?
+
+      :eligible_for_fip_funding
+    end
+  end
+
+  def training_state
+    @training_state ||= begin
+      return :no_longer_involved if changed_training?
+      return :leaving if is_leaving_school?
+      return :left if has_left_school?
+      return :joining if is_joining_school?
+
+      return :withdrawn_programme if withdrawn_participant?
+      return :withdrawn_training if withdrawn_training?
+      return :deferred_training if deferred_training?
+      return :completed_training if completed_training?
+
+      ect_training_state
+    end
+  end
+
+  def mentoring_state
+    @mentoring_state ||= begin
+      return :not_a_mentor unless mentor?
+
+      if mentoring?
+        return :active_mentoring_ero if previous_participation?
+
+        :active_mentoring
+      else
+        return :not_yet_mentoring_ero if previous_participation?
+
+        :not_yet_mentoring
+      end
+    end
+  end
+
+  def ect_training_state
+    @ect_training_state ||= begin
+      if on_fip?
+        return :registered_for_fip_no_partner if no_partnership?
+        return :registered_for_fip_training unless induction_start_date_in_past?
+
+        return :active_fip_training
+      end
+
+      if on_cip?
+        return :registered_for_cip_training unless induction_start_date_in_past?
+
+        return :active_cip_training
+      end
+
+      if on_design_our_own?
+        return :registered_for_diy_training unless induction_start_date_in_past?
+
+        return :active_diy_training
+      end
+
+      :not_registered_for_training
+    end
+  end
+
+  def record_state
+    @record_state ||= begin
+      return training_state if withdrawn_participant? || (transitioning_or_not_currently_training? && !mentor?)
+      return validation_state unless validation_status_valid?
+      return training_eligibility_state unless eligible_for_training?
+      return fip_funding_eligibility_state if on_fip? && !applicable_funding_state?
+      return mentoring_state if mentor?
+
+      training_state
+    end
+  end
+
+  def validation_status_valid?
+    validation_state == :valid
+  end
+
+private
+
+  def latest_request_for_details
+    return nil unless participant_profile.transient_request_for_details_status
+
+    Email.new(status: participant_profile.transient_request_for_details_status)
+  end
+
+  def mentoring?
+    @mentoring ||= mentor? && participant_profile.transient_current_mentees
+  end
+
+  def mentored?
+    @mentored ||= mentor? && participant_profile.transient_mentees
+  end
+
+  def transitioning_or_not_currently_training?
+    %i[
+      withdrawn_training
+      deferred_training
+      completed_training
+      joining
+      leaving
+      left
+    ].include?(training_state)
+  end
+
+  def eligible_for_training?
+    %i[
+      eligible_for_mentor_training
+      eligible_for_induction_training
+    ].include?(training_eligibility_state)
+  end
+
+  def applicable_funding_state?
+    %i[
+      eligible_for_mentor_funding
+      eligible_for_mentor_funding_primary
+      eligible_for_fip_funding
+      ineligible_secondary
+      ineligible_ero
+      ineligible_ero_primary
+      ineligible_ero_secondary
+    ].include?(fip_funding_eligibility_state)
+  end
+
+  def on_fip?
+    relevant_induction_programme&.full_induction_programme?
+  end
+
+  def on_cip?
+    relevant_induction_programme&.core_induction_programme?
+  end
+
+  def on_design_our_own?
+    relevant_induction_programme&.design_our_own?
+  end
+
+  def mentor?
+    participant_profile.mentor?
+  end
+
+  def primary_profile?
+    participant_profile.primary_profile?
+  end
+
+  def secondary_profile?
+    participant_profile.secondary_profile?
+  end
+
+  def sparsity_uplift?
+    participant_profile.sparsity_uplift
+  end
+
+  def pupil_premium_uplift?
+    participant_profile.pupil_premium_uplift
+  end
+
+  def uplift?
+    sparsity_uplift? || pupil_premium_uplift?
+  end
+
+  def eligibility_not_checked?
+    participant_profile.ecf_participant_eligibility.blank? && (participant_profile.ect? || participant_profile.teacher_profile&.trn.present?)
+  end
+
+  def eligible?
+    participant_profile.ecf_participant_eligibility&.eligible_status?
+  end
+
+  def eligible_no_qts?
+    eligible? && participant_profile.ecf_participant_eligibility&.no_qts_reason?
+  end
+
+  def ineligible?
+    participant_profile.ecf_participant_eligibility&.ineligible_status?
+  end
+
+  def ineligible_active_flags?
+    ineligible? && participant_profile.ecf_participant_eligibility&.active_flags_reason?
+  end
+
+  def ineligible_exempt_from_induction?
+    ineligible? && participant_profile.ecf_participant_eligibility&.exempt_from_induction_reason?
+  end
+
+  def ineligible_duplicate_profile?
+    ineligible? && participant_profile.ecf_participant_eligibility&.duplicate_profile_reason?
+  end
+
+  def ineligible_previous_induction?
+    ineligible? && participant_profile.ecf_participant_eligibility&.previous_induction_reason?
+  end
+
+  def ineligible_previous_participation?
+    ineligible? && participant_profile.ecf_participant_eligibility&.previous_participation_reason?
+  end
+
+  def previous_participation?
+    participant_profile.ecf_participant_eligibility&.previous_participation_reason?
+  end
+
+  def manual_checks?
+    participant_profile.ecf_participant_eligibility&.manual_check_status?
+  end
+
+  def manual_check_active_flags?
+    manual_checks? && participant_profile.ecf_participant_eligibility&.active_flags_reason?
+  end
+
+  def manual_check_different_trn?
+    manual_checks? && participant_profile.ecf_participant_eligibility&.different_trn_reason?
+  end
+
+  def manual_check_no_induction?
+    manual_checks? && participant_profile.ecf_participant_eligibility&.no_induction_reason?
+  end
+
+  def manual_check_no_qts?
+    manual_checks? && participant_profile.ecf_participant_eligibility&.no_qts_reason?
+  end
+
+  def induction_start_date_in_past?
+    participant_profile.induction_start_date&.past?
+  end
+
+  def awaiting_validation_data?
+    participant_profile.teacher_profile&.trn.nil? && participant_profile.ecf_participant_validation_data.blank?
+  end
+
+  def request_for_details_submitted?
+    awaiting_validation_data? && latest_request_for_details&.submitted?
+  end
+
+  def request_for_details_failed?
+    awaiting_validation_data? && latest_request_for_details&.failed?
+  end
+
+  def request_for_details_delivered?
+    awaiting_validation_data? && latest_request_for_details&.delivered?
+  end
+
+  def validation_api_failed?
+    participant_profile.ecf_participant_validation_data&.api_failure || false
+  end
+
+  def no_tra_record_found?
+    return participant_profile.teacher_profile&.trn.nil? unless mentor?
+
+    participant_profile.ecf_participant_validation_data&.trn.present? && participant_profile.teacher_profile&.trn.nil?
+  end
+
+  def no_partnership?
+    relevant_induction_programme&.partnership&.lead_provider.nil?
+  end
+
+  def relevant_induction_programme
+    @relevant_induction_programme ||= induction_record&.induction_programme || participant_profile.school_cohort&.default_induction_programme
+  end
+
+  def withdrawn_training?
+    induction_record.present? ? induction_record.training_status_withdrawn? : participant_profile.training_status_withdrawn?
+  end
+
+  def deferred_training?
+    induction_record.present? ? induction_record.training_status_deferred? : participant_profile.training_status_deferred?
+  end
+
+  def withdrawn_participant?
+    induction_record.present? ? induction_record.withdrawn_induction_status? : participant_profile.withdrawn_record?
+  end
+
+  def completed_training?
+    induction_record&.completed_induction_status?
+  end
+
+  def changed_training?
+    induction_record&.changed_induction_status?
+  end
+
+  def is_leaving_school?
+    induction_record&.leaving_induction_status? && induction_record&.end_date&.future?
+  end
+
+  def has_left_school?
+    induction_record&.leaving_induction_status? && induction_record&.end_date&.past?
+  end
+
+  def is_joining_school?
+    induction_record&.active_induction_status? && induction_record&.school_transfer && induction_record&.start_date&.future?
+  end
+end

--- a/app/views/admin/participants/statuses/show.html.erb
+++ b/app/views/admin/participants/statuses/show.html.erb
@@ -86,27 +86,27 @@
 <%= govuk_summary_list(actions: true) do |sl|
   sl.with_row do |row|
     row.with_key(text: "Validation status")
-    row.with_value(text: govuk_tag(text: states.validation_state.humanize, colour: "grey"))
+    row.with_value(text: govuk_tag(text: states.validation_state.to_s.humanize, colour: "grey"))
   end
 
   sl.with_row do |row|
     row.with_key(text: "Training eligibility status")
-    row.with_value(text: govuk_tag(text: states.training_eligibility_state.humanize, colour: "grey"))
+    row.with_value(text: govuk_tag(text: states.training_eligibility_state.to_s.humanize, colour: "grey"))
   end
 
   sl.with_row do |row|
     row.with_key(text: "FIP funding eligibility status")
-    row.with_value(text: govuk_tag(text: states.fip_funding_eligibility_state.humanize, colour: "grey"))
+    row.with_value(text: govuk_tag(text: states.fip_funding_eligibility_state.to_s.humanize, colour: "grey"))
   end
 
   sl.with_row do |row|
     row.with_key(text: "Mentoring status")
-    row.with_value(text: govuk_tag(text: states.mentoring_state.humanize, colour: "grey"))
+    row.with_value(text: govuk_tag(text: states.mentoring_state.to_s.humanize, colour: "grey"))
   end
 
   sl.with_row do |row|
     row.with_key(text: "Training status")
-    row.with_value(text: govuk_tag(text: states.training_state.humanize, colour: "grey"))
+    row.with_value(text: govuk_tag(text: states.training_state.to_s.humanize, colour: "grey"))
   end
 end %>
 

--- a/spec/models/email_spec.rb
+++ b/spec/models/email_spec.rb
@@ -9,6 +9,34 @@ RSpec.describe Email, type: :model do
     it { is_expected.to have_many(:associations) }
   end
 
+  describe "status fields" do
+    context "when status is submitted" do
+      subject(:email) { described_class.create!(status: "submitted") }
+
+      it { is_expected.to be_submitted }
+      it { is_expected.not_to be_delivered }
+      it { is_expected.not_to be_failed }
+    end
+
+    context "when status is delivered" do
+      subject(:email) { described_class.create!(status: "delivered") }
+
+      it { is_expected.to be_delivered }
+      it { is_expected.not_to be_submitted }
+      it { is_expected.not_to be_failed }
+    end
+
+    Email::FAILED_STATUSES.each do |status|
+      context "when status is #{status}" do
+        subject(:email) { described_class.create!(status:) }
+
+        it { is_expected.to be_failed }
+        it { is_expected.not_to be_submitted }
+        it { is_expected.not_to be_delivered }
+      end
+    end
+  end
+
   describe "#create_association_with" do
     let(:school) { create(:seed_school, urn: "123123", name: "Imaginary High School") }
 

--- a/spec/services/determine_training_record_state_spec.rb
+++ b/spec/services/determine_training_record_state_spec.rb
@@ -20,10 +20,10 @@ RSpec.describe DetermineTrainingRecordState do
       expect(determined_state.training_state).to eq training_state
       expect(determined_state.record_state).to eq record_state
 
-      expect(I18n.t("status_tags.admin_participant_status").keys).to include record_state&.to_sym
-      expect(I18n.t("status_tags.appropriate_body_participant_status").keys).to include record_state&.to_sym
-      expect(I18n.t("status_tags.delivery_partner_participant_status").keys).to include record_state&.to_sym
-      expect(I18n.t("status_tags.school_participant_status").keys).to include record_state&.to_sym
+      expect(I18n.t("status_tags.admin_participant_status").keys).to include record_state
+      expect(I18n.t("status_tags.appropriate_body_participant_status").keys).to include record_state
+      expect(I18n.t("status_tags.delivery_partner_participant_status").keys).to include record_state
+      expect(I18n.t("status_tags.school_participant_status").keys).to include record_state
     end
   end
 
@@ -49,360 +49,360 @@ RSpec.describe DetermineTrainingRecordState do
         let!(:participant_profile) { scenarios.ect_on_fip_no_validation.participant_profile }
 
         include_examples "determines states as",
-                         "validation_not_started",
-                         "checks_not_complete",
-                         "checks_not_complete",
-                         "not_a_mentor",
-                         "registered_for_fip_training",
-                         "validation_not_started"
+                         :validation_not_started,
+                         :checks_not_complete,
+                         :checks_not_complete,
+                         :not_a_mentor,
+                         :registered_for_fip_training,
+                         :validation_not_started
       end
 
       context "and a request for details has been submitted" do
         let!(:participant_profile) { scenarios.ect_on_fip_details_request_submitted.participant_profile }
 
         include_examples "determines states as",
-                         "request_for_details_submitted",
-                         "checks_not_complete",
-                         "checks_not_complete",
-                         "not_a_mentor",
-                         "registered_for_fip_training",
-                         "request_for_details_submitted"
+                         :request_for_details_submitted,
+                         :checks_not_complete,
+                         :checks_not_complete,
+                         :not_a_mentor,
+                         :registered_for_fip_training,
+                         :request_for_details_submitted
       end
 
       context "and a request for details has failed" do
         let!(:participant_profile) { scenarios.ect_on_fip_details_request_failed.participant_profile }
 
         include_examples "determines states as",
-                         "request_for_details_failed",
-                         "checks_not_complete",
-                         "checks_not_complete",
-                         "not_a_mentor",
-                         "registered_for_fip_training",
-                         "request_for_details_failed"
+                         :request_for_details_failed,
+                         :checks_not_complete,
+                         :checks_not_complete,
+                         :not_a_mentor,
+                         :registered_for_fip_training,
+                         :request_for_details_failed
       end
 
       context "and a request for details has been delivered" do
         let!(:participant_profile) { scenarios.ect_on_fip_details_request_delivered.participant_profile }
 
         include_examples "determines states as",
-                         "request_for_details_delivered",
-                         "checks_not_complete",
-                         "checks_not_complete",
-                         "not_a_mentor",
-                         "registered_for_fip_training",
-                         "request_for_details_delivered"
+                         :request_for_details_delivered,
+                         :checks_not_complete,
+                         :checks_not_complete,
+                         :not_a_mentor,
+                         :registered_for_fip_training,
+                         :request_for_details_delivered
       end
 
       context "and the validation API has failed" do
         let!(:participant_profile) { scenarios.ect_on_fip_validation_api_failure.participant_profile }
 
         include_examples "determines states as",
-                         "internal_error",
-                         "checks_not_complete",
-                         "checks_not_complete",
-                         "not_a_mentor",
-                         "registered_for_fip_training",
-                         "internal_error"
+                         :internal_error,
+                         :checks_not_complete,
+                         :checks_not_complete,
+                         :not_a_mentor,
+                         :registered_for_fip_training,
+                         :internal_error
       end
 
       context "and no TRA record could be found" do
         let!(:participant_profile) { scenarios.ect_on_fip_no_tra_record.participant_profile }
 
         include_examples "determines states as",
-                         "tra_record_not_found",
-                         "checks_not_complete",
-                         "checks_not_complete",
-                         "not_a_mentor",
-                         "registered_for_fip_training",
-                         "tra_record_not_found"
+                         :tra_record_not_found,
+                         :checks_not_complete,
+                         :checks_not_complete,
+                         :not_a_mentor,
+                         :registered_for_fip_training,
+                         :tra_record_not_found
       end
 
       context "and the school is eligible for sparsity uplift" do
         let!(:participant_profile) { scenarios.ect_on_fip_sparsity_uplift.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_induction_training",
-                         "eligible_for_fip_funding",
-                         "not_a_mentor",
-                         "active_fip_training",
-                         "active_fip_training"
+                         :valid,
+                         :eligible_for_induction_training,
+                         :eligible_for_fip_funding,
+                         :not_a_mentor,
+                         :active_fip_training,
+                         :active_fip_training
       end
 
       context "and the school is eligible for pupil premium uplift" do
         let!(:participant_profile) { scenarios.ect_on_fip_pupil_premium_uplift.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_induction_training",
-                         "eligible_for_fip_funding",
-                         "not_a_mentor",
-                         "active_fip_training",
-                         "active_fip_training"
+                         :valid,
+                         :eligible_for_induction_training,
+                         :eligible_for_fip_funding,
+                         :not_a_mentor,
+                         :active_fip_training,
+                         :active_fip_training
       end
 
       context "and the school has no eligible uplifts" do
         let!(:participant_profile) { scenarios.ect_on_fip_no_uplift.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_induction_training",
-                         "eligible_for_fip_funding",
-                         "not_a_mentor",
-                         "active_fip_training",
-                         "active_fip_training"
+                         :valid,
+                         :eligible_for_induction_training,
+                         :eligible_for_fip_funding,
+                         :not_a_mentor,
+                         :active_fip_training,
+                         :active_fip_training
       end
 
       context "and active flags have been found on the TRA record" do
         let!(:participant_profile) { scenarios.ect_on_fip_manual_check_active_flags.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "active_flags",
-                         "active_flags",
-                         "not_a_mentor",
-                         "active_fip_training",
-                         "active_flags"
+                         :valid,
+                         :active_flags,
+                         :active_flags,
+                         :not_a_mentor,
+                         :active_fip_training,
+                         :active_flags
       end
 
       context "and a different TRN was identified with the details provided" do
         let!(:participant_profile) { scenarios.ect_on_fip_manual_check_different_trn.participant_profile }
 
         include_examples "determines states as",
-                         "different_trn",
-                         "eligible_for_induction_training",
-                         "eligible_for_fip_funding",
-                         "not_a_mentor",
-                         "active_fip_training",
-                         "different_trn"
+                         :different_trn,
+                         :eligible_for_induction_training,
+                         :eligible_for_fip_funding,
+                         :not_a_mentor,
+                         :active_fip_training,
+                         :different_trn
       end
 
       context "and no induction start date has been recorded by the AB yet" do
         let!(:participant_profile) { scenarios.ect_on_fip_manual_check_no_induction.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_induction_training",
-                         "no_induction_start",
-                         "not_a_mentor",
-                         "registered_for_fip_training",
-                         "no_induction_start"
+                         :valid,
+                         :eligible_for_induction_training,
+                         :no_induction_start,
+                         :not_a_mentor,
+                         :registered_for_fip_training,
+                         :no_induction_start
       end
 
       context "and they do not have QTS on record" do
         let!(:participant_profile) { scenarios.ect_on_fip_manual_check_no_qts.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "not_qualified",
-                         "not_qualified",
-                         "not_a_mentor",
-                         "active_fip_training",
-                         "not_qualified"
+                         :valid,
+                         :not_qualified,
+                         :not_qualified,
+                         :not_a_mentor,
+                         :active_fip_training,
+                         :not_qualified
       end
 
       context "and the active flags have been investigated and found to be relevant" do
         let!(:participant_profile) { scenarios.ect_on_fip_ineligible_active_flags.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "not_allowed",
-                         "not_allowed",
-                         "not_a_mentor",
-                         "active_fip_training",
-                         "not_allowed"
+                         :valid,
+                         :not_allowed,
+                         :not_allowed,
+                         :not_a_mentor,
+                         :active_fip_training,
+                         :not_allowed
       end
 
       context "and the active flags have been investigated and found to be irrelevant" do
         let!(:participant_profile) { scenarios.ect_on_fip_eligible_active_flags.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_induction_training",
-                         "eligible_for_fip_funding",
-                         "not_a_mentor",
-                         "active_fip_training",
-                         "active_fip_training"
+                         :valid,
+                         :eligible_for_induction_training,
+                         :eligible_for_fip_funding,
+                         :not_a_mentor,
+                         :active_fip_training,
+                         :active_fip_training
       end
 
       context "and a duplicate profile has been found but no duplicity is recorded" do
         let!(:participant_profile) { scenarios.ect_on_fip_ineligible_duplicate_profile.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "duplicate_profile",
-                         "duplicate_profile",
-                         "not_a_mentor",
-                         "active_fip_training",
-                         "duplicate_profile"
+                         :valid,
+                         :duplicate_profile,
+                         :duplicate_profile,
+                         :not_a_mentor,
+                         :active_fip_training,
+                         :duplicate_profile
       end
 
       context "and they are exempt from induction" do
         let!(:participant_profile) { scenarios.ect_on_fip_ineligible_exempt_from_induction.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "exempt_from_induction",
-                         "exempt_from_induction",
-                         "not_a_mentor",
-                         "active_fip_training",
-                         "exempt_from_induction"
+                         :valid,
+                         :exempt_from_induction,
+                         :exempt_from_induction,
+                         :not_a_mentor,
+                         :active_fip_training,
+                         :exempt_from_induction
       end
 
       context "and they have a previous induction recorded" do
         let!(:participant_profile) { scenarios.ect_on_fip_ineligible_previous_induction.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "previous_induction",
-                         "previous_induction",
-                         "not_a_mentor",
-                         "active_fip_training",
-                         "previous_induction"
+                         :valid,
+                         :previous_induction,
+                         :previous_induction,
+                         :not_a_mentor,
+                         :active_fip_training,
+                         :previous_induction
       end
 
       context "and they have had no eligibility checks performed yet" do
         let!(:participant_profile) { scenarios.ect_on_fip_no_eligibility_checks.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "checks_not_complete",
-                         "checks_not_complete",
-                         "not_a_mentor",
-                         "active_fip_training",
-                         "checks_not_complete"
+                         :valid,
+                         :checks_not_complete,
+                         :checks_not_complete,
+                         :not_a_mentor,
+                         :active_fip_training,
+                         :checks_not_complete
       end
 
       context "and they have been made eligible by DfE" do
         let!(:participant_profile) { scenarios.ect_on_fip_eligible.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_induction_training",
-                         "eligible_for_fip_funding",
-                         "not_a_mentor",
-                         "active_fip_training",
-                         "active_fip_training"
+                         :valid,
+                         :eligible_for_induction_training,
+                         :eligible_for_fip_funding,
+                         :not_a_mentor,
+                         :active_fip_training,
+                         :active_fip_training
       end
 
       context "and the school has not yet reported the training providers" do
         let!(:participant_profile) { scenarios.ect_on_fip_no_partnership.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_induction_training",
-                         "eligible_for_fip_funding",
-                         "not_a_mentor",
-                         "registered_for_fip_no_partner",
-                         "registered_for_fip_no_partner"
+                         :valid,
+                         :eligible_for_induction_training,
+                         :eligible_for_fip_funding,
+                         :not_a_mentor,
+                         :registered_for_fip_no_partner,
+                         :registered_for_fip_no_partner
       end
 
       context "and they are active" do
         let!(:participant_profile) { scenarios.ect_on_fip_in_training.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_induction_training",
-                         "eligible_for_fip_funding",
-                         "not_a_mentor",
-                         "active_fip_training",
-                         "active_fip_training"
+                         :valid,
+                         :eligible_for_induction_training,
+                         :eligible_for_fip_funding,
+                         :not_a_mentor,
+                         :active_fip_training,
+                         :active_fip_training
       end
 
       context "and they have been withdrawn by a training provider through the API" do
         let!(:participant_profile) { scenarios.ect_on_fip_withdrawn.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_induction_training",
-                         "eligible_for_fip_funding",
-                         "not_a_mentor",
-                         "withdrawn_training",
-                         "withdrawn_training"
+                         :valid,
+                         :eligible_for_induction_training,
+                         :eligible_for_fip_funding,
+                         :not_a_mentor,
+                         :withdrawn_training,
+                         :withdrawn_training
       end
 
       context "and they have been re-enrolled after being withdrawn by a training provider through the API" do
         let!(:participant_profile) { scenarios.ect_on_fip_enrolled_after_withdraw.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_induction_training",
-                         "eligible_for_fip_funding",
-                         "not_a_mentor",
-                         "active_fip_training",
-                         "active_fip_training"
+                         :valid,
+                         :eligible_for_induction_training,
+                         :eligible_for_fip_funding,
+                         :not_a_mentor,
+                         :active_fip_training,
+                         :active_fip_training
       end
 
       context "and they were withdrawn before an induction record was created for them" do
         let!(:participant_profile) { scenarios.ect_on_fip_withdrawn_no_induction_record.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_induction_training",
-                         "eligible_for_fip_funding",
-                         "not_a_mentor",
-                         "withdrawn_training",
-                         "withdrawn_training"
+                         :valid,
+                         :eligible_for_induction_training,
+                         :eligible_for_fip_funding,
+                         :not_a_mentor,
+                         :withdrawn_training,
+                         :withdrawn_training
       end
 
       context "and their training has been deferred" do
         let!(:participant_profile) { scenarios.ect_on_fip_deferred.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_induction_training",
-                         "eligible_for_fip_funding",
-                         "not_a_mentor",
-                         "deferred_training",
-                         "deferred_training"
+                         :valid,
+                         :eligible_for_induction_training,
+                         :eligible_for_fip_funding,
+                         :not_a_mentor,
+                         :deferred_training,
+                         :deferred_training
       end
 
       context "and they have been withdrawn from the programme" do
         let!(:participant_profile) { scenarios.ect_on_fip_withdrawn_from_programme.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_induction_training",
-                         "eligible_for_fip_funding",
-                         "not_a_mentor",
-                         "withdrawn_programme",
-                         "withdrawn_programme"
+                         :valid,
+                         :eligible_for_induction_training,
+                         :eligible_for_fip_funding,
+                         :not_a_mentor,
+                         :withdrawn_programme,
+                         :withdrawn_programme
       end
 
       context "and they have completed their induction training" do
         let!(:participant_profile) { scenarios.ect_on_fip_completed.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_induction_training",
-                         "eligible_for_fip_funding",
-                         "not_a_mentor",
-                         "completed_training",
-                         "completed_training"
+                         :valid,
+                         :eligible_for_induction_training,
+                         :eligible_for_fip_funding,
+                         :not_a_mentor,
+                         :completed_training,
+                         :completed_training
       end
 
       context "and the cohort has been changed" do
         let!(:participant_profile) { scenarios.ect_on_fip_after_cohort_transfer.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_induction_training",
-                         "eligible_for_fip_funding",
-                         "not_a_mentor",
-                         "active_fip_training",
-                         "active_fip_training"
+                         :valid,
+                         :eligible_for_induction_training,
+                         :eligible_for_fip_funding,
+                         :not_a_mentor,
+                         :active_fip_training,
+                         :active_fip_training
       end
 
       context "and the mentor has been changed" do
         let!(:participant_profile) { scenarios.ect_on_fip_after_mentor_change.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_induction_training",
-                         "eligible_for_fip_funding",
-                         "not_a_mentor",
-                         "active_fip_training",
-                         "active_fip_training"
+                         :valid,
+                         :eligible_for_induction_training,
+                         :eligible_for_fip_funding,
+                         :not_a_mentor,
+                         :active_fip_training,
+                         :active_fip_training
       end
 
       context "in transfer scenario" do
@@ -412,72 +412,72 @@ RSpec.describe DetermineTrainingRecordState do
           let!(:participant_profile) { scenarios.ect_on_fip_leaving.participant_profile }
 
           include_examples "determines states as",
-                           "valid",
-                           "eligible_for_induction_training",
-                           "eligible_for_fip_funding",
-                           "not_a_mentor",
-                           "leaving",
-                           "leaving"
+                           :valid,
+                           :eligible_for_induction_training,
+                           :eligible_for_fip_funding,
+                           :not_a_mentor,
+                           :leaving,
+                           :leaving
         end
 
         context "and they have left their current school" do
           let!(:participant_profile) { scenarios.ect_on_fip_left.participant_profile }
 
           include_examples "determines states as",
-                           "valid",
-                           "eligible_for_induction_training",
-                           "eligible_for_fip_funding",
-                           "not_a_mentor",
-                           "left",
-                           "left"
+                           :valid,
+                           :eligible_for_induction_training,
+                           :eligible_for_fip_funding,
+                           :not_a_mentor,
+                           :left,
+                           :left
         end
 
         context "and they are transferring from their current school" do
           let!(:participant_profile) { scenarios.ect_on_fip_transferring.participant_profile }
 
           include_examples "determines states as",
-                           "valid",
-                           "eligible_for_induction_training",
-                           "eligible_for_fip_funding",
-                           "not_a_mentor",
-                           "leaving",
-                           "leaving"
+                           :valid,
+                           :eligible_for_induction_training,
+                           :eligible_for_fip_funding,
+                           :not_a_mentor,
+                           :leaving,
+                           :leaving
         end
 
         context "and they have transferred from their current school" do
           let!(:participant_profile) { scenarios.ect_on_fip_transferred.participant_profile }
 
           include_examples "determines states as",
-                           "valid",
-                           "eligible_for_induction_training",
-                           "eligible_for_fip_funding",
-                           "not_a_mentor",
-                           "left",
-                           "left"
+                           :valid,
+                           :eligible_for_induction_training,
+                           :eligible_for_fip_funding,
+                           :not_a_mentor,
+                           :left,
+                           :left
         end
 
         context "and they are joining their current school" do
           let!(:participant_profile) { scenarios.ect_on_fip_joining.participant_profile }
 
           include_examples "determines states as",
-                           "valid",
-                           "eligible_for_induction_training",
-                           "eligible_for_fip_funding",
-                           "not_a_mentor",
-                           "joining",
-                           "joining"
+                           :valid,
+                           :eligible_for_induction_training,
+                           :eligible_for_fip_funding,
+                           :not_a_mentor,
+                           :joining,
+                           :joining
         end
 
         context "and they have joined their current school" do
           let!(:participant_profile) { scenarios.ect_on_fip_joined.participant_profile }
 
           include_examples "determines states as",
-                           "valid",
-                           "eligible_for_induction_training",
-                           "eligible_for_fip_funding",
-                           "not_a_mentor",
-                           "active_fip_training",
-                           "active_fip_training"
+                           :valid,
+                           :eligible_for_induction_training,
+                           :eligible_for_fip_funding,
+                           :not_a_mentor,
+                           :active_fip_training,
+                           :active_fip_training
         end
       end
     end
@@ -487,288 +487,288 @@ RSpec.describe DetermineTrainingRecordState do
         let!(:participant_profile) { scenarios.ect_on_cip_no_validation.participant_profile }
 
         include_examples "determines states as",
-                         "validation_not_started",
-                         "checks_not_complete",
-                         "checks_not_complete",
-                         "not_a_mentor",
-                         "registered_for_cip_training",
-                         "validation_not_started"
+                         :validation_not_started,
+                         :checks_not_complete,
+                         :checks_not_complete,
+                         :not_a_mentor,
+                         :registered_for_cip_training,
+                         :validation_not_started
       end
 
       context "and a request for details has been submitted" do
         let!(:participant_profile) { scenarios.ect_on_cip_details_request_submitted.participant_profile }
 
         include_examples "determines states as",
-                         "request_for_details_submitted",
-                         "checks_not_complete",
-                         "checks_not_complete",
-                         "not_a_mentor",
-                         "registered_for_cip_training",
-                         "request_for_details_submitted"
+                         :request_for_details_submitted,
+                         :checks_not_complete,
+                         :checks_not_complete,
+                         :not_a_mentor,
+                         :registered_for_cip_training,
+                         :request_for_details_submitted
       end
 
       context "and a request for details has failed" do
         let!(:participant_profile) { scenarios.ect_on_cip_details_request_failed.participant_profile }
 
         include_examples "determines states as",
-                         "request_for_details_failed",
-                         "checks_not_complete",
-                         "checks_not_complete",
-                         "not_a_mentor",
-                         "registered_for_cip_training",
-                         "request_for_details_failed"
+                         :request_for_details_failed,
+                         :checks_not_complete,
+                         :checks_not_complete,
+                         :not_a_mentor,
+                         :registered_for_cip_training,
+                         :request_for_details_failed
       end
 
       context "and a request for details has been delivered" do
         let!(:participant_profile) { scenarios.ect_on_cip_details_request_delivered.participant_profile }
 
         include_examples "determines states as",
-                         "request_for_details_delivered",
-                         "checks_not_complete",
-                         "checks_not_complete",
-                         "not_a_mentor",
-                         "registered_for_cip_training",
-                         "request_for_details_delivered"
+                         :request_for_details_delivered,
+                         :checks_not_complete,
+                         :checks_not_complete,
+                         :not_a_mentor,
+                         :registered_for_cip_training,
+                         :request_for_details_delivered
       end
 
       context "and the validation API has failed" do
         let!(:participant_profile) { scenarios.ect_on_cip_validation_api_failure.participant_profile }
 
         include_examples "determines states as",
-                         "internal_error",
-                         "checks_not_complete",
-                         "checks_not_complete",
-                         "not_a_mentor",
-                         "registered_for_cip_training",
-                         "internal_error"
+                         :internal_error,
+                         :checks_not_complete,
+                         :checks_not_complete,
+                         :not_a_mentor,
+                         :registered_for_cip_training,
+                         :internal_error
       end
 
       context "and no TRA record could be found" do
         let!(:participant_profile) { scenarios.ect_on_cip_no_tra_record.participant_profile }
 
         include_examples "determines states as",
-                         "tra_record_not_found",
-                         "checks_not_complete",
-                         "checks_not_complete",
-                         "not_a_mentor",
-                         "registered_for_cip_training",
-                         "tra_record_not_found"
+                         :tra_record_not_found,
+                         :checks_not_complete,
+                         :checks_not_complete,
+                         :not_a_mentor,
+                         :registered_for_cip_training,
+                         :tra_record_not_found
       end
 
       context "and active flags have been found on the TRA record" do
         let!(:participant_profile) { scenarios.ect_on_cip_manual_check_active_flags.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "active_flags",
-                         "active_flags",
-                         "not_a_mentor",
-                         "active_cip_training",
-                         "active_flags"
+                         :valid,
+                         :active_flags,
+                         :active_flags,
+                         :not_a_mentor,
+                         :active_cip_training,
+                         :active_flags
       end
 
       context "and a different TRN was identified with the details provided" do
         let!(:participant_profile) { scenarios.ect_on_cip_manual_check_different_trn.participant_profile }
 
         include_examples "determines states as",
-                         "different_trn",
-                         "eligible_for_induction_training",
-                         "eligible_for_fip_funding",
-                         "not_a_mentor",
-                         "active_cip_training",
-                         "different_trn"
+                         :different_trn,
+                         :eligible_for_induction_training,
+                         :eligible_for_fip_funding,
+                         :not_a_mentor,
+                         :active_cip_training,
+                         :different_trn
       end
 
       context "and no induction start date has been recorded by the AB yet" do
         let!(:participant_profile) { scenarios.ect_on_cip_manual_check_no_induction.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_induction_training",
-                         "no_induction_start",
-                         "not_a_mentor",
-                         "registered_for_cip_training",
-                         "registered_for_cip_training"
+                         :valid,
+                         :eligible_for_induction_training,
+                         :no_induction_start,
+                         :not_a_mentor,
+                         :registered_for_cip_training,
+                         :registered_for_cip_training
       end
 
       context "and they do not have QTS on record" do
         let!(:participant_profile) { scenarios.ect_on_cip_manual_check_no_qts.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "not_qualified",
-                         "not_qualified",
-                         "not_a_mentor",
-                         "active_cip_training",
-                         "not_qualified"
+                         :valid,
+                         :not_qualified,
+                         :not_qualified,
+                         :not_a_mentor,
+                         :active_cip_training,
+                         :not_qualified
       end
 
       context "and the active flags have been investigated and found to be relevant" do
         let!(:participant_profile) { scenarios.ect_on_cip_ineligible_active_flags.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "not_allowed",
-                         "not_allowed",
-                         "not_a_mentor",
-                         "active_cip_training",
-                         "not_allowed"
+                         :valid,
+                         :not_allowed,
+                         :not_allowed,
+                         :not_a_mentor,
+                         :active_cip_training,
+                         :not_allowed
       end
 
       context "and the active flags have been investigated and found to be irrelevant" do
         let!(:participant_profile) { scenarios.ect_on_cip_eligible_active_flags.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_induction_training",
-                         "eligible_for_fip_funding",
-                         "not_a_mentor",
-                         "active_cip_training",
-                         "active_cip_training"
+                         :valid,
+                         :eligible_for_induction_training,
+                         :eligible_for_fip_funding,
+                         :not_a_mentor,
+                         :active_cip_training,
+                         :active_cip_training
       end
 
       context "and a duplicate profile has been found but no duplicity is recorded" do
         let!(:participant_profile) { scenarios.ect_on_cip_ineligible_duplicate_profile.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "duplicate_profile",
-                         "duplicate_profile",
-                         "not_a_mentor",
-                         "active_cip_training",
-                         "duplicate_profile"
+                         :valid,
+                         :duplicate_profile,
+                         :duplicate_profile,
+                         :not_a_mentor,
+                         :active_cip_training,
+                         :duplicate_profile
       end
 
       context "and they are exempt from induction" do
         let!(:participant_profile) { scenarios.ect_on_cip_ineligible_exempt_from_induction.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "exempt_from_induction",
-                         "exempt_from_induction",
-                         "not_a_mentor",
-                         "active_cip_training",
-                         "exempt_from_induction"
+                         :valid,
+                         :exempt_from_induction,
+                         :exempt_from_induction,
+                         :not_a_mentor,
+                         :active_cip_training,
+                         :exempt_from_induction
       end
 
       context "and they have a previous induction recorded" do
         let!(:participant_profile) { scenarios.ect_on_cip_ineligible_previous_induction.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "previous_induction",
-                         "previous_induction",
-                         "not_a_mentor",
-                         "active_cip_training",
-                         "previous_induction"
+                         :valid,
+                         :previous_induction,
+                         :previous_induction,
+                         :not_a_mentor,
+                         :active_cip_training,
+                         :previous_induction
       end
 
       context "and they have had no eligibility checks performed yet" do
         let!(:participant_profile) { scenarios.ect_on_cip_no_eligibility_checks.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "checks_not_complete",
-                         "checks_not_complete",
-                         "not_a_mentor",
-                         "active_cip_training",
-                         "checks_not_complete"
+                         :valid,
+                         :checks_not_complete,
+                         :checks_not_complete,
+                         :not_a_mentor,
+                         :active_cip_training,
+                         :checks_not_complete
       end
 
       context "and they have been made eligible by DfE" do
         let!(:participant_profile) { scenarios.ect_on_cip_eligible.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_induction_training",
-                         "eligible_for_fip_funding",
-                         "not_a_mentor",
-                         "active_cip_training",
-                         "active_cip_training"
+                         :valid,
+                         :eligible_for_induction_training,
+                         :eligible_for_fip_funding,
+                         :not_a_mentor,
+                         :active_cip_training,
+                         :active_cip_training
       end
 
       context "and they are active" do
         let!(:participant_profile) { scenarios.ect_on_cip_in_training.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_induction_training",
-                         "eligible_for_fip_funding",
-                         "not_a_mentor",
-                         "active_cip_training",
-                         "active_cip_training"
+                         :valid,
+                         :eligible_for_induction_training,
+                         :eligible_for_fip_funding,
+                         :not_a_mentor,
+                         :active_cip_training,
+                         :active_cip_training
       end
 
       context "and they have been withdrawn by a training provider through the API" do
         let!(:participant_profile) { scenarios.ect_on_cip_withdrawn.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_induction_training",
-                         "eligible_for_fip_funding",
-                         "not_a_mentor",
-                         "withdrawn_training",
-                         "withdrawn_training"
+                         :valid,
+                         :eligible_for_induction_training,
+                         :eligible_for_fip_funding,
+                         :not_a_mentor,
+                         :withdrawn_training,
+                         :withdrawn_training
       end
 
       context "and they have been re-enrolled after being withdrawn by a training provider through the API" do
         let!(:participant_profile) { scenarios.ect_on_cip_enrolled_after_withdraw.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_induction_training",
-                         "eligible_for_fip_funding",
-                         "not_a_mentor",
-                         "active_cip_training",
-                         "active_cip_training"
+                         :valid,
+                         :eligible_for_induction_training,
+                         :eligible_for_fip_funding,
+                         :not_a_mentor,
+                         :active_cip_training,
+                         :active_cip_training
       end
 
       context "and they were withdrawn before an induction record was created for them" do
         let!(:participant_profile) { scenarios.ect_on_cip_withdrawn_no_induction_record.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_induction_training",
-                         "eligible_for_fip_funding",
-                         "not_a_mentor",
-                         "withdrawn_training",
-                         "withdrawn_training"
+                         :valid,
+                         :eligible_for_induction_training,
+                         :eligible_for_fip_funding,
+                         :not_a_mentor,
+                         :withdrawn_training,
+                         :withdrawn_training
       end
 
       context "and their training has been deferred" do
         let!(:participant_profile) { scenarios.ect_on_cip_deferred.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_induction_training",
-                         "eligible_for_fip_funding",
-                         "not_a_mentor",
-                         "deferred_training",
-                         "deferred_training"
+                         :valid,
+                         :eligible_for_induction_training,
+                         :eligible_for_fip_funding,
+                         :not_a_mentor,
+                         :deferred_training,
+                         :deferred_training
       end
 
       context "and they have been withdrawn from the programme" do
         let!(:participant_profile) { scenarios.ect_on_cip_withdrawn_from_programme.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_induction_training",
-                         "eligible_for_fip_funding",
-                         "not_a_mentor",
-                         "withdrawn_programme",
-                         "withdrawn_programme"
+                         :valid,
+                         :eligible_for_induction_training,
+                         :eligible_for_fip_funding,
+                         :not_a_mentor,
+                         :withdrawn_programme,
+                         :withdrawn_programme
       end
 
       context "and they have completed their induction training" do
         let!(:participant_profile) { scenarios.ect_on_cip_completed.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_induction_training",
-                         "eligible_for_fip_funding",
-                         "not_a_mentor",
-                         "completed_training",
-                         "completed_training"
+                         :valid,
+                         :eligible_for_induction_training,
+                         :eligible_for_fip_funding,
+                         :not_a_mentor,
+                         :completed_training,
+                         :completed_training
       end
 
       context "in transfer scenario" do
@@ -778,72 +778,72 @@ RSpec.describe DetermineTrainingRecordState do
           let!(:participant_profile) { scenarios.ect_on_cip_leaving.participant_profile }
 
           include_examples "determines states as",
-                           "valid",
-                           "eligible_for_induction_training",
-                           "eligible_for_fip_funding",
-                           "not_a_mentor",
-                           "leaving",
-                           "leaving"
+                           :valid,
+                           :eligible_for_induction_training,
+                           :eligible_for_fip_funding,
+                           :not_a_mentor,
+                           :leaving,
+                           :leaving
         end
 
         context "and they have left their current school" do
           let!(:participant_profile) { scenarios.ect_on_cip_left.participant_profile }
 
           include_examples "determines states as",
-                           "valid",
-                           "eligible_for_induction_training",
-                           "eligible_for_fip_funding",
-                           "not_a_mentor",
-                           "left",
-                           "left"
+                           :valid,
+                           :eligible_for_induction_training,
+                           :eligible_for_fip_funding,
+                           :not_a_mentor,
+                           :left,
+                           :left
         end
 
         context "and they are transferring from their current school" do
           let!(:participant_profile) { scenarios.ect_on_cip_transferring.participant_profile }
 
           include_examples "determines states as",
-                           "valid",
-                           "eligible_for_induction_training",
-                           "eligible_for_fip_funding",
-                           "not_a_mentor",
-                           "leaving",
-                           "leaving"
+                           :valid,
+                           :eligible_for_induction_training,
+                           :eligible_for_fip_funding,
+                           :not_a_mentor,
+                           :leaving,
+                           :leaving
         end
 
         context "and they have transferred from their current school" do
           let!(:participant_profile) { scenarios.ect_on_cip_transferred.participant_profile }
 
           include_examples "determines states as",
-                           "valid",
-                           "eligible_for_induction_training",
-                           "eligible_for_fip_funding",
-                           "not_a_mentor",
-                           "left",
-                           "left"
+                           :valid,
+                           :eligible_for_induction_training,
+                           :eligible_for_fip_funding,
+                           :not_a_mentor,
+                           :left,
+                           :left
         end
 
         context "and they are joining their current school" do
           let!(:participant_profile) { scenarios.ect_on_cip_joining.participant_profile }
 
           include_examples "determines states as",
-                           "valid",
-                           "eligible_for_induction_training",
-                           "eligible_for_fip_funding",
-                           "not_a_mentor",
-                           "joining",
-                           "joining"
+                           :valid,
+                           :eligible_for_induction_training,
+                           :eligible_for_fip_funding,
+                           :not_a_mentor,
+                           :joining,
+                           :joining
         end
 
         context "and they have joined their current school" do
           let!(:participant_profile) { scenarios.ect_on_cip_joined.participant_profile }
 
           include_examples "determines states as",
-                           "valid",
-                           "eligible_for_induction_training",
-                           "eligible_for_fip_funding",
-                           "not_a_mentor",
-                           "active_cip_training",
-                           "active_cip_training"
+                           :valid,
+                           :eligible_for_induction_training,
+                           :eligible_for_fip_funding,
+                           :not_a_mentor,
+                           :active_cip_training,
+                           :active_cip_training
         end
       end
     end
@@ -853,360 +853,360 @@ RSpec.describe DetermineTrainingRecordState do
         let!(:participant_profile) { scenarios.mentor_on_fip_no_validation.participant_profile }
 
         include_examples "determines states as",
-                         "validation_not_started",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "registered_for_fip_training",
-                         "validation_not_started"
+                         :validation_not_started,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :registered_for_fip_training,
+                         :validation_not_started
       end
 
       context "and a request for details has been submitted" do
         let!(:participant_profile) { scenarios.mentor_on_fip_details_request_submitted.participant_profile }
 
         include_examples "determines states as",
-                         "request_for_details_submitted",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "registered_for_fip_training",
-                         "request_for_details_submitted"
+                         :request_for_details_submitted,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :registered_for_fip_training,
+                         :request_for_details_submitted
       end
 
       context "and a request for details has failed" do
         let!(:participant_profile) { scenarios.mentor_on_fip_details_request_failed.participant_profile }
 
         include_examples "determines states as",
-                         "request_for_details_failed",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "registered_for_fip_training",
-                         "request_for_details_failed"
+                         :request_for_details_failed,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :registered_for_fip_training,
+                         :request_for_details_failed
       end
 
       context "and a request for details has been delivered" do
         let!(:participant_profile) { scenarios.mentor_on_fip_details_request_delivered.participant_profile }
 
         include_examples "determines states as",
-                         "request_for_details_delivered",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "registered_for_fip_training",
-                         "request_for_details_delivered"
+                         :request_for_details_delivered,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :registered_for_fip_training,
+                         :request_for_details_delivered
       end
 
       context "and the validation API has failed" do
         let!(:participant_profile) { scenarios.mentor_on_fip_validation_api_failure.participant_profile }
 
         include_examples "determines states as",
-                         "internal_error",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "registered_for_fip_training",
-                         "internal_error"
+                         :internal_error,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :registered_for_fip_training,
+                         :internal_error
       end
 
       context "and no TRA record could be found" do
         let!(:participant_profile) { scenarios.mentor_on_fip_no_tra_record.participant_profile }
 
         include_examples "determines states as",
-                         "tra_record_not_found",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "registered_for_fip_training",
-                         "tra_record_not_found"
+                         :tra_record_not_found,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :registered_for_fip_training,
+                         :tra_record_not_found
       end
 
       context "and active flags have been found on the TRA record" do
         let!(:participant_profile) { scenarios.mentor_on_fip_manual_check_active_flags.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "active_flags",
-                         "active_flags",
-                         "active_mentoring",
-                         "registered_for_fip_training",
-                         "active_flags"
+                         :valid,
+                         :active_flags,
+                         :active_flags,
+                         :active_mentoring,
+                         :registered_for_fip_training,
+                         :active_flags
       end
 
       context "and a different TRN was identified with the details provided" do
         let!(:participant_profile) { scenarios.mentor_on_fip_manual_check_different_trn.participant_profile }
 
         include_examples "determines states as",
-                         "different_trn",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "registered_for_fip_training",
-                         "different_trn"
+                         :different_trn,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :registered_for_fip_training,
+                         :different_trn
       end
 
       context "and they do not have QTS on record" do
         let!(:participant_profile) { scenarios.mentor_on_fip_manual_check_no_qts.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "registered_for_fip_training",
-                         "active_mentoring"
+                         :valid,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :registered_for_fip_training,
+                         :active_mentoring
       end
 
       context "and they do not have QTS on record but had been made eligible by DfE" do
         let!(:participant_profile) { scenarios.mentor_on_fip_eligible_no_qts.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "registered_for_fip_training",
-                         "active_mentoring"
+                         :valid,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :registered_for_fip_training,
+                         :active_mentoring
       end
 
       context "and the active flags have been investigated and found to be relevant" do
         let!(:participant_profile) { scenarios.mentor_on_fip_ineligible_active_flags.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "not_allowed",
-                         "not_allowed",
-                         "active_mentoring",
-                         "registered_for_fip_training",
-                         "not_allowed"
+                         :valid,
+                         :not_allowed,
+                         :not_allowed,
+                         :active_mentoring,
+                         :registered_for_fip_training,
+                         :not_allowed
       end
 
       context "and the active flags have been investigated and found to be irrelevant" do
         let!(:participant_profile) { scenarios.mentor_on_fip_eligible_active_flags.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "registered_for_fip_training",
-                         "active_mentoring"
+                         :valid,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :registered_for_fip_training,
+                         :active_mentoring
       end
 
       context "and a duplicate profile has been found but no duplicity is recorded" do
         let!(:participant_profile) { scenarios.mentor_on_fip_ineligible_duplicate_profile.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_mentor_training",
-                         "ineligible_secondary",
-                         "active_mentoring",
-                         "registered_for_fip_training",
-                         "active_mentoring"
+                         :valid,
+                         :eligible_for_mentor_training,
+                         :ineligible_secondary,
+                         :active_mentoring,
+                         :registered_for_fip_training,
+                         :active_mentoring
       end
 
       context "and they have a previous participation recorded" do
         let!(:participant_profile) { scenarios.mentor_ero_on_fip.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_mentor_training",
-                         "ineligible_ero",
-                         "active_mentoring_ero",
-                         "registered_for_fip_training",
-                         "active_mentoring_ero"
+                         :valid,
+                         :eligible_for_mentor_training,
+                         :ineligible_ero,
+                         :active_mentoring_ero,
+                         :registered_for_fip_training,
+                         :active_mentoring_ero
       end
 
       context "and they have a previous participation recorded and have been made eligible by DfE" do
         let!(:participant_profile) { scenarios.mentor_ero_on_fip_eligible.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring_ero",
-                         "registered_for_fip_training",
-                         "active_mentoring_ero"
+                         :valid,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring_ero,
+                         :registered_for_fip_training,
+                         :active_mentoring_ero
       end
 
       context "and they have had no eligibility checks performed yet" do
         let!(:participant_profile) { scenarios.mentor_on_fip_no_eligibility_checks.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "checks_not_complete",
-                         "checks_not_complete",
-                         "active_mentoring",
-                         "registered_for_fip_training",
-                         "checks_not_complete"
+                         :valid,
+                         :checks_not_complete,
+                         :checks_not_complete,
+                         :active_mentoring,
+                         :registered_for_fip_training,
+                         :checks_not_complete
       end
 
       context "and they have been made eligible by DfE" do
         let!(:participant_profile) { scenarios.mentor_on_fip_eligible.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "registered_for_fip_training",
-                         "active_mentoring"
+                         :valid,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :registered_for_fip_training,
+                         :active_mentoring
       end
 
       context "and they have a duplicate profile but this is the primary one" do
         let!(:participant_profile) { scenarios.mentor_on_fip_profile_duplicity_primary.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding_primary",
-                         "active_mentoring",
-                         "registered_for_fip_training",
-                         "active_mentoring"
+                         :valid,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding_primary,
+                         :active_mentoring,
+                         :registered_for_fip_training,
+                         :active_mentoring
       end
 
       context "and they have a duplicate profile and this is the secondary one" do
         let!(:participant_profile) { scenarios.mentor_on_fip_profile_duplicity_secondary.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_mentor_training",
-                         "ineligible_secondary",
-                         "active_mentoring",
-                         "registered_for_fip_training",
-                         "active_mentoring"
+                         :valid,
+                         :eligible_for_mentor_training,
+                         :ineligible_secondary,
+                         :active_mentoring,
+                         :registered_for_fip_training,
+                         :active_mentoring
       end
 
       context "and the school has not yet reported the training providers" do
         let!(:participant_profile) { scenarios.mentor_on_fip_no_partnership.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "registered_for_fip_no_partner",
-                         "active_mentoring"
+                         :valid,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :registered_for_fip_no_partner,
+                         :active_mentoring
       end
 
       context "and they are active" do
         let!(:participant_profile) { scenarios.mentor_on_fip.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "registered_for_fip_training",
-                         "active_mentoring"
+                         :valid,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :registered_for_fip_training,
+                         :active_mentoring
       end
 
       context "and they are currently not mentoring" do
         let!(:participant_profile) { scenarios.mentor_on_fip_with_no_mentees.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "not_yet_mentoring",
-                         "eligible_for_mentor_funding",
-                         "not_yet_mentoring",
-                         "registered_for_fip_training",
-                         "not_yet_mentoring"
+                         :valid,
+                         :not_yet_mentoring,
+                         :eligible_for_mentor_funding,
+                         :not_yet_mentoring,
+                         :registered_for_fip_training,
+                         :not_yet_mentoring
       end
 
       context "and they are no longer mentoring" do
         let!(:participant_profile) { scenarios.mentor_on_fip_no_longer_mentoring.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "not_yet_mentoring",
-                         "registered_for_fip_training",
-                         "not_yet_mentoring"
+                         :valid,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :not_yet_mentoring,
+                         :registered_for_fip_training,
+                         :not_yet_mentoring
       end
 
       context "and their mentee has been withdrawn" do
         let!(:participant_profile) { scenarios.mentor_on_fip_withdrawn_mentee.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "not_yet_mentoring",
-                         "registered_for_fip_training",
-                         "not_yet_mentoring"
+                         :valid,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :not_yet_mentoring,
+                         :registered_for_fip_training,
+                         :not_yet_mentoring
       end
 
       context "and they have been withdrawn by a training provider through the API" do
         let!(:participant_profile) { scenarios.mentor_on_fip_withdrawn.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "withdrawn_training",
-                         "active_mentoring"
+                         :valid,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :withdrawn_training,
+                         :active_mentoring
       end
 
       context "and they have been re-enrolled after being withdrawn by a training provider through the API" do
         let!(:participant_profile) { scenarios.mentor_on_fip_enrolled_after_withdraw.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "registered_for_fip_training",
-                         "active_mentoring"
+                         :valid,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :registered_for_fip_training,
+                         :active_mentoring
       end
 
       context "and they were withdrawn before an induction record was created for them" do
         let!(:participant_profile) { scenarios.mentor_on_fip_withdrawn_no_induction_record.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "withdrawn_training",
-                         "active_mentoring"
+                         :valid,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :withdrawn_training,
+                         :active_mentoring
       end
 
       context "and their training has been deferred" do
         let!(:participant_profile) { scenarios.mentor_on_fip_deferred.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "deferred_training",
-                         "active_mentoring"
+                         :valid,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :deferred_training,
+                         :active_mentoring
       end
 
       context "and they have been withdrawn from the programme" do
         let!(:participant_profile) { scenarios.mentor_on_fip_withdrawn_from_programme.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "withdrawn_programme",
-                         "withdrawn_programme"
+                         :valid,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :withdrawn_programme,
+                         :withdrawn_programme
       end
 
       context "and they have completed their mentor training" do
         let!(:participant_profile) { scenarios.mentor_on_fip_completed.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "completed_training",
-                         "active_mentoring"
+                         :valid,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :completed_training,
+                         :active_mentoring
       end
 
       context "in transfer scenario" do
@@ -1216,72 +1216,72 @@ RSpec.describe DetermineTrainingRecordState do
           let!(:participant_profile) { scenarios.mentor_on_fip_leaving.participant_profile }
 
           include_examples "determines states as",
-                           "valid",
-                           "eligible_for_mentor_training",
-                           "eligible_for_mentor_funding",
-                           "active_mentoring",
-                           "leaving",
-                           "active_mentoring"
+                           :valid,
+                           :eligible_for_mentor_training,
+                           :eligible_for_mentor_funding,
+                           :active_mentoring,
+                           :leaving,
+                           :active_mentoring
         end
 
         context "and they have left their current school" do
           let!(:participant_profile) { scenarios.mentor_on_fip_left.participant_profile }
 
           include_examples "determines states as",
-                           "valid",
-                           "eligible_for_mentor_training",
-                           "eligible_for_mentor_funding",
-                           "active_mentoring",
-                           "left",
-                           "active_mentoring"
+                           :valid,
+                           :eligible_for_mentor_training,
+                           :eligible_for_mentor_funding,
+                           :active_mentoring,
+                           :left,
+                           :active_mentoring
         end
 
         context "and they are transferring from their current school" do
           let!(:participant_profile) { scenarios.mentor_on_fip_transferring.participant_profile }
 
           include_examples "determines states as",
-                           "valid",
-                           "eligible_for_mentor_training",
-                           "eligible_for_mentor_funding",
-                           "active_mentoring",
-                           "leaving",
-                           "active_mentoring"
+                           :valid,
+                           :eligible_for_mentor_training,
+                           :eligible_for_mentor_funding,
+                           :active_mentoring,
+                           :leaving,
+                           :active_mentoring
         end
 
         context "and they have transferred from their current school" do
           let!(:participant_profile) { scenarios.mentor_on_fip_transferred.participant_profile }
 
           include_examples "determines states as",
-                           "valid",
-                           "eligible_for_mentor_training",
-                           "eligible_for_mentor_funding",
-                           "active_mentoring",
-                           "left",
-                           "active_mentoring"
+                           :valid,
+                           :eligible_for_mentor_training,
+                           :eligible_for_mentor_funding,
+                           :active_mentoring,
+                           :left,
+                           :active_mentoring
         end
 
         context "and they are joining their current school" do
           let!(:participant_profile) { scenarios.mentor_on_fip_joining.participant_profile }
 
           include_examples "determines states as",
-                           "valid",
-                           "eligible_for_mentor_training",
-                           "eligible_for_mentor_funding",
-                           "active_mentoring",
-                           "joining",
-                           "active_mentoring"
+                           :valid,
+                           :eligible_for_mentor_training,
+                           :eligible_for_mentor_funding,
+                           :active_mentoring,
+                           :joining,
+                           :active_mentoring
         end
 
         context "and they have joined their current school" do
           let!(:participant_profile) { scenarios.mentor_on_fip_joined.participant_profile }
 
           include_examples "determines states as",
-                           "valid",
-                           "eligible_for_mentor_training",
-                           "eligible_for_mentor_funding",
-                           "active_mentoring",
-                           "registered_for_fip_training",
-                           "active_mentoring"
+                           :valid,
+                           :eligible_for_mentor_training,
+                           :eligible_for_mentor_funding,
+                           :active_mentoring,
+                           :registered_for_fip_training,
+                           :active_mentoring
         end
       end
     end
@@ -1291,324 +1291,324 @@ RSpec.describe DetermineTrainingRecordState do
         let!(:participant_profile) { scenarios.mentor_on_cip_no_validation.participant_profile }
 
         include_examples "determines states as",
-                         "validation_not_started",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "registered_for_cip_training",
-                         "validation_not_started"
+                         :validation_not_started,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :registered_for_cip_training,
+                         :validation_not_started
       end
 
       context "and a request for details has been submitted" do
         let!(:participant_profile) { scenarios.mentor_on_cip_details_request_submitted.participant_profile }
 
         include_examples "determines states as",
-                         "request_for_details_submitted",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "registered_for_cip_training",
-                         "request_for_details_submitted"
+                         :request_for_details_submitted,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :registered_for_cip_training,
+                         :request_for_details_submitted
       end
 
       context "and a request for details has failed" do
         let!(:participant_profile) { scenarios.mentor_on_cip_details_request_failed.participant_profile }
 
         include_examples "determines states as",
-                         "request_for_details_failed",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "registered_for_cip_training",
-                         "request_for_details_failed"
+                         :request_for_details_failed,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :registered_for_cip_training,
+                         :request_for_details_failed
       end
 
       context "and a request for details has been delivered" do
         let!(:participant_profile) { scenarios.mentor_on_cip_details_request_delivered.participant_profile }
 
         include_examples "determines states as",
-                         "request_for_details_delivered",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "registered_for_cip_training",
-                         "request_for_details_delivered"
+                         :request_for_details_delivered,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :registered_for_cip_training,
+                         :request_for_details_delivered
       end
 
       context "and the validation API has failed" do
         let!(:participant_profile) { scenarios.mentor_on_cip_validation_api_failure.participant_profile }
 
         include_examples "determines states as",
-                         "internal_error",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "registered_for_cip_training",
-                         "internal_error"
+                         :internal_error,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :registered_for_cip_training,
+                         :internal_error
       end
 
       context "and no TRA record could be found" do
         let!(:participant_profile) { scenarios.mentor_on_cip_no_tra_record.participant_profile }
 
         include_examples "determines states as",
-                         "tra_record_not_found",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "registered_for_cip_training",
-                         "tra_record_not_found"
+                         :tra_record_not_found,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :registered_for_cip_training,
+                         :tra_record_not_found
       end
 
       context "and active flags have been found on the TRA record" do
         let!(:participant_profile) { scenarios.mentor_on_cip_manual_check_active_flags.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "active_flags",
-                         "active_flags",
-                         "active_mentoring",
-                         "registered_for_cip_training",
-                         "active_flags"
+                         :valid,
+                         :active_flags,
+                         :active_flags,
+                         :active_mentoring,
+                         :registered_for_cip_training,
+                         :active_flags
       end
 
       context "and a different TRN was identified with the details provided" do
         let!(:participant_profile) { scenarios.mentor_on_cip_manual_check_different_trn.participant_profile }
 
         include_examples "determines states as",
-                         "different_trn",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "registered_for_cip_training",
-                         "different_trn"
+                         :different_trn,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :registered_for_cip_training,
+                         :different_trn
       end
 
       context "and they do not have QTS on record" do
         let!(:participant_profile) { scenarios.mentor_on_cip_manual_check_no_qts.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "registered_for_cip_training",
-                         "active_mentoring"
+                         :valid,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :registered_for_cip_training,
+                         :active_mentoring
       end
 
       context "and they do not have QTS on record but had been made eligible by DfE" do
         let!(:participant_profile) { scenarios.mentor_on_cip_eligible_no_qts.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "registered_for_cip_training",
-                         "active_mentoring"
+                         :valid,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :registered_for_cip_training,
+                         :active_mentoring
       end
 
       context "and the active flags have been investigated and found to be relevant" do
         let!(:participant_profile) { scenarios.mentor_on_cip_ineligible_active_flags.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "not_allowed",
-                         "not_allowed",
-                         "active_mentoring",
-                         "registered_for_cip_training",
-                         "not_allowed"
+                         :valid,
+                         :not_allowed,
+                         :not_allowed,
+                         :active_mentoring,
+                         :registered_for_cip_training,
+                         :not_allowed
       end
 
       context "and the active flags have been investigated and found to be irrelevant" do
         let!(:participant_profile) { scenarios.mentor_on_cip_eligible_active_flags.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "registered_for_cip_training",
-                         "active_mentoring"
+                         :valid,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :registered_for_cip_training,
+                         :active_mentoring
       end
 
       context "and a duplicate profile has been found but no duplicity is recorded" do
         let!(:participant_profile) { scenarios.mentor_on_cip_ineligible_duplicate_profile.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_mentor_training",
-                         "ineligible_secondary",
-                         "active_mentoring",
-                         "registered_for_cip_training",
-                         "active_mentoring"
+                         :valid,
+                         :eligible_for_mentor_training,
+                         :ineligible_secondary,
+                         :active_mentoring,
+                         :registered_for_cip_training,
+                         :active_mentoring
       end
 
       context "and they have a previous participation recorded" do
         let!(:participant_profile) { scenarios.mentor_ero_on_cip.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_mentor_training",
-                         "ineligible_ero",
-                         "active_mentoring_ero",
-                         "registered_for_cip_training",
-                         "active_mentoring_ero"
+                         :valid,
+                         :eligible_for_mentor_training,
+                         :ineligible_ero,
+                         :active_mentoring_ero,
+                         :registered_for_cip_training,
+                         :active_mentoring_ero
       end
 
       context "and they have a previous participation recorded and have been made eligible by DfE" do
         let!(:participant_profile) { scenarios.mentor_ero_on_cip_eligible.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring_ero",
-                         "registered_for_cip_training",
-                         "active_mentoring_ero"
+                         :valid,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring_ero,
+                         :registered_for_cip_training,
+                         :active_mentoring_ero
       end
 
       context "and they have had no eligibility checks performed yet" do
         let!(:participant_profile) { scenarios.mentor_on_cip_no_eligibility_checks.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "checks_not_complete",
-                         "checks_not_complete",
-                         "active_mentoring",
-                         "registered_for_cip_training",
-                         "checks_not_complete"
+                         :valid,
+                         :checks_not_complete,
+                         :checks_not_complete,
+                         :active_mentoring,
+                         :registered_for_cip_training,
+                         :checks_not_complete
       end
 
       context "and they have been made eligible by DfE" do
         let!(:participant_profile) { scenarios.mentor_on_cip_eligible.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "registered_for_cip_training",
-                         "active_mentoring"
+                         :valid,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :registered_for_cip_training,
+                         :active_mentoring
       end
 
       context "and they have a duplicate profile but this is the primary one" do
         let!(:participant_profile) { scenarios.mentor_on_cip_profile_duplicity_primary.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding_primary",
-                         "active_mentoring",
-                         "registered_for_cip_training",
-                         "active_mentoring"
+                         :valid,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding_primary,
+                         :active_mentoring,
+                         :registered_for_cip_training,
+                         :active_mentoring
       end
 
       context "and they have a duplicate profile and this is the secondary one" do
         let!(:participant_profile) { scenarios.mentor_on_cip_profile_duplicity_secondary.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_mentor_training",
-                         "ineligible_secondary",
-                         "active_mentoring",
-                         "registered_for_cip_training",
-                         "active_mentoring"
+                         :valid,
+                         :eligible_for_mentor_training,
+                         :ineligible_secondary,
+                         :active_mentoring,
+                         :registered_for_cip_training,
+                         :active_mentoring
       end
 
       context "and they are active" do
         let!(:participant_profile) { scenarios.mentor_on_cip.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "registered_for_cip_training",
-                         "active_mentoring"
+                         :valid,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :registered_for_cip_training,
+                         :active_mentoring
       end
 
       context "and they are currently not mentoring" do
         let!(:participant_profile) { scenarios.mentor_on_cip_with_no_mentees.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "not_yet_mentoring",
-                         "eligible_for_mentor_funding",
-                         "not_yet_mentoring",
-                         "registered_for_cip_training",
-                         "not_yet_mentoring"
+                         :valid,
+                         :not_yet_mentoring,
+                         :eligible_for_mentor_funding,
+                         :not_yet_mentoring,
+                         :registered_for_cip_training,
+                         :not_yet_mentoring
       end
 
       context "and they have been withdrawn by a training provider through the API" do
         let!(:participant_profile) { scenarios.mentor_on_cip_withdrawn.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "withdrawn_training",
-                         "active_mentoring"
+                         :valid,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :withdrawn_training,
+                         :active_mentoring
       end
 
       context "and they have been re-enrolled after being withdrawn by a training provider through the API" do
         let!(:participant_profile) { scenarios.mentor_on_cip_enrolled_after_withdraw.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "registered_for_cip_training",
-                         "active_mentoring"
+                         :valid,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :registered_for_cip_training,
+                         :active_mentoring
       end
 
       context "and they were withdrawn before an induction record was created for them" do
         let!(:participant_profile) { scenarios.mentor_on_cip_withdrawn_no_induction_record.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "withdrawn_training",
-                         "active_mentoring"
+                         :valid,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :withdrawn_training,
+                         :active_mentoring
       end
 
       context "and their training has been deferred" do
         let!(:participant_profile) { scenarios.mentor_on_cip_deferred.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "deferred_training",
-                         "active_mentoring"
+                         :valid,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :deferred_training,
+                         :active_mentoring
       end
 
       context "and they have been withdrawn from the programme" do
         let!(:participant_profile) { scenarios.mentor_on_cip_withdrawn_from_programme.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "withdrawn_programme",
-                         "withdrawn_programme"
+                         :valid,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :withdrawn_programme,
+                         :withdrawn_programme
       end
 
       context "and they have completed their induction training" do
         let!(:participant_profile) { scenarios.mentor_on_cip_completed.participant_profile }
 
         include_examples "determines states as",
-                         "valid",
-                         "eligible_for_mentor_training",
-                         "eligible_for_mentor_funding",
-                         "active_mentoring",
-                         "completed_training",
-                         "active_mentoring"
+                         :valid,
+                         :eligible_for_mentor_training,
+                         :eligible_for_mentor_funding,
+                         :active_mentoring,
+                         :completed_training,
+                         :active_mentoring
       end
 
       context "in transfer scenario" do
@@ -1618,72 +1618,72 @@ RSpec.describe DetermineTrainingRecordState do
           let!(:participant_profile) { scenarios.mentor_on_cip_leaving.participant_profile }
 
           include_examples "determines states as",
-                           "valid",
-                           "eligible_for_mentor_training",
-                           "eligible_for_mentor_funding",
-                           "active_mentoring",
-                           "leaving",
-                           "active_mentoring"
+                           :valid,
+                           :eligible_for_mentor_training,
+                           :eligible_for_mentor_funding,
+                           :active_mentoring,
+                           :leaving,
+                           :active_mentoring
         end
 
         context "and they have left their current school" do
           let!(:participant_profile) { scenarios.mentor_on_cip_left.participant_profile }
 
           include_examples "determines states as",
-                           "valid",
-                           "eligible_for_mentor_training",
-                           "eligible_for_mentor_funding",
-                           "active_mentoring",
-                           "left",
-                           "active_mentoring"
+                           :valid,
+                           :eligible_for_mentor_training,
+                           :eligible_for_mentor_funding,
+                           :active_mentoring,
+                           :left,
+                           :active_mentoring
         end
 
         context "and they are transferring from their current school" do
           let!(:participant_profile) { scenarios.mentor_on_cip_transferring.participant_profile }
 
           include_examples "determines states as",
-                           "valid",
-                           "eligible_for_mentor_training",
-                           "eligible_for_mentor_funding",
-                           "active_mentoring",
-                           "leaving",
-                           "active_mentoring"
+                           :valid,
+                           :eligible_for_mentor_training,
+                           :eligible_for_mentor_funding,
+                           :active_mentoring,
+                           :leaving,
+                           :active_mentoring
         end
 
         context "and they have transferred from their current school" do
           let!(:participant_profile) { scenarios.mentor_on_cip_transferred.participant_profile }
 
           include_examples "determines states as",
-                           "valid",
-                           "eligible_for_mentor_training",
-                           "eligible_for_mentor_funding",
-                           "active_mentoring",
-                           "left",
-                           "active_mentoring"
+                           :valid,
+                           :eligible_for_mentor_training,
+                           :eligible_for_mentor_funding,
+                           :active_mentoring,
+                           :left,
+                           :active_mentoring
         end
 
         context "and they are joining their current school" do
           let!(:participant_profile) { scenarios.mentor_on_cip_joining.participant_profile }
 
           include_examples "determines states as",
-                           "valid",
-                           "eligible_for_mentor_training",
-                           "eligible_for_mentor_funding",
-                           "active_mentoring",
-                           "joining",
-                           "active_mentoring"
+                           :valid,
+                           :eligible_for_mentor_training,
+                           :eligible_for_mentor_funding,
+                           :active_mentoring,
+                           :joining,
+                           :active_mentoring
         end
 
         context "and they have joined their current school" do
           let!(:participant_profile) { scenarios.mentor_on_cip_joined.participant_profile }
 
           include_examples "determines states as",
-                           "valid",
-                           "eligible_for_mentor_training",
-                           "eligible_for_mentor_funding",
-                           "active_mentoring",
-                           "registered_for_cip_training",
-                           "active_mentoring"
+                           :valid,
+                           :eligible_for_mentor_training,
+                           :eligible_for_mentor_funding,
+                           :active_mentoring,
+                           :registered_for_cip_training,
+                           :active_mentoring
         end
       end
     end

--- a/spec/services/determine_training_record_state_spec.rb
+++ b/spec/services/determine_training_record_state_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe DetermineTrainingRecordState do
   let!(:current_school) { nil }
 
   subject(:determined_state) do
-    described_class.call(participant_profile:, school: current_school)
+    participant_profiles = ParticipantProfile.where(id: participant_profile.id)
+    described_class.call(participant_profiles:, school: current_school)
   end
 
   shared_examples "determines states as" do |validation_state, training_eligibility_state, fip_funding_eligibility_state, mentoring_state, training_state, record_state|
@@ -28,22 +29,6 @@ RSpec.describe DetermineTrainingRecordState do
   end
 
   describe "#call" do
-    context "when not called with a ParticipantProfile" do
-      subject { described_class.call(participant_profile: TeacherProfile.new).record_state.participant_profile }
-
-      it "Raises an ArgumentError" do
-        expect { subject.participant_profile }.to raise_error ArgumentError
-      end
-    end
-
-    context "when not called with an InductionRecord" do
-      subject { described_class.call(participant_profile: scenarios.ect_on_cip_in_training.participant_profile, induction_record: TeacherProfile.new).record_state.participant_profile }
-
-      it "Raises an ArgumentError" do
-        expect { subject.participant_profile }.to raise_error ArgumentError
-      end
-    end
-
     context "when a FIP ECT" do
       context "and is awaiting validation" do
         let!(:participant_profile) { scenarios.ect_on_fip_no_validation.participant_profile }

--- a/spec/services/induction/find_by_spec.rb
+++ b/spec/services/induction/find_by_spec.rb
@@ -14,13 +14,17 @@ RSpec.describe Induction::FindBy do
   let(:school_3) { NewSeeds::Scenarios::Schools::School.new.build.chosen_fip_and_partnered_in(cohort:) }
   let(:ect) { NewSeeds::Scenarios::Participants::Ects::Ect.new(school_cohort: school_1.school_cohort).build }
 
+  let(:appropriate_body_1) { create(:appropriate_body_local_authority) }
+  let(:appropriate_body_2) { create(:appropriate_body_local_authority) }
+  let(:appropriate_body_5) { create(:appropriate_body_national_organisation) }
+
   let(:participant_profile) { ect.participant_profile }
 
-  let!(:induction_1) { ect.add_induction_record(induction_programme: school_1.induction_programme, start_date: Date.new(current_year, 9, 1), end_date: Date.new(current_year, 10, 1), induction_status: "leaving") }
-  let!(:induction_2) { ect.add_induction_record(induction_programme: school_2.induction_programme, start_date: Date.new(current_year, 10, 1), end_date: Date.new(current_year, 11, 1), induction_status: "leaving") }
+  let!(:induction_1) { ect.add_induction_record(induction_programme: school_1.induction_programme, start_date: Date.new(current_year, 9, 1), end_date: Date.new(current_year, 10, 1), induction_status: "leaving", appropriate_body: appropriate_body_1) }
+  let!(:induction_2) { ect.add_induction_record(induction_programme: school_2.induction_programme, start_date: Date.new(current_year, 10, 1), end_date: Date.new(current_year, 11, 1), induction_status: "leaving", appropriate_body: appropriate_body_2) }
   let!(:induction_3) { ect.add_induction_record(induction_programme: school_3.induction_programme, start_date: Date.new(current_year, 11, 1), end_date: Date.new(current_year, 12, 1), induction_status: "changed") }
   let!(:induction_4) { ect.add_induction_record(induction_programme: school_3.induction_programme, start_date: Date.new(current_year, 12, 1), end_date: Date.new(current_year + 1, 1, 1), induction_status: "leaving") }
-  let!(:induction_5) { ect.add_induction_record(induction_programme: school_3.induction_programme, start_date: Date.new(current_year + 1, 1, 1), end_date: nil, induction_status: "leaving") }
+  let!(:induction_5) { ect.add_induction_record(induction_programme: school_3.induction_programme, start_date: Date.new(current_year + 1, 1, 1), end_date: nil, induction_status: "leaving", appropriate_body: appropriate_body_5) }
 
   subject(:service) { described_class }
 
@@ -116,6 +120,16 @@ RSpec.describe Induction::FindBy do
           expect(service.call(participant_profile:, school: school_1.school)).to eq induction_1
           expect(service.call(participant_profile:, school: school_2.school)).to eq induction_2
           expect(service.call(participant_profile:, school: school_3.school)).to eq induction_5
+        end
+      end
+    end
+
+    context "when an appropriate body is supplied" do
+      it "returns the latest induction record for that appropriate body" do
+        travel_to a_point_in_time do
+          expect(service.call(participant_profile:, appropriate_body: appropriate_body_1)).to eq induction_1
+          expect(service.call(participant_profile:, appropriate_body: appropriate_body_2)).to eq induction_2
+          expect(service.call(participant_profile:, appropriate_body: appropriate_body_5)).to eq induction_5
         end
       end
     end


### PR DESCRIPTION
WIP - spike that converts the logic to Ruby and attempts to use a single ActiveRecord query to load the necessary data for multiple participant profiles