### PR TITLE
[CST-1988] Give better info to SITs when adding already enrolled participants is failing

### DIFF
--- a/app/forms/schools/add_participants/who_to_add_wizard.rb
+++ b/app/forms/schools/add_participants/who_to_add_wizard.rb
@@ -27,6 +27,9 @@ module Schools
           cannot_add_mismatch
           cannot_add_mentor_at_multiple_schools
           cannot_add_already_enrolled_at_school
+          cannot_add_already_enrolled_at_school_but_leaving
+          cannot_add_already_enrolled_at_school_but_withdrawn
+          cannot_add_already_enrolled_at_school_but_deferred
           cannot_add_registration_not_yet_open
         ]
       end
@@ -81,6 +84,22 @@ module Schools
 
       def already_enrolled_at_school?
         existing_induction_record.school == school
+      end
+
+      def already_enrolled_at_school_and_training?
+        already_enrolled_at_school? && existing_induction_record.active_induction_status? && existing_induction_record.training_status_active?
+      end
+
+      def already_enrolled_at_school_but_leaving?
+        already_enrolled_at_school? && existing_induction_record.leaving_induction_status?
+      end
+
+      def already_enrolled_at_school_but_withdrawn?
+        already_enrolled_at_school? && existing_induction_record.training_status_withdrawn?
+      end
+
+      def already_enrolled_at_school_but_deferred?
+        already_enrolled_at_school? && existing_induction_record.training_status_deferred?
       end
 
       def show_path_for(step:)

--- a/app/forms/schools/add_participants/wizard_steps/cannot_add_already_enrolled_at_school_but_deferred_step.rb
+++ b/app/forms/schools/add_participants/wizard_steps/cannot_add_already_enrolled_at_school_but_deferred_step.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Schools
+  module AddParticipants
+    module WizardSteps
+      class CannotAddAlreadyEnrolledAtSchoolButDeferredStep < CannotAddStep
+      end
+    end
+  end
+end

--- a/app/forms/schools/add_participants/wizard_steps/cannot_add_already_enrolled_at_school_but_leaving_step.rb
+++ b/app/forms/schools/add_participants/wizard_steps/cannot_add_already_enrolled_at_school_but_leaving_step.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Schools
+  module AddParticipants
+    module WizardSteps
+      class CannotAddAlreadyEnrolledAtSchoolButLeavingStep < CannotAddStep
+      end
+    end
+  end
+end

--- a/app/forms/schools/add_participants/wizard_steps/cannot_add_already_enrolled_at_school_but_withdrawn_step.rb
+++ b/app/forms/schools/add_participants/wizard_steps/cannot_add_already_enrolled_at_school_but_withdrawn_step.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Schools
+  module AddParticipants
+    module WizardSteps
+      class CannotAddAlreadyEnrolledAtSchoolButWithdrawnStep < CannotAddStep
+      end
+    end
+  end
+end

--- a/app/forms/schools/add_participants/wizard_steps/who_to_add_participant_checks.rb
+++ b/app/forms/schools/add_participants/wizard_steps/who_to_add_participant_checks.rb
@@ -18,8 +18,14 @@ module Schools
             cohort_checks
           elsif adding_an_ect_profile_to_a_mentor?
             :cannot_add_ect_because_already_a_mentor
-          elsif wizard.already_enrolled_at_school?
+          elsif wizard.already_enrolled_at_school_and_training?
             :cannot_add_already_enrolled_at_school
+          elsif wizard.already_enrolled_at_school_but_leaving?
+            :cannot_add_already_enrolled_at_school_but_leaving
+          elsif wizard.already_enrolled_at_school_but_withdrawn?
+            :cannot_add_already_enrolled_at_school_but_withdrawn
+          elsif wizard.already_enrolled_at_school_but_deferred?
+            :cannot_add_already_enrolled_at_school_but_deferred
           else
             transfer_step_for_type
           end

