### PR TITLE
Change XL headings to L

### DIFF
--- a/app/components/admin/schools/cohort_component.html.erb
+++ b/app/components/admin/schools/cohort_component.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-!-margin-bottom-9">
-  <%= tag.h2(heading, class: "govuk-heading-l") %>
+  <%= tag.h2(heading, class: "govuk-heading-m") %>
 
   <% if empty? %>
 

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -61,8 +61,8 @@ module AdminHelper
     content_for(:title) { "#{full_name} - #{section}" }
 
     safe_join([
-      tag.span(role, class: "govuk-caption-xl"),
-      tag.h1(class: "govuk-heading-xl govuk-!-margin-bottom-4") { safe_join([full_name, visually_hidden]) },
+      tag.span(role, class: "govuk-caption-l"),
+      tag.h1(class: "govuk-heading-l govuk-!-margin-bottom-4") { safe_join([full_name, visually_hidden]) },
       tag.p(class: "govuk-!-margin-top-1 govuk-!-margin-bottom-1") do
         safe_join(
           [

--- a/app/views/accessibility_statements/show.html.erb
+++ b/app/views/accessibility_statements/show.html.erb
@@ -2,7 +2,7 @@
 <% content_for :before_content, govuk_back_link( text: "Back", href: :back) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Accessibility statement for Manage training for early career teachers service</h1>
+    <h1 class="govuk-heading-l">Accessibility statement for Manage training for early career teachers service</h1>
     <p class="govuk-body">This statement applies to the Manage training for early career teachers service.</p>
     <p class="govuk-body">This service is run by the Department for Education. We want as many people as possible to be able to use it. You should be able to:</p>
     <ul class="govuk-list govuk-list--bullet">
@@ -20,7 +20,7 @@
           rel: "noopener noreferrer" %> has advice on making your device easier to use if you have an access need.
     </p>
 
-    <h2 class="govuk-heading-l">How accessible this service is</h2>
+    <h2 class="govuk-heading-m">How accessible this service is</h2>
 
     <p class="govuk-body">
       When tested, the service was compliant with
@@ -37,7 +37,7 @@
       <%= govuk_mail_to("continuing-professional-development@digital.education.gov.uk") %>
     </p>
 
-    <h2 class="govuk-heading-l">Reporting accessibility problems with this service</h2>
+    <h2 class="govuk-heading-m">Reporting accessibility problems with this service</h2>
 
     <p class="govuk-body">If you find any problems not listed on this page or think we are not meeting accessibility requirements, contact us:</p>
     <p class="govuk-body">Email:<br>
@@ -48,7 +48,7 @@
           target: :_blank,
           rel: "noopener noreferrer" %>
     </p>
-    <h2 class="govuk-heading-l">Enforcement procedure</h2>
+    <h2 class="govuk-heading-m">Enforcement procedure</h2>
     <p class="govuk-body">The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’).</p>
     <p class="govuk-body">If you are not happy with how we respond to your complaint,
       <%= govuk_link_to 'contact the Equality Advisory and Support Service (EASS) (opens in a new tab)',
@@ -57,10 +57,10 @@
           rel: "noopener noreferrer" %>
     </p>
 
-    <h2 class="govuk-heading-l">Technical information about this service’s accessibility</h2>
+    <h2 class="govuk-heading-m">Technical information about this service’s accessibility</h2>
     <p class="govuk-body">The Department for Education is committed to making this service accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.</p>
 
-    <h2 class="govuk-heading-l">Compliance status</h2>
+    <h2 class="govuk-heading-m">Compliance status</h2>
     <p class="govuk-body">This service is found to be compliant with the
       <%= govuk_link_to 'Web Content Accessibility Guidelines version 2.1) AA standard (opens in a new tab)',
           "https://www.w3.org/TR/WCAG21/",
@@ -77,13 +77,13 @@
 
     <%= render MailToSupportComponent.new %></p>
 
-    <h3 class="govuk-heading-m">Disproportionate burden</h3>
+    <h3 class="govuk-heading-s">Disproportionate burden</h3>
     <p class="govuk-body">Not applicable</p>
 
-    <h3 class="govuk-heading-m">Content not within scope of this accessibility statement</h3>
+    <h3 class="govuk-heading-s">Content not within scope of this accessibility statement</h3>
     <p class="govuk-body">Not applicable</p>
 
-    <h2 class="govuk-heading-l">Preparation of this accessibility statement</h2>
+    <h2 class="govuk-heading-m">Preparation of this accessibility statement</h2>
     <p class="govuk-body">This statement was prepared on 16 April 2021 and updated 9 August 2022.</p>
     <p class="govuk-body">The service was last tested on 9 August 2022 for compliance with WCAG 2.1 AA.</p>
     <p class="govuk-body">

--- a/app/views/admin/administrators/administrators/new.html.erb
+++ b/app/views/admin/administrators/administrators/new.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Add a new admin user</h1>
+    <h1 class="govuk-heading-l">Add a new admin user</h1>
     <p class="govuk-body">This should be someone from the Department for Education</p>
     <%= form_for @user, url: confirm_admin_administrators_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>

--- a/app/views/admin/gias/home/index.html.erb
+++ b/app/views/admin/gias/home/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "GIAS changes to schools" %>
 
-<h1 class="govuk-heading-xl">GIAS changes to schools</h1>
+<h1 class="govuk-heading-l">GIAS changes to schools</h1>
 
 <h2 class="govuk-heading-l">
   <%= govuk_link_to "Major school changes", admin_gias_major_school_changes_path %>

--- a/app/views/admin/gias/major_school_changes/index.html.erb
+++ b/app/views/admin/gias/major_school_changes/index.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-xl">Major school changes</h1>
+    <h1 class="govuk-heading-l">Major school changes</h1>
 
     <% if @closed_schools.any? || @opened_schools.any? %>
       <% if @closed_schools.any? %>

--- a/app/views/admin/gias/school_changes/index.html.erb
+++ b/app/views/admin/gias/school_changes/index.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Schools with changes</h1>
+    <h1 class="govuk-heading-l">Schools with changes</h1>
 
     <% if @schools.any? %>
       <table class="govuk-table govuk-!-margin-bottom-8">

--- a/app/views/admin/gias/school_changes/show.html.erb
+++ b/app/views/admin/gias/school_changes/show.html.erb
@@ -2,7 +2,7 @@
 <% content_for :before_content, govuk_back_link(text: "Back", href: admin_gias_school_changes_path) %>
 
 <span class="govuk-caption-l"><%= @school.name_and_urn %></span>
-<h1 class="govuk-heading-xl">School details changes</h1>
+<h1 class="govuk-heading-l">School details changes</h1>
 <table class="govuk-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">

--- a/app/views/admin/gias/schools/show.html.erb
+++ b/app/views/admin/gias/schools/show.html.erb
@@ -3,7 +3,7 @@
 
 <span class="govuk-caption-l"><%= @school.name_and_urn %></span>
 
-<h1 class="govuk-heading-xl">School details</h1>
+<h1 class="govuk-heading-l">School details</h1>
 <% if @school.counterpart&.eligible? %>
   <p class="govuk-body">
     <%= govuk_link_to "View live school", admin_school_path(id: @school.counterpart.slug), target: "_blank" %>

--- a/app/views/admin/gias/schools_to_add/index.html.erb
+++ b/app/views/admin/gias/schools_to_add/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "Schools to add" %>
 <% content_for :before_content, govuk_back_link(text: "Back", href: admin_gias_home_index_path) %>
 
-<h1 class="govuk-heading-xl">Schools to add</h1>
+<h1 class="govuk-heading-l">Schools to add</h1>
 
 <% if @schools.any? %>
   <table class="govuk-table govuk-!-margin-bottom-8">

--- a/app/views/admin/gias/schools_to_close/index.html.erb
+++ b/app/views/admin/gias/schools_to_close/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "School closures" %>
 <% content_for :before_content, govuk_back_link(text: "Back", href: admin_gias_home_index_path) %>
 
-<h1 class="govuk-heading-xl">Schools to close</h1>
+<h1 class="govuk-heading-l">Schools to close</h1>
 
 <% if @schools.any? %>
   <table class="govuk-table govuk-!-margin-bottom-8">

--- a/app/views/admin/home/show.html.erb
+++ b/app/views/admin/home/show.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <h1 class="govuk-heading-xl">Overview</h1>
+    <h1 class="govuk-heading-l">Overview</h1>
 
     <table class="govuk-table govuk-!-margin-bottom-9">
       <caption class="govuk-table__caption govuk-table__caption--m">Schools registered for 2023 to 2024</caption>

--- a/app/views/admin/notes/edit.html.erb
+++ b/app/views/admin/notes/edit.html.erb
@@ -11,7 +11,7 @@
             value: @participant_profile.notes,
             rows: 10,
             width: "three-quarters",
-            label: { text: "Add notes", tag: "h1", size: "xl" },
+            label: { text: "Add notes", tag: "h1", size: "l" },
             hint: { text: "Give details about any changes made to this participant. Notes are for internal use only" }
             ) %>
 

--- a/app/views/admin/npq/applications/analysis/invalid_payments_analysis.html.erb
+++ b/app/views/admin/npq/applications/analysis/invalid_payments_analysis.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-header-xl">NPQ Application analysis</h1>
+    <h1 class="govuk-heading-l">NPQ Application analysis</h1>
 
     <p class="govuk-body-l">Paid or Payable declarations made against a rejected or pending NPQ Application</p>
 

--- a/app/views/admin/npq/applications/change_email/edit.html.erb
+++ b/app/views/admin/npq/applications/change_email/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for :before_content, govuk_back_link( text: "Back", href: admin_npq_applications_application_path(@npq_application)) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Change applicant's email address</h1>
+    <h1 class="govuk-heading-l">Change applicant's email address</h1>
     <%= form_for @npq_application.user, url: admin_npq_applications_change_email_path(@npq_application), method: :put do |f| %>
       <%= f.govuk_text_field :email, label: { text: "Email address" } %>
       <%= f.govuk_submit %>

--- a/app/views/admin/npq/applications/change_logs/show.html.erb
+++ b/app/views/admin/npq/applications/change_logs/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_content, govuk_back_link(text: 'Back', href: admin_npq_applications_edge_case_path(@npq_application)) %>
 
-<h1 class="govuk-heading-xl">Change log</h1>
+<h1 class="govuk-heading-l">Change log</h1>
 
 <div class="govuk-inset-text govuk-!-margin-bottom-2">
   Only changes made after September 2023 are shown.

--- a/app/views/admin/npq/applications/change_name/edit.html.erb
+++ b/app/views/admin/npq/applications/change_name/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for :before_content, govuk_back_link( text: "Back", href: admin_npq_applications_application_path(@npq_application)) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Change applicant's name</h1>
+    <h1 class="govuk-heading-l">Change applicant's name</h1>
     <%= form_for @npq_application.user, url: admin_npq_applications_change_name_path(@npq_application), method: :put do |f| %>
       <%= f.govuk_text_field :full_name, label: { text: "Full name" } %>
       <%= f.govuk_submit %>

--- a/app/views/admin/npq/applications/edge_cases/show.html.erb
+++ b/app/views/admin/npq/applications/edge_cases/show.html.erb
@@ -1,4 +1,4 @@
-<h1 class="govuk-heading-xl"><%= @npq_application.user.full_name %></h1>
+<h1 class="govuk-heading-l"><%= @npq_application.user.full_name %></h1>
 
 <% content_for :before_content, govuk_back_link(text: "Back", href: admin_npq_applications_edge_cases_path) %>
 

--- a/app/views/admin/npq/applications/eligibility_imports/new.html.erb
+++ b/app/views/admin/npq/applications/eligibility_imports/new.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-xl"><%= t(".title") %></h1>
+    <h1 class="govuk-heading-l"><%= t(".title") %></h1>
 
     <p class="govuk-body">
       To schedule an import of an eligibility update file, please upload your file to the dedicated secure drive on Google Drive then enter the filename below.

--- a/app/views/admin/npq/applications/exports/new.html.erb
+++ b/app/views/admin/npq/applications/exports/new.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-xl"><%= t(".title") %></h1>
+    <h1 class="govuk-heading-l"><%= t(".title") %></h1>
 
     <div class="admin-search-box">
       <%= form_for(@export_form, url: admin_npq_applications_exports_path) do |f| %>

--- a/app/views/admin/participants/add_to_school_mentor_pool/new.html.erb
+++ b/app/views/admin/participants/add_to_school_mentor_pool/new.html.erb
@@ -4,8 +4,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <span class="govuk-caption-xl">Adding <%=  @participant_profile.user.full_name %> to a school mentor pool</span>
-    <h1 class="govuk-heading-xl">What’s the URN of the school</h1>
+    <span class="govuk-caption-l">Adding <%=  @participant_profile.user.full_name %> to a school mentor pool</span>
+    <h1 class="govuk-heading-l">What’s the URN of the school</h1>
     <%= form_for @add_mentor_to_school, url: admin_participant_add_to_school_mentor_pool_path(@participant_profile), method: :post do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_text_field :school_urn, label: { text: "School URN" }, hint: { text: "Enter the 6-digit URN of the new school, for example 123456" } %>

--- a/app/views/admin/participants/change_email/edit.html.erb
+++ b/app/views/admin/participants/change_email/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for :before_content, govuk_back_link( text: "Back", href: admin_participant_path(@participant_profile)) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Change <%= @participant_profile.ect? ? "ECT’s" : "mentor’s" %> email address</h1>
+    <h1 class="govuk-heading-l">Change <%= @participant_profile.ect? ? "ECT’s" : "mentor’s" %> email address</h1>
     <%= form_for @participant_profile.user, url: admin_participant_change_email_path(@participant_profile), method: :put do |f| %>
       <%= f.govuk_text_field :email, label: { text: "Email address" } %>
       <%= f.govuk_submit %>

--- a/app/views/admin/participants/change_name/edit.html.erb
+++ b/app/views/admin/participants/change_name/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for :before_content, govuk_back_link( text: "Back", href: admin_participant_path(@participant_profile)) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Change <%= @participant_profile.ect? ? "ECT’s" : "mentor’s" %> name</h1>
+    <h1 class="govuk-heading-l">Change <%= @participant_profile.ect? ? "ECT’s" : "mentor’s" %> name</h1>
     <%= form_for @participant_profile.user, url: admin_participant_change_name_path(@participant_profile), method: :put do |f| %>
       <%= f.govuk_text_field :full_name, label: { text: "Full name" } %>
       <%= f.govuk_submit %>

--- a/app/views/admin/participants/change_relationship/cannot_change_programme.html.erb
+++ b/app/views/admin/participants/change_relationship/cannot_change_programme.html.erb
@@ -5,8 +5,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @wizard.participant_role_and_name %></span>
-    <h1 class="govuk-heading-xl"><%= title %></h1>
+    <span class="govuk-caption-l"><%= @wizard.participant_role_and_name %></span>
+    <h1 class="govuk-heading-l"><%= title %></h1>
 
     <p class="govuk-body">This person has already received declarations from their provider.</p>
     <p class="govuk-body">Changing this participant’s programme will need to be handled manually.</p>

--- a/app/views/admin/participants/change_relationship/change_training_programme.html.erb
+++ b/app/views/admin/participants/change_relationship/change_training_programme.html.erb
@@ -14,8 +14,8 @@
                 @wizard.form.options,
                 :id,
                 :name,
-                legend: { text: title, tag: 'h1', size: 'xl' },
-                caption: { text: @wizard.participant_role_and_name, size: 'xl' }) %>
+                legend: { text: title, tag: 'h1', size: 'l' },
+                caption: { text: @wizard.participant_role_and_name, size: 'l' }) %>
 
             <%= f.govuk_submit "Continue" %>
         <% end %>

--- a/app/views/admin/participants/change_relationship/choose_delivery_partner.html.erb
+++ b/app/views/admin/participants/change_relationship/choose_delivery_partner.html.erb
@@ -14,8 +14,8 @@
                 @wizard.form.options,
                 :id,
                 :name,
-                legend: { text: title, tag: 'h1', size: 'xl' },
-                caption: { text: @wizard.participant_role_and_name, size: 'xl' }) %>
+                legend: { text: title, tag: 'h1', size: 'l' },
+                caption: { text: @wizard.participant_role_and_name, size: 'l' }) %>
 
             <%= f.govuk_submit "Continue" %>
         <% end %>

--- a/app/views/admin/participants/change_relationship/choose_lead_provider.html.erb
+++ b/app/views/admin/participants/change_relationship/choose_lead_provider.html.erb
@@ -14,8 +14,8 @@
                 @wizard.form.options,
                 :id,
                 :name,
-                legend: { text: title, tag: 'h1', size: 'xl' },
-                caption: { text: @wizard.participant_role_and_name, size: 'xl' }) %>
+                legend: { text: title, tag: 'h1', size: 'l' },
+                caption: { text: @wizard.participant_role_and_name, size: 'l' }) %>
 
             <%= f.govuk_submit "Continue" %>
         <% end %>

--- a/app/views/admin/participants/change_relationship/confirm_new_relationship.html.erb
+++ b/app/views/admin/participants/change_relationship/confirm_new_relationship.html.erb
@@ -6,8 +6,8 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <span class="govuk-caption-xl"><%= @wizard.participant_role_and_name %></span>
-        <h1 class="govuk-heading-xl"><%= title %></h1>
+        <span class="govuk-caption-l"><%= @wizard.participant_role_and_name %></span>
+        <h1 class="govuk-heading-l"><%= title %></h1>
 
         <%= form_with model: @wizard.form, url: url_for(action: :update), scope: @wizard.session_key, method: :put do |f| %>
             <%= f.hidden_field :confirmed, value: "yes" %>

--- a/app/views/admin/participants/change_relationship/confirm_selected_partnership.html.erb
+++ b/app/views/admin/participants/change_relationship/confirm_selected_partnership.html.erb
@@ -6,8 +6,8 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <span class="govuk-caption-xl"><%= @wizard.participant_role_and_name %></span>
-        <h1 class="govuk-heading-xl"><%= title %></h1>
+        <span class="govuk-caption-l"><%= @wizard.participant_role_and_name %></span>
+        <h1 class="govuk-heading-l"><%= title %></h1>
 
         <%= form_with model: @wizard.form, url: url_for(action: :update), scope: @wizard.session_key, method: :put do |f| %>
             <%= f.hidden_field :confirmed, value: "yes" %>

--- a/app/views/admin/participants/change_relationship/reason_for_change.html.erb
+++ b/app/views/admin/participants/change_relationship/reason_for_change.html.erb
@@ -14,8 +14,8 @@
                 @wizard.form.options,
                 :id,
                 :name,
-                legend: { text: title, tag: 'h1', size: 'xl' },
-                caption: { text: @wizard.participant_role_and_name, size: 'xl' }) %>
+                legend: { text: title, tag: 'h1', size: 'l' },
+                caption: { text: @wizard.participant_role_and_name, size: 'l' }) %>
 
             <%= f.govuk_submit "Continue" %>
         <% end %>

