### PR TITLE
Add DFE analytics to API controller

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -3,6 +3,8 @@
 module Api
   class ApiController < ActionController::API
     include ActionController::MimeResponds
+    include DfE::Analytics::Requests
+
     before_action :remove_charset
     rescue_from ActionController::ParameterMissing, with: :missing_parameter_response
     rescue_from ActionController::UnpermittedParameters, with: :unpermitted_parameter_response

--- a/spec/requests/dfe_analytics_spec.rb
+++ b/spec/requests/dfe_analytics_spec.rb
@@ -24,5 +24,17 @@ RSpec.describe "DfE Analytics", type: :request do
       Cohort.create!(start_year: 2005)
       expect(:create_entity).to have_been_enqueued_as_analytics_events
     end
+
+    context "with lead provider API requests" do
+      let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
+      let(:token)             { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider:) }
+      let(:bearer_token)      { "Bearer #{token}" }
+
+      it "sends DFE Analytics web request event" do
+        default_headers[:Authorization] = bearer_token
+
+        expect { get "/api/v3/participants/ecf" }.to have_sent_analytics_event_types(:web_request)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

We aren't tracking API requests as `web_request` in DfE Analytics

- Ticket: n/a

### Changes proposed in this pull request
Add dfe analytics to API controller to start tracking API requests in BQ events

### Guidance to review
thanks @ethax-ross for your help in finding this!