--- a/app/views/schools/add_participants/cannot_add_already_enrolled_at_school_but_deferred.html.erb
+++ b/app/views/schools/add_participants/cannot_add_already_enrolled_at_school_but_deferred.html.erb
@@ -1,0 +1,23 @@
+<% title =  "You cannot add #{@wizard.full_name}" %>
+<% content_for :title, title %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-xl"><%= @school.name %></span>
+    <h1 class="govuk-heading-xl"><%= title %></h1>
+
+    <% if @wizard.existing_induction_record.enrolled_in_fip? %>
+      <p class="govuk-body">They've already been registered. You reported that they've taken a leave of absence from your school.</p>
+
+      <% if @wizard.existing_lead_provider.present? %>
+          <p class="govuk-body">If you reported this by mistake, or they've returned to school, contact your training provider (<%= @wizard.existing_lead_provider.name %>) and ask for them to be reinstated.</p>
+          <p class="govuk-body">Once your provider confirms this with us, we'll update this person's training record for you.</p>
+      <% end %>
+    <% elsif @wizard.existing_induction_record.enrolled_in_cip? %>
+      <p class="govuk-body">They've already been registered. You reported that they've taken a leave of absence from your school. </p>
+      <p class="govuk-body">If you reported this by mistake, or they’ve returned to school, email our support team for help: <%= govuk_mail_to "continuing-professional-development@digital.education.gov.uk" %></p>
+    <% end %>
+
+    <%= govuk_link_to "View your ECTs and mentors", @wizard.dashboard_path, no_visited_state: true %>
+  </div>
+</div>

--- a/app/views/schools/add_participants/cannot_add_already_enrolled_at_school_but_leaving.html.erb
+++ b/app/views/schools/add_participants/cannot_add_already_enrolled_at_school_but_leaving.html.erb
@@ -1,0 +1,15 @@
+<% title =  "You cannot add #{@wizard.full_name}" %>
+<% content_for :title, title %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-xl"><%= @school.name %></span>
+    <h1 class="govuk-heading-xl"><%= title %></h1>
+
+    <p class="govuk-body">They've already been registered. You reported that they're leaving your school, or taking a temporary leave of absence. </p>
+
+    <p class="govuk-body">If you reported this by mistake, email our support team for help: <%= govuk_mail_to "continuing-professional-development@digital.education.gov.uk" %></p>
+
+    <%= govuk_link_to "View your ECTs and mentors", @wizard.dashboard_path, no_visited_state: true %>
+  </div>
+</div>

--- a/app/views/schools/add_participants/cannot_add_already_enrolled_at_school_but_withdrawn.html.erb
+++ b/app/views/schools/add_participants/cannot_add_already_enrolled_at_school_but_withdrawn.html.erb
@@ -1,0 +1,23 @@
+<% title =  "You cannot add #{@wizard.full_name}" %>
+<% content_for :title, title %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-xl"><%= @school.name %></span>
+    <h1 class="govuk-heading-xl"><%= title %></h1>
+
+    <% if @wizard.existing_induction_record.enrolled_in_fip? %>
+      <p class="govuk-body">They've already been registered. You reported that they left your school, or are no longer taking part in ECF-based training.</p>
+
+      <% if @wizard.existing_lead_provider.present? %>
+        <p class="govuk-body">If you reported this by mistake, contact your training provider (<%= @wizard.existing_lead_provider.name %>) and ask for them to be reinstated.</p>
+        <p class="govuk-body">Once your provider confirms this with us, we'll update this person's training record for you.</p>
+      <% end %>
+    <% elsif @wizard.existing_induction_record.enrolled_in_cip? %>
+      <p class="govuk-body">They've already been registered. You reported that they left your school, or are no longer taking part in ECF-based training.</p>
+      <p class="govuk-body">If you reported this by mistake, email our support team for help: <%= govuk_mail_to "continuing-professional-development@digital.education.gov.uk" %></p>
+    <% end %>
+
+    <%= govuk_link_to "View your ECTs and mentors", @wizard.dashboard_path, no_visited_state: true %>
+  </div>
+</div>

--- a/spec/forms/schools/add_participants/wizard_steps/cannot_add_already_enrolled_at_school_but_deferred_step_spec.rb
+++ b/spec/forms/schools/add_participants/wizard_steps/cannot_add_already_enrolled_at_school_but_deferred_step_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec.describe Schools::AddParticipants::WizardSteps::CannotAddAlreadyEnrolledAtSchoolButDeferredStep, type: :model do
+  subject(:step) { described_class.new }
+
+  describe "#next_step" do
+    it "does not have a next step" do
+      expect(step.next_step).to eql :none
+    end
+  end
+end