--- a/app/views/admin/participants/change_relationship/relationship_already_exists.html.erb
+++ b/app/views/admin/participants/change_relationship/relationship_already_exists.html.erb
@@ -5,8 +5,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @wizard.participant_role_and_name %></span>
-    <h1 class="govuk-heading-xl"><%= title %></h1>
+    <span class="govuk-caption-l"><%= @wizard.participant_role_and_name %></span>
+    <h1 class="govuk-heading-l"><%= title %></h1>
 
     <%= govuk_summary_list do |summary_list| %>
       <% summary_list.with_row do |row| %>

--- a/app/views/admin/participants/index.html.erb
+++ b/app/views/admin/participants/index.html.erb
@@ -1,4 +1,4 @@
-<h1 class="govuk-header-xl">Participants</h1>
+<h1 class="govuk-heading-l">Participants</h1>
 
 <%= render SearchBox.new(
   query: params[:query],

--- a/app/views/admin/participants/induction_records/edit_preferred_email.html.erb
+++ b/app/views/admin/participants/induction_records/edit_preferred_email.html.erb
@@ -1,7 +1,7 @@
 <% content_for :before_content, govuk_back_link( text: "Back", href: admin_participant_path(@participant_profile)) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Change the preferred email for this induction record</h1>
+    <h1 class="govuk-heading-l">Change the preferred email for this induction record</h1>
     <%= form_for @induction_record, url: update_preferred_email_admin_participant_induction_records_path(@participant_profile, @induction_record), method: :put do |f| %>
 
       <%= f.govuk_collection_select :preferred_identity_id,

--- a/app/views/admin/participants/remove.html.erb
+++ b/app/views/admin/participants/remove.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Confirm you want to delete <%= @participant_profile.user.full_name %></h1>
+    <h1 class="govuk-heading-l">Confirm you want to delete <%= @participant_profile.user.full_name %></h1>
     <p class="govuk-body">All information connected to this participant will be deleted and cannot be recovered.</p>
     <%= form_with url: admin_participant_path(@participant_profile), method: :delete do |f| %>
       <%= f.govuk_submit "Confirm" %>

--- a/app/views/admin/participants/school_transfer/cannot_transfer.html.erb
+++ b/app/views/admin/participants/school_transfer/cannot_transfer.html.erb
@@ -5,9 +5,9 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-        
-    <span class="govuk-caption-xl">Transferring school - <%= @school_transfer_form.participant_name %></span>
-    <h1 class="govuk-heading-xl"><%= title %></h1>
+
+    <span class="govuk-caption-l">Transferring school - <%= @school_transfer_form.participant_name %></span>
+    <h1 class="govuk-heading-l"><%= title %></h1>
 
     <p class="govuk-body">We cannot transfer to this school because <%= @school_transfer_form.cannot_transfer_reason %></p>
 

--- a/app/views/admin/participants/school_transfer/check_answers.html.erb
+++ b/app/views/admin/participants/school_transfer/check_answers.html.erb
@@ -5,8 +5,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl">Transferring school - <%= @school_transfer_form.participant_name %></span>
-    <h1 class="govuk-heading-xl"><%= title %></h1>
+    <span class="govuk-caption-l">Transferring school - <%= @school_transfer_form.participant_name %></span>
+    <h1 class="govuk-heading-l"><%= title %></h1>
 
     <%= govuk_summary_list do |summary_list| %>
       <% summary_list.with_row do |row| %>

--- a/app/views/admin/participants/school_transfer/email.html.erb
+++ b/app/views/admin/participants/school_transfer/email.html.erb
@@ -10,8 +10,8 @@
       <%= f.govuk_error_summary %>
       <%= f.govuk_text_field :email,
           width: "two-thirds",
-          label: { text: title, tag: :h1, size: 'xl' },
-          caption: { text: "Transferring school - #{@school_transfer_form.participant_name}", size: 'xl' } do %>
+          label: { text: title, tag: :h1, size: 'l' },
+          caption: { text: "Transferring school - #{@school_transfer_form.participant_name}", size: 'l' } do %>
 
           <p class="govuk-body">You can enter their personal or school email address.</p>
       <% end %>

--- a/app/views/admin/participants/school_transfer/select_school.html.erb
+++ b/app/views/admin/participants/school_transfer/select_school.html.erb
@@ -3,8 +3,8 @@
 <% content_for :before_content, govuk_back_link( text: "Back", href: admin_participant_path(@participant_profile)) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl">Transferring school - <%= @school_transfer_form.participant_name %></span>
-    <h1 class="govuk-heading-xl"><%= title %></h1>
+    <span class="govuk-caption-l">Transferring school - <%= @school_transfer_form.participant_name %></span>
+    <h1 class="govuk-heading-l"><%= title %></h1>
     <%= form_for @school_transfer_form, url: { action: :select_school }, method: :put do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_number_field :new_school_urn, label: { text: "School URN" }, hint: { text: "Enter the 6-digit URN of the new school, for example 123456" } %>

--- a/app/views/admin/participants/school_transfer/start_date.html.erb
+++ b/app/views/admin/participants/school_transfer/start_date.html.erb
@@ -9,8 +9,8 @@
           <%= f.govuk_date_field :start_date,
               start_date: true,
               width: "two-thirds",
-              legend: { text: title, tag: :h1, size: 'xl' },
-              caption: { text: "Transferring school - #{@school_transfer_form.participant_name}", size: 'xl' },
+              legend: { text: title, tag: :h1, size: 'l' },
+              caption: { text: "Transferring school - #{@school_transfer_form.participant_name}", size: 'l' },
               hint: { text: "For example, 14 7 2023"}
           %>
           <%= f.govuk_submit "Continue" %>

--- a/app/views/admin/participants/school_transfer/transfer_options.html.erb
+++ b/app/views/admin/participants/school_transfer/transfer_options.html.erb
@@ -3,11 +3,11 @@
 <% content_for :before_content, govuk_back_link(text: "Back", href: { action: @school_transfer_form.previous_step }) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl">Transferring school - <%= @school_transfer_form.participant_name %></span>
+    <span class="govuk-caption-l">Transferring school - <%= @school_transfer_form.participant_name %></span>
     <%= form_for @school_transfer_form, url: { action: :transfer_options }, method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset :transfer_choice, legend: { text: title, tag: "h1", size: "xl" } do %>
+      <%= f.govuk_radio_buttons_fieldset :transfer_choice, legend: { text: title, tag: "h1", size: "l" } do %>
           <% @school_transfer_form.transfer_options.each do |option| %>
             <%= f.govuk_radio_button :transfer_choice, option.id, label: { text: option.description } %>
           <% end %>

--- a/app/views/admin/participants/validation_data/date_of_birth.html.erb
+++ b/app/views/admin/participants/validation_data/date_of_birth.html.erb
@@ -8,8 +8,8 @@
       <%= f.govuk_date_field :date_of_birth,
         date_of_birth: true,
         width: "two-thirds",
-        legend: { text: title, size: "xl", tag: "h1" },
-        caption: { text: "Validate", size: "xl" },
+        legend: { text: title, size: "l", tag: "h1" },
+        caption: { text: "Validate", size: "l" },
         hint: { text: "For example, 14 7 1990"}
       %>
       <%= f.govuk_submit %>

--- a/app/views/admin/participants/validation_data/full_name.html.erb
+++ b/app/views/admin/participants/validation_data/full_name.html.erb
@@ -7,8 +7,8 @@
       <%= f.govuk_error_summary %>
       <%= f.govuk_text_field :full_name,
         width: "two-thirds",
-        label: { text: title, size: "xl", tag: "h1" },
-        caption: { text: "Validate", size: "xl" },
+        label: { text: title, size: "l", tag: "h1" },
+        caption: { text: "Validate", size: "l" },
         hint: { text: "The name registered with the Teaching Regulation Agency (TRA) might be different from the name used somewhere else in the service" }
       %>
       <%= f.govuk_submit %>

--- a/app/views/admin/participants/validation_data/nino.html.erb
+++ b/app/views/admin/participants/validation_data/nino.html.erb
@@ -7,8 +7,8 @@
       <%= f.govuk_error_summary %>
       <%= f.govuk_text_field :nino,
         width: "two-thirds",
-        label: { text: title, size: "xl", tag: "h1" },
-        caption: { text: "Validate", size: "xl" },
+        label: { text: title, size: "l", tag: "h1" },
+        caption: { text: "Validate", size: "l" },
         hint: { text: "For example, QQ 12 34 56 C" }
       %>
       <%= f.govuk_submit %>

--- a/app/views/admin/participants/validation_data/trn.html.erb
+++ b/app/views/admin/participants/validation_data/trn.html.erb
@@ -7,8 +7,8 @@
       <%= f.govuk_error_summary %>
       <%= f.govuk_text_field :trn,
         width: "two-thirds",
-        label: { text: title, size: "xl", tag: "h1" },
-        caption: { text: "Validate", size: "xl" }
+        label: { text: title, size: "l", tag: "h1" },
+        caption: { text: "Validate", size: "l" }
       %>
       <%= f.govuk_submit %>
     <% end %>

--- a/app/views/admin/schools/cohorts/challenge_partnership/confirm.html.erb
+++ b/app/views/admin/schools/cohorts/challenge_partnership/confirm.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
-    <h1 class="govuk-heading-xl">
+    <h1 class="govuk-heading-l">
       You are reporting an incorrect partnership
     </h1>
 

--- a/app/views/admin/schools/cohorts/challenge_partnership/new.html.erb
+++ b/app/views/admin/schools/cohorts/challenge_partnership/new.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
+    <h1 class="govuk-heading-l">
       Report an incorrect partnership
     </h1>
 

--- a/app/views/admin/schools/cohorts/change_programme/confirm.html.erb
+++ b/app/views/admin/schools/cohorts/change_programme/confirm.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
-    <h1 class="govuk-heading-xl">
+    <h1 class="govuk-heading-l">
       You are choosing to change Induction programme to: <%= t @induction_choice_form.programme_choice,
                                                                scope: "admin.induction_choice_form.confirmation_options",
                                                                cohort: @induction_choice_form.cohort.display_name %>

--- a/app/views/admin/schools/cohorts/change_training_materials/confirm.html.erb
+++ b/app/views/admin/schools/cohorts/change_training_materials/confirm.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
-    <h1 class="govuk-heading-xl">
+    <h1 class="govuk-heading-l">
       You are choosing to change course to: <%= @core_induction_programme_choice_form.core_induction_programme.name %>
     </h1>
     <%= form_for @core_induction_programme_choice_form, url: admin_school_change_training_materials_path, method: :put do |f| %>

--- a/app/views/admin/schools/cohorts/change_training_materials/show.html.erb
+++ b/app/views/admin/schools/cohorts/change_training_materials/show.html.erb
@@ -6,7 +6,7 @@
                                            CoreInductionProgramme.all,
                                            :id,
                                            :name,
-                                           legend: { text: "Change course for #{@school.name} #{@cohort.academic_year}", tag: "h1", size: "xl" } %>
+                                           legend: { text: "Change course for #{@school.name} #{@cohort.academic_year}", tag: "h1", size: "l" } %>
       <%= f.govuk_submit "Continue" %>
     <% end %>
   </div>

--- a/app/views/admin/schools/cohorts/index.html.erb
+++ b/app/views/admin/schools/cohorts/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "#{@school.name} cohorts" %>
 
-<h1 class="govuk-heading-xl"><%= @school.name %></h1>
+<h1 class="govuk-heading-l"><%= @school.name %></h1>
 <%= render partial: "admin/schools/shared/navigation" %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/admin/schools/induction_coordinators/_induction_tutor_form.html.erb
+++ b/app/views/admin/schools/induction_coordinators/_induction_tutor_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_for(form_object, as: :tutor_details, url: form_url, method: form_method) do |f| %>
   <%= f.govuk_error_summary %>
-  <h1 class="govuk-heading-xl"><%= heading %></h1>
+  <h1 class="govuk-heading-l"><%= heading %></h1>
   <%= f.govuk_text_field( :full_name, label: { text: "Full name" }) %>
   <%= f.govuk_email_field( :email, label: { text: "Email address" }) %>
   <%= f.govuk_submit submit_label %>

--- a/app/views/admin/schools/participants/index.html.erb
+++ b/app/views/admin/schools/participants/index.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, "School detail: participants" %>
 
-<h1 class="govuk-heading-xl"><%= @school.name %></h1>
+<h1 class="govuk-heading-l"><%= @school.name %></h1>
 <%= render partial: "admin/schools/shared/navigation" %>
 
-<h2 class="govuk-heading-l">Participants</h2>
+<h2 class="govuk-heading-m">Participants</h2>
 
 <% if @participant_profiles.present? %>
   <table class="govuk-table">

--- a/app/views/admin/schools/replace_or_update_induction_tutor/show.html.erb
+++ b/app/views/admin/schools/replace_or_update_induction_tutor/show.html.erb
@@ -11,7 +11,7 @@
             @replace_or_update_tutor_form.choices,
             :id,
             :name,
-            legend: { text: title, size: "xl", tag: "h1" },
+            legend: { text: title, size: "l", tag: "h1" },
           ) %>
       <%= f.govuk_submit "Continue" %>
     <% end %>

--- a/app/views/admin/schools/show.html.erb
+++ b/app/views/admin/schools/show.html.erb
@@ -1,8 +1,8 @@
 <% content_for :title, "School detail: overview" %>
 
-<h1 class="govuk-heading-xl"><%= @school.name %></h1>
+<h1 class="govuk-heading-l"><%= @school.name %></h1>
 <%= render partial: "admin/schools/shared/navigation" %>
-<h2 class="govuk-heading-l">Overview</h2>
+<h2 class="govuk-heading-m">Overview</h2>
 
 <% if @induction_coordinator && ImpersonationPolicy.new(current_user, @induction_coordinator).create? %>
   <%= govuk_button_to("Impersonate induction tutor", admin_impersonate_path,

--- a/app/views/admin/suppliers/delivery_partners/edit.html.erb
+++ b/app/views/admin/suppliers/delivery_partners/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Edit <%= @delivery_partner.name %></h1>
+    <h1 class="govuk-heading-l">Edit <%= @delivery_partner.name %></h1>
 
     <%= form_for @delivery_partner_form, url: admin_delivery_partner_path(@delivery_partner), method: :patch do |f| %>
 

--- a/app/views/admin/test_data/cip_schools/index.html.erb
+++ b/app/views/admin/test_data/cip_schools/index.html.erb
@@ -1,8 +1,8 @@
 <% title = "Test Data" %>
 <% content_for :title, title %>
 
-<span class="govuk-caption-xl">Schools that have chosen CIP for <%= Cohort.current.academic_year %></span>
-<h1 class="govuk-heading-xl"><%= title %></h1>
+<span class="govuk-caption-l">Schools that have chosen CIP for <%= Cohort.current.academic_year %></span>
+<h1 class="govuk-heading-l"><%= title %></h1>
 
 <%= render partial: "admin/test_data/nav" %>
 

--- a/app/views/admin/test_data/fip_schools/index.html.erb
+++ b/app/views/admin/test_data/fip_schools/index.html.erb
@@ -1,8 +1,8 @@
 <% title = "Test Data" %>
 <% content_for :title, title %>
 
-<span class="govuk-caption-xl">Schools that have chosen FIP for <%= Cohort.current.academic_year %></span>
-<h1 class="govuk-heading-xl"><%= title %></h1>
+<span class="govuk-caption-l">Schools that have chosen FIP for <%= Cohort.current.academic_year %></span>
+<h1 class="govuk-heading-l"><%= title %></h1>
 
 <%= render partial: "admin/test_data/nav" %>
 

--- a/app/views/admin/test_data/unclaimed_schools/index.html.erb
+++ b/app/views/admin/test_data/unclaimed_schools/index.html.erb
@@ -1,8 +1,8 @@
 <% title = "Test Data" %>
 <% content_for :title, title %>
 
-<span class="govuk-caption-xl">Schools without an induction tutor</span>
-<h1 class="govuk-heading-xl"><%= title %></h1>
+<span class="govuk-caption-l">Schools without an induction tutor</span>
+<h1 class="govuk-heading-l"><%= title %></h1>
 
 <%= render partial: "admin/test_data/nav" %>
 

--- a/app/views/admin/test_data/yet_to_choose_schools/index.html.erb
+++ b/app/views/admin/test_data/yet_to_choose_schools/index.html.erb
@@ -1,8 +1,8 @@
 <% title = "Test Data" %>
 <% content_for :title, title %>
 
-<span class="govuk-caption-xl">Schools that haven’t chosen a programme this year</span>
-<h1 class="govuk-heading-xl"><%= title %></h1>
+<span class="govuk-caption-l">Schools that haven’t chosen a programme this year</span>
+<h1 class="govuk-heading-l"><%= title %></h1>
 
 <%= render partial: "admin/test_data/nav" %>
 

--- a/app/views/appropriate_bodies/appropriate_bodies/index.html.erb
+++ b/app/views/appropriate_bodies/appropriate_bodies/index.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @choose_organisation_form, url: appropriate_bodies_path do |f| %>
       <%= f.govuk_error_summary %>
-      <%= f.govuk_radio_buttons_fieldset :appropriate_body_id, legend: { text: "What organisation do you want to view?", tag: 'h1', size: 'xl' }, caption: { text: "Appropriate body", tag: "span", size: "xl" } do %>
+      <%= f.govuk_radio_buttons_fieldset :appropriate_body_id, legend: { text: "What organisation do you want to view?", tag: 'h1', size: 'l' }, caption: { text: "Appropriate body", tag: "span", size: "l" } do %>
         <p>Choose an organisation to view its participants.</p>
 
         <% @choose_organisation_form.appropriate_body_options.each_with_index do |(val, name), n| %>

--- a/app/views/appropriate_bodies/participants/index.html.erb
+++ b/app/views/appropriate_bodies/participants/index.html.erb
@@ -1,7 +1,7 @@
-<span class="govuk-caption-xl">Appropriate body</span>
-<h1 class="govuk-heading-xl"><%= @appropriate_body.name %> Participants</h1>
+<span class="govuk-caption-l">Appropriate body</span>
+<h1 class="govuk-heading-l"><%= @appropriate_body.name %> Participants</h1>
 
-<span class="govuk-caption-xl"><%= Cohort.current.academic_year %> academic year</span>
+<span class="govuk-caption-l"><%= Cohort.current.academic_year %> academic year</span>
 
 <p class="govuk-body govuk-!-text-align-right">
   <%= govuk_link_to "Download (csv)", appropriate_body_participants_path(params.permit(:query, :role, :academic_year, :status).merge({format: :csv})) %>

--- a/app/views/appropriate_body_selection/_autocomplete_body_selection.html.erb
+++ b/app/views/appropriate_body_selection/_autocomplete_body_selection.html.erb
@@ -2,8 +2,8 @@
   appropriate_bodies,
   :id,
   :name,
-  label: { text: title, tag: :h1, size: 'xl' },
-  caption: { text: appropriate_body_school_name, size: 'xl' },
+  label: { text: title, tag: :h1, size: 'l' },
+  caption: { text: appropriate_body_school_name, size: 'l' },
   options: { include_blank: true },
   class: "autocomplete") do %>
 

