### PR TITLE
[CST-2028] Adopt new way to process induction completion dates

### DIFF
--- a/app/jobs/build_completion_candidates_list_job.rb
+++ b/app/jobs/build_completion_candidates_list_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# This job builds a list of candidates to check for an induction completion date
+# The list will be processed by the SetParticipantCompletionDateJob
+class BuildCompletionCandidatesListJob < ApplicationJob
+  def perform
+    Participants::BuildCompletionCandidateList.call
+  rescue StandardError => e
+    Rails.logger.error("BuildCompletionCandidatesListJob: #{e.message}")
+  end
+end

--- a/app/jobs/set_participant_completion_date_job.rb
+++ b/app/jobs/set_participant_completion_date_job.rb
@@ -1,39 +1,18 @@
 # frozen_string_literal: true
 
-# This is a one off job to update all of the induction completion dates from DQT for
+# This is a job to update all of the induction completion dates from DQT for
 # all of the 2021/2022 ECTs that do not currently have them.
+# (see BuildCompletionCandidatesListJob for how the list is populated)
 # It runs in batches of 200 as we have a 300 lookup per minute limit on the API
 # This could get adapted later to be a regular running process with a bit more logic
 class SetParticipantCompletionDateJob < ApplicationJob
+  MAX_CANDIDATES = 200
+
   def perform
-    ParticipantProfile::ECT
-      .eligible_status
-      .joins(:teacher_profile)
-      .includes(:teacher_profile)
-      .where.not(teacher_profile: { trn: nil })
-      .where.not(induction_start_date: nil)
-      .where(induction_completion_date: nil)
-      .where(created_at: ...Cohort.find_by(start_year: 2023).registration_start_date)
-      .order(:updated_at)
-      .limit(200)
-      .each do |participant_profile|
-        induction = DQT::GetInductionRecord.call(trn: participant_profile.teacher_profile.trn)
-
-        # prevent touches from cascading up to User and being exposed in the API
-        User.no_touching do
-          if induction.blank?
-            participant_profile.touch
-            next
-          end
-
-          completion_date = induction["endDate"]
-
-          Induction::Complete.call(participant_profile:, completion_date:) if completion_date.present?
-
-          # put at the bottom of the list for the next iteration if nothing changed
-          participant_profile.touch
-        end
-      end
+    CompletionCandidate.limit(MAX_CANDIDATES).each do |candidate|
+      Participants::CheckAndSetCompletionDate.call(candidate.participant_profile)
+      candidate.destroy!
+    end
   rescue StandardError => e
     Rails.logger.error("SetParticipantCompletionDateJob: #{e.message}")
   end

--- a/app/jobs/set_participant_completion_date_job.rb
+++ b/app/jobs/set_participant_completion_date_job.rb
@@ -10,7 +10,7 @@ class SetParticipantCompletionDateJob < ApplicationJob
 
   def perform
     CompletionCandidate.limit(MAX_CANDIDATES).each do |candidate|
-      Participants::CheckAndSetCompletionDate.call(candidate.participant_profile)
+      Participants::CheckAndSetCompletionDate.call(participant_profile: candidate.participant_profile)
       candidate.destroy!
     end
   rescue StandardError => e

--- a/app/models/completion_candidate.rb
+++ b/app/models/completion_candidate.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class CompletionCandidate < ApplicationRecord
+  self.primary_key = "participant_profile_id"
+
+  belongs_to :participant_profile
+end

--- a/app/services/participants/build_completion_candidate_list.rb
+++ b/app/services/participants/build_completion_candidate_list.rb
@@ -33,10 +33,14 @@ module Participants
           AND c.start_year IN (2020,2021,2022)
           AND pp.induction_start_date IS NOT NULL
           AND pp.induction_completion_date IS NULL
-          AND pp.created_at < '2023-9-1'
+          AND pp.created_at < '#{registration_start_date}'
           AND tp.trn IS NOT NULL;
         SQL
       )
+    end
+
+    def registration_start_date
+      Cohort.find_by(start_year: 2023).registration_start_date.to_date.to_s
     end
   end
 end

--- a/app/services/participants/build_completion_candidate_list.rb
+++ b/app/services/participants/build_completion_candidate_list.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# This service builds a list of candidates to check for an induction completion date
+# The list will be processed by the SetParticipantCompletionDateJob
+# This could be improved later to more intelligently select which records to include
+# as at the moment it's just including all 2021 and 2022 ECTs
+module Participants
+  class BuildCompletionCandidateList < BaseService
+    def call
+      ActiveRecord::Base.transaction do
+        clean_candidate_list
+        build_candidate_list
+      end
+      CompletionCandidate.count
+    end
+
+  private
+
+    def clean_candidate_list
+      CompletionCandidate.delete_all
+    end
+
+    def build_candidate_list
+      ActiveRecord::Base.connection.execute(
+        <<~SQL
+          INSERT INTO completion_candidates (participant_profile_id)
+          SELECT pp.id
+          FROM participant_profiles pp
+          JOIN teacher_profiles tp ON tp.id = pp.teacher_profile_id
+          JOIN schedules s ON s.id = pp.schedule_id
+          JOIN cohorts c ON c.id = s.cohort_id
+          WHERE pp.type = 'ParticipantProfile::ECT'
+          AND c.start_year IN (2020,2021,2022)
+          AND pp.induction_start_date IS NOT NULL
+          AND pp.induction_completion_date IS NULL
+          AND pp.created_at < '2023-9-1'
+          AND tp.trn IS NOT NULL;
+        SQL
+      )
+    end
+  end
+end