--- a/spec/forms/schools/add_participants/wizard_steps/cannot_add_already_enrolled_at_school_but_leaving_step_spec.rb
+++ b/spec/forms/schools/add_participants/wizard_steps/cannot_add_already_enrolled_at_school_but_leaving_step_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec.describe Schools::AddParticipants::WizardSteps::CannotAddAlreadyEnrolledAtSchoolButLeavingStep, type: :model do
+  subject(:step) { described_class.new }
+
+  describe "#next_step" do
+    it "does not have a next step" do
+      expect(step.next_step).to eql :none
+    end
+  end
+end

--- a/spec/forms/schools/add_participants/wizard_steps/cannot_add_already_enrolled_at_school_but_withdrawn_step_spec.rb
+++ b/spec/forms/schools/add_participants/wizard_steps/cannot_add_already_enrolled_at_school_but_withdrawn_step_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec.describe Schools::AddParticipants::WizardSteps::CannotAddAlreadyEnrolledAtSchoolButWithdrawnStep, type: :model do
+  subject(:step) { described_class.new }
+
+  describe "#next_step" do
+    it "does not have a next step" do
+      expect(step.next_step).to eql :none
+    end
+  end
+end

--- a/spec/forms/schools/add_participants/wizard_steps/date_of_birth_step_spec.rb
+++ b/spec/forms/schools/add_participants/wizard_steps/date_of_birth_step_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Schools::AddParticipants::WizardSteps::DateOfBirthStep, type: :mo
     let(:ect) { false }
     let(:mentor) { false }
     let(:different_type) { false }
-    let(:already_at_school) { false }
+    let(:already_at_school_and_training) { false }
     let(:different_name) { false }
     let(:sit_mentor) { false }
     let(:found_in_dqt) { false }
@@ -47,13 +47,19 @@ RSpec.describe Schools::AddParticipants::WizardSteps::DateOfBirthStep, type: :mo
     let(:need_setup) { false }
     let(:confirm_start_term) { false }
     let(:participant_withdrawn) { false }
+    let(:already_enrolled_at_school_but_leaving) { false }
+    let(:already_enrolled_at_school_but_withdrawn) { false }
+    let(:already_enrolled_at_school_but_deferred) { false }
 
     before do
       allow(wizard).to receive(:participant_exists?).and_return(participant_exists)
       allow(wizard).to receive(:ect_participant?).and_return(ect)
       allow(wizard).to receive(:mentor_participant?).and_return(mentor)
       allow(wizard).to receive(:existing_participant_is_a_different_type?).and_return(different_type)
-      allow(wizard).to receive(:already_enrolled_at_school?).and_return(already_at_school)
+      allow(wizard).to receive(:already_enrolled_at_school_and_training?).and_return(already_at_school_and_training)
+      allow(wizard).to receive(:already_enrolled_at_school_but_leaving?).and_return(already_enrolled_at_school_but_leaving)
+      allow(wizard).to receive(:already_enrolled_at_school_but_withdrawn?).and_return(already_enrolled_at_school_but_withdrawn)
+      allow(wizard).to receive(:already_enrolled_at_school_but_deferred?).and_return(already_enrolled_at_school_but_deferred)
       allow(wizard).to receive(:dqt_record_has_different_name?).and_return(different_name)
       allow(wizard).to receive(:sit_mentor?).and_return(sit_mentor)
       allow(wizard).to receive(:found_participant_in_dqt?).and_return(found_in_dqt)
@@ -114,7 +120,7 @@ RSpec.describe Schools::AddParticipants::WizardSteps::DateOfBirthStep, type: :mo
           let(:mentor) { true }
 
           context "when the ECT is already enrolled at the school" do
-            let(:already_at_school) { true }
+            let(:already_at_school_and_training) { true }
 
             before do
               allow(wizard).to receive(:set_ect_mentor)
@@ -127,10 +133,36 @@ RSpec.describe Schools::AddParticipants::WizardSteps::DateOfBirthStep, type: :mo
 
       context "when the participant is the same type" do
         context "when the participant is already enrolled at the school" do
-          let(:already_at_school) { true }
+          context "when the participant is leaving" do
+            let(:already_enrolled_at_school_but_leaving) { true }
 