--- a/app/views/appropriate_body_selection/_radio_button_body_selection.html.erb
+++ b/app/views/appropriate_body_selection/_radio_button_body_selection.html.erb
@@ -2,8 +2,8 @@
   appropriate_bodies,
   :id,
   :name,
-  legend: { text: title, tag: :h1, size: 'xl' },
-  caption: { text: appropriate_body_school_name, size: 'xl' }) do %>
+  legend: { text: title, tag: :h1, size: 'l' },
+  caption: { text: appropriate_body_school_name, size: 'l' }) do %>
 
   <div class="govuk-inset-text">
     Remember to contact the appropriate body directly to appoint them for your ECTs, if you have not done so already.

--- a/app/views/appropriate_body_selection/body_appointed.html.erb
+++ b/app/views/appropriate_body_selection/body_appointed.html.erb
@@ -11,8 +11,8 @@
         @appropriate_body_form.body_appointed_choices,
         :id, :name,
         inline: true,
-        legend: { text: title, tag: :h1, size: 'xl' },
-        caption: { text: appropriate_body_school_name, size: 'xl' }) do %>
+        legend: { text: title, tag: :h1, size: 'l' },
+        caption: { text: appropriate_body_school_name, size: 'l' }) do %>
       <% end %>
 
       <%= f.govuk_submit "Continue" %>

--- a/app/views/appropriate_body_selection/body_type.html.erb
+++ b/app/views/appropriate_body_selection/body_type.html.erb
@@ -11,8 +11,8 @@
         :body_type,
         @appropriate_body_form.body_type_choices,
         :id, :name,
-        legend: { text: title, tag: :h1, size: 'xl' },
-        caption: { text: appropriate_body_school_name, size: 'xl' }) do %>
+        legend: { text: title, tag: :h1, size: 'l' },
+        caption: { text: appropriate_body_school_name, size: 'l' }) do %>
 
           <%= yield :pre_form %>
         <% end %>

--- a/app/views/appropriate_body_selection/preconfirm.html.erb
+++ b/app/views/appropriate_body_selection/preconfirm.html.erb
@@ -4,8 +4,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= appropriate_body_school_name %></span>
-    <h1 class="govuk-heading-xl"><%= title %></h1>
+    <span class="govuk-caption-l"><%= appropriate_body_school_name %></span>
+    <h1 class="govuk-heading-l"><%= title %></h1>
 
     <p class="govuk-body">
       This change will only apply to ECTs and mentors who have started or will start

--- a/app/views/challenge_partnerships/already_challenged.html.erb
+++ b/app/views/challenge_partnerships/already_challenged.html.erb
@@ -1,4 +1,4 @@
 <% content_for :title, "Error: mistake reported" %>
 
-<h1 class="govuk-heading-xl">Someone at <%= @school_name %> has already reported this issue</h1>
+<h1 class="govuk-heading-l">Someone at <%= @school_name %> has already reported this issue</h1>
 <p class="govuk-body">If you still need to report that your school has been confirmed incorrectly contact: <%= render MailToSupportComponent.new %></p>

--- a/app/views/challenge_partnerships/link_expired.html.erb
+++ b/app/views/challenge_partnerships/link_expired.html.erb
@@ -1,4 +1,4 @@
 <% content_for :title, "Error: Expired report link" %>
 
-<h1 class="govuk-heading-xl">This link has expired</h1>
+<h1 class="govuk-heading-l">This link has expired</h1>
 <p class="govuk-body">Contact: <%= render MailToSupportComponent.new %></p>

--- a/app/views/challenge_partnerships/show.html.erb
+++ b/app/views/challenge_partnerships/show.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Report that your school has been signed up incorrectly</h1>
+    <h1 class="govuk-heading-l">Report that your school has been signed up incorrectly</h1>
     <p class="govuk-body"><%= @challenge_partnership_form.school_name %>  has received a confirmation
       from <%= @challenge_partnership_form.delivery_partner_name %>,
       with <%= @challenge_partnership_form.lead_provider_name %>, but you believe this is incorrect.</p>

--- a/app/views/check_account/show.html.erb
+++ b/app/views/check_account/show.html.erb
@@ -4,7 +4,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        <h1 class="govuk-heading-xl">How to access this service</h1>
+        <h1 class="govuk-heading-l">How to access this service</h1>
 
         <h2 class="govuk-heading-m">Schools</h2>
         <p class="govuk-body"><%= govuk_link_to "Send your school a link", resend_email_request_nomination_invite_path, class: "govuk-link govuk-link--no-visited-state" %> to use this service. You’ll be asked to nominate someone to set up your training programme.</p>

--- a/app/views/choose_roles/contact_support.html.erb
+++ b/app/views/choose_roles/contact_support.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Contact us so we can check your permissions</h1>
+    <h1 class="govuk-heading-l">Contact us so we can check your permissions</h1>
     <p class="govuk-body">To add, remove or change your role, we need to check and confirm your permissions.</p>
     <p class="govuk-body">Contact us at <%= govuk_mail_to "continuing-professional-development@digital.education.gov.uk" %> and we will make sure you can access everything you need.</p>
   </div>

--- a/app/views/choose_roles/show.html.erb
+++ b/app/views/choose_roles/show.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @choose_role_form, url: choose_role_path do |f| %>
       <%= f.govuk_error_summary %>
-      <%= f.govuk_radio_buttons_fieldset :role, legend: { text: "What role do you want to view?", tag: 'h1', size: 'xl' } do %>
+      <%= f.govuk_radio_buttons_fieldset :role, legend: { text: "What role do you want to view?", tag: 'h1', size: 'l' } do %>
         <p>Choose a role to view relevant organisations.</p>
 
         <% @choose_role_form.role_options.each_with_index do |(val, name), n| %>

--- a/app/views/cookies/show.html.erb
+++ b/app/views/cookies/show.html.erb
@@ -2,7 +2,7 @@
 <% content_for :before_content, govuk_back_link( text: "Back", href: @backlink) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Cookies</h1>
+    <h1 class="govuk-heading-l">Cookies</h1>
     <p>Cookies are small files saved on your phone, tablet or computer when you visit a website.</p>
     <p>We use cookies to make the Manage training for early career teachers service (the service) work and collect information about how you use our service.</p>
 

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-grid-column-two-thirds">
     <% if current_user.lead_provider? %>
       <%= render partial: "navigation" %>
-      <h1 class="govuk-heading-xl"><%= @lead_provider.name %></h1>
+      <h1 class="govuk-heading-l"><%= @lead_provider.name %></h1>
       <% @lead_provider.cohorts.where(start_year: ..Cohort.active_registration_cohort.start_year).each do |cohort| %>
         <h2 class="govuk-heading-m">
           <%= govuk_link_to "Confirm your schools for the #{cohort.description} academic year", lead_providers_report_schools_start_path(cohort: cohort) %>
@@ -15,7 +15,7 @@
       </h2>
       <p>See which schools have added their early career teachers and mentors.</p>
     <% else %>
-      <h1 class="govuk-heading-xl">You cannot use this service yet</h1>
+      <h1 class="govuk-heading-l">You cannot use this service yet</h1>
       <p class="govuk-body">
         If your school induction tutor has added your information as an early career teacher (ECT) or mentor, we’ll
         contact you soon.

--- a/app/views/delivery_partners/delivery_partners/index.html.erb
+++ b/app/views/delivery_partners/delivery_partners/index.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @choose_organisation_form, url: delivery_partners_path do |f| %>
       <%= f.govuk_error_summary %>
-      <%= f.govuk_radio_buttons_fieldset :delivery_partner_id, legend: { text: "What organisation do you want to view?", tag: 'h1', size: 'xl' }, caption: { text: "Delivery partner", tag: "span", size: "xl" } do %>
+      <%= f.govuk_radio_buttons_fieldset :delivery_partner_id, legend: { text: "What organisation do you want to view?", tag: 'h1', size: 'l' }, caption: { text: "Delivery partner", tag: "span", size: "l" } do %>
         <p>Choose an organisation to view its participants.</p>
 
         <% @choose_organisation_form.delivery_partner_options.each_with_index do |(val, name), n| %>

--- a/app/views/delivery_partners/participants/index.html.erb
+++ b/app/views/delivery_partners/participants/index.html.erb
@@ -1,5 +1,5 @@
-<span class="govuk-caption-xl">Delivery partner</span>
-<h1 class="govuk-heading-xl"><%= delivery_partner.name %> Participants</h1>
+<span class="govuk-caption-l">Delivery partner</span>
+<h1 class="govuk-heading-l"><%= delivery_partner.name %> Participants</h1>
 
 <p class="govuk-body govuk-!-text-align-right">
   <%= govuk_link_to "Download (csv)", delivery_partner_participants_path(params.permit(:query, :role, :academic_year, :status).merge({format: :csv})) %>

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Page not found</h1>
+    <h1 class="govuk-heading-l">Page not found</h1>
     <p class="govuk-body">If you typed the web address, check it is correct.</p>
     <p class="govuk-body">If you pasted the web address, check you copied the entire address.</p>
     <p class="govuk-body">If the web address is correct or you selected a link or button,

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Sorry, there’s a problem with the service</h1>
+    <h1 class="govuk-heading-l">Sorry, there’s a problem with the service</h1>
     <p class="govuk-body">Try again later.</p>
     <p class="govuk-body">If you need to do something urgently, contact: <%= render MailToSupportComponent.new %></p>
   </div>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Page not found</h1>
+    <h1 class="govuk-heading-l">Page not found</h1>
     <p class="govuk-body">If you typed the web address, check it is correct.</p>
     <p class="govuk-body">If you pasted the web address, check you copied the entire address.</p>
     <p class="govuk-body">If the web address is correct or you selected a link or button,

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">The change you wanted was rejected.</h1>
+    <h1 class="govuk-heading-l">The change you wanted was rejected.</h1>
     <p class="govuk-body">Maybe you tried to change something you didn’t have access to.</p>
     <p class="govuk-body">If you are the application owner check the logs for more information.</p>
   </div>

--- a/app/views/finance/adjustments/delete.html.erb
+++ b/app/views/finance/adjustments/delete.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @adjustment, url: finance_statement_adjustment_path(@statement, @adjustment), method: :delete do |f| %>
-      <h1 class="govuk-heading-xl">Are you sure you want to remove the '<%= @adjustment.payment_type %>' adjustment?</h1>
+      <h1 class="govuk-heading-l">Are you sure you want to remove the '<%= @adjustment.payment_type %>' adjustment?</h1>
       <%= f.govuk_submit "Confirm and continue" %>
       <%= govuk_link_to "Cancel", finance_statement_adjustments_path(@statement), class: "govuk-!-margin-left-6", style: "display: inline-block; margin-top: 8px;" %>
     <% end %>

--- a/app/views/finance/adjustments/edit.html.erb
+++ b/app/views/finance/adjustments/edit.html.erb
@@ -12,22 +12,22 @@
       <% when "step1" %>
         <%= f.govuk_text_field(
                 :payment_type,
-                caption: { text: "Change or remove an adjustment", size: "xl" },
-                label: { text: "What is the name of the adjustment", tag: "h1", size: "xl" },
+                caption: { text: "Change or remove an adjustment", size: "l" },
+                label: { text: "What is the name of the adjustment", tag: "h1", size: "l" },
                 hint: { text: "Describe what the adjustment is for. For example 'IT consultant fee'" }
             ) %>
         <%= f.govuk_submit "Continue" %>
       <% when "step2" %>
         <%= f.govuk_text_field(
                 :amount,
-                caption: { text: "Change or remove an adjustment", size: "xl" },
-                label: { text: "How much is the payment?", tag: "h1", size: "xl" }
+                caption: { text: "Change or remove an adjustment", size: "l" },
+                label: { text: "How much is the payment?", tag: "h1", size: "l" }
             ) %>
         <%= f.hidden_field(:payment_type) %>
         <%= f.govuk_submit "Continue" %>
       <% when "confirm" %>
-        <span class="govuk-caption-xl">Change or remove an adjustment</span>
-        <h1 class="govuk-heading-xl">Check your answers</h1>
+        <span class="govuk-caption-l">Change or remove an adjustment</span>
+        <h1 class="govuk-heading-l">Check your answers</h1>
 
         <%= govuk_table do |table| %>
           <% table.with_head do |head| %>

--- a/app/views/finance/adjustments/index.html.erb
+++ b/app/views/finance/adjustments/index.html.erb
@@ -6,10 +6,10 @@
       <%= f.govuk_error_summary %>
 
       <% if params[:added_new].present? %>
-        <h1 class="govuk-heading-xl">You have added an adjustment</h1>
+        <h1 class="govuk-heading-l">You have added an adjustment</h1>
       <% else %>
-        <span class="govuk-caption-xl">Change or remove an adjustment</span>
-        <h1 class="govuk-heading-xl">Additional adjustments</h1>
+        <span class="govuk-caption-l">Change or remove an adjustment</span>
+        <h1 class="govuk-heading-l">Additional adjustments</h1>
       <% end %>
 
       <%= govuk_table do |table| %>

--- a/app/views/finance/adjustments/new.html.erb
+++ b/app/views/finance/adjustments/new.html.erb
@@ -12,22 +12,22 @@
       <% when "step1" %>
         <%= f.govuk_text_field(
                 :payment_type,
-                caption: { text: "Add adjustment", size: "xl" },
-                label: { text: "What is the name of the adjustment", tag: "h1", size: "xl" },
+                caption: { text: "Add adjustment", size: "l" },
+                label: { text: "What is the name of the adjustment", tag: "h1", size: "l" },
                 hint: { text: "Describe what the adjustment is for. For example 'IT consultant fee'" }
             ) %>
         <%= f.govuk_submit "Continue" %>
       <% when "step2" %>
         <%= f.govuk_text_field(
                 :amount,
-                caption: { text: "Add adjustment", size: "xl" },
-                label: { text: "How much is the payment?", tag: "h1", size: "xl" }
+                caption: { text: "Add adjustment", size: "l" },
+                label: { text: "How much is the payment?", tag: "h1", size: "l" }
             ) %>
         <%= f.hidden_field(:payment_type) %>
         <%= f.govuk_submit "Continue" %>
       <% when "confirm" %>
-        <span class="govuk-caption-xl">Add adjustment</span>
-        <h1 class="govuk-heading-xl">Check your answers</h1>
+        <span class="govuk-caption-l">Add adjustment</span>
+        <h1 class="govuk-heading-l">Check your answers</h1>
 
         <%= govuk_table do |table| %>
           <% table.with_head do |head| %>

--- a/app/views/finance/banding_tracker/provider_choices/new.html.erb
+++ b/app/views/finance/banding_tracker/provider_choices/new.html.erb
@@ -10,7 +10,7 @@
         @providers,
         :id,
         :name,
-        legend: { text: 'Choose provider', size: "xl", tag: "h1" },
+        legend: { text: 'Choose provider', size: "l", tag: "h1" },
       ) %>
       <%= f.govuk_submit "Continue" %>
     <% end %>

--- a/app/views/finance/banding_tracker/providers/show.html.erb
+++ b/app/views/finance/banding_tracker/providers/show.html.erb
@@ -7,7 +7,7 @@
   Use this to check declarations are being added to the right payment band
 </div>
 
-<h2 class="govuk-heading-xl"><%= @lead_provider.name %></h2>
+<h2 class="govuk-heading-l"><%= @lead_provider.name %></h2>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/app/views/finance/change_lead_provider_approval_statuses/new.html.erb
+++ b/app/views/finance/change_lead_provider_approval_statuses/new.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Are you sure you want to change the status to pending?</h1>
+    <h1 class="govuk-heading-l">Are you sure you want to change the status to pending?</h1>
 
     <div class="govuk-inset-text">
       <p>

--- a/app/views/finance/ecf/change_training_statuses/new.html.erb
+++ b/app/views/finance/ecf/change_training_statuses/new.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Change training status</h1>
+    <h1 class="govuk-heading-l">Change training status</h1>
 
     <div class="govuk-inset-text">
       <p>

--- a/app/views/finance/ecf/duplicates/edit.html.erb
+++ b/app/views/finance/ecf/duplicates/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for :before_content, govuk_breadcrumbs(breadcrumbs: @breadcrumbs) %>
 
 <span class="govuk-caption-l"><%= @participant_profile.profile_type %></span>
-<h1 class="govuk-heading-xl">Delete duplicate profiles for <%= @participant_profile.user.full_name %></h1>
+<h1 class="govuk-heading-l">Delete duplicate profiles for <%= @participant_profile.user.full_name %></h1>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/app/views/finance/ecf/duplicates/index.html.erb
+++ b/app/views/finance/ecf/duplicates/index.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-xl">Search duplicate records</h1>
+    <h1 class="govuk-heading-l">Search duplicate records</h1>
   </div>
 </div>
 

--- a/app/views/finance/ecf/participant_declarations/voided/show.html.erb
+++ b/app/views/finance/ecf/participant_declarations/voided/show.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Voided declarations</h1>
+    <h1 class="govuk-heading-l">Voided declarations</h1>
   </div>
 </div>
 

--- a/app/views/finance/ecf/statements/show.html.erb
+++ b/app/views/finance/ecf/statements/show.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-xl"><%= t(".title") %></h1>
+    <h1 class="govuk-heading-l"><%= t(".title") %></h1>
 
     <span class="govuk-caption-l"><%= @ecf_lead_provider.name %></span>
     <h2 class="govuk-heading-l"><%= @statement.name %></h2>

--- a/app/views/finance/landing_page/show.html.erb
+++ b/app/views/finance/landing_page/show.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Manage CPD contracts</h1>
+    <h1 class="govuk-heading-l">Manage CPD contracts</h1>
 
     <h2 class="govuk-heading-m"><%= govuk_link_to "View financial statements", finance_payment_breakdowns_url %></h2>
     <p class="govuk-body">View, download and update financial statements for lead providers.</p>

--- a/app/views/finance/npq/change_lead_providers/confirm.html.erb
+++ b/app/views/finance/npq/change_lead_providers/confirm.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-xl">Check your answers before saving this change</h1>
+    <h1 class="govuk-heading-l">Check your answers before saving this change</h1>
 
     <div class="govuk-inset-text">
       <p>

--- a/app/views/finance/npq/change_lead_providers/new.html.erb
+++ b/app/views/finance/npq/change_lead_providers/new.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-xl">Change lead provider</h1>
+    <h1 class="govuk-heading-l">Change lead provider</h1>
 
     <div class="govuk-inset-text">
       <p>

--- a/app/views/finance/npq/change_training_statuses/new.html.erb
+++ b/app/views/finance/npq/change_training_statuses/new.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Change training status</h1>
+    <h1 class="govuk-heading-l">Change training status</h1>
 
     <div class="govuk-inset-text">
       <p>

--- a/app/views/finance/npq/participant_declarations/voided/show.html.erb
+++ b/app/views/finance/npq/participant_declarations/voided/show.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Voided declarations</h1>
+    <h1 class="govuk-heading-l">Voided declarations</h1>
   </div>
 </div>
 

