### PR TITLE
Set cohort change to one month until properly fixed

### DIFF
--- a/spec/cypress/app_commands/scenarios/admin/schools.rb
+++ b/spec/cypress/app_commands/scenarios/admin/schools.rb
@@ -8,8 +8,8 @@ coordinator.induction_coordinator_profile.schools.first.destroy!
 coordinator.induction_coordinator_profile.schools = [school]
 
 school_with_cohorts = FactoryBot.create(:school, name: "Cohort School", urn: 900_123)
-cohort_2021 = Cohort.find_or_create_by!(start_year: 2021, registration_start_date: Date.new(2021, 5, 10), academic_year_start_date: Date.new(2021, 10, 1))
-cohort_2022 = Cohort.find_or_create_by!(start_year: 2022, registration_start_date: Date.new(2022, 5, 10), academic_year_start_date: Date.new(2022, 10, 1))
+cohort_2021 = Cohort.find_or_create_by!(start_year: 2021, registration_start_date: Date.new(2021, 5, 10), academic_year_start_date: Date.new(2021, 11, 1))
+cohort_2022 = Cohort.find_or_create_by!(start_year: 2022, registration_start_date: Date.new(2022, 5, 10), academic_year_start_date: Date.new(2022, 11, 1))
 
 cip_1 = FactoryBot.create(:core_induction_programme, name: "CIP Programme 1")
 cip_2 = FactoryBot.create(:core_induction_programme, name: "CIP Programme 2")

--- a/spec/factories/cohorts.rb
+++ b/spec/factories/cohorts.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
   factory :cohort do
     start_year { Faker::Number.unique.between(from: 2022, to: 2100) }
     registration_start_date { Date.new(start_year.to_i, 6, 5) }
-    academic_year_start_date { Date.new(start_year.to_i, 10, 1) }
+    academic_year_start_date { Date.new(start_year.to_i, 11, 1) }
     automatic_assignment_period_end_date { Date.new(start_year.to_i + 1, 3, 31) }
 
     initialize_with do
@@ -16,15 +16,15 @@ FactoryBot.define do
     end
 
     trait :previous do
-      start_year { Date.current.year - (Date.current.month < 10 ? 2 : 1) }
+      start_year { Date.current.year - (Date.current.month < 11 ? 2 : 1) }
     end
 
     trait :current do
-      start_year { Date.current.year - (Date.current.month < 10 ? 1 : 0) }
+      start_year { Date.current.year - (Date.current.month < 11 ? 1 : 0) }
     end
 
     trait :next do
-      start_year { Date.current.year + (Date.current.month < 10 ? 0 : 1) }
+      start_year { Date.current.year + (Date.current.month < 11 ? 0 : 1) }
     end
 
     trait :consecutive_years do

--- a/spec/factories/seeds/cohort_factory.rb
+++ b/spec/factories/seeds/cohort_factory.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     sequence(:start_year) { Faker::Number.unique.between(from: 2050, to: 3025) }
 
     registration_start_date { Date.new(start_year, 6, 5) }
-    academic_year_start_date { Date.new(start_year, 10, 1) }
+    academic_year_start_date { Date.new(start_year, 11, 1) }
     automatic_assignment_period_end_date { Date.new(start_year + 1, 3, 31) }
 
     initialize_with do

--- a/spec/features/schools/participants/transfer_out/ppt_transferred_in_and_transferred_out_spec.rb
+++ b/spec/features/schools/participants/transfer_out/ppt_transferred_in_and_transferred_out_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "old and new SIT transferring the same participant", type: :feature, js: true, rutabaga: false, travel_to: Time.zone.local(2021, 10, 21) do
+RSpec.describe "old and new SIT transferring the same participant", type: :feature, js: true, rutabaga: false, travel_to: Time.zone.local(2021, 11, 21) do
   context "Transfer out an ECT that has already been transferred in" do
     before do
       set_participant_data
@@ -83,7 +83,7 @@ RSpec.describe "old and new SIT transferring the same participant", type: :featu
     def when_i_add_a_valid_end_date
       legend = "When is #{@participant_data[:full_name]} leaving your school?"
 
-      fill_in_date(legend, with: "2022-10-24")
+      fill_in_date(legend, with: "2022-11-24")
     end
 
     def when_i_select(option)
