### PR TITLE
Update dfe-analytics to latest version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -113,7 +113,7 @@ gem "rouge"
 
 gem "auto_strip_attributes", "~> 2.6"
 
-gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.6.0"
+gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.11.0"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/DFE-Digital/dfe-analytics.git
-  revision: b1617a618bdcfb505f6ba8f7b1c0b5efa20a3f1a
-  tag: v1.6.0
+  revision: efcd939fecbc64574a3e1d5d5efef7e14b65f39f
+  tag: v1.11.0
   specs:
-    dfe-analytics (1.6.0)
+    dfe-analytics (1.11.0)
       google-cloud-bigquery (~> 1.38)
       request_store_rails (~> 2)
 

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -155,6 +155,7 @@
   - disable_from_year
   :participant_profiles:
   - id
+  - school_id
   - type
   - core_induction_programme_id
   - cohort_id


### PR DESCRIPTION
Includes bug fixes for supporting models using single table inheritance.

I'm not sure why `school_id` wasn't being picked up in earlier versions of the gem but its a field that definitely exists in the database so we can/should be sending it.

I've tested on the review app and its pulling through STI models into BigQuery correctly now.