--- a/app/views/finance/npq/statements/show.html.erb
+++ b/app/views/finance/npq/statements/show.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-xl">National professional qualifications (NPQs)</h1>
+    <h1 class="govuk-heading-l">National professional qualifications (NPQs)</h1>
     <span class="govuk-caption-l"><%= @statement.cpd_lead_provider.name %></span>
     <h2 class="govuk-heading-l"><%= @statement.name %></h2>
 

--- a/app/views/finance/participants/index.html.erb
+++ b/app/views/finance/participants/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_content, govuk_back_link(text: "Back", href: finance_landing_page_path) %>
 
-<h1 class="govuk-heading-xl">CPD contract data</h1>
+<h1 class="govuk-heading-l">CPD contract data</h1>
 
 <%= render SearchBox.new(
   query: params[:query],

--- a/app/views/finance/participants/show.html.erb
+++ b/app/views/finance/participants/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_content, govuk_back_link(text: "Back", href: finance_participants_path) %>
 
-<h1 class="govuk-heading-xl">Participant</h1>
+<h1 class="govuk-heading-l">Participant</h1>
 
 <h2>Identities</h2>
 

--- a/app/views/finance/payment_authorisations/new.html.erb
+++ b/app/views/finance/payment_authorisations/new.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-xl"><%= I18n.t("finance.statements.payment_authorisations.title", statement_name: @statement.name) %></h1>
+    <h1 class="govuk-heading-l"><%= I18n.t("finance.statements.payment_authorisations.title", statement_name: @statement.name) %></h1>
 
     <%= form_for @payment_authorisation_form, url: finance_statement_payment_authorisations_path(@statement), as: :finance_payment_authorisation do |f| %>
       <%= f.govuk_error_summary %>

--- a/app/views/finance/payment_breakdowns/select_programme.html.erb
+++ b/app/views/finance/payment_breakdowns/select_programme.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @choose_programme_form, url: { action: :choose_programme }, method: :post do |f| %>
       <%= f.govuk_error_summary %>
-      <h1 class="govuk-heading-xl">Choose trainee payments scheme</h1>
+      <h1 class="govuk-heading-l">Choose trainee payments scheme</h1>
       <%= f.govuk_collection_radio_buttons(
             :programme,
             @choose_programme_form.programme_choices,

--- a/app/views/finance/payment_breakdowns/select_provider_ecf.html.erb
+++ b/app/views/finance/payment_breakdowns/select_provider_ecf.html.erb
@@ -10,7 +10,7 @@
             @choose_programme_form.ecf_providers,
             :id,
             :name,
-            legend: { text: 'Choose provider', size: "xl", tag: "h1" },
+            legend: { text: 'Choose provider', size: "l", tag: "h1" },
             ) %>
       <%= f.govuk_submit "Continue" %>
     <% end %>

--- a/app/views/finance/payment_breakdowns/select_provider_npq.html.erb
+++ b/app/views/finance/payment_breakdowns/select_provider_npq.html.erb
@@ -10,7 +10,7 @@
             @choose_programme_form.npq_providers,
             :id,
             :name,
-            legend: { text: 'Choose provider', size: "xl", tag: "h1" },
+            legend: { text: 'Choose provider', size: "l", tag: "h1" },
             ) %>
       <%= f.govuk_submit "Continue" %>
     <% end %>

--- a/app/views/finance/schedules/index.html.erb
+++ b/app/views/finance/schedules/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_content, govuk_back_link(text: "Back", href: finance_landing_page_path) %>
 
-<h1 class="govuk-heading-xl">Schedules</h1>
+<h1 class="govuk-heading-l">Schedules</h1>
 
 <% @cohorts.each do |cohort| %>
   <h2>Cohort: <%= cohort.start_year %></h2>

--- a/app/views/finance/schedules/show.html.erb
+++ b/app/views/finance/schedules/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :before_content, govuk_back_link(text: "Back", href: finance_schedules_path) %>
 
-<span class="govuk-caption-xl"><%= @schedule.cohort.start_year %></span>
-<h1 class="govuk-heading-xl"><%= @schedule.schedule_identifier %></h1>
+<span class="govuk-caption-l"><%= @schedule.cohort.start_year %></span>
+<h1 class="govuk-heading-l"><%= @schedule.schedule_identifier %></h1>
 
 <table class="govuk-table">
   <caption class="govuk-table__caption govuk-table__caption--l">Milestones</caption>

--- a/app/views/layouts/content_markdown.html.erb
+++ b/app/views/layouts/content_markdown.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :title, t("page_titles.lead_providers.content.#{@page_name}") %>
 
 <%= render layout: "layouts/width_container" do %>
-  <h1 class="govuk-heading-xl"><%= t("page_titles.lead_providers.content.#{@page_name}") %></h1>
+  <h1 class="govuk-heading-l"><%= t("page_titles.lead_providers.content.#{@page_name}") %></h1>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds lead-provider-content">

--- a/app/views/lead_providers/content/index.html.erb
+++ b/app/views/lead_providers/content/index.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h1 class="app-masthead__title govuk-heading-xl">Manage data quickly and easily</h1>
+        <h1 class="app-masthead__title govuk-heading-l">Manage data quickly and easily</h1>
         <div class="app-masthead__description">
           <p class="govuk-body-l">Login to the service to manage or test ECF and NPQ integrations and see school details</p>
         </div>

--- a/app/views/lead_providers/partnerships/show.html.erb
+++ b/app/views/lead_providers/partnerships/show.html.erb
@@ -24,7 +24,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl govuk-!-margin-bottom-6">
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-6">
       <%= @school.name %>
     </h1>
   </div>
@@ -39,7 +39,7 @@
 <div class="govuk-grid-row govuk-!-margin-bottom-6">
   <div class="govuk-grid-column-one-third">
     <div class="dashboard-numbers key-number">
-      <p class="govuk-heading-xl">
+      <p class="govuk-heading-l">
         <%= @school.early_career_teacher_profiles_for(@selected_cohort).count -%>
       </p>
       <p class="govuk-heading-s">ECTs added</p>
@@ -47,7 +47,7 @@
   </div>
   <div class="govuk-grid-column-one-third">
     <div class="dashboard-numbers key-number">
-      <p class="govuk-heading-xl">
+      <p class="govuk-heading-l">
         <%= @school.mentor_profiles_for(@selected_cohort).count -%>
       </p>
       <p class="govuk-heading-s">mentors added</p>

--- a/app/views/lead_providers/report_schools/base/start.html.erb
+++ b/app/views/lead_providers/report_schools/base/start.html.erb
@@ -11,7 +11,7 @@
       <% end %>
     <% end %>
 
-    <h1 class="govuk-heading-xl">You’ve chosen to confirm schools for the <%= @report_schools_form.cohort.description %> academic year</h1>
+    <h1 class="govuk-heading-l">You’ve chosen to confirm schools for the <%= @report_schools_form.cohort.description %> academic year</h1>
 
     <%= govuk_button_link_to "Continue", lead_providers_report_schools_delivery_partner_path %>
   </div>

--- a/app/views/lead_providers/report_schools/confirm/no_schools.html.erb
+++ b/app/views/lead_providers/report_schools/confirm/no_schools.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "All schools removed" %>
 
-<h1 class="govuk-heading-xl">You have removed all schools from the list</h1>
+<h1 class="govuk-heading-l">You have removed all schools from the list</h1>
 
 <% if report_schools_form.source == "csv" %>
   <%= govuk_button_link_to "Upload a new CSV", lead_providers_report_schools_csv_path %>

--- a/app/views/lead_providers/report_schools/confirm/show.html.erb
+++ b/app/views/lead_providers/report_schools/confirm/show.html.erb
@@ -4,7 +4,7 @@
   <% content_for :before_content, govuk_back_link(text: 'Back', href: lead_providers_report_schools_csv_path) %>
 <% end %>
 
-<h1 class="govuk-heading-xl">Confirm that you have an agreement with <%= @schools.count %> <%= "school".pluralize(@schools.count) %></h1>
+<h1 class="govuk-heading-l">Confirm that you have an agreement with <%= @schools.count %> <%= "school".pluralize(@schools.count) %></h1>
 
 <%= govuk_warning_text text: "Only confirm schools for the cohort that starts in the next academic year (#{report_schools_form.cohort.display_name})." %>
 

--- a/app/views/lead_providers/report_schools/csv/errors.html.erb
+++ b/app/views/lead_providers/report_schools/csv/errors.html.erb
@@ -5,7 +5,7 @@
      csv_valid_rows: @valid_schools.count,
      csv_errors: @errors.map {|error| error[:message].parameterize.underscore}.tally,
    ) %>
-<h1 class="govuk-heading-xl">Your CSV has errors</h1>
+<h1 class="govuk-heading-l">Your CSV has errors</h1>
 
 <p class="govuk-body">We have found <%= @urns.count %> rows in your CSV:</p>
 <ul class="govuk-list govuk-list--bullet">

--- a/app/views/lead_providers/report_schools/csv/show.html.erb
+++ b/app/views/lead_providers/report_schools/csv/show.html.erb
@@ -7,7 +7,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Upload a CSV of school URNs</h1>
+    <h1 class="govuk-heading-l">Upload a CSV of school URNs</h1>
     <p class="govuk-body">Your CSV must have:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>one column with the school URNs only (Column A)</li>

--- a/app/views/lead_providers/report_schools/delivery_partners/show.html.erb
+++ b/app/views/lead_providers/report_schools/delivery_partners/show.html.erb
@@ -9,7 +9,7 @@
         delivery_partners,
         :id,
         :name,
-        legend: { text: "Choose the delivery partner", size: "xl", tag: "h1" },
+        legend: { text: "Choose the delivery partner", size: "l", tag: "h1" },
         hint: { text: "Select the delivery partner that these schools have confirmed an agreement with." }) %>
       <%= f.govuk_submit "Continue" %>
     <% end %>

--- a/app/views/lead_providers/your_schools/index.html.erb
+++ b/app/views/lead_providers/your_schools/index.html.erb
@@ -13,7 +13,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Your schools</h1>
+    <h1 class="govuk-heading-l">Your schools</h1>
     <%= govuk_button_link_to "Confirm more schools", lead_providers_report_schools_start_path if @selected_cohort == Cohort.current %>
     <%= govuk_button_link_to "Download schools for #{@selected_cohort&.display_name}", active_lead_providers_partnerships_path(cohort: @selected_cohort, format: :csv) if @total_provider_schools.positive? %>
   </div>
@@ -32,7 +32,7 @@
 <div class="govuk-grid-row govuk-!-margin-bottom-6">
   <div class="govuk-grid-column-one-third">
     <div class="dashboard-numbers">
-      <p class="govuk-heading-xl"><%= @total_provider_schools %></p>
+      <p class="govuk-heading-l"><%= @total_provider_schools %></p>
       <p class="govuk-heading-s"><%= "School".pluralize(@total_provider_schools) %> recruited</p>
     </div>
   </div>

--- a/app/views/nominations/nominate_induction_coordinator/check.html.erb
+++ b/app/views/nominations/nominate_induction_coordinator/check.html.erb
@@ -8,8 +8,8 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        <span class="govuk-caption-xl"><%= @nominate_induction_tutor_form.school.name %></span>
-        <h1 class="govuk-heading-xl">Check your answers</h1>
+        <span class="govuk-caption-l"><%= @nominate_induction_tutor_form.school.name %></span>
+        <h1 class="govuk-heading-l">Check your answers</h1>
 
         <dl class="govuk-summary-list govuk-!-margin-bottom-7">
             <div class="govuk-summary-list__row">

--- a/app/views/nominations/nominate_induction_coordinator/email.html.erb
+++ b/app/views/nominations/nominate_induction_coordinator/email.html.erb
@@ -7,7 +7,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        <span class="govuk-caption-xl"><%= @nominate_induction_tutor_form.school.name %></span>
+        <span class="govuk-caption-l"><%= @nominate_induction_tutor_form.school.name %></span>
 
         <%= form_for @nominate_induction_tutor_form, url: { action: :check_email }, method: :put do |f| %>
         <%= f.govuk_error_summary %>
@@ -16,7 +16,7 @@
                 :email,
                 label: { text: "What’s #{possessive_name(@nominate_induction_tutor_form.full_name)} email address?",
                 tag: "h1",
-                size: "xl" },
+                size: "l" },
                 width: "two-thirds") do %>
 
                 <p class="govuk-body">We’ll use this address to contact them with more information.</p>

--- a/app/views/nominations/nominate_induction_coordinator/full_name.html.erb
+++ b/app/views/nominations/nominate_induction_coordinator/full_name.html.erb
@@ -7,11 +7,11 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        <span class="govuk-caption-xl"><%= @nominate_induction_tutor_form.school.name %></span>
+        <span class="govuk-caption-l"><%= @nominate_induction_tutor_form.school.name %></span>
         <%= form_for @nominate_induction_tutor_form, url: { action: :check_name }, method: :put do |f| %>
         <%= f.govuk_error_summary %>
             <div class="govuk-form-group" >
-                <%= f.govuk_text_field(:full_name, label: { text: "What’s the full name of your induction tutor?", tag: "h1", size: "xl" }, width: "two-thirds" )%>
+                <%= f.govuk_text_field(:full_name, label: { text: "What’s the full name of your induction tutor?", tag: "h1", size: "l" }, width: "two-thirds" )%>
             </div>
             <%= f.hidden_field :token, value: @nominate_induction_tutor_form.token %>
             <%= f.govuk_submit "Continue" %>

--- a/app/views/nominations/nominate_induction_coordinator/link_expired.html.erb
+++ b/app/views/nominations/nominate_induction_coordinator/link_expired.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        <h1 class="govuk-heading-xl">This link has expired</h1>
+        <h1 class="govuk-heading-l">This link has expired</h1>
 
         <p class="govuk-body govuk-!-margin-bottom-7">You need to request another email with a new link</p>
 

--- a/app/views/nominations/nominate_induction_coordinator/link_invalid.html.erb
+++ b/app/views/nominations/nominate_induction_coordinator/link_invalid.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        <h1 class="govuk-heading-xl">The link provided is invalid</h1>
+        <h1 class="govuk-heading-l">The link provided is invalid</h1>
 
         <%= govuk_button_link_to "Resend email", choose_location_request_nomination_invite_path %>
 

--- a/app/views/nominations/nominate_induction_coordinator/name_different.html.erb
+++ b/app/views/nominations/nominate_induction_coordinator/name_different.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        <h1 class="govuk-heading-xl"><%= t('errors.full_name.does_not_match') %></h1>
+        <h1 class="govuk-heading-l"><%= t('errors.full_name.does_not_match') %></h1>
 
         <p class="govuk-body">An induction tutor has already been nominated using this email address, but the name does not match our records.</p>
         <p class="govuk-body govuk-!-margin-bottom-7"><%= govuk_link_to "Change the name", full_name_nominate_induction_coordinator_path %> or contact: <%= render MailToSupportComponent.new %></p>

--- a/app/views/nominations/nominate_induction_coordinator/start_nomination.html.erb
+++ b/app/views/nominations/nominate_induction_coordinator/start_nomination.html.erb
@@ -6,8 +6,8 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        <span class="govuk-caption-xl"><%= @nominate_induction_tutor_form.school.name %></span>
-        <h1 class="govuk-heading-xl">Nominate an induction tutor for your school</h1>
+        <span class="govuk-caption-l"><%= @nominate_induction_tutor_form.school.name %></span>
+        <h1 class="govuk-heading-x">Nominate an induction tutor for your school</h1>
 
         <p class="govuk-body">Your induction tutor will be our single point of contact for ECF-based training at your school. They’ll use our service to:</p>
         <ul class="govuk-list govuk-list--bullet">

--- a/app/views/nominations/request_nomination_invite/already_nominated.html.erb
+++ b/app/views/nominations/request_nomination_invite/already_nominated.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-header-xl">An induction tutor has already been nominated</h1>
+    <h1 class="govuk-heading-l">An induction tutor has already been nominated</h1>
 
     <p class="govuk-body">Your school has already nominated an induction tutor to use our service.</p>
     <p class="govuk-body">We have sent links to schools using their email address on our register, Get Information about Schools (GIAS).</p>

--- a/app/views/nominations/request_nomination_invite/choose_location.html.erb
+++ b/app/views/nominations/request_nomination_invite/choose_location.html.erb
@@ -12,7 +12,7 @@
                 @local_authorities,
                 :id,
                 :name,
-                label: { text: "What’s your school’s local authority?", tag: "h1", size: "xl" },
+                label: { text: "What’s your school’s local authority?", tag: "h1", size: "l" },
                 width: "two-thirds",
                 options: { include_blank: true },
                 class: ["js-location-select"]) do %>

--- a/app/views/nominations/request_nomination_invite/choose_school.html.erb
+++ b/app/views/nominations/request_nomination_invite/choose_school.html.erb
@@ -12,7 +12,7 @@
             @nomination_request_form.available_schools,
             :id,
             :name_with_address,
-            label: { text: "What’s the name of your school?", tag: "h1", size: "xl"  },
+            label: { text: "What’s the name of your school?", tag: "h1", size: "l"  },
             options: { include_blank: true },
             class: ["js-school-select"]) %>
 

--- a/app/views/nominations/request_nomination_invite/limit_reached.html.erb
+++ b/app/views/nominations/request_nomination_invite/limit_reached.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        <h1 class="govuk-header-xl">You can only send <%= @limit[:max] %> <%= "email".pluralize(@limit[:max]) %> per <%= @limit[:within].inspect %></h1>
+        <h1 class="govuk-heading-l">You can only send <%= @limit[:max] %> <%= "email".pluralize(@limit[:max]) %> per <%= @limit[:within].inspect %></h1>
         <p class="govuk-body">You can try again later.</p>
 
         <h2 class="govuk-heading-m">If your school has not received this email</h2>

--- a/app/views/nominations/request_nomination_invite/not_eligible.html.erb
+++ b/app/views/nominations/request_nomination_invite/not_eligible.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-header-xl">
+    <h1 class="govuk-heading-l">
       Sorry, teachers cannot serve statutory induction at your school
     </h1>
 

--- a/app/views/nominations/request_nomination_invite/review.html.erb
+++ b/app/views/nominations/request_nomination_invite/review.html.erb
@@ -4,7 +4,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <h1 class="govuk-heading-xl">Confirm this is your school</h1>
+    <h1 class="govuk-heading-l">Confirm this is your school</h1>
 
 
     <%= render partial: 'nominations/school_details', locals: { school: @nomination_request_form.school, title: "Your school" } %>

--- a/app/views/nominations/request_nomination_invite/success.html.erb
+++ b/app/views/nominations/request_nomination_invite/success.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-  <h1 class="govuk-heading-xl">Check your school email</h1>
+  <h1 class="govuk-heading-l">Check your school email</h1>
 
     <p class="govuk-body">
       We’ve sent an email to

