### PR TITLE
Fix undefined local variable or method induction_tutor_email error on IneligibleParticipantMailer

### DIFF
--- a/app/mailers/ineligible_participant_mailer.rb
+++ b/app/mailers/ineligible_participant_mailer.rb
@@ -13,10 +13,11 @@ class IneligibleParticipantMailer < ApplicationMailer
 
   def ect_previous_induction_email
     participant_profile = params[:participant_profile]
+    induction_tutor_email = params[:induction_tutor_email]
 
     template_mail(
       ECT_PREVIOUS_INDUCTION_TEMPLATE,
-      to: params[:induction_tutor_email],
+      to: induction_tutor_email,
       rails_mailer: mailer_name,
       rails_mail_template: action_name,
       personalisation: {
@@ -27,11 +28,12 @@ class IneligibleParticipantMailer < ApplicationMailer
 
   def ect_previous_induction_email_previously_eligible
     participant_profile = params[:participant_profile]
+    induction_tutor_email = params[:induction_tutor_email]
 
     sit = Identity.find_user_by(email: induction_tutor_email)
     template_mail(
       ECT_PREVIOUS_INDUCTION_PREVIOUSLY_ELIGIBLE_TEMPLATE,
-      to: params[:induction_tutor_email],
+      to: induction_tutor_email,
       rails_mailer: mailer_name,
       rails_mail_template: action_name,
       personalisation: {


### PR DESCRIPTION
### Context

Sentry error is being raised in a daily basis.

https://dfe-teacher-services.sentry.io/issues/4310296798/?referrer=slack&notification_uuid=1318e182-dab9-4bcc-8cba-681f1fa945b1&alert_rule_id=7310304&alert_type=issue

### Changes proposed in this pull request

Fix undefined local variable or method `induction_tutor_email' for #<IneligibleParticipantMaile> (NameError)