### PR TITLE
Add breadcrumb to school and participant views

### DIFF
--- a/app/helpers/school_breadcrumbs_helper.rb
+++ b/app/helpers/school_breadcrumbs_helper.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 module SchoolBreadcrumbsHelper
-  def breadcrumbs(active_school = nil, active_cohort = nil)
+  def breadcrumbs(active_school = nil, active_participant = nil)
     breadcrumbs = base_breadcrumbs
     breadcrumbs.merge!({ active_school.name => schools_dashboard_path(school_id: active_school) }) if active_school.present?
-    breadcrumbs.merge!({ "#{active_cohort.display_name} cohort" => schools_cohort_path(school_id: active_school, cohort_id: active_cohort) }) if active_cohort.present?
+    breadcrumbs.merge!({ "Manage mentors and ECTs" => school_participants_path(school_id: active_school)}) if active_participant.present?
     breadcrumbs
   end
 

--- a/app/helpers/school_breadcrumbs_helper.rb
+++ b/app/helpers/school_breadcrumbs_helper.rb
@@ -4,7 +4,7 @@ module SchoolBreadcrumbsHelper
   def breadcrumbs(active_school = nil, active_participant = nil)
     breadcrumbs = base_breadcrumbs
     breadcrumbs.merge!({ active_school.name => schools_dashboard_path(school_id: active_school) }) if active_school.present?
-    breadcrumbs.merge!({ "Manage mentors and ECTs" => school_participants_path(school_id: active_school)}) if active_participant.present?
+    breadcrumbs.merge!({ "Manage mentors and ECTs" => school_participants_path(school_id: active_school) }) if active_participant.present?
     breadcrumbs
   end
 

--- a/app/views/schools/participants/index.html.erb
+++ b/app/views/schools/participants/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "Early career teachers and mentors" %>
 
-<% content_for :before_content, govuk_back_link(text: "Back", href: schools_dashboard_path) %>
+<% content_for :before_content, govuk_breadcrumbs(breadcrumbs: breadcrumbs(@school)) %>
 
 <div class="govuk-grid-row">
   <% if participants_count(@school.school_cohorts) > 0 %>

--- a/app/views/schools/participants/show.html.erb
+++ b/app/views/schools/participants/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "ECT or mentor details" %>
 
-<% content_for :before_content, govuk_back_link(text: "Back", href: school_participants_path) %>
+<% content_for :before_content, govuk_breadcrumbs(breadcrumbs: breadcrumbs(@school, @profile)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/spec/helpers/school_breadcrumbs_helper_spec.rb
+++ b/spec/helpers/school_breadcrumbs_helper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SchoolBreadcrumbsHelper, type: :helper do
   include Devise::Test::ControllerHelpers
 
   let(:school) { induction_coordinator.induction_coordinator_profile.schools.first }
-  let!(:cohort) { Cohort.current || create(:cohort, :current) }
+  let(:participant) { create(:teacher_profile) }
 
   before do
     sign_in induction_coordinator
@@ -20,15 +20,15 @@ RSpec.describe SchoolBreadcrumbsHelper, type: :helper do
         expect(helper.breadcrumbs).to eql({})
       end
 
-      it "returns the school path" do
+      it "returns the school page" do
         expect(helper.breadcrumbs(school)).to eql({ school.name => schools_dashboard_path(school_id: school.slug) })
       end
 
-      it "returns the cohort path" do
-        expect(helper.breadcrumbs(school, cohort)).to(
+      it "returns the school page and the Manage mentors and ECTs page" do
+        expect(helper.breadcrumbs(school, participant)).to(
           eql({
             school.name => schools_dashboard_path(school_id: school.slug),
-            "#{cohort.display_name} cohort" => schools_cohort_path(school_id: school.slug, cohort_id: cohort.start_year),
+            "Manage mentors and ECTs" => school_participants_path(school_id: school.slug),
           }),
         )
       end
@@ -38,11 +38,11 @@ RSpec.describe SchoolBreadcrumbsHelper, type: :helper do
       let(:schools) { create_list(:school, rand(2..5)) }
       let(:induction_coordinator) { create(:user, :induction_coordinator, school_ids: schools.map(&:id)) }
 
-      it "returns the schools index page" do
+      it "returns the Mange your schools page" do
         expect(helper.breadcrumbs).to eql({ "Manage your schools" => schools_dashboard_index_path })
       end
 
-      it "returns the school path" do
+      it "returns the Mange your schools page and the school page" do
         expect(helper.breadcrumbs(school)).to(
           eql({
             "Manage your schools" => schools_dashboard_index_path,
@@ -51,12 +51,12 @@ RSpec.describe SchoolBreadcrumbsHelper, type: :helper do
         )
       end
 
-      it "returns the cohort path" do
-        expect(helper.breadcrumbs(school, cohort)).to(
+      it "returns the Mange your schools page, the school page and the Manage mentors and ECTs page" do
+        expect(helper.breadcrumbs(school, participant)).to(
           eql({
             "Manage your schools" => schools_dashboard_index_path,
             school.name => schools_dashboard_path(school_id: school.slug),
-            "#{cohort.display_name} cohort" => schools_cohort_path(school_id: school.slug, cohort_id: cohort.start_year),
+            "Manage mentors and ECTs" => school_participants_path(school_id: school.slug),
           }),
         )
       end


### PR DESCRIPTION
This adds a breadcrumb instead of "back" links to the "Manage mentors and ECTs" page and the participant profile pages.

Where a user has access to more than 1 school, the breadcrumb starts with the "Manage your schools" link.

All other pages which are in a flow to add or change information continue to use back links instead.

🗂️ [Jira card](https://dfedigital.atlassian.net/jira/software/projects/CST/boards/119)

## Screenshots

| Page | Before | After (single school) | After (2+ schools)
|----|----|-----|---|
| Manage mentors and ECTs | <img width="755" alt="Screenshot 2023-10-03 at 14 39 05" src="https://github.com/DFE-Digital/early-careers-framework/assets/30665/442d4155-7f28-470c-9021-bdc2df1c3b8c"> | <img width="667" alt="Screenshot 2023-10-03 at 14 39 16" src="https://github.com/DFE-Digital/early-careers-framework/assets/30665/034949dc-7e4f-4a25-a421-3a628730c79e"> | <img width="685" alt="Screenshot 2023-10-03 at 14 40 25" src="https://github.com/DFE-Digital/early-careers-framework/assets/30665/7adb7894-3558-4d89-97d6-f4bf977fefc0"> |
| Participant profile | <img width="794" alt="Screenshot 2023-10-03 at 14 39 42" src="https://github.com/DFE-Digital/early-careers-framework/assets/30665/554ec9d9-c0e0-4ed5-a778-2d5ee5973695"> | <img width="740" alt="Screenshot 2023-10-03 at 14 39 28" src="https://github.com/DFE-Digital/early-careers-framework/assets/30665/3f2a652d-c9b7-4d6d-b37a-b4f2d99f8ddd"> | <img width="786" alt="Screenshot 2023-10-03 at 14 40 34" src="https://github.com/DFE-Digital/early-careers-framework/assets/30665/cbc6e086-d701-468c-a82f-9c95cb3c7a11"> |