@@ -179,7 +179,7 @@ RSpec.describe "old and new SIT transferring the same participant", type: :featu
         trn: "1001000",
         full_name: "Sally Teacher",
         start_date: Time.zone.today.prev_month,
-        end_date: Date.new(2022, 10, 24),
+        end_date: Date.new(2022, 11, 24),
         email: "sally-teacher@example.com",
       }
     end

--- a/spec/features/schools/participants/transfer_out/transfer_out_only_spec.rb
+++ b/spec/features/schools/participants/transfer_out/transfer_out_only_spec.rb
@@ -6,7 +6,7 @@ Dir.glob(Rails.root.join("db/new_seeds/scenarios/**/*.rb")).each do |scenario|
   require scenario
 end
 
-RSpec.describe "transfer out participants", type: :feature, js: true, rutabaga: false, travel_to: Time.zone.local(2022, 10, 21) do
+RSpec.describe "transfer out participants", type: :feature, js: true, rutabaga: false, travel_to: Time.zone.local(2022, 11, 21) do
   context "Transfer out an ECT" do
     before do
       allow_participant_transfer_mailers
@@ -74,13 +74,13 @@ RSpec.describe "transfer out participants", type: :feature, js: true, rutabaga: 
     def when_i_add_an_invalid_date
       legend = "When is #{@ect.full_name} leaving your school?"
 
-      fill_in_date(legend, with: "23-10-24")
+      fill_in_date(legend, with: "23-11-24")
     end
 
     def when_i_add_a_valid_end_date
       legend = "When is #{@ect.full_name} leaving your school?"
 
-      fill_in_date(legend, with: "2022-10-24")
+      fill_in_date(legend, with: "2022-11-24")
     end
 
     def when_i_select(option)
@@ -106,7 +106,7 @@ RSpec.describe "transfer out participants", type: :feature, js: true, rutabaga: 
     def then_i_should_be_on_the_check_your_answers_page
       expect(page).to have_selector("h1", text: "Check your answers")
       expect(page).to have_selector("dd", text: @ect.full_name)
-      expect(page).to have_selector("dd", text: Date.new(2022, 10, 24).to_fs(:govuk))
+      expect(page).to have_selector("dd", text: Date.new(2022, 11, 24).to_fs(:govuk))
     end
 
     def then_i_should_be_on_the_complete_page

--- a/spec/features/schools/training_dashboard/manage_fip_training_spec.rb
+++ b/spec/features/schools/training_dashboard/manage_fip_training_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "./manage_training_steps"
 
-RSpec.describe "Manage FIP training", js: true, travel_to: Time.zone.local(2021, 10, 17, 16, 15, 0) do
+RSpec.describe "Manage FIP training", js: true, travel_to: Time.zone.local(2021, 11, 17, 16, 15, 0) do
   include ManageTrainingSteps
 
   scenario "FIP Induction Coordinator with training provider" do

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Cohort, type: :model do
   describe ".current" do
     describe "when the current date matches the academic year start date" do
       it "returns the cohort with start_year the current year" do
-        Timecop.freeze(Date.new(2021, 10, 1)) do
+        Timecop.freeze(Date.new(2021, 11, 1)) do
           expect(Cohort.current.start_year).to eq 2021
         end
       end
@@ -49,7 +49,7 @@ RSpec.describe Cohort, type: :model do
   describe ".next" do
     describe "when the current date matches the academic year start date" do
       it "returns the cohort with start_year the next year" do
-        Timecop.freeze(Date.new(2021, 10, 1)) do
+        Timecop.freeze(Date.new(2021, 11, 1)) do
           expect(Cohort.next.start_year).to eq 2022
         end
       end
@@ -67,7 +67,7 @@ RSpec.describe Cohort, type: :model do
   describe ".previous" do
     describe "when exactly 1 year ago matches the academic year start date" do
       it "returns the cohort with start_year the previous year" do
-        Timecop.freeze(Date.new(2021, 10, 10)) do
+        Timecop.freeze(Date.new(2021, 11, 10)) do
           expect(Cohort.previous.start_year).to eq 2020
         end
       end
@@ -84,14 +84,14 @@ RSpec.describe Cohort, type: :model do
 
   describe ".containing_date" do
     it "returns the cohort which contains the given date" do
