### PR TITLE
Log the x-real-ip header

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,7 @@ class ApplicationController < ActionController::Base
   before_action :previous_url_for_cookies_page, except: :check
   before_action :check_privacy_policy_accepted, except: :check
   before_action :set_sentry_user, except: :check, unless: :devise_controller?
+  before_action :log_x_real_ip_header
 
   def check
     head :ok
@@ -25,6 +26,19 @@ class ApplicationController < ActionController::Base
   end
 
 private
+
+  def log_x_real_ip_header
+    Rails.logger.info("x-real-ip: #{obfuscate_ip(request.headers['x-real-ip'])} (remote ip: #{obfuscate_ip(request.remote_ip)})")
+  end
+
+  def obfuscate_ip(ip)
+    return if ip.blank?
+
+    ip_segments = ip.split(".")
+    return unless ip_segments.count == 4
+
+    "#{ip_segments.first}.***.***.#{ip_segments.last}"
+  end
 
   def previous_url_for_cookies_page
     if request.get? && controller_name == "cookies"

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -9,6 +9,37 @@ RSpec.describe ApplicationController do
     end
   end
 
+  describe "logging ip addresses" do
+    before { allow(Rails.logger).to receive(:info) }
+
+    it "logs the x-real-ip header and remote_ip" do
+      request.headers.merge!("REMOTE_ADDR" => "1.2.3.4")
+      request.headers.merge!({ "X-Real-IP" => "9.8.7.6" })
+      get :index
+
+      expect(Rails.logger).to have_received(:info).with("x-real-ip: 9.***.***.6 (remote ip: 1.***.***.4)")
+    end
+
+    context "when there is no x-real-ip header or remote_ip" do
+      it "logs out successfully" do
+        request.headers.merge!("REMOTE_ADDR" => "")
+        get :index
+
+        expect(Rails.logger).to have_received(:info).with("x-real-ip:  (remote ip: )")
+      end
+    end
+
+    context "when there is an IP address in an unexpected format" do
+      it "logs out successfully" do
+        request.headers.merge!("REMOTE_ADDR" => "2001:0db8:85a3:0000:0000:8a2e:0370:7334")
+        request.headers.merge!({ "X-Real-IP" => "9.8.7.6/25" })
+        get :index
+
+        expect(Rails.logger).to have_received(:info).with("x-real-ip: 9.***.***.6/25 (remote ip: )")
+      end
+    end
+  end
+
   describe "#set_sentry_user" do
     context "when user not signed in" do
       it "sets sentry user to nil" do


### PR DESCRIPTION
We want to make sure this header is set in production before we use it for rate limiting.

Taken from review app logs:

```
[2023-10-04T10:56:25.291568 #1]  INFO -- : [cb3581de6f8b1971c7875103d24411bc] x-real-ip: 94.***.***.115 (remote ip: 94.***.***.115)
```