--- a/app/services/participants/build_completion_candidate_list.rb
+++ b/app/services/participants/build_completion_candidate_list.rb
@@ -22,7 +22,7 @@ module Participants
 
     def build_candidate_list
       ActiveRecord::Base.connection.execute(
-        <<~SQL
+        <<~SQL,
           INSERT INTO completion_candidates (participant_profile_id)
           SELECT pp.id
           FROM participant_profiles pp

--- a/app/services/participants/check_and_set_completion_date.rb
+++ b/app/services/participants/check_and_set_completion_date.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Participants
+  class CheckAndSetCompletionDate < BaseService
+    def call
+      return unless participant_profile.ect?
+      Induction::Complete.call(participant_profile:, completion_date:) if completion_date.present?
+    end
+
+  private
+    attr_reader :participant_profile
+
+    def initialize(participant_profile:)
+      @participant_profile = participant_profile
+    end
+
+    def completion_date
+      induction&.fetch("endDate", nil)
+    end
+
+    def induction
+      @induction ||= DQT::GetInductionRecord.call(trn: participant_profile.teacher_profile.trn)
+    end
+  end
+end

--- a/app/services/participants/check_and_set_completion_date.rb
+++ b/app/services/participants/check_and_set_completion_date.rb
@@ -4,10 +4,12 @@ module Participants
   class CheckAndSetCompletionDate < BaseService
     def call
       return unless participant_profile.ect?
+
       Induction::Complete.call(participant_profile:, completion_date:) if completion_date.present?
     end
 
   private
+
     attr_reader :participant_profile
 
     def initialize(participant_profile:)

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -1,5 +1,7 @@
 ---
 :shared:
+  :completion_candidates:
+    - participant_profile_id
   :versions:
   - id
   - item_type

--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -33,6 +33,10 @@ send_outcomes_to_qualified_teachers_api:
   cron: "*/10 * * * *"
   class: "ParticipantOutcomes::BatchSendLatestOutcomesJob"
   queue: participant_outcomes
+build_completion_candidates_list_job:
+  cron: "15 23 * * *"
+  class: "BuildCompletionCandidatesListJob"
+  queue: default
 set_participant_completion_date_job:
   cron: "*/2 0-8 * * *"
   class: "SetParticipantCompletionDateJob"

--- a/db/migrate/20230929161148_create_completion_candidate.rb
+++ b/db/migrate/20230929161148_create_completion_candidate.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateCompletionCandidate < ActiveRecord::Migration[7.0]
+  def change
+    create_table(:completion_candidates, primary_key: :participant_profile_id, id: false) do |t|
+      t.uuid :participant_profile_id
+      t.index :participant_profile_id, unique: true
+    end
+
+    add_foreign_key :completion_candidates, :participant_profiles, on_delete: :cascade, validate: false
+  end
+end

--- a/db/migrate/20230929170240_validate_completion_candidates.rb
+++ b/db/migrate/20230929170240_validate_completion_candidates.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateCompletionCandidates < ActiveRecord::Migration[7.0]
+  def change
+    validate_foreign_key :completion_candidates, :participant_profiles
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_19_093921) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_29_170240) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -126,6 +126,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_19_093921) do
     t.datetime "updated_at", null: false
     t.index ["cohort_id", "lead_provider_id"], name: "index_cohorts_lead_providers_on_cohort_id_and_lead_provider_id"
     t.index ["lead_provider_id", "cohort_id"], name: "index_cohorts_lead_providers_on_lead_provider_id_and_cohort_id"
+  end
+
+  create_table "completion_candidates", id: false, force: :cascade do |t|
+    t.uuid "participant_profile_id"
+    t.index ["participant_profile_id"], name: "index_completion_candidates_on_participant_profile_id", unique: true
   end
 
   create_table "core_induction_programmes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1064,6 +1069,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_19_093921) do
   add_foreign_key "call_off_contracts", "lead_providers"
   add_foreign_key "cohorts_lead_providers", "cohorts"
   add_foreign_key "cohorts_lead_providers", "lead_providers"
+  add_foreign_key "completion_candidates", "participant_profiles", on_delete: :cascade
   add_foreign_key "data_stage_school_changes", "data_stage_schools"
   add_foreign_key "data_stage_school_links", "data_stage_schools"
   add_foreign_key "deleted_duplicates", "participant_profiles", column: "primary_participant_profile_id"