-      expect(Cohort.containing_date(Date.new(2021, 10, 1)).start_year).to eq 2021
-      expect(Cohort.containing_date(Date.new(2022, 10, 10)).start_year).to eq 2022
+      expect(Cohort.containing_date(Date.new(2021, 11, 1)).start_year).to eq 2021
+      expect(Cohort.containing_date(Date.new(2022, 11, 10)).start_year).to eq 2022
       expect(Cohort.containing_date(Date.new(2023, 1, 10)).start_year).to eq 2022
       expect(Cohort.containing_date(Date.new(2024, 3, 22)).start_year).to eq 2023
     end
 
     context "when outside the currently added cohorts" do
-      let(:oob_date) { Date.new(Cohort.maximum(:start_year) + 1, 10, 1) }
+      let(:oob_date) { Date.new(Cohort.maximum(:start_year) + 1, 11, 1) }
 
       it "returns nil" do
         expect(Cohort.containing_date(oob_date)).to be_nil
@@ -101,7 +101,7 @@ RSpec.describe Cohort, type: :model do
 
   describe ".within_next_registration_period?" do
     before do
-      Cohort.find_by(start_year: 2023).update!(registration_start_date: Date.new(2023, 6, 1), academic_year_start_date: Date.new(2023, 10, 1))
+      Cohort.find_by(start_year: 2023).update!(registration_start_date: Date.new(2023, 6, 1), academic_year_start_date: Date.new(2023, 11, 1))
     end
 
     context "when the current time is after the registration start date for then next cohort" do
@@ -114,7 +114,7 @@ RSpec.describe Cohort, type: :model do
 
     context "when the active_registration_cohort and the current cohort are the same" do
       it "returns false" do
-        Timecop.freeze(Date.new(2023, 10, 1)) do
+        Timecop.freeze(Date.new(2023, 11, 1)) do
           expect(Cohort).not_to be_within_next_registration_period
         end
       end

--- a/spec/requests/schools/dashboard_spec.rb
+++ b/spec/requests/schools/dashboard_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Schools::Dashboard", type: :request do
   let(:school) { user.schools.first }
 
   before do
-    travel_to Date.new(2022, 10, 1)
+    travel_to Date.new(2022, 11, 1)
     sign_in user
   end
 

--- a/spec/requests/schools/programme_choice_spec.rb
+++ b/spec/requests/schools/programme_choice_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Schools::ProgrammeChoice", type: :request, travel_to: Date.new(2021, 10, 1) do
+RSpec.describe "Schools::ProgrammeChoice", type: :request, travel_to: Date.new(2021, 11, 1) do
   let(:user) { create(:user, :induction_coordinator) }
   let(:school) { user.induction_coordinator_profile.schools.first }
   let(:cohort) { create(:cohort, start_year: 2021) }

--- a/spec/services/induction/amend_participant_cohort_spec.rb
+++ b/spec/services/induction/amend_participant_cohort_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Induction::AmendParticipantCohort do
 
       it "returns false and set errors" do
         # FIXME: this is temp until cohort specs are reverted back to 1/9
-        travel_to Date.new(Cohort.ordered_by_start_year.last.start_year + 2, 10, 1)
+        travel_to Date.new(Cohort.ordered_by_start_year.last.start_year + 2, 11, 1)
 
         expect(form.save).to be_falsey
         expect(form.errors[:target_cohort]).to_not be_nil

