### PR TITLE
[CST-1960] - Bug Fix: allow declarations to exist with change of circumstances option

### DIFF
--- a/app/forms/admin/participants/change_relationship/change_relationship_wizard.rb
+++ b/app/forms/admin/participants/change_relationship/change_relationship_wizard.rb
@@ -142,7 +142,7 @@ module Admin
         end
 
         def programme_can_be_changed?
-          !participant_has_declarations_with_the_current_provider?
+          reason_for_change_circumstances? || !participant_has_declarations_with_the_current_provider?
         end
 
         def show_path_for(step:)

--- a/spec/forms/admin/participants/change_relationship/change_relationship_wizard_spec.rb
+++ b/spec/forms/admin/participants/change_relationship/change_relationship_wizard_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+RSpec.describe Admin::Participants::ChangeRelationship::ChangeRelationshipWizard, type: :model do
+  let(:current_step) { :reason_for_change }
+  let(:data_store) { instance_double(FormData::ChangeParticipantRelationshipStore) }
+  let(:admin_user) { create(:seed_admin_profile, :with_user) }
+  let(:school) { create(:seed_school, :with_induction_coordinator) }
+  let(:cohort) { create(:seed_cohort, start_year: 2022) }
+  let(:request) { {} }
+  let(:school_cohort) { create(:seed_school_cohort, :fip, cohort:, school:) }
+  let(:induction_programme) { create(:seed_induction_programme, :fip, :with_partnership, school_cohort:, school:, cohort:) }
+  let!(:participant_profile) { create(:seed_ect_participant_profile, :with_teacher_profile, :with_participant_identity, :with_schedule, school_cohort:) }
+
+  let(:submitted_params) { {} }
+
+  subject(:wizard) { described_class.new(current_step:, default_step_name: :reason_for_change, data_store:, current_user: admin_user, participant_profile:, request:, submitted_params:) }
+
+  before do
+    allow(data_store).to receive(:set)
+    allow(data_store).to receive(:participant_profile).and_return(participant_profile)
+    Induction::Enrol.call(participant_profile:, induction_programme:, start_date: Date.new(cohort.start_year, 9, 1))
+  end
+
+  describe "#programme_can_be_changed?" do
+    let!(:relationship) { create(:seed_partnership, :with_lead_provider, :with_delivery_partner, school:, cohort:, relationship: true) }
+    let(:circumstances_change) { false }
+    let(:has_declarations) { false }
+
+    before do
+      allow(data_store).to receive(:reason_for_change_circumstances?).and_return(circumstances_change)
+      allow(wizard).to receive(:participant_has_declarations_with_the_current_provider?).and_return(has_declarations)
+    end
+
+    context "when the reason for change is mistake" do
+      it "returns true" do
+        expect(wizard).to be_programme_can_be_changed
+      end
+
+      context "when the participant has declarations with their current provider" do
+        let(:has_declarations) { true }
+
+        it "returns false" do
+          expect(wizard).not_to be_programme_can_be_changed
+        end
+      end
+    end
+
+    context "when the reason for change is circumstances" do
+      let(:circumstances_change) { true }
+
+      it "returns true" do
+        expect(wizard).to be_programme_can_be_changed
+      end
+    end
+  end
+end

--- a/spec/forms/admin/participants/change_relationship/change_relationship_wizard_spec.rb
+++ b/spec/forms/admin/participants/change_relationship/change_relationship_wizard_spec.rb
@@ -4,12 +4,8 @@ RSpec.describe Admin::Participants::ChangeRelationship::ChangeRelationshipWizard
   let(:current_step) { :reason_for_change }
   let(:data_store) { instance_double(FormData::ChangeParticipantRelationshipStore) }
   let(:admin_user) { create(:seed_admin_profile, :with_user) }
-  let(:school) { create(:seed_school, :with_induction_coordinator) }
-  let(:cohort) { create(:seed_cohort, start_year: 2022) }
   let(:request) { {} }
-  let(:school_cohort) { create(:seed_school_cohort, :fip, cohort:, school:) }
-  let(:induction_programme) { create(:seed_induction_programme, :fip, :with_partnership, school_cohort:, school:, cohort:) }
-  let!(:participant_profile) { create(:seed_ect_participant_profile, :with_teacher_profile, :with_participant_identity, :with_schedule, school_cohort:) }
+  let!(:participant_profile) { create(:seed_ect_participant_profile, :valid) }
 
   let(:submitted_params) { {} }
 
@@ -18,11 +14,9 @@ RSpec.describe Admin::Participants::ChangeRelationship::ChangeRelationshipWizard
   before do
     allow(data_store).to receive(:set)
     allow(data_store).to receive(:participant_profile).and_return(participant_profile)
-    Induction::Enrol.call(participant_profile:, induction_programme:, start_date: Date.new(cohort.start_year, 9, 1))
   end
 
   describe "#programme_can_be_changed?" do
-    let!(:relationship) { create(:seed_partnership, :with_lead_provider, :with_delivery_partner, school:, cohort:, relationship: true) }
     let(:circumstances_change) { false }
     let(:has_declarations) { false }
 


### PR DESCRIPTION
### Context

- Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-1960)

Intermittent problem existed where in the admin console, attempting to change a participants relationship resulted in being kicked out to the participant details when clicking "Continue" on the first wizard page.
This appears to happen only in the following scenario:
* Admin chooses the change of circumstances option
* The participant has declarations with their current provider
* There is at least one other relationship at the school

On clicking "Continue" the next step (:change_training_programme) is loaded and it checks that you should be allowed to land here. This test checks whether the partnership can be changed but does not consider that it is OK to change when the participant has declarations if the admin chose the 'change of circumstances" option.  It is not OK to have declarations if the admin chose the "mistake" option.

### Changes proposed in this pull request
Fix the logic

### Guidance to review