--- a/app/views/pages/_user_research_fully_booked.html.erb
+++ b/app/views/pages/_user_research_fully_booked.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
-    <h1 class="govuk-heading-xl">All research sessions are currently booked</h1>
+    <h1 class="govuk-heading-l">All research sessions are currently booked</h1>
     <p class="govuk-body">Thank you for your interest in our research. All sessions have now been booked.</p>
 
     <p class="govuk-body">

--- a/app/views/pages/_user_research_sign_up.html.erb
+++ b/app/views/pages/_user_research_sign_up.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
 
-    <h1 class="govuk-heading-xl">Can you help us with our research?</h1>
+    <h1 class="govuk-heading-l">Can you help us with our research?</h1>
 
     <p class="govuk-body">
       All early career teachers now complete a 2-year induction programme. Before this starts, we need to check your

--- a/app/views/pages/core_materials_info.html.erb
+++ b/app/views/pages/core_materials_info.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "Core induction materials" %>
 <% content_for :before_content, govuk_back_link(text: "Back", href: :back) %>
 
-<h1 class="govuk-heading-xl">Choose study materials for your early career teachers</h1>
+<h1 class="govuk-heading-l">Choose study materials for your early career teachers</h1>
 
 <p>It’s important to choose the right training materials for your school.</p>
 

--- a/app/views/pages/induction_tutor_materials/ambition_institute/_handbooks_and_outlines.html.erb
+++ b/app/views/pages/induction_tutor_materials/ambition_institute/_handbooks_and_outlines.html.erb
@@ -1,4 +1,4 @@
-<h1 class="govuk-heading-xl govuk-!-margin-bottom-9">Ambition Institute’s handbooks and training outlines</h1>
+<h1 class="govuk-heading-l govuk-!-margin-bottom-9">Ambition Institute’s handbooks and training outlines</h1>
 
 <h2 class="govuk-heading-l govuk-!-margin-bottom-3">Handbooks</h2>
 

--- a/app/views/pages/induction_tutor_materials/education_development_trust/_handbooks_and_outlines.html.erb
+++ b/app/views/pages/induction_tutor_materials/education_development_trust/_handbooks_and_outlines.html.erb
@@ -1,4 +1,4 @@
-<h1 class="govuk-heading-xl govuk-!-margin-bottom-9">
+<h1 class="govuk-heading-l govuk-!-margin-bottom-9">
   Education Development Trust’s handbooks and training outlines
 </h1>
 

--- a/app/views/pages/induction_tutor_materials/teach_first/year_one.html.erb
+++ b/app/views/pages/induction_tutor_materials/teach_first/year_one.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <h1 class="govuk-heading-xl govuk-!-margin-bottom-9">Teach First’s handbooks and training outlines</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-9">Teach First’s handbooks and training outlines</h1>
 
     <h2 class="govuk-heading-l govuk-!-margin-bottom-3">Handbooks</h2>
     <p>The sequence document provides an overview of how the programme is structured across the 2 years of induction.</p>

--- a/app/views/pages/induction_tutor_materials/ucl_institute_of_education/_handbooks_and_outlines.html.erb
+++ b/app/views/pages/induction_tutor_materials/ucl_institute_of_education/_handbooks_and_outlines.html.erb
@@ -1,4 +1,4 @@
-<h1 class="govuk-heading-xl govuk-!-margin-bottom-9">University College London’s handbooks and training outlines</h1>
+<h1 class="govuk-heading-l govuk-!-margin-bottom-9">University College London’s handbooks and training outlines</h1>
 <h2 class="govuk-heading-l govuk-!-margin-bottom-3">Handbooks</h2>
 <p>The programme handbook outlines how UCL Early Career Teacher Consortium’s coaching and mentoring programme works.</p>
 <%= govuk_link_to "Programme Handbook (PDF, 1002 KB, 74 pages)",

--- a/app/views/pages/year_2020_core_materials_info.html.erb
+++ b/app/views/pages/year_2020_core_materials_info.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <h1 class="govuk-heading-xl">Support materials summary</h1>
+    <h1 class="govuk-heading-l">Support materials summary</h1>
 
     <p>You can choose resources from one of 4 DfE-accredited providers</p>
 

--- a/app/views/participants/no_access/show.html.erb
+++ b/app/views/participants/no_access/show.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">You do not have access to this service</h1>
+    <h1 class="govuk-heading-l">You do not have access to this service</h1>
 
     <p>This may be because:</p>
     <ul class="govuk-list govuk-list--bullet">

--- a/app/views/participants/start_registrations/show.html.erb
+++ b/app/views/participants/start_registrations/show.html.erb
@@ -1,8 +1,8 @@
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">    
-    
-    <h1 class="govuk-heading-xl">Register for DfE funding for ECF-based training and mentoring</h1>
-    
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l">Register for DfE funding for ECF-based training and mentoring</h1>
+
     <p class="govuk-body">This service is for:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>early career teachers (ECTs) in England, due to start ECF-based training as part of their induction</li>
@@ -24,6 +24,6 @@
     <p class="govuk-body">You must <%= govuk_link_to "apply for a TRN", get_a_trn_participants_start_registrations_path %> before you can use this service. You need a TRN to be eligible for DfE-funded mentor training and access to training materials</p>
 
     <%= govuk_button_link_to "Continue", new_user_session_path %>
-    
+
   </div>
 </div>

--- a/app/views/participants/validations/check_trn_given.html.erb
+++ b/app/views/participants/validations/check_trn_given.html.erb
@@ -3,7 +3,7 @@
     <%= form_for validation_form, url: { action: :update }, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset :check_trn_given, inline: true, legend: { text: "Have you been given a teacher reference number (TRN)?", tag: 'h1', size: 'xl' } do %>
+      <%= f.govuk_radio_buttons_fieldset :check_trn_given, inline: true, legend: { text: "Have you been given a teacher reference number (TRN)?", tag: 'h1', size: 'l' } do %>
         <p class="govuk-body">You’ll have a TRN if you hold, or are working towards qualified teacher status (QTS) in England.</p>
         <p class="govuk-body">You can usually find it on your payslip, teachers’ pension documents, or teacher training records.</p>
 

--- a/app/views/participants/validations/do_you_want_to_add_mentor_information.html.erb
+++ b/app/views/participants/validations/do_you_want_to_add_mentor_information.html.erb
@@ -9,7 +9,7 @@
       <%= f.govuk_collection_radio_buttons(
         :do_you_want_to_add_mentor_information_choice, @participant_validation_form.add_mentor_information_choices,
         :id, :name,
-        legend: { text: title, size: "xl", tag: "h1" },
+        legend: { text: title, size: "l", tag: "h1" },
         hint: { text: "We need to check your details on the Teaching Regulation Agency records. This is to make sure you qualify for this programme." }
       ) %>
       <%= f.govuk_submit "Continue" %>

--- a/app/views/participants/validations/dob.html.erb
+++ b/app/views/participants/validations/dob.html.erb
@@ -10,7 +10,7 @@
       <%= f.govuk_date_field :dob,
         date_of_birth: true,
         width: "three-quarters",
-        legend: { text: title, tag: 'h1', size: 'xl' },
+        legend: { text: title, tag: 'h1', size: 'l' },
         hint: { text: "For example 14 7 1990"}
       %>
 

--- a/app/views/participants/validations/name.html.erb
+++ b/app/views/participants/validations/name.html.erb
@@ -6,7 +6,7 @@
     <%= form_for validation_form, url: { action: :update }, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_text_field :full_name, label: { text: "What was your full name when you started your ITT?", tag: 'h1', size: 'xl' }, class: %w[govuk-!-width-two-thirds] %>
+      <%= f.govuk_text_field :full_name, label: { text: "What was your full name when you started your ITT?", tag: 'h1', size: 'l' }, class: %w[govuk-!-width-two-thirds] %>
 
       <%= f.govuk_submit "Continue" %>
     <% end %>

--- a/app/views/participants/validations/name_changed.html.erb
+++ b/app/views/participants/validations/name_changed.html.erb
@@ -6,7 +6,7 @@
     <%= form_for validation_form, url: { action: :update }, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-xl">Is this the name you used when you started your initial teacher training (ITT)?</h1>
+      <h1 class="govuk-heading-l">Is this the name you used when you started your initial teacher training (ITT)?</h1>
       <div class="govuk-inset-text">
         <p>
           <span class="govuk-!-font-weight-bold">Name:</span>

--- a/app/views/participants/validations/nino.html.erb
+++ b/app/views/participants/validations/nino.html.erb
@@ -7,7 +7,7 @@
     <%= form_for validation_form, url: { action: :update }, method: :patch do |f| %>
       <%= f.govuk_error_summary  %>
 
-      <h1 class="govuk-heading-xl"><%= title %></h1>
+      <h1 class="govuk-heading-l"><%= title %></h1>
 
       <%= f.govuk_text_field :nino,
         width: "three-quarters",

--- a/app/views/participants/validations/no_match.html.erb
+++ b/app/views/participants/validations/no_match.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl"><%= title %></h1>
+    <h1 class="govuk-heading-l"><%= title %></h1>
     <p class="govuk-body">Check the information you entered is correct.</p>
     <dl class="govuk-summary-list govuk-!-margin-bottom-9">
 

--- a/app/views/participants/validations/trn.html.erb
+++ b/app/views/participants/validations/trn.html.erb
@@ -9,7 +9,7 @@
       <%= f.hidden_field :no_trn, value: false %>
       <%= f.govuk_text_field :trn,
         width: "three-quarters",
-        label: { text: title, tag: :h1, size: 'xl' },
+        label: { text: title, tag: :h1, size: 'l' },
         hint: -> do
       %>
         <p class="govuk-body">This unique ID is:</p>

--- a/app/views/privacy_policies/show.html.erb
+++ b/app/views/privacy_policies/show.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        <h1 class="govuk-heading-xl">Privacy policy</h1>
+        <h1 class="govuk-heading-l">Privacy policy</h1>
 
         <% if !@policy.acceptance_required?(current_user) %>
             <% content_for :before_content, govuk_back_link(text: "Back", href: :back) %>

--- a/app/views/sandbox/show.html.erb
+++ b/app/views/sandbox/show.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">Use our sandbox environment</h1>
+      <h1 class="govuk-heading-l">Use our sandbox environment</h1>
 
       <p class="govuk-body">Sandbox is a test environment for the Manage teacher CPD service.</p>
       <p class="govuk-body">Login to sandbox to experience the service as a school induction tutor, lead provider and software vendor.</p>

--- a/app/views/schools/add_participants/cannot_add.html.erb
+++ b/app/views/schools/add_participants/cannot_add.html.erb
@@ -5,8 +5,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @school.name %></span>
-    <h1 class="govuk-heading-xl"><%= title %></h1>
+    <span class="govuk-caption-l"><%= @school.name %></span>
+    <h1 class="govuk-heading-l"><%= title %></h1>
 
     <p class="govuk-body">Our records show this person is already registered on an ECF-based training programme at a different school</p>
     <p class="govuk-body">Contact us for help to register this person at your school: <%= render MailToSupportComponent.new %></p>

--- a/app/views/schools/add_participants/cannot_add_already_enrolled_at_school.html.erb
+++ b/app/views/schools/add_participants/cannot_add_already_enrolled_at_school.html.erb
@@ -3,8 +3,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @school.name %></span>
-    <h1 class="govuk-heading-xl"><%= title %></h1>
+    <span class="govuk-caption-l"><%= @school.name %></span>
+    <h1 class="govuk-heading-l"><%= title %></h1>
 
     <p class="govuk-body">Our records show this person is already registered on an ECF-based training programme at your school</p>
 

--- a/app/views/schools/add_participants/cannot_add_ect_because_already_a_mentor.html.erb
+++ b/app/views/schools/add_participants/cannot_add_ect_because_already_a_mentor.html.erb
@@ -5,8 +5,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @school.name %></span>
-    <h1 class="govuk-heading-xl"><%= title %></h1>
+    <span class="govuk-caption-l"><%= @school.name %></span>
+    <h1 class="govuk-heading-l"><%= title %></h1>
 
     <p class="govuk-body">Our records show <%= @wizard.full_name %> is currently registered as a mentor.</p>
     <p class="govuk-body">Our service currently does not allow you to change a mentor into an ECT.</p>

--- a/app/views/schools/add_participants/cannot_add_manual_transfer.html.erb
+++ b/app/views/schools/add_participants/cannot_add_manual_transfer.html.erb
@@ -5,8 +5,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @school.name %></span>
-    <h1 class="govuk-heading-xl"><%= title %></h1>
+    <span class="govuk-caption-l"><%= @school.name %></span>
+    <h1 class="govuk-heading-l"><%= title %></h1>
 
     <p class="govuk-body"><%= @wizard.possessive_name %> record needs to be transferred manually.</p>
     <p class="govuk-body">Contact us for help to register this person at your school: <%= render MailToSupportComponent.new %></p>

--- a/app/views/schools/add_participants/cannot_add_mentor_at_multiple_schools.html.erb
+++ b/app/views/schools/add_participants/cannot_add_mentor_at_multiple_schools.html.erb
@@ -5,8 +5,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @school.name %></span>
-    <h1 class="govuk-heading-xl"><%= title %></h1>
+    <span class="govuk-caption-l"><%= @school.name %></span>
+    <h1 class="govuk-heading-l"><%= title %></h1>
 
     <p class="govuk-body">
       <%= @wizard.full_name %> can mentor ECTs at multiple schools but our service does not currently support this.

--- a/app/views/schools/add_participants/cannot_add_mentor_because_already_an_ect.html.erb
+++ b/app/views/schools/add_participants/cannot_add_mentor_because_already_an_ect.html.erb
@@ -5,8 +5,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @school.name %></span>
-    <h1 class="govuk-heading-xl"><%= title %></h1>
+    <span class="govuk-caption-l"><%= @school.name %></span>
+    <h1 class="govuk-heading-l"><%= title %></h1>
 
     <p class="govuk-body">Our records show <%= @wizard.full_name %> is currently registered as an ECT.</p>
     <p class="govuk-body">Our service currently does not allow you to change an ECT into a mentor.</p>

--- a/app/views/schools/add_participants/cannot_add_mentor_without_trn.html.erb
+++ b/app/views/schools/add_participants/cannot_add_mentor_without_trn.html.erb
@@ -5,8 +5,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @school.name %></span>
-    <h1 class="govuk-heading-xl">
+    <span class="govuk-caption-l"><%= @school.name %></span>
+    <h1 class="govuk-heading-l">
       <%= title %> without <%= @wizard.sit_mentor? ? "your" : "their" %> TRN
     </h1>
 

--- a/app/views/schools/add_participants/cannot_add_mismatch.html.erb
+++ b/app/views/schools/add_participants/cannot_add_mismatch.html.erb
@@ -5,8 +5,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @school.name %></span>
-    <h1 class="govuk-heading-xl"><%= title %></h1>
+    <span class="govuk-caption-l"><%= @school.name %></span>
+    <h1 class="govuk-heading-l"><%= title %></h1>
 
     <p class="govuk-body">We cannot add this person based on the information you’ve entered.</p>
     <p class="govuk-body">Contact us for help to register this <%= @wizard.ect_or_mentor_label %> at your school: <%= render MailToSupportComponent.new %></p>

--- a/app/views/schools/add_participants/cannot_add_registration_not_yet_open.html.erb
+++ b/app/views/schools/add_participants/cannot_add_registration_not_yet_open.html.erb
@@ -5,8 +5,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @school.name %></span>
-    <h1 class="govuk-heading-xl"><%= title %></h1>
+    <span class="govuk-caption-l"><%= @school.name %></span>
+    <h1 class="govuk-heading-l"><%= title %></h1>
 
     <p class="govuk-body">Our service is not open for registrations so you cannot add this participant yet.</p>
     <p class="govuk-body">We will contact you when registrations are open.</p>

--- a/app/views/schools/add_participants/cannot_add_yourself_as_ect.html.erb
+++ b/app/views/schools/add_participants/cannot_add_yourself_as_ect.html.erb
@@ -8,8 +8,8 @@
     <%= form_with model: @form, url: url_for(action: :update), scope: @wizard.form_scope, method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-xl"><%= @school.name %></span>
-      <h1 class="govuk-heading-xl"><%= title %></h1>
+      <span class="govuk-caption-l"><%= @school.name %></span>
+      <h1 class="govuk-heading-l"><%= title %></h1>
 
       <%= f.govuk_radio_buttons_fieldset :participant_type , legend: { text: "What would you like to do?", size: 'm' } do %>
         <%= f.govuk_radio_button :participant_type, :mentor, label: { text: "Add myself as a mentor instead" }, link_errors: true %>

--- a/app/views/schools/add_participants/cannot_find_their_details.html.erb
+++ b/app/views/schools/add_participants/cannot_find_their_details.html.erb
@@ -7,8 +7,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <span class="govuk-caption-xl"><%= @school.name %></span>
-    <h1 class="govuk-heading-xl">We cannot find <%= @wizard.possessive_name %> record</h1>
+    <span class="govuk-caption-l"><%= @school.name %></span>
+    <h1 class="govuk-heading-l">We cannot find <%= @wizard.possessive_name %> record</h1>
 
     <p class="govuk-body">Check the information you entered is correct.</p>
     <p class="govuk-body">

--- a/app/views/schools/add_participants/cannot_transfer_no_fip.html.erb
+++ b/app/views/schools/add_participants/cannot_transfer_no_fip.html.erb
@@ -2,8 +2,8 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <span class="govuk-caption-xl"><%= @school.name %></span>
-        <h1 class="govuk-heading-xl"><%= @wizard.full_name.presence || "This ECT" %>’s training record needs to be
+        <span class="govuk-caption-l"><%= @school.name %></span>
+        <h1 class="govuk-heading-l"><%= @wizard.full_name.presence || "This ECT" %>’s training record needs to be
             transferred manually</h1>
         <p class="govuk-body">Email our support team at
             <%= govuk_mail_to "continuing-professional-development@digital.education.gov.uk" %>

--- a/app/views/schools/add_participants/check_answers.html.erb
+++ b/app/views/schools/add_participants/check_answers.html.erb
@@ -4,8 +4,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @school.name %></span>
-    <h1 class="govuk-heading-xl">Check your answers</h1>
+    <span class="govuk-caption-l"><%= @school.name %></span>
+    <h1 class="govuk-heading-l">Check your answers</h1>
     <p class="govuk-body">
       You cannot change the name, TRN or date of birth as these have already been matched with the Teaching Regulation Agency (TRA) record.
     </p>

--- a/app/views/schools/add_participants/choose_mentor.html.erb
+++ b/app/views/schools/add_participants/choose_mentor.html.erb
@@ -9,8 +9,8 @@
       <%= f.govuk_error_summary %>
       <%= f.hidden_field :mentor_id, value: '' %>
       <%= f.govuk_radio_buttons_fieldset :mentor_id,
-                                         legend: { text: title, tag: 'h1', size: 'xl' },
-                                         caption: { text: @school.name, size: 'xl' } do %>
+                                         legend: { text: title, tag: 'h1', size: 'l' },
+                                         caption: { text: @school.name, size: 'l' } do %>
         <% @wizard.mentor_options.each_with_index do |mentor, i| %>
           <%= f.govuk_radio_button :mentor_id, mentor.id, label: { text: mentor.full_name }, link_errors: i == 0 %>
         <% end %>