-          it "returns :cannot_add_already_enrolled_at_school" do
-            expect(step.next_step).to eql :cannot_add_already_enrolled_at_school
+            it "returns :cannot_add_already_enrolled_at_school_but_leaving" do
+              expect(step.next_step).to eql :cannot_add_already_enrolled_at_school_but_leaving
+            end
+          end
+
+          context "when the participant is withdrawn" do
+            let(:already_enrolled_at_school_but_withdrawn) { true }
+
+            it "returns :cannot_add_already_enrolled_at_school_but_withdrawn" do
+              expect(step.next_step).to eql :cannot_add_already_enrolled_at_school_but_withdrawn
+            end
+          end
+
+          context "when the participant is deferred" do
+            let(:already_enrolled_at_school_but_deferred) { true }
+
+            it "returns :cannot_add_already_enrolled_at_school_but_deferred" do
+              expect(step.next_step).to eql :cannot_add_already_enrolled_at_school_but_deferred
+            end
+          end
+
+          context "when the participant is training" do
+            let(:already_at_school_and_training) { true }
+
+            it "returns :cannot_add_already_enrolled_at_school" do
+              expect(step.next_step).to eql :cannot_add_already_enrolled_at_school
+            end
           end
         end
 

--- a/spec/forms/schools/add_participants/wizard_steps/nino_step_spec.rb
+++ b/spec/forms/schools/add_participants/wizard_steps/nino_step_spec.rb
@@ -20,7 +20,10 @@ RSpec.describe Schools::AddParticipants::WizardSteps::NinoStep, type: :model do
     let(:different_participant_type) { false }
     let(:ect_participant) { false }
     let(:mentor_participant) { false }
-    let(:already_at_school) { false }
+    let(:already_enrolled_at_school_and_training) { false }
+    let(:already_enrolled_at_school_but_leaving) { false }
+    let(:already_enrolled_at_school_but_withdrawn) { false }
+    let(:already_enrolled_at_school_but_deferred) { false }
     let(:different_name) { false }
     let(:found_dqt_record) { false }
     let(:sit_mentor) { false }
@@ -34,7 +37,10 @@ RSpec.describe Schools::AddParticipants::WizardSteps::NinoStep, type: :model do
       allow(wizard).to receive(:existing_participant_is_a_different_type?).and_return(different_participant_type)
       allow(wizard).to receive(:ect_participant?).and_return(ect_participant)
       allow(wizard).to receive(:mentor_participant?).and_return(mentor_participant)
-      allow(wizard).to receive(:already_enrolled_at_school?).and_return(already_at_school)
+      allow(wizard).to receive(:already_enrolled_at_school_and_training?).and_return(already_enrolled_at_school_and_training)
+      allow(wizard).to receive(:already_enrolled_at_school_but_leaving?).and_return(already_enrolled_at_school_but_leaving)
+      allow(wizard).to receive(:already_enrolled_at_school_but_withdrawn?).and_return(already_enrolled_at_school_but_withdrawn)
+      allow(wizard).to receive(:already_enrolled_at_school_but_deferred?).and_return(already_enrolled_at_school_but_deferred)
       allow(wizard).to receive(:dqt_record_has_different_name?).and_return(different_name)
       allow(wizard).to receive(:found_participant_in_dqt?).and_return(found_dqt_record)
       allow(wizard).to receive(:sit_mentor?).and_return(sit_mentor)
@@ -95,7 +101,7 @@ RSpec.describe Schools::AddParticipants::WizardSteps::NinoStep, type: :model do
           let(:mentor_participant) { true }
 
           context "when the ECT is already enrolled at the school" do
-            let(:already_at_school) { true }
+            let(:already_enrolled_at_school_and_training) { true }
 
             before do
               allow(wizard).to receive(:set_ect_mentor)
@@ -106,8 +112,8 @@ RSpec.describe Schools::AddParticipants::WizardSteps::NinoStep, type: :model do
         end
       end
 
-      context "when the participant is already enrolled at the school" do
-        let(:already_at_school) { true }
+      context "when the participant is already enrolled at the school and training" do
+        let(:already_enrolled_at_school_and_training) { true }
 
         it "returns :cannot_add_already_enrolled_at_school" do
           expect(step.next_step).to eql :cannot_add_already_enrolled_at_school


### PR DESCRIPTION

### Context

- Ticket: CST-1988

We want to provide better info to SITs if they try to register somebody at the same school who is withdrawn/deferred/leaving.

### Changes proposed in this pull request
- Add new wizard steps and views for enrolled participants who are withdrawn, deferred and leaving
- Update the `WhoToAddParticipantChecks#existing_participant_checks` method to route the SIT to the new views based on the participant's status

### Guidance to review
As an SIT, try to add participants (Mentors or ECTs) who are already enrolled at the same school and confirm the correct info is displayed based on their training/induction status (active, leaving, withdrawn, deferred) and their induction programme.