--- a/spec/services/participants/build_completion_candidate_list_spec.rb
+++ b/spec/services/participants/build_completion_candidate_list_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Participants::BuildCompletionCandidateList do
+  let(:cohort_21) { create(:seed_cohort, start_year: 2021) }
+  let(:cohort_22) { create(:seed_cohort, start_year: 2022) }
+  let(:cohort_23) { create(:seed_cohort, start_year: 2023) }
+
+  let!(:ect_21) { make_ect_for_cohort(cohort_21) }
+  let!(:ect_22) { make_ect_for_cohort(cohort_22) }
+  let!(:ect_23) { make_ect_for_cohort(cohort_23) }
+
+  subject(:service_call) { described_class.call }
+
+  describe "#call" do
+    it "adds eligible ECTs from 2021 and 2022 to the list" do
+      expect { service_call }.to change { CompletionCandidate.count }.by(2)
+    end
+
+    it "does not add ECTs from 2023" do
+      service_call
+      expect(CompletionCandidate.all).not_to include ect_23
+    end
+
+    context "when an ECT does not have an induction start date" do
+      before do
+        ect_22.update!(induction_start_date: nil)
+      end
+
+      it "does not add them to the list" do
+        service_call
+        expect(CompletionCandidate.all).not_to include ect_22
+      end
+    end
+  end
+
+  def make_ect_for_cohort(cohort)
+    start_date = Date.new(cohort.start_year, 9, 1)
+    travel_to(start_date) do
+      schedule = create(:seed_finance_schedule, cohort:)
+      profile = create(:ect_participant_profile, schedule:, induction_start_date: start_date)
+    end
+  end
+end

--- a/spec/services/participants/build_completion_candidate_list_spec.rb
+++ b/spec/services/participants/build_completion_candidate_list_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Participants::BuildCompletionCandidateList do
     start_date = Date.new(cohort.start_year, 9, 1)
     travel_to(start_date) do
       schedule = create(:seed_finance_schedule, cohort:)
-      profile = create(:ect_participant_profile, schedule:, induction_start_date: start_date)
+      create(:ect_participant_profile, schedule:, induction_start_date: start_date)
     end
   end
 end

--- a/spec/services/participants/build_completion_candidate_list_spec.rb
+++ b/spec/services/participants/build_completion_candidate_list_spec.rb
@@ -33,6 +33,17 @@ RSpec.describe Participants::BuildCompletionCandidateList do
         expect(CompletionCandidate.all).not_to include ect_22
       end
     end
+
+    context "when an ECT has an induction completion date" do
+      before do
+        ect_22.update!(induction_completion_date: 1.week.ago)
+      end
+
+      it "does not add them to the list" do
+        service_call
+        expect(CompletionCandidate.all).not_to include ect_22
+      end
+    end
   end
 
   def make_ect_for_cohort(cohort)

--- a/spec/services/participants/check_and_set_completion_date_spec.rb
+++ b/spec/services/participants/check_and_set_completion_date_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Participants::CheckAndSetCompletionDate do
+  let(:participant_profile) { create(:seed_ect_participant_profile, :valid) }
+  let!(:induction_record) { create(:seed_induction_record, :with_induction_programme, :with_schedule, participant_profile:) }
+  let(:trn) { participant_profile.teacher_profile.trn }
+  let(:completion_date) { 1.month.ago.to_date }
+  let(:dqt_induction_record) { { "endDate" => completion_date } }
+
+  subject(:service_call) { described_class.call(participant_profile:) }
+
+  describe "#call" do
+    before do
+      allow(DQT::GetInductionRecord).to receive(:call).with(trn:).and_return(dqt_induction_record)
+      service_call
+    end
+
+    it "sets the induction completion date" do
+      expect(participant_profile.induction_completion_date).to eq completion_date
+    end
+
+    context "when the participant does not have a completion date" do
+      let(:dqt_induction_record) { nil }
+
+      it "does not set a completion date" do
+        expect(participant_profile.induction_completion_date).to be_nil
+      end
+    end
+
+    context "when the participant is not an ECT" do
+      let(:participant_profile) { create(:seed_mentor_participant_profile, :valid) }
+
+      it "does not set a completion date" do
+        expect(participant_profile.induction_completion_date).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-2028)
Our original "one-time" backfill job ended up being run every night to check the DQT for induction completion dates.
The `touch` method used to move records to the end of the queue resulted in phantom updates being exposed to providers.

This PR adds a table to hold list of candidates for checking that can be processed and cleared down without causing any side-effects to other parts of the service.

A future piece of work is planned that will review the candidate selection algorithm and perhaps find a more intelligent and cohort-proof method. At the moment it is the same as the previous method that includes all ECTs registered prior to the 2023 academic year that have started an induction.

### Changes proposed in this pull request
Add a new `completion_candidates` table and model
Add a new service to check for a completion date and update participant
Add a new service to build candidate list
Add new job to run candidate list builder

### Guidance to review