--- a/app/views/schools/add_participants/confirm_appropriate_body.html.erb
+++ b/app/views/schools/add_participants/confirm_appropriate_body.html.erb
@@ -7,8 +7,8 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <span class="govuk-caption-xl"><%= @school.name %></span>
-      <h1 class="govuk-heading-xl"><%= title %></h1>
+      <span class="govuk-caption-l"><%= @school.name %></span>
+      <h1 class="govuk-heading-l"><%= title %></h1>
 
       <%= govuk_inset_text(text: @wizard.school_cohort.appropriate_body.name) %>
 

--- a/app/views/schools/add_participants/confirm_mentor_transfer.html.erb
+++ b/app/views/schools/add_participants/confirm_mentor_transfer.html.erb
@@ -13,8 +13,8 @@
         simple_yes_no_options,
         :id, :name,
         inline: true,
-        caption: { text: @school.name, size: 'xl' },
-        legend: { text: title, tag: 'h1', size: 'xl' }) do %>
+        caption: { text: @school.name, size: 'l' },
+        legend: { text: title, tag: 'h1', size: 'l' }) do %>
 
         <p class="govuk-body">
           Our records show this person is already registered as a mentor at a different school.

--- a/app/views/schools/add_participants/confirm_transfer.html.erb
+++ b/app/views/schools/add_participants/confirm_transfer.html.erb
@@ -7,8 +7,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <span class="govuk-caption-xl"><%= @school.name %></span>
-    <h1 class="govuk-heading-xl"><%= title %></h1>
+    <span class="govuk-caption-l"><%= @school.name %></span>
+    <h1 class="govuk-heading-l"><%= title %></h1>
 
     <p class="govuk-body govuk-!-margin-bottom-7">
       Our records show this person is already registered on an ECF-based training progamme at a different school.

--- a/app/views/schools/add_participants/continue_current_programme.html.erb
+++ b/app/views/schools/add_participants/continue_current_programme.html.erb
@@ -5,7 +5,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @school.name %></span>
+    <span class="govuk-caption-l"><%= @school.name %></span>
     <%= form_with model: @wizard.form, url: url_for(action: :update), scope: @wizard.form_scope, method: :put do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_collection_radio_buttons(
@@ -13,7 +13,7 @@
         simple_yes_no_options,
         :id, :name,
         inline: true,
-        legend: { text: title, tag: 'h1', size: 'xl' }) do %>
+        legend: { text: title, tag: 'h1', size: 'l' }) do %>
 
         <% if @wizard.transfer_has_same_provider_and_different_delivery_partner? %>
           <p class="govuk-body">This is the same lead provider, but a different delivery partner to other ECTs and mentors at your school.</p>

--- a/app/views/schools/add_participants/date_of_birth.html.erb
+++ b/app/views/schools/add_participants/date_of_birth.html.erb
@@ -7,14 +7,14 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <span class="govuk-caption-xl"><%= @school.name %></span>
+    <span class="govuk-caption-l"><%= @school.name %></span>
 
     <%= form_with model: @form, url: url_for(action: :update), scope: @wizard.form_scope, method: :put do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_date_field :date_of_birth,
         date_of_birth: true,
         width: "three-quarters",
-        legend: { text: title, tag: "h1", size: "xl" },
+        legend: { text: title, tag: "h1", size: "l" },
         hint: { text: "For example, 14 7 1990" } %>
 
       <%= f.govuk_submit "Continue" %>

--- a/app/views/schools/add_participants/different_name.html.erb
+++ b/app/views/schools/add_participants/different_name.html.erb
@@ -8,8 +8,8 @@
     <%= form_with model: @form, url: url_for(action: :update), scope: @wizard.form_scope, method: :put do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_text_field :full_name, width: "three-quarters",
-        label: { text: title, tag: :h1, size: 'xl', class: "govuk-!-margin-bottom-8" },
-        caption: { text: @school.name, size: 'xl' } do %>
+        label: { text: title, tag: :h1, size: 'l', class: "govuk-!-margin-bottom-8" },
+        caption: { text: @school.name, size: 'l' } do %>
         <p class="govuk-body">We just need their first name and last name, not titles like Mr, Mrs, Dr.</p>
         <p class="govuk-body">We need to match their name with the record held by the Teacher Regulation Agency (TRA).</p>
       <% end %>

--- a/app/views/schools/add_participants/email.html.erb
+++ b/app/views/schools/add_participants/email.html.erb
@@ -8,8 +8,8 @@
       <%= f.govuk_error_summary %>
       <%= f.govuk_text_field :email,
         width: "two-thirds",
-        label: { text: "What’s #{@wizard.possessive_name} email address?", tag: :h1, size: 'xl' },
-        caption: { text: @school.name, size: 'xl' } do %>
+        label: { text: "What’s #{@wizard.possessive_name} email address?", tag: :h1, size: 'l' },
+        caption: { text: @school.name, size: 'l' } do %>
 
         <p class="govuk-body govuk-!-margin-top-7">You can enter their personal or school email address.</p>
       <% end %>

--- a/app/views/schools/add_participants/email_already_taken.html.erb
+++ b/app/views/schools/add_participants/email_already_taken.html.erb
@@ -5,12 +5,12 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% if @wizard.email_used_in_the_same_school? %>
-      <h1 class="govuk-heading-xl">This email has already been added</h1>
+      <h1 class="govuk-heading-l">This email has already been added</h1>
       <p class="govuk-body govuk-!-margin-bottom-7">
         This email address has already been used to add an early career teacher or mentor.
       </p>
     <% else %>
-      <h1 class="govuk-heading-xl">This email is being used by someone at another school</h1>
+      <h1 class="govuk-heading-l">This email is being used by someone at another school</h1>
       <p class="govuk-body govuk-!-margin-bottom-7">
         Contact them directly to check whether they need to be transferred to your school.
       </p>

--- a/app/views/schools/add_participants/join_school_programme.html.erb
+++ b/app/views/schools/add_participants/join_school_programme.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @school.name %></span>
+    <span class="govuk-caption-l"><%= @school.name %></span>
     <%= form_with model: @wizard.form, url: url_for(action: :update), scope: @wizard.form_scope, method: :put do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_collection_radio_buttons(
@@ -14,7 +14,7 @@
         simple_yes_no_options,
         :id, :name,
         inline: true,
-        legend: { text: title, tag: 'h1', size: 'xl' }) do %>
+        legend: { text: title, tag: 'h1', size: 'l' }) do %>
 
         <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Lead provider</h2>
         <p class="govuk-body govuk-!-margin-bottom-1"><%= @wizard.lead_provider&.name %></p>

--- a/app/views/schools/add_participants/joining_date.html.erb
+++ b/app/views/schools/add_participants/joining_date.html.erb
@@ -7,13 +7,13 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <span class="govuk-caption-xl"><%= @school.name %></span>
+    <span class="govuk-caption-l"><%= @school.name %></span>
 
     <%= form_with model: @wizard.form, url: url_for(action: :update), scope: @wizard.form_scope, method: :put do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_date_field :start_date,
         width: "two-thirds",
-        legend: { text: title, tag: "h1", size: "xl", class: "govuk-heading-xl" },
+        legend: { text: title, tag: "h1", size: "l", class: "govuk-heading-l" },
         hint: { text: "For example, 14 7 2023" } do %>
 
         <p class="govuk-body">

--- a/app/views/schools/add_participants/known_by_another_name.html.erb
+++ b/app/views/schools/add_participants/known_by_another_name.html.erb
@@ -14,7 +14,7 @@
         simple_yes_no_options,
         :id, :name,
         inline: true,
-        legend: { text: title, tag: 'h1', size: 'xl' }) do %>
+        legend: { text: title, tag: 'h1', size: 'l' }) do %>
 
         <p class="govuk-body govuk-!-margin-bottom-7">
           They are registered under a different name in the records held by the Teaching Regulation Agency (TRA).

--- a/app/views/schools/add_participants/name.html.erb
+++ b/app/views/schools/add_participants/name.html.erb
@@ -14,8 +14,8 @@
     <%= form_with model: @form, url: url_for(action: :update), scope: @wizard.form_scope, method: :put do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_text_field :full_name, width: "three-quarters",
-        label: { text: full_name_label, tag: :h1, size: 'xl' },
-        caption: { text: @school.name, size: 'xl' },
+        label: { text: full_name_label, tag: :h1, size: 'l' },
+        caption: { text: @school.name, size: 'l' },
         hint: { text: "We just need their first name and last name, not titles like Mr, Mrs, Dr." } %>
       <%= f.govuk_submit "Continue" %>
     <% end %>

--- a/app/views/schools/add_participants/need_training_setup.html.erb
+++ b/app/views/schools/add_participants/need_training_setup.html.erb
@@ -5,8 +5,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @school.name %></span>
-    <h1 class="govuk-heading-xl"><%= title %></h1>
+    <span class="govuk-caption-l"><%= @school.name %></span>
+    <h1 class="govuk-heading-l"><%= title %></h1>
 
     <p class="govuk-body">Before you can register <%= @wizard.full_name_or_yourself %> for ECF-based training at your school,
       you’ll need to set up training for the <%= @wizard.cohort_to_place_participant.description %> academic year.

--- a/app/views/schools/add_participants/nino.html.erb
+++ b/app/views/schools/add_participants/nino.html.erb
@@ -7,14 +7,14 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <span class="govuk-caption-xl"><%= @school.name %></span>
+    <span class="govuk-caption-l"><%= @school.name %></span>
 
     <%= form_with model: @form, url: url_for(action: :update), scope: @wizard.form_scope, method: :put do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_text_field :nino,
                              width: "two-thirds",
                              spellcheck: false,
-                             label: { text: title, size: 'xl', tag: 'h1', class: 'govuk-heading-xl' },
+                             label: { text: title, size: 'l', tag: 'h1', class: 'govuk-heading-l' },
                              hint: { text: "It’s on their National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’." } %>
       <%= f.govuk_submit "Continue" %>
     <% end %>

--- a/app/views/schools/add_participants/participant_type.html.erb
+++ b/app/views/schools/add_participants/participant_type.html.erb
@@ -5,11 +5,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <span class="govuk-caption-xl"><%= @school.name %></span>
+    <span class="govuk-caption-l"><%= @school.name %></span>
 
     <%= form_with model: @form, url: url_for(action: :update), scope: @wizard.form_scope, method: :put do |f| %>
       <%= f.govuk_error_summary %>
-      <%= f.govuk_radio_buttons_fieldset :participant_type , legend: { text: "Who do you want to add?", tag: 'h1', size: 'xl' } do %>
+      <%= f.govuk_radio_buttons_fieldset :participant_type , legend: { text: "Who do you want to add?", tag: 'h1', size: 'l' } do %>
         <p class="govuk-body govuk-!-margin-top-4">
           This could be a new teacher or a teacher transferring from another school where they’ve started ECF-based training or mentoring.
         </p>

--- a/app/views/schools/add_participants/start_date.html.erb
+++ b/app/views/schools/add_participants/start_date.html.erb
@@ -7,13 +7,13 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <span class="govuk-caption-xl"><%= @school.name %></span>
+    <span class="govuk-caption-l"><%= @school.name %></span>
 
     <%= form_with model: @wizard.form, url: url_for(action: :update), scope: @wizard.form_scope, method: :put do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_date_field :start_date,
         width: "two-thirds",
-        legend: { text: title, tag: "h1", size: "xl", class: "govuk-heading-xl" },
+        legend: { text: title, tag: "h1", size: "l", class: "govuk-heading-l" },
         hint: { text: "For example, 14 9 2022" } do %>
 
         <p class="govuk-body">This is the date when the ECT’s induction programme formally starts. This may be different to their contract start date.</p>

--- a/app/views/schools/add_participants/start_term.html.erb
+++ b/app/views/schools/add_participants/start_term.html.erb
@@ -21,8 +21,8 @@
         @wizard.form.start_term_options,
         :id,
         :name,
-        legend: { text: title, tag: 'h1', size: 'xl' },
-        caption: { text: @school.name, size: "xl" },
+        legend: { text: title, tag: 'h1', size: 'l' },
+        caption: { text: @school.name, size: "l" },
         hint: { text: hint }) %>
 
       <%= f.govuk_submit "Continue" %>

--- a/app/views/schools/add_participants/still_cannot_find_their_details.html.erb
+++ b/app/views/schools/add_participants/still_cannot_find_their_details.html.erb
@@ -6,8 +6,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @school.name %></span>
-    <h1 class="govuk-heading-xl"><%= title %></h1>
+    <span class="govuk-caption-l"><%= @school.name %></span>
+    <h1 class="govuk-heading-l"><%= title %></h1>
 
     <p class="govuk-body">
       This could be because the information does not match their Teaching Regulation Agency (TRA) record

--- a/app/views/schools/add_participants/trn.html.erb
+++ b/app/views/schools/add_participants/trn.html.erb
@@ -7,12 +7,12 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        <span class="govuk-caption-xl"><%= @school.name %></span>
+        <span class="govuk-caption-l"><%= @school.name %></span>
 
         <%= form_with model: @form, url: url_for(action: :update), scope: @wizard.form_scope, method: :put do |f| %>
             <%= f.govuk_error_summary %>
             <%= f.govuk_text_field :trn,
-                label: { text: title, tag: "h1", size: "xl", class: 'govuk-heading-xl' },
+                label: { text: title, tag: "h1", size: "l", class: 'govuk-heading-l' },
                 width: "two-thirds" do %>
             <p class="govuk-body">This unique ID:</p>
             <ul class="govuk-list govuk-list--bullet">

--- a/app/views/schools/add_participants/what_we_need.html.erb
+++ b/app/views/schools/add_participants/what_we_need.html.erb
@@ -5,8 +5,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @school.name %></span>
-    <h1 class="govuk-heading-xl"><%= @title %></h1>
+    <span class="govuk-caption-l"><%= @school.name %></span>
+    <h1 class="govuk-heading-l"><%= @title %></h1>
 
     <p class="govuk-body">You must tell us their:</p>
     <ul class="govuk-list govuk-list--bullet">

--- a/app/views/schools/add_participants/yourself.html.erb
+++ b/app/views/schools/add_participants/yourself.html.erb
@@ -4,8 +4,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @school.name %></span>
-    <h1 class="govuk-heading-xl">Are you sure you want to add yourself as a mentor?</h1>
+    <span class="govuk-caption-l"><%= @school.name %></span>
+    <h1 class="govuk-heading-l">Are you sure you want to add yourself as a mentor?</h1>
 
     <p class="govuk-body">The induction tutor and mentor roles are separate.
       <%= govuk_link_to "Check what each role needs to do", schools_participant_roles_path, no_visited_state: true %>.

--- a/app/views/schools/change_sit/check_details.html.erb
+++ b/app/views/schools/change_sit/check_details.html.erb
@@ -2,8 +2,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @induction_tutor_form.school.name %></span>
-    <h1 class="govuk-heading-xl">Check your answers</h1>
+    <span class="govuk-caption-l"><%= @induction_tutor_form.school.name %></span>
+    <h1 class="govuk-heading-l">Check your answers</h1>
 
     <dl class="govuk-summary-list govuk-!-margin-bottom-9">
       <div class="govuk-summary-list__row">

--- a/app/views/schools/change_sit/confirm.html.erb
+++ b/app/views/schools/change_sit/confirm.html.erb
@@ -2,11 +2,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @induction_tutor_form.school.name %></span>
+    <span class="govuk-caption-l"><%= @induction_tutor_form.school.name %></span>
     <% if has_multiple_schools? %>
-      <h1 class="govuk-heading-xl">Are you sure you want to replace the induction tutor for <%= @induction_tutor_form.school.name %></h1>
+      <h1 class="govuk-heading-l">Are you sure you want to replace the induction tutor for <%= @induction_tutor_form.school.name %></h1>
     <% else %>
-      <h1 class="govuk-heading-xl">Are you sure you want to replace the induction tutor for your school?</h1>
+      <h1 class="govuk-heading-l">Are you sure you want to replace the induction tutor for your school?</h1>
     <% end %>
     <p class="govuk-body">You can only assign one induction tutor to use this service for your school.</p>
     <p class="govuk-body">You will no longer be able to:</p>

--- a/app/views/schools/change_sit/email.html.erb
+++ b/app/views/schools/change_sit/email.html.erb
@@ -6,8 +6,8 @@
       <%= f.govuk_error_summary %>
       <%= f.govuk_text_field(:email,
                              label: -> {
-                               tag.span(@induction_tutor_form.school.name, class: "govuk-caption-xl") +
-                                 tag.h1("What’s #{@induction_tutor_form.full_name}’s email address?", class: "govuk-heading-xl")
+                               tag.span(@induction_tutor_form.school.name, class: "govuk-caption-l") +
+                                 tag.h1("What’s #{@induction_tutor_form.full_name}’s email address?", class: "govuk-heading-l")
                              },
                              hint: { text: "We'll use this address to contact them with more information" })
       %>

--- a/app/views/schools/change_sit/name.html.erb
+++ b/app/views/schools/change_sit/name.html.erb
@@ -6,8 +6,8 @@
       <%= f.govuk_error_summary %>
       <%= f.govuk_text_field(:full_name,
                              label: -> {
-                               tag.span(@induction_tutor_form.school.name, class: "govuk-caption-xl") +
-                               tag.h1("What’s the full name of the new induction tutor?", class: "govuk-heading-xl") },
+                               tag.span(@induction_tutor_form.school.name, class: "govuk-caption-l") +
+                               tag.h1("What’s the full name of the new induction tutor?", class: "govuk-heading-l") },
           ) %>
       <%= f.govuk_submit "Continue" %>
     <% end %>

--- a/app/views/schools/choose_programme/confirm_programme.html.erb
+++ b/app/views/schools/choose_programme/confirm_programme.html.erb
@@ -6,8 +6,8 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        <span class="govuk-caption-xl"><%= @school.name %></span>
-        <h1 class="govuk-heading-xl">Confirm your training programme</h1>
+        <span class="govuk-caption-l"><%= @school.name %></span>
+        <h1 class="govuk-heading-l">Confirm your training programme</h1>
         <p class="govuk-body govuk-!-margin-bottom-7">You’ve chosen to <%= t @induction_choice_form.programme_choice, scope: "schools.induction_choice_form.confirmation_options", cohort: @induction_choice_form.cohort.display_name %>.</p>
 
     <%= form_for @induction_choice_form, url: choose_appropriate_body_schools_choose_programme_path do |f| %>

--- a/app/views/schools/choose_programme/show.html.erb
+++ b/app/views/schools/choose_programme/show.html.erb
@@ -6,7 +6,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        <span class="govuk-caption-xl"><%= @school.name %></span>
+        <span class="govuk-caption-l"><%= @school.name %></span>
 
         <%= form_for @induction_choice_form, url: schools_choose_programme_path, method: :post do |f| %>
             <%= f.govuk_error_summary %>
@@ -15,7 +15,7 @@
               @induction_choice_form.programme_choices,
               :id,
               :name,