--- a/spec/services/participants/sync_dqt_induction_start_date_spec.rb
+++ b/spec/services/participants/sync_dqt_induction_start_date_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Participants::SyncDQTInductionStartDate, with_feature_flags: { co
 
   context "when the participant was added to the service before 1st Jun 2023" do
     let(:participant_created_at) { Date.new(2023, 5, 31) }
-    let(:dqt_induction_start_date) { Date.new(2022, 10, 1) }
+    let(:dqt_induction_start_date) { Date.new(2022, 11, 1) }
 
     context "when participant's induction start date is present" do
       let(:participant_induction_start_date) { Date.new(2022, 9, 1) }
@@ -121,7 +121,7 @@ RSpec.describe Participants::SyncDQTInductionStartDate, with_feature_flags: { co
     end
 
     context "when the DQT induction start date's related cohort and the participant's cohort are the same" do
-      let(:dqt_induction_start_date) { Date.new(2022, 10, 2) }
+      let(:dqt_induction_start_date) { Date.new(2022, 11, 2) }
       let(:participant_cohort_start_year) { 2022 }
 
       it "changes the participant's induction start date only" do
@@ -133,7 +133,7 @@ RSpec.describe Participants::SyncDQTInductionStartDate, with_feature_flags: { co
     end
 
     context "when the DQT induction start date's related cohort and the participant's cohort are different" do
-      let(:dqt_induction_start_date) { Date.new(Cohort.current.start_year, 10, 2) }
+      let(:dqt_induction_start_date) { Date.new(Cohort.current.start_year, 11, 2) }
       let(:participant_cohort_start_year) { Cohort.previous.start_year }
       let(:target_school_cohort) do
         create(:seed_school_cohort, :fip, cohort: Cohort.current, school: participant_profile.school)
@@ -153,7 +153,7 @@ RSpec.describe Participants::SyncDQTInductionStartDate, with_feature_flags: { co
     end
 
     context "when the cohort can't be amended" do
-      let(:dqt_induction_start_date) { Date.new(Cohort.current.start_year, 10, 2) }
+      let(:dqt_induction_start_date) { Date.new(Cohort.current.start_year, 11, 2) }
       let(:participant_cohort_start_year) { Cohort.previous.start_year }
 
       it "does not change the participant and save the errors" do
@@ -166,7 +166,7 @@ RSpec.describe Participants::SyncDQTInductionStartDate, with_feature_flags: { co
     end
 
     context "when an error is already present from a previous job" do
-      let(:dqt_induction_start_date) { Date.new(Cohort.current.start_year, 10, 2) }
+      let(:dqt_induction_start_date) { Date.new(Cohort.current.start_year, 11, 2) }
       let!(:error) { SyncDQTInductionStartDateError.create!(participant_profile:, message: "test message") }
 
       context "when the participant is successfully processed" do

--- a/spec/services/record_declaration_spec.rb
+++ b/spec/services/record_declaration_spec.rb
@@ -297,7 +297,7 @@ RSpec.describe RecordDeclaration do
 
   context "when the participant is an ECF" do
     let(:schedule)              { Finance::Schedule::ECF.find_by(schedule_identifier: "ecf-standard-september", cohort: current_cohort) }
-    let(:declaration_date)      { Date.new(current_cohort.start_year, 10, 1) } # FIXME: schedule.milestones.find_by(declaration_type: "started").start_date
+    let(:declaration_date)      { Date.new(current_cohort.start_year, 11, 1) } # FIXME: schedule.milestones.find_by(declaration_type: "started").start_date
     let(:traits)                { [] }
     let(:opts)                  { {} }
     let(:participant_profile) do

--- a/spec/services/record_declarations/actions/make_declarations_payable_spec.rb
+++ b/spec/services/record_declarations/actions/make_declarations_payable_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe RecordDeclarations::Actions::MakeDeclarationsPayable do
   let(:cpd_lead_provider)                { create(:cpd_lead_provider, :with_lead_provider, :with_npq_lead_provider) }
-  let(:cutoff_date)                      { Time.zone.local(2021, 11, 1) }
+  let(:cutoff_date)                      { Time.zone.local(2021, 11, 15) }
   let(:before_cutoff_date)               { cutoff_date - 1.day }
   let(:after_cutoff_date)                { cutoff_date + 1.day }
   let(:eligible_before_start_date_count) { 3 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -110,7 +110,7 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     # create cohorts since 2020 with default schedule
-    end_year = Date.current.month < 10 ? Date.current.year : Date.current.year + 1
+    end_year = Date.current.month < 11 ? Date.current.year : Date.current.year + 1
     (2020..end_year).each do |start_year|
       cohort = Cohort.find_by(start_year:) || FactoryBot.create(:cohort, start_year:)
       Finance::Schedule::ECF.default_for(cohort:) || FactoryBot.create(:ecf_schedule, cohort:)


### PR DESCRIPTION
### Context
After the cohort rolled over in academic start date 1/9, many specs failed, which means main and deployment is blocked. To fix those we need time. For now to unblock deployment temporarily push the problem to one month from now, to allow fixing the failures properly once and for all.

- Ticket: n/a

### Changes proposed in this pull request

- Set academic cohort to 1/11 in factories and setup
- Set all other specs to 1/11 for now temp until this is fixed properly

### Guidance to review
meh
