### PR TITLE
[CPDLP-2466] Add induction_end_date into API v3 ecf participants endpoint

### DIFF
--- a/app/serializers/api/v3/ecf/participant_serializer.rb
+++ b/app/serializers/api/v3/ecf/participant_serializer.rb
@@ -137,6 +137,7 @@ module Api
               withdrawal: withdrawal(profile:, cpd_lead_provider: params[:cpd_lead_provider], latest_induction_record:),
               deferral: deferral(profile:, cpd_lead_provider: params[:cpd_lead_provider], latest_induction_record:),
               created_at: profile.created_at.rfc3339,
+              induction_end_date: profile.induction_completion_date&.strftime("%Y-%m-%d"),
             }
           }.compact
         end

--- a/docs/source/ecf/guidance.html.md
+++ b/docs/source/ecf/guidance.html.md
@@ -426,7 +426,8 @@ For more detailed information see the specifications for this [view multiple ECF
             "delivery_partner_id": "cd3a12347-7308-4879-942a-c4a70ced400a",
             "withdrawal": null,
             "deferral": null,
-            "created_at": "2021-05-31T02:22:32.000Z"
+            "created_at": "2021-05-31T02:22:32.000Z",
+            "induction_end_date": "2022-01-12"
           }
         ],
         "participant_id_changes": [
@@ -486,7 +487,8 @@ For more detailed information see the specifications for this [view a single ECF
           "delivery_partner_id": "cd3a12347-7308-4879-942a-c4a70ced400a",
           "withdrawal": null,
           "deferral": null,
-          "created_at": "2021-05-31T02:22:32.000Z"
+          "created_at": "2021-05-31T02:22:32.000Z",
+          "induction_end_date": "2022-01-12"
         }
       ],
       "participant_id_changes": [
@@ -509,9 +511,9 @@ A single mentor can be assigned to multiple ECTs, including ECTs who are trainin
 
 ‘Unfunded mentors’ are mentors who are registered with other providers.
 
-A participant will have the same `participant_id` throughout the API. 
+A participant will have the same `participant_id` throughout the API.
 
-If a participant is a mentor and linked to an ECT, then the `mentor_id` that appears on the response for their ECT will be the mentor’s `participant_id`. 
+If a participant is a mentor and linked to an ECT, then the `mentor_id` that appears on the response for their ECT will be the mentor’s `participant_id`.
 
 If the mentor is an unfunded mentor, then the identifier will be their `participant_id`.
 
@@ -723,7 +725,7 @@ As soon as school induction tutors have entered the information to the DfE servi
 GET /api/v3/participants/ecf/transfers
 ```
 
-#### What providers will see in the API 
+#### What providers will see in the API
 
 ##### What providers will see when a participant is leaving them
 | Scenario | Participant status | Transfer response |
@@ -758,7 +760,7 @@ An example response body is listed below. Successful requests will return respon
 
 * transfer data can appear incomplete as induction tutors can enter transfer information at different times. **For example,** a participant is planning on transferring from school X to school Y. School X’s induction tutor confirms the participant will be leaving, but school Y’s induction tutor has not yet confirmed the participant will be joining. At this stage the only data available via the API is from the school the participant is leaving
 * where a participant’s transfer from one provider to another is complete, the original provider should maintain data accuracy and [notify DfE that the participant has withdrawn from training](/api-reference/ecf/guidance/#notify-dfe-a-participant-has-withdrawn-from-training). **For example,** a participant has transferred from provider X to provider Y. The relevant school induction tutors have confirmed that the participant has left one school and joined the other. At this stage provider X will [view the participant’s data](/api-reference/ecf/guidance.html#view-a-single-participant-39-s-data) to see `“participant_status”: “left”`. They can then [notify DfE a participant has withdrawn from training with them](/api-reference/ecf/guidance/#notify-dfe-a-participant-has-withdrawn-from-training). This will update the participant’s `training_status`  to `withdrawn`
-* it’s possible for the induction tutor from the new school to report a joiner before the old school’s induction tutor. In this case, the `leaving_date` value would be null until reported by the old school’s induction tutor 
+* it’s possible for the induction tutor from the new school to report a joiner before the old school’s induction tutor. In this case, the `leaving_date` value would be null until reported by the old school’s induction tutor
 
 For more detailed information see the specifications for this [view participant transfers endpoint](/api-reference/reference-v3.html#api-v3-participants-ecf-transfers-get).
 
@@ -820,7 +822,7 @@ An example response body is listed below. Successful requests will return respon
 
 * transfer data can appear incomplete as induction tutors can enter transfer information at different times. **For example,** a participant is planning on transferring from school X to school Y. School X’s induction tutor confirms the participant will be leaving, but school Y’s induction tutor has not yet confirmed the participant will be joining. At this stage the only data available via the API is from the school the participant is leaving
 * where a participant’s transfer from one provider to another is complete, the original provider should maintain data accuracy and [notify DfE that the participant has withdrawn from training](/api-reference/ecf/guidance/#notify-dfe-a-participant-has-withdrawn-from-training). **For example,** a participant has transferred from provider X to provider Y. The relevant school induction tutors have confirmed that the participant has left one school and joined the other. At this stage provider X will [view the participant’s data](/api-reference/ecf/guidance.html#view-a-single-participant-39-s-data) to see `“participant_status”: “left”`. They should then [notify DfE a participant has withdrawn from training with them](/api-reference/ecf/guidance/#notify-dfe-a-participant-has-withdrawn-from-training). This will update the participant’s `training_status`  to `withdrawn`
-* it’s possible for the induction tutor from the new school to report a joiner before the old school’s induction tutor. In this case, the `leaving_date` value would be null until reported by the old school’s induction tutor 
+* it’s possible for the induction tutor from the new school to report a joiner before the old school’s induction tutor. In this case, the `leaving_date` value would be null until reported by the old school’s induction tutor
 
 For more detailed information see the specifications for this [view a participant transfer endpoint](/api-reference/reference-v3.html#api-v3-participants-ecf-id-transfers-get).
 

--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -9,15 +9,13 @@ If you have any questions or comments about these notes, please contact DfE via 
 
 ## 10 October 2023
 
-Providers can now see if and when an early career teacher has completed their induction in the API v3.
+Lead providers integrated with v3 of the API can now view details of ECTs that have completed their induction.
 
-We’ve done this by adding a new field, `induction_end_date`, to the participant profile ECF endpoint.
+We've added a new field, `induction_end_date`, to [ECFEnrolment](/api-reference/reference-v3.html#schema-ecfenrolment). We populate the field with data gathered about the date an ECT completed their induction from the Database of Qualified Teachers (DQT).
 
-The `induction_end_date` field sits in the data responses for ECF participants.
+We check the DQT on a daily basis for data about induction completion. We'll update a participant's records when we confirm they've completed their induction. Lead providers can use the [`updated_since` filter on the GET participants endpoint](/api-reference/reference-v3.html#schema-ecfparticipantfilter) to check for this kind of update.
 
-[Example response body for all participant data](https://manage-training-for-early-career-teachers.education.gov.uk/api-reference/ecf/guidance.html#view-all-participant-data-example-response-body)
-
-[Example response body for a single participant’s data](https://cpd-ecf-review-4094-web.test.teacherservices.cloud/api-reference/ecf/guidance.html#view-a-single-participant-39-s-data-example-response-body)
+Lead providers can use the field to identify participants that have completed their induction, and which may need to be placed on a [reduced schedule](/api-reference/ecf/schedules-and-milestone-dates.html#reduced-schedule).
 
 ## 9 October 2023
 

--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -7,6 +7,18 @@ weight: 8
 
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
 
+## 10 October 2023
+
+Providers can now see if and when an early career teacher has completed their induction in the API v3.
+
+We’ve done this by adding a new field, `induction_end_date`, to the participant profile ECF endpoint.
+
+The `induction_end_date` field sits in the data responses for ECF participants.
+
+[Example response body for all participant data](https://manage-training-for-early-career-teachers.education.gov.uk/api-reference/ecf/guidance.html#view-all-participant-data-example-response-body)
+
+[Example response body for a single participant’s data](https://cpd-ecf-review-4094-web.test.teacherservices.cloud/api-reference/ecf/guidance.html#view-a-single-participant-39-s-data-example-response-body)
+
 ## 9 October 2023
 
 The DfE has released a change to the `updated_at` functionality of the [ECFPartnershipAttributes](/api-reference/reference-v3.html#schema-ecfpartnershipattributes).
@@ -60,9 +72,9 @@ Providers should pause API calls during this time. You’ll be able to start usi
 
 We will be changing the sandbox URL to [https://sb.manage-training-for-early-career-teachers.education.gov.uk/](https://sb.manage-training-for-early-career-teachers.education.gov.uk/) on Thursday 7 September.
 
-The sandbox environment will be unavailable between 5pm and 7pm on 7 September while we make this change. 
+The sandbox environment will be unavailable between 5pm and 7pm on 7 September while we make this change.
 
-Providers should:  
+Providers should:
 
 * pause testing between 5pm and 7pm on 7 September
 * update their base URL for their integrations once the sandbox environment becomes available again to avoid any data loss

--- a/spec/docs/v1/npq_participants_spec.rb
+++ b/spec/docs/v1/npq_participants_spec.rb
@@ -97,13 +97,14 @@ describe "API", type: :request, swagger_doc: "v1/api_spec.json" do
                   "NPQ Participant" do
     let(:participant) { npq_application }
     let(:profile)     { npq_application.profile }
-    let!(:contract)   { create(:npq_contract, npq_course: npq_application.npq_course, npq_lead_provider: npq_application.npq_lead_provider) }
+    let(:schedule)    { create(:npq_leadership_schedule, schedule_identifier: "npq-aso-june", name: "NPQ ASO June", cohort: npq_application.cohort) }
+    let!(:contract)   { create(:npq_contract, npq_course: npq_application.npq_course, npq_lead_provider: npq_application.npq_lead_provider, cohort: npq_application.cohort) }
 
     let(:attributes) do
       {
         schedule_identifier: schedule.schedule_identifier,
         course_identifier: npq_application.npq_course.identifier,
-        cohort: schedule.cohort.start_year,
+        cohort: npq_application.cohort.start_year,
       }
     end
 

--- a/spec/docs/v2/npq_participants_spec.rb
+++ b/spec/docs/v2/npq_participants_spec.rb
@@ -97,13 +97,14 @@ describe "API", type: :request, swagger_doc: "v2/api_spec.json" do
                   "NPQ Participant" do
     let(:participant) { npq_application }
     let(:profile)     { npq_application.profile }
-    let!(:contract)   { create(:npq_contract, npq_course: npq_application.npq_course, npq_lead_provider: npq_application.npq_lead_provider) }
+    let(:schedule)    { create(:npq_leadership_schedule, schedule_identifier: "npq-aso-june", name: "NPQ ASO June", cohort: npq_application.cohort) }
+    let!(:contract)   { create(:npq_contract, npq_course: npq_application.npq_course, npq_lead_provider: npq_application.npq_lead_provider, cohort: npq_application.cohort) }
 
     let(:attributes) do
       {
         schedule_identifier: schedule.schedule_identifier,
         course_identifier: npq_application.npq_course.identifier,
-        cohort: schedule.cohort.start_year,
+        cohort: npq_application.cohort.start_year,
       }
     end
 

--- a/spec/docs/v3/ecf_participants_spec.rb
+++ b/spec/docs/v3/ecf_participants_spec.rb
@@ -195,13 +195,14 @@ describe "API", type: :request, swagger_doc: "v3/api_spec.json" do
                               date: "2021-06-31T02:22:32.000Z",
                             },
                             created_at: "2022-11-09T16:07:38Z",
+                            induction_end_date: "2022-01-12",
                           },
                         ],
-                        "participant_id_changes": [
+                        participant_id_changes: [
                           {
-                            "from_participant_id": "db3a7848-7308-4879-942a-c4a70ced400a",
-                            "to_participant_id": "23dd8d66-e11f-4139-9001-86b4f9abcb02",
-                            "changed_at": "2023-09-23T02:22:32.000Z",
+                            from_participant_id: "db3a7848-7308-4879-942a-c4a70ced400a",
+                            to_participant_id: "23dd8d66-e11f-4139-9001-86b4f9abcb02",
+                            changed_at: "2023-09-23T02:22:32.000Z",
                           },
                         ],
                       },
@@ -356,13 +357,14 @@ describe "API", type: :request, swagger_doc: "v3/api_spec.json" do
                             },
                             deferral: nil,
                             created_at: "2022-11-09T16:07:38Z",
+                            induction_end_date: "2022-01-12",
                           },
                         ],
-                        "participant_id_changes": [
+                        participant_id_changes: [
                           {
-                            "from_participant_id": "db3a7848-7308-4879-942a-c4a70ced400a",
-                            "to_participant_id": "23dd8d66-e11f-4139-9001-86b4f9abcb02",
-                            "changed_at": "2023-09-23T02:22:32.000Z",
+                            from_participant_id: "db3a7848-7308-4879-942a-c4a70ced400a",
+                            to_participant_id: "23dd8d66-e11f-4139-9001-86b4f9abcb02",
+                            changed_at: "2023-09-23T02:22:32.000Z",
                           },
                         ],
                       },

--- a/spec/docs/v3/npq_participants_spec.rb
+++ b/spec/docs/v3/npq_participants_spec.rb
@@ -121,14 +121,14 @@ describe "API", type: :request, swagger_doc: "v3/api_spec.json" do
                   "NPQ Participant" do
     let(:participant) { npq_application }
     let(:profile)     { npq_application.profile }
-    let(:schedule)    { create(:npq_leadership_schedule, schedule_identifier: "npq-aso-june", name: "NPQ ASO June") }
-    let!(:contract)   { create(:npq_contract, npq_course: npq_application.npq_course, npq_lead_provider: npq_application.npq_lead_provider) }
+    let(:schedule)    { create(:npq_leadership_schedule, schedule_identifier: "npq-aso-june", name: "NPQ ASO June", cohort: npq_application.cohort) }
+    let!(:contract)   { create(:npq_contract, npq_course: npq_application.npq_course, npq_lead_provider: npq_application.npq_lead_provider, cohort: npq_application.cohort) }
 
     let(:attributes) do
       {
         schedule_identifier: schedule.schedule_identifier,
         course_identifier: npq_application.npq_course.identifier,
-        cohort: schedule.cohort.start_year,
+        cohort: npq_application.cohort.start_year,
       }
     end
 

--- a/spec/requests/api/v3/ecf/participants_spec.rb
+++ b/spec/requests/api/v3/ecf/participants_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "API ECF Participants", type: :request do
   let!(:school_cohort) { create(:school_cohort, :fip, :with_induction_programme, lead_provider: cpd_lead_provider.lead_provider, cohort: cohort_2021) }
   let!(:mentor_profile) do
     travel_to 3.days.ago do
-      create(:mentor, school_cohort:, lead_provider:)
+      create(:mentor, school_cohort:, lead_provider:, induction_completion_date: Date.parse("2022-01-12"))
     end
   end
 
@@ -32,7 +32,7 @@ RSpec.describe "API ECF Participants", type: :request do
   end
 
   let!(:withdrawn_ect_profile_record) { create(:ect, :withdrawn_record, school_cohort:, lead_provider:) }
-  let(:early_career_teacher_profile) { create(:ect, :eligible_for_funding, school_cohort:) }
+  let(:early_career_teacher_profile) { create(:ect, :eligible_for_funding, school_cohort:, induction_completion_date: Date.parse("2022-01-12")) }
 
   describe "GET /api/v3/participants/ecf" do
     context "when authorized" do
@@ -308,6 +308,7 @@ RSpec.describe "API ECF Participants", type: :request do
                 "withdrawal": nil,
                 "deferral": nil,
                 "created_at": early_career_teacher_profile.created_at.rfc3339,
+                "induction_end_date": early_career_teacher_profile.induction_completion_date&.strftime("%Y-%m-%d"),
               }],
             },
           },

--- a/spec/requests/api/v3/ecf/participants_spec.rb
+++ b/spec/requests/api/v3/ecf/participants_spec.rb
@@ -308,7 +308,7 @@ RSpec.describe "API ECF Participants", type: :request do
                 "withdrawal": nil,
                 "deferral": nil,
                 "created_at": early_career_teacher_profile.created_at.rfc3339,
-                "induction_end_date": early_career_teacher_profile.induction_completion_date&.strftime("%Y-%m-%d"),
+                "induction_end_date": "2022-01-12",
               }],
             },
           },

--- a/spec/serializers/api/v3/ecf/participant_serializer_spec.rb
+++ b/spec/serializers/api/v3/ecf/participant_serializer_spec.rb
@@ -53,7 +53,7 @@ module Api
                       withdrawal: nil,
                       deferral: nil,
                       created_at: ect_profile.created_at.rfc3339,
-                      induction_end_date: ect_profile.induction_completion_date&.strftime("%Y-%m-%d"),
+                      induction_end_date: "2022-01-12",
                     },
                   ],
               },
@@ -92,7 +92,7 @@ module Api
                   withdrawal: nil,
                   deferral: nil,
                   created_at: mentor_profile.created_at.rfc3339,
-                  induction_end_date: mentor_profile.induction_completion_date&.strftime("%Y-%m-%d"),
+                  induction_end_date: nil,
                 })
               end
             end

--- a/spec/serializers/api/v3/ecf/participant_serializer_spec.rb
+++ b/spec/serializers/api/v3/ecf/participant_serializer_spec.rb
@@ -14,7 +14,7 @@ module Api
           let(:school_cohort) { create(:school_cohort, :fip, :with_induction_programme, delivery_partner:, school:, cohort:, lead_provider: cpd_lead_provider.lead_provider) }
           let!(:provider_relationship) { create(:provider_relationship, cohort:, delivery_partner:, lead_provider: cpd_lead_provider.lead_provider) }
           let(:participant) { create(:user) }
-          let!(:ect_profile) { create(:ect, :eligible_for_funding, school_cohort:, user: participant) }
+          let!(:ect_profile) { create(:ect, :eligible_for_funding, school_cohort:, user: participant, induction_completion_date: Date.parse("2022-01-12")) }
 
           subject { described_class.new([participant], params: { cpd_lead_provider: }) }
 
@@ -53,6 +53,7 @@ module Api
                       withdrawal: nil,
                       deferral: nil,
                       created_at: ect_profile.created_at.rfc3339,
+                      induction_end_date: ect_profile.induction_completion_date&.strftime("%Y-%m-%d"),
                     },
                   ],
               },
@@ -91,6 +92,7 @@ module Api
                   withdrawal: nil,
                   deferral: nil,
                   created_at: mentor_profile.created_at.rfc3339,
+                  induction_end_date: mentor_profile.induction_completion_date&.strftime("%Y-%m-%d"),
                 })
               end
             end

--- a/swagger/v3/api_spec.json
+++ b/swagger/v3/api_spec.json
@@ -2434,7 +2434,8 @@
                                 "reason": "other",
                                 "date": "2021-06-31T02:22:32.000Z"
                               },
-                              "created_at": "2021-05-31T02:22:32.000Z"
+                              "created_at": "2021-05-31T02:22:32.000Z",
+                              "induction_end_date": "2022-01-12"
                             }
                           ],
                           "participant_id_changes": [
@@ -2578,7 +2579,8 @@
                                 "reason": "other",
                                 "date": "2021-06-31T02:22:32.000Z"
                               },
-                              "created_at": "2021-05-31T02:22:32.000Z"
+                              "created_at": "2021-05-31T02:22:32.000Z",
+                              "induction_end_date": "2022-01-12"
                             }
                           ],
                           "participant_id_changes": [
@@ -3268,6 +3270,13 @@
             "type": "string",
             "format": "date-time",
             "example": "2021-05-31T02:22:32.000Z"
+          },
+          "induction_end_date": {
+            "description": "The ECF participant induction completion date",
+            "type": "string",
+            "nullable": true,
+            "format": "date",
+            "example": "2022-01-12"
           }
         }
       },

--- a/swagger/v3/component_schemas/ECFEnrolment.yml
+++ b/swagger/v3/component_schemas/ECFEnrolment.yml
@@ -116,3 +116,9 @@ properties:
     type: string
     format: date-time
     example: "2021-05-31T02:22:32.000Z"
+  induction_end_date:
+    description: The ECF participant induction end date
+    type: string
+    format: date
+    nullable: true
+    example: "2022-01-12"


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-2466](https://dfedigital.atlassian.net/browse/CPDLP-2466)

We would like to surface data to let providers know that a participant has completed their induction.

### Changes proposed in this pull request

Add induction_completion_date into API v3 ecf participants endpoint

[CPDLP-2466]: https://dfedigital.atlassian.net/browse/CPDLP-2466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