-              legend: { text: "How do you want to run your training in #{@induction_choice_form.cohort.start_year} to #{@induction_choice_form.cohort.start_year + 1}?", size: "xl", tag: "h1" }
+              legend: { text: "How do you want to run your training in #{@induction_choice_form.cohort.start_year} to #{@induction_choice_form.cohort.start_year + 1}?", size: "l", tag: "h1" }
             ) do %>
               <p class="govuk-body">To learn more about your training options, visit
                 <%= govuk_link_to "How to set up training for early career teachers (opens in new tab)",

--- a/app/views/schools/cohort_setup/_change_lead_provider_confirmation.html.erb
+++ b/app/views/schools/cohort_setup/_change_lead_provider_confirmation.html.erb
@@ -1,5 +1,5 @@
-<span class="govuk-caption-xl"><%= @school.name %></span>
-<h1 class="govuk-heading-xl">You are going to form a new partnership with a lead provider</h1>
+<span class="govuk-caption-l"><%= @school.name %></span>
+<h1 class="govuk-heading-l">You are going to form a new partnership with a lead provider</h1>
 
 <p class="govuk-body">
   You must contact the new provider who will report the partnership to the DfE.

--- a/app/views/schools/cohort_setup/_change_to_core_induction_programme_confirmation.html.erb
+++ b/app/views/schools/cohort_setup/_change_to_core_induction_programme_confirmation.html.erb
@@ -1,5 +1,5 @@
-<span class="govuk-caption-xl"><%= @school.name %></span>
-<h1 class="govuk-heading-xl">Confirm your training programme</h1>
+<span class="govuk-caption-l"><%= @school.name %></span>
+<h1 class="govuk-heading-l">Confirm your training programme</h1>
 
 <p class="govuk-body">You‘ve chosen to deliver your own programme using DfE accredited materials.</p>
 

--- a/app/views/schools/cohort_setup/_change_to_design_our_own_confirmation.html.erb
+++ b/app/views/schools/cohort_setup/_change_to_design_our_own_confirmation.html.erb
@@ -1,5 +1,5 @@
-<span class="govuk-caption-xl"><%= @school.name %></span>
-<h1 class="govuk-heading-xl">Are you sure you want to run your own training programme?</h1>
+<span class="govuk-caption-l"><%= @school.name %></span>
+<h1 class="govuk-heading-l">Are you sure you want to run your own training programme?</h1>
 
 <p class="govuk-body">
   You’re choosing to design and deliver your own programme based on the early career

--- a/app/views/schools/cohort_setup/appropriate_body.html.erb
+++ b/app/views/schools/cohort_setup/appropriate_body.html.erb
@@ -14,8 +14,8 @@
                                                      @wizard.form.choices,
                                                      :id,
                                                      :name,
-                                                     legend: { text: title, tag: :h1, size: 'xl' },
-                                                     caption: { text: @school.name, size: 'xl' }) do %>
+                                                     legend: { text: title, tag: :h1, size: 'l' },
+                                                     caption: { text: @school.name, size: 'l' }) do %>
                     <div class="govuk-inset-text">
                         Remember to contact the appropriate body directly to appoint them for your ECTs, if you have not done so already.
                     </div>
@@ -25,8 +25,8 @@
                                               @wizard.form.choices,
                                               :id,
                                               :name,
-                                              label: { text: title, tag: :h1, size: 'xl' },
-                                              caption: { text: @school.name, size: 'xl' },
+                                              label: { text: title, tag: :h1, size: 'l' },
+                                              caption: { text: @school.name, size: 'l' },
                                               options: { include_blank: true },
                                               class: "autocomplete") do %>
                     <div class="govuk-inset-text">

--- a/app/views/schools/cohort_setup/appropriate_body_appointed.html.erb
+++ b/app/views/schools/cohort_setup/appropriate_body_appointed.html.erb
@@ -11,8 +11,8 @@
                 :appropriate_body_appointed,
                 simple_yes_no_options,
                 :id, :name,
-                legend: { text: title, tag: :h1, size: 'xl' },
-                caption: { text: @school.name, size: 'xl' }) do %>
+                legend: { text: title, tag: :h1, size: 'l' },
+                caption: { text: @school.name, size: 'l' }) do %>
             <% end %>
 
             <%= f.govuk_submit "Continue" %>

--- a/app/views/schools/cohort_setup/appropriate_body_type.html.erb
+++ b/app/views/schools/cohort_setup/appropriate_body_type.html.erb
@@ -12,8 +12,8 @@
                 @wizard.form.choices,
                 :id,
                 :name,
-                legend: { text: title, tag: :h1, size: 'xl' },
-                caption: { text: @school.name, size: 'xl' }) do %>
+                legend: { text: title, tag: :h1, size: 'l' },
+                caption: { text: @school.name, size: 'l' }) do %>
 
                 <p class="govuk-body">If any of your ECTs will work with a different appropriate body, you can tell us that when you register them later.</p>
             <% end %>

--- a/app/views/schools/cohort_setup/expect_any_ects.html.erb
+++ b/app/views/schools/cohort_setup/expect_any_ects.html.erb
@@ -10,7 +10,7 @@
         <%= form_with model: @wizard.form, url: url_for(action: :update), scope: @wizard.to_key, method: :put do |f| %>
             <%= f.govuk_error_summary %>
 
-            <span class="govuk-caption-xl"><%= @wizard.school.name %></span>
+            <span class="govuk-caption-l"><%= @wizard.school.name %></span>
 
             <% hint_text = capture do %>
               <p>This means teachers who have completed their initial teacher training, but have not started their 2-year induction yet.</p>

--- a/app/views/schools/cohort_setup/how_will_you_run_training.html.erb
+++ b/app/views/schools/cohort_setup/how_will_you_run_training.html.erb
@@ -5,7 +5,7 @@
 
 <% content_for :before_content, govuk_back_link(text: "Back", href: wizard_back_link_path) %>
 
-<span class="govuk-caption-xl"><%= @school.name %></span>
+<span class="govuk-caption-l"><%= @school.name %></span>
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -18,7 +18,7 @@
                 @wizard.form.choices,
                 :id,
                 :name,
-                legend: { text: title, tag: 'h1', size: 'xl' }) do %>
+                legend: { text: title, tag: 'h1', size: 'l' }) do %>
 
                 <p class="govuk-body govuk-!-margin-top-4">To learn more about your training options, visit
                     <%= govuk_link_to "How to set up training for early career teachers (opens in new tab)",

--- a/app/views/schools/cohort_setup/keep_providers.html.erb
+++ b/app/views/schools/cohort_setup/keep_providers.html.erb
@@ -7,7 +7,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        <span class="govuk-caption-xl"><%= @school.name %></span>
+        <span class="govuk-caption-l"><%= @school.name %></span>
 
         <%= form_with model: @wizard.form, url: url_for(action: :update), scope: @wizard.to_key, method: :put do |f| %>
             <%= f.govuk_error_summary %>
@@ -16,7 +16,7 @@
                 simple_yes_no_options,
                 :id,
                 :name,
-                legend: { text: title, tag: 'h1', size: 'xl' }) do %>
+                legend: { text: title, tag: 'h1', size: 'l' }) do %>
 
                 <h2 class="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-margin-top-5">Your DfE-funded lead
                     provider</h2>

--- a/app/views/schools/cohort_setup/programme_confirmation.html.erb
+++ b/app/views/schools/cohort_setup/programme_confirmation.html.erb
@@ -4,8 +4,8 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <span class="govuk-caption-xl"><%= @school.name %></span>
-        <h1 class="govuk-heading-xl">Are you sure this is how you want to run your training?</h1>
+        <span class="govuk-caption-l"><%= @school.name %></span>
+        <h1 class="govuk-heading-l">Are you sure this is how you want to run your training?</h1>
 
         <% if @wizard.how_will_you_run_training == 'full_induction_programme' %>
             <p class="govuk-body">You‘ve chosen to use a training provider, funded by DfE.</p>

--- a/app/views/schools/cohort_setup/providers_relationship_has_changed.html.erb
+++ b/app/views/schools/cohort_setup/providers_relationship_has_changed.html.erb
@@ -6,8 +6,8 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <span class="govuk-caption-xl"><%= @school.name %></span>
-        <h1 class="govuk-heading-xl"><%= title %></h1>
+        <span class="govuk-caption-l"><%= @school.name %></span>
+        <h1 class="govuk-heading-l"><%= title %></h1>
 
         <p class="govuk-body">Your lead provider and delivery partner are no longer working together to
             deliver ECF-based training.</p>

--- a/app/views/schools/cohort_setup/what_changes.html.erb
+++ b/app/views/schools/cohort_setup/what_changes.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <span class="govuk-caption-xl"><%= @school.name %></span>
+        <span class="govuk-caption-l"><%= @school.name %></span>
 
         <%= form_with model: @wizard.form, url: url_for(action: :update), scope: @wizard.to_key, method: :put do |f| %>
             <%= f.govuk_error_summary %>
@@ -16,7 +16,7 @@
                 @wizard.form.choices,
                 :id,
                 :name,
-                legend: { text: title, tag: 'h1', size: 'xl' }) do %>
+                legend: { text: title, tag: 'h1', size: 'l' }) do %>
                 <p class="govuk-body">The change will only apply for ECTs and mentors starting in the <% @cohort.description %> academic year.</p>
             <% end %>
 

--- a/app/views/schools/cohort_setup/what_we_need.html.erb
+++ b/app/views/schools/cohort_setup/what_we_need.html.erb
@@ -4,8 +4,8 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <span class="govuk-caption-xl"><%= @school.name %></span>
-        <h1 class="govuk-heading-xl">What we need to know</h1>
+        <span class="govuk-caption-l"><%= @school.name %></span>
+        <h1 class="govuk-heading-l">What we need to know</h1>
         <h2 class="govuk-heading-m">Tell us if any new ECTs or mentors will start training at your school in
             the <%= @wizard.cohort.description %> academic year</h2>
 

--- a/app/views/schools/cohorts/add.html.erb
+++ b/app/views/schools/cohorts/add.html.erb
@@ -3,8 +3,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @school.name %></span>
-    <h1 class="govuk-heading-xl"><%= title %></h1>
+    <span class="govuk-caption-l"><%= @school.name %></span>
+    <h1 class="govuk-heading-l"><%= title %></h1>
     <p class="govuk-body">
       We are working on this functionality and it should be available shortly.
     </p>

--- a/app/views/schools/cohorts/change_programme.html.erb
+++ b/app/views/schools/cohorts/change_programme.html.erb
@@ -5,8 +5,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <span class="govuk-caption-xl"><%= @school.name %></span>
-    <h1 class="govuk-heading-xl">Change how you run your training programme</h1>
+    <span class="govuk-caption-l"><%= @school.name %></span>
+    <h1 class="govuk-heading-l">Change how you run your training programme</h1>
 
     <% if @school_cohort.school_chose_fip? %>
     

--- a/app/views/schools/cohorts/programme_choice.html.erb
+++ b/app/views/schools/cohorts/programme_choice.html.erb
@@ -4,8 +4,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @cohort.display_name %></span>
-    <h1 class="govuk-heading-xl govuk-!-margin-top-2">Choose an induction programme</h1>
+    <span class="govuk-caption-l"><%= @cohort.display_name %></span>
+    <h1 class="govuk-heading-l govuk-!-margin-top-2">Choose an induction programme</h1>
     <p class="govuk-body-l">
       <strong>You’ve chosen to:</strong>
       <%= I18n.t "schools.induction_choice_form.confirmation_options.#{@school_cohort.induction_programme_choice}", cohort: @school_cohort.cohort.start_year %>

--- a/app/views/schools/core_programme/materials/edit.html.erb
+++ b/app/views/schools/core_programme/materials/edit.html.erb
@@ -5,14 +5,14 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         
-        <span class="govuk-caption-xl"><%= @school.name %></span>
+        <span class="govuk-caption-l"><%= @school.name %></span>
         <%= form_for @form, url: { action: :update }, method: :put do |f| %>
             <%= f.govuk_error_summary %>
             <%= f.govuk_collection_radio_buttons :core_induction_programme_id,
                                            CoreInductionProgramme.all,
                                            :id,
                                            :name,
-                                           legend: { text: "Which training materials do you want to use?", size: "xl", tag: "h1" } %>
+                                           legend: { text: "Which training materials do you want to use?", size: "l", tag: "h1" } %>
             <%= f.govuk_submit "Continue" %>
         <% end %>
 

--- a/app/views/schools/core_programme/materials/info.html.erb
+++ b/app/views/schools/core_programme/materials/info.html.erb
@@ -5,8 +5,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     
-    <span class="govuk-caption-xl"><%= @school.name %></span>
-    <h1 class="govuk-heading-xl">Do you know which accredited materials you want to use?</h1>
+    <span class="govuk-caption-l"><%= @school.name %></span>
+    <h1 class="govuk-heading-l">Do you know which accredited materials you want to use?</h1>
 
     <p class="govuk-body">You’ll be choosing materials for any new ECTs.</p>
     <p class="govuk-body govuk-!-margin-bottom-7">They’ll access these materials on our service, and usually complete their training programme over 2 years.</p>

--- a/app/views/schools/core_programme/materials/show.html.erb
+++ b/app/views/schools/core_programme/materials/show.html.erb
@@ -4,8 +4,8 @@
 <div class="govuk-grid-row">
 	<div class="govuk-grid-column-two-thirds">
 
-		<span class="govuk-caption-xl"><%= @school.name %></span>
-		<h1 class="govuk-heading-xl">Changing your accredited materials</h1>
+		<span class="govuk-caption-l"><%= @school.name %></span>
+		<h1 class="govuk-heading-l">Changing your accredited materials</h1>
 		
 		<p class="govuk-body">Each set of accredited materials is different. Before you change your materials:</p>
 		<ul class='govuk-list govuk-list--bullet'>

--- a/app/views/schools/dashboard/index.html.erb
+++ b/app/views/schools/dashboard/index.html.erb
@@ -1,6 +1,6 @@
 <%= content_for :title, "Manage your schools" %>
 
-<h1 class="govuk-heading-xl">Manage your schools</h1>
+<h1 class="govuk-heading-l">Manage your schools</h1>
 
 <table class="govuk-table">
   <thead class="govuk-table__head">

--- a/app/views/schools/dashboard/show.html.erb
+++ b/app/views/schools/dashboard/show.html.erb
@@ -6,8 +6,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @school.name %></span>
-    <h1 class="govuk-heading-xl">Manage your training</h1>
+    <span class="govuk-caption-l"><%= @school.name %></span>
+    <h1 class="govuk-heading-l">Manage your training</h1>
 
     <div class="wrapper-dashboard-v2">
       <%= govuk_button_link_to "Manage mentors and ECTs", school_participants_path %>

--- a/app/views/schools/participants/edit_email.html.erb
+++ b/app/views/schools/participants/edit_email.html.erb
@@ -2,7 +2,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <span class="govuk-caption-xl"><%= @school.name %></span>
+    <span class="govuk-caption-l"><%= @school.name %></span>
 
     <%= form_with model: @induction_record.preferred_identity,
                   scope: '',
@@ -14,9 +14,9 @@
                              width: 'two-thirds',
                              hint: -> { tag.p(t('participant.edit_email_hint')) },
                              label: { text: t('participant.edit_email', name: @profile.full_name),
-                                      size: 'xl',
+                                      size: 'l',
                                       tag: 'h1',
-                                      class: 'govuk-heading-xl' } %>
+                                      class: 'govuk-heading-l' } %>
       <%= f.govuk_submit %>
     <% end %>
   </div>

--- a/app/views/schools/participants/edit_mentor.html.erb
+++ b/app/views/schools/participants/edit_mentor.html.erb
@@ -7,7 +7,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <span class="govuk-caption-xl"><%= @school.name %></span>
+    <span class="govuk-caption-l"><%= @school.name %></span>
 
     <%= form_with model: @mentor_form,
                   url: school_participant_update_mentor_path(participant_id: @profile, from_mentor: params[:from_mentor]),
@@ -16,7 +16,7 @@
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset :mentor_id,
-                                         legend: { text: "Who is the mentor for #{@profile.user.full_name}?", tag: 'h1', size: 'xl' } do %>
+                                         legend: { text: "Who is the mentor for #{@profile.user.full_name}?", tag: 'h1', size: 'l' } do %>
         <% @mentor_form.available_mentors.each_with_index do |mentor, i| %>
           <%= f.govuk_radio_button :mentor_id, mentor.id, label: { text: mentor.full_name }, link_errors: i == 0 %>
         <% end %>

--- a/app/views/schools/participants/edit_name.html.erb
+++ b/app/views/schools/participants/edit_name.html.erb
@@ -6,7 +6,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <span class="govuk-caption-xl"><%= @school.name %></span>
+    <span class="govuk-caption-l"><%= @school.name %></span>
     <%= form_with model: @profile.user, scope: '',
                   url: school_participant_update_name_path,
                   method: :put do |f| %>
@@ -15,9 +15,9 @@
                              value: nil,
                              width: 'two-thirds',
                              label: { text: t('participant.edit_name', name: @profile.full_name),
-                                      size: 'xl',
+                                      size: 'l',
                                       tag: 'h1',
-                                      class: 'govuk-heading-xl' } %>
+                                      class: 'govuk-heading-l' } %>
       <%= f.govuk_submit %>
     <% end %>
 

--- a/app/views/schools/participants/email_used.html.erb
+++ b/app/views/schools/participants/email_used.html.erb
@@ -1,7 +1,7 @@
 <% content_for :before_content, govuk_back_link(text: "Back", href: school_participant_edit_email_path) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">That email address is already in use</h1>
+    <h1 class="govuk-heading-l">That email address is already in use</h1>
     <p class="govuk-body">Check the address entered and try again.</p>
     <%= govuk_button_link_to("Try again", school_participant_edit_email_path) %>
   </div>

--- a/app/views/schools/participants/mentor_change_confirmation.html.erb
+++ b/app/views/schools/participants/mentor_change_confirmation.html.erb
@@ -7,7 +7,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl"><%= @message %></h1>
+    <h1 class="govuk-heading-l"><%= @message %></h1>
 
     <br>
     <%= govuk_button_link_to("Back to manage mentors and ECTs",

--- a/app/views/schools/participants/reason_to_edit_name.html.erb
+++ b/app/views/schools/participants/reason_to_edit_name.html.erb
@@ -4,7 +4,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @school.name %></span>
+    <span class="govuk-caption-l"><%= @school.name %></span>
 
     <%= form_with model: edit_name_reason(@selected_reason),
                   scope: '',
@@ -16,7 +16,7 @@
             :reason,
             :name,
             legend: -> { tag.h1(t('page_titles.schools.participants.reason_to_edit_name', name: @profile.full_name),
-                                class: 'govuk-heading-xl') }
+                                class: 'govuk-heading-l') }
           ) %>
       <%= f.govuk_submit "Continue" %>
     <% end %>

--- a/app/views/schools/participants/remove.html.erb
+++ b/app/views/schools/participants/remove.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :before_content, govuk_back_link(text: "Back", href: school_participant_path(id: @profile)) %>
 
-<h1 class="govuk-heading-xl">Confirm you want to remove <%= @profile.user.full_name %></h1>
+<h1 class="govuk-heading-l">Confirm you want to remove <%= @profile.user.full_name %></h1>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/participants/replace_with_a_different_person.html.erb
+++ b/app/views/schools/participants/replace_with_a_different_person.html.erb
@@ -7,8 +7,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @school.name %></span>
-    <h1 class="govuk-heading-xl">
+    <span class="govuk-caption-l"><%= @school.name %></span>
+    <h1 class="govuk-heading-l">
       <%= t('page_titles.schools.participants.replace_with_a_different_person', name: @profile.full_name) %>
     </h1>
     <h2 class="govuk-heading-m">Contact the lead provider to withdraw this

--- a/app/views/schools/participants/should_not_have_been_registered.html.erb
+++ b/app/views/schools/participants/should_not_have_been_registered.html.erb
@@ -7,8 +7,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @school.name %></span>
-    <h1 class="govuk-heading-xl">
+    <span class="govuk-caption-l"><%= @school.name %></span>
+    <h1 class="govuk-heading-l">
       <%= t('page_titles.schools.participants.should_not_have_been_registered', name: @profile.user.full_name) %>
     </h1>
 

--- a/app/views/schools/participants/show.html.erb
+++ b/app/views/schools/participants/show.html.erb
@@ -5,8 +5,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <span class="govuk-caption-xl"><%= @school.name %></span>
-    <h1 class="govuk-heading-xl"><%= @profile.full_name %></h1>
+    <span class="govuk-caption-l"><%= @school.name %></span>
+    <h1 class="govuk-heading-l"><%= @profile.full_name %></h1>
 
     <h2 class="govuk-heading-l"><%= @profile.role %></h2>
 

--- a/app/views/schools/partnerships/_confirm_with_provider.html.erb
+++ b/app/views/schools/partnerships/_confirm_with_provider.html.erb
@@ -1,4 +1,4 @@
-<h1 class="govuk-heading-xl">Signing up with a training provider</h1>
+<h1 class="govuk-heading-l">Signing up with a training provider</h1>
 
 <p>You sign up with a training provider directly.</p>
 <p>They will confirm this with the DfE and you will be notified. (You do not need to confirm this here.)</p>

--- a/app/views/schools/partnerships/_signed_up_with_provider.html.erb
+++ b/app/views/schools/partnerships/_signed_up_with_provider.html.erb
@@ -1,4 +1,4 @@
-<h1 class="govuk-heading-xl">Signed up with a training provider</h1>
+<h1 class="govuk-heading-l">Signed up with a training provider</h1>
 
 <table class="govuk-table">
   <caption class="govuk-table__caption govuk-table__caption--m">Your training provider</caption>

--- a/app/views/schools/partnerships/index.html.erb
+++ b/app/views/schools/partnerships/index.html.erb
@@ -8,7 +8,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @cohort.display_name %></span>
+    <span class="govuk-caption-l"><%= @cohort.display_name %></span>
     <% if @partnership %>
     <%= render partial: "signed_up_with_provider" %>
     <% else %>

--- a/app/views/schools/setup_school_cohort/change_provider.html.erb
+++ b/app/views/schools/setup_school_cohort/change_provider.html.erb
@@ -8,7 +8,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        <span class="govuk-caption-xl"><%= @school.name %></span>
+        <span class="govuk-caption-l"><%= @school.name %></span>
 
         <%= form_for @setup_school_cohort_form, url: { action: :change_provider }, method: :put do |f| %>
         <%= f.govuk_error_summary %>
@@ -17,7 +17,7 @@
             @setup_school_cohort_form.change_provider_choices,
             :id, :name,
             inline: true,
-            legend: { text: title, tag: 'h1', size: 'xl' }) do %>
+            legend: { text: title, tag: 'h1', size: 'l' }) do %>
 
             <h2 class="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-margin-top-5">Your DfE-funded lead provider</h2>
             <p class="govuk-body"><%= previous_cohort.lead_provider&.name %></p>

--- a/app/views/schools/setup_school_cohort/how_will_you_run_training.html.erb
+++ b/app/views/schools/setup_school_cohort/how_will_you_run_training.html.erb
@@ -5,7 +5,7 @@
 
 <% content_for :before_content, govuk_back_link(text: "Back", href: expect_any_ects_schools_setup_school_cohort_path) %>
 
-<span class="govuk-caption-xl"><%= @school.name %></span>
+<span class="govuk-caption-l"><%= @school.name %></span>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -18,7 +18,7 @@
         :how_will_you_run_training_choice,
         @setup_school_cohort_form.how_will_you_run_training_choices(cip_only: @school.cip_only?),
         :id, :name,
-        legend: { text: title, tag: 'h1', size: 'xl' }) do %>
+        legend: { text: title, tag: 'h1', size: 'l' }) do %>
 
         <p class="govuk-body">This choice will only apply for ECTs and mentors starting in the <%= registration_cohort %> academic year.</p>
         <p class="govuk-body">

--- a/app/views/schools/transfer_out/check_answers.html.erb
+++ b/app/views/schools/transfer_out/check_answers.html.erb
@@ -4,8 +4,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @school.name %></span>
-    <h1 class="govuk-heading-xl">Check your answers</h1>
+    <span class="govuk-caption-l"><%= @school.name %></span>
+    <h1 class="govuk-heading-l">Check your answers</h1>
 
     <%= govuk_summary_list do |summary_list| %>
       <% summary_list.with_row do |row| %>

--- a/app/views/schools/transfer_out/check_transfer.html.erb
+++ b/app/views/schools/transfer_out/check_transfer.html.erb
@@ -6,8 +6,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <span class="govuk-caption-xl"><%= @school.name %></span>
-    <h1 class="govuk-heading-xl"><%= title %></h1>
+    <span class="govuk-caption-l"><%= @school.name %></span>
+    <h1 class="govuk-heading-l"><%= title %></h1>
 
     <p class="govuk-body">Confirm if this participant is moving to another school to continue their ECF-based training.</p>
 

--- a/app/views/schools/transfer_out/teacher_end_date.html.erb
+++ b/app/views/schools/transfer_out/teacher_end_date.html.erb
@@ -12,8 +12,8 @@
 
             <%= f.govuk_date_field :end_date,
                 width: "two-thirds",
-                legend: { text: title, tag: :h1, size: 'xl' },
-                caption: { text: @school.name, size: 'xl' },
+                legend: { text: title, tag: :h1, size: 'l' },
+                caption: { text: @school.name, size: 'l' },
                 hint: { text: "For example, 14 7 2023"}
             %>
             <%= f.govuk_submit "Continue" %>

--- a/app/views/shared/_get_a_trn.html.erb
+++ b/app/views/shared/_get_a_trn.html.erb
@@ -1,4 +1,4 @@
-<h1 class="govuk-heading-xl">Get a Teacher Reference Number (TRN)</h1>
+<h1 class="govuk-heading-l">Get a Teacher Reference Number (TRN)</h1>
 
 <h2 class="govuk-heading-m">Why do I need this?</h2>
 

--- a/app/views/shared/_roles.html.erb
+++ b/app/views/shared/_roles.html.erb
@@ -6,10 +6,10 @@
   <div class="govuk-grid-column-two-thirds">
 
     <% if @school&.name %>
-      <span class="govuk-caption-xl"><%= @school&.name %></span>
+      <span class="govuk-caption-l"><%= @school&.name %></span>
     <% end %>
 
-    <h1 class="govuk-heading-xl">Check what each person needs to do in the early career teacher training programme</h1>
+    <h1 class="govuk-heading-l">Check what each person needs to do in the early career teacher training programme</h1>
 
     <p class="govuk-body">Teachers will need to do different things to prepare for and complete the early career teacher
       (ECT) training programme, depending on their role.</p>

--- a/app/views/start/appropriate_bodies.html.erb
+++ b/app/views/start/appropriate_bodies.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <h1 class="govuk-heading-xl">Check data about early career teachers and mentors</h1>
+    <h1 class="govuk-heading-l">Check data about early career teachers and mentors</h1>
 
     <h2 class="govuk-heading-m">Sign in as an Appropriate Body (AB)</h2>
 

--- a/app/views/start/delivery_partners.html.erb
+++ b/app/views/start/delivery_partners.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <h1 class="govuk-heading-xl">Check data about early career teachers and mentors</h1>
+    <h1 class="govuk-heading-l">Check data about early career teachers and mentors</h1>
 
     <p class="govuk-body">Use this service to find out what data the DfE has about participants and mentors that are doing an ECF-based training programme, including details provided by school induction tutors.</p>
     <p class="govuk-body">There may be differences between this data and what’s on your lead provider’s portal, including data that’s out of date.</p>

--- a/app/views/start/index.html.erb
+++ b/app/views/start/index.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Manage training for early career teachers</h1>
+    <h1 class="govuk-heading-l">Manage training for early career teachers</h1>
 
     <p class="govuk-body">Use this service to set up ECF-based training for your early career teachers (ECTs) or tell us about a change at your school.</p>
 

--- a/app/views/users/sessions/link_invalid.html.erb
+++ b/app/views/users/sessions/link_invalid.html.erb
@@ -1,3 +1,3 @@
-<h1 class="govuk-heading-xl">That link has expired</h1>
+<h1 class="govuk-heading-l">That link has expired</h1>
 
 <%= govuk_button_link_to "Sign in", new_user_session_path %>

--- a/app/views/users/sessions/login_email_sent.html.erb
+++ b/app/views/users/sessions/login_email_sent.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <h1 class="govuk-heading-xl">Check your email</h1>
+    <h1 class="govuk-heading-l">Check your email</h1>
     <p class="govuk-body">We’ve sent an email to <strong><%= @login_email %></strong>.</p>
 
     <p class="govuk-body">

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -7,7 +7,7 @@
         <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
         <%= f.govuk_error_summary %>
 
-            <h1 class="govuk-heading-xl">Sign in</h1>
+            <h1 class="govuk-heading-l">Sign in</h1>
             <div class="govuk-form-group">
                 <%= f.govuk_email_field :email, label: { text: "Email address" } %>
             </div>

--- a/app/views/users/sessions/redirect_from_magic_link.html.erb
+++ b/app/views/users/sessions/redirect_from_magic_link.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "Complete sign in" %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">You’re now signed in</h1>
+    <h1 class="govuk-heading-l">You’re now signed in</h1>
     <%= form_with(url: users_sign_in_with_token_path) do |f| %>
       <div class="field">
         <%= hidden_field_tag :login_token, @login_token %>

--- a/app/views/users/sessions/signed_out.html.erb
+++ b/app/views/users/sessions/signed_out.html.erb
@@ -1,2 +1,2 @@
-<h1 class="govuk-heading-xl">You’re now signed out</h1>
+<h1 class="govuk-heading-l">You’re now signed out</h1>
 <p class="govuk-body">You can close this tab or <%= govuk_link_to "sign in again", new_user_session_path %>.</p>

--- a/data/privacy_policy.html
+++ b/data/privacy_policy.html
@@ -1,6 +1,6 @@
-<h2 class="govuk-heading-l">Who we are and why we process personal data</h2>
+<h2 class="govuk-heading-m">Who we are and why we process personal data</h2>
 <p class="govuk-body">
-  We are Teacher Continuing Professional Development (CPD), within the Department for Education (DfE).
+ We are Teacher Continuing Professional Development (CPD), within the Department for Education (DfE).
 </p>
 <p class="govuk-body">
   The National Professional Qualifications programme (NPQ) and the Early Career Framework
@@ -23,7 +23,7 @@
   Mentions of “us” and “we” means CPD and “you” means anyone using this service.
 </p>
 
-<h2 class="govuk-heading-l">How we look after your personal data</h2>
+<h2 class="govuk-heading-m">How we look after your personal data</h2>
 
 <p class="govuk-body">
   Any information we collect when you use our services will be used and looked after by:
@@ -48,7 +48,7 @@
   improve the service.
 </p>
 
-<h2 class="govuk-heading-l">Why our use of your personal data is lawful</h2>
+<h2 class="govuk-heading-m">Why our use of your personal data is lawful</h2>
 <p class="govuk-body">
   In order for our use of your personal data to be lawful, we need to meet one, or more,
   conditions in the data protection legislation.
@@ -59,13 +59,13 @@
   these purposes, to exercise its functions.
 </p>
 
-<h2 class="govuk-heading-l">What personal data we collect</h2>
+<h2 class="govuk-heading-m">What personal data we collect</h2>
 <p class="govuk-body">
   The personal data we collect will depend on whether you are a candidate, school induction
   tutor, teacher training provider or induction provider.
 </p>
 
-<h3 class="govuk-heading-m">What personal data we collect</h3>
+<h3 class="govuk-heading-s">What personal data we collect</h3>
 <p class="govuk-body">
   If you’re a candidate using the Manage Continuing Professional Development Service we
   will collect the following information about you:
@@ -81,7 +81,7 @@
   <li>what your role is</li>
 </ul>
 
-<h3 class="govuk-heading-m">What data we collect if you are a school induction tutor</h3>
+<h3 class="govuk-heading-s">What data we collect if you are a school induction tutor</h3>
 <p class="govuk-body">
   If you are a school induction tutor using the Manage Continuing Professional Development
   Service we will collect the following information about you:
@@ -93,7 +93,7 @@
   <li>what your role is</li>
 </ul>
 
-<h3 class="govuk-heading-m">What data we collect if you work for a teacher training provider or induction provider</h3>
+<h3 class="govuk-heading-s">What data we collect if you work for a teacher training provider or induction provider</h3>
 <p class="govuk-body">
   If you process teacher training applications or ECF induction registrations we will collect the
   following information about you:
@@ -106,8 +106,8 @@
   <li>what your role is</li>
 </ul>
 
-<h2 class="govuk-heading-l">How we use your data</h2>
-<h3 class="govuk-heading-m">Processing applications and registrations</h3>
+<h2 class="govuk-heading-m">How we use your data</h2>
+<h3 class="govuk-heading-s">Processing applications and registrations</h3>
 <p class="govuk-body">
   Processing applications and registrations includes the following:
 </p>
@@ -122,7 +122,7 @@
   <li>Match, link and analyse your data along with other datasets</li>
 </ul>
 
-<h3 class="govuk-heading-m">Building better application and registration processes</h3>
+<h3 class="govuk-heading-s">Building better application and registration processes</h3>
 <p class="govuk-body">
   We’ll use your data to help us build better processes. For example, we’ll look at any
   feedback you give us about our services so we can improve them.
@@ -131,20 +131,20 @@
   We may contact you to carry out user research.
 </p>
 
-<h3 class="govuk-heading-m">Getting insight to make government policy better</h3>
+<h3 class="govuk-heading-s">Getting insight to make government policy better</h3>
 <p class="govuk-body">
   We might match, link and analyse your data along with other datasets to help us inform
   government policy around teacher recruitment and retention.
 </p>
 
-<h3 class="govuk-heading-m">Keep you informed of additional relevant government policies</h3>
+<h3 class="govuk-heading-s">Keep you informed of additional relevant government policies</h3>
 <p class="govuk-body">
   We might match, link and analyse your data along with other datasets to contact and inform
   you about additional government policies relevant to you. You will have the opportunity to
   opt out of this communication if and when you are contacted.
 </p>
 
-<h3 class="govuk-heading-m">Quality assuring, evaluating and monitoring the policy</h3>
+<h3 class="govuk-heading-s">Quality assuring, evaluating and monitoring the policy</h3>
 <p class="govuk-body">
   We might match, link and analyse your data along with other datasets to share with auditors,
   evaluators and relevant bodies in order to carry out appropriate quality assurance,
@@ -156,7 +156,7 @@
   have the opportunity to opt out of this stage of the process if and when you are contacted.
 </p>
 
-<h2 class="govuk-heading-l">Who we share your data with</h2>
+<h2 class="govuk-heading-m">Who we share your data with</h2>
 <p class="govuk-body">
   We need to share personal data for the purposes mentioned above.
 </p>
@@ -165,7 +165,7 @@
   Education (School Teachers’ Qualifications) (England) Regulations 2003.
 </p>
 
-<h3 class="govuk-heading-m">Sharing data with teacher training providers and ECF induction providers</h3>
+<h3 class="govuk-heading-s">Sharing data with teacher training providers and ECF induction providers</h3>
 <p class="govuk-body">
   We share school induction tutor and candidate data with the teacher training providers and
   ECF induction providers.
@@ -180,7 +180,7 @@
   <li>get in touch with you if there’s a security issue concerning your data</li>
 </ul>
 
-<h3 class="govuk-heading-m">External organisations who process data</h3>
+<h3 class="govuk-heading-s">External organisations who process data</h3>
 <h4 class="govuk-heading-s">Customer service systems</h4>
 <p class="govuk-body">
   We use a customer service management system to process some personal data, such as
@@ -233,7 +233,7 @@
   induction will be documented against your Teaching Regulation Agency records.
 </p>
 
-<h2 class="govuk-heading-l">Your rights</h2>
+<h2 class="govuk-heading-m">Your rights</h2>
 <p class="govuk-body">
   Under the Data Protection Act 2018, you have the right to find out what data we have about
   you. This includes the right to:
@@ -256,7 +256,7 @@
   </a>
 </p>
 
-<h2 class="govuk-heading-l">Your rights</h2>
+<h2 class="govuk-heading-m">Your rights</h2>
 <p class="govuk-body">
   If you want to ask us to remove your data or get access to the data we have about you, you
   can email us:
@@ -284,7 +284,7 @@
   </a>
 </p>
 
-<h2 class="govuk-heading-l">Keeping our privacy policy up to date</h2>
+<h2 class="govuk-heading-m">Keeping our privacy policy up to date</h2>
 <p class="govuk-body">
   We reserve the right to update this privacy notice at any time, and we will provide you with a
   new privacy notice when we make any substantial updates. We will also notify you in other

--- a/spec/helpers/admin_helper_spec.rb
+++ b/spec/helpers/admin_helper_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe AdminHelper, type: :helper do
     end
 
     it "returns a caption containing the user role" do
-      expect(subject).to have_css(".govuk-caption-xl", text: "Mentor")
+      expect(subject).to have_css(".govuk-caption-l", text: "Mentor")
     end
 
     it "returns the TRN" do


### PR DESCRIPTION
Following a change to the GOV.UK Design System guidance, this drops all the h1 headings from Extra Large (XL) size, down to Large (L).

Where the heading is on a content page with subheadings, the subheadings are now set to Medium (M) for the h2 and small (S) for any h3s.

🗂️ [Jira card](https://dfedigital.atlassian.net/jira/software/projects/CST/boards/119)

## Context

The default size for h1 headings in the GOV.UK Design System used to be XL - but this [was changed in March 2020](https://github.com/DFE-Digital/early-careers-framework/pull/4075) to L.

Pages can still use the XL size if necessary - eg if there are 4 headings levels (h1 to h4), or if the page is more of a content page and the title is very short (like on some GOVUK page). But the default is now a bit smaller.
