### PR TITLE
[CPDLP-2470] Change to / update of SIT does not touch updated_at field of partnership (or school response)

### DIFF
--- a/app/serializers/api/v3/ecf/partnership_serializer.rb
+++ b/app/serializers/api/v3/ecf/partnership_serializer.rb
@@ -51,7 +51,12 @@ module Api
         end
 
         attribute :updated_at do |partnership|
-          partnership.updated_at.rfc3339
+          [
+            partnership.updated_at,
+            partnership.school.updated_at,
+            partnership.delivery_partner&.updated_at,
+            partnership.school&.induction_coordinators&.first&.updated_at,
+          ].compact.max.rfc3339
         end
       end
     end

--- a/app/services/api/v3/ecf/partnerships_query.rb
+++ b/app/services/api/v3/ecf/partnerships_query.rb
@@ -20,7 +20,15 @@ module Api
             .where(partnerships: { cohort: cohorts })
             .order(sort_order(default: "partnerships.created_at ASC", model: Partnership))
             .distinct
-          scope = scope.where("partnerships.updated_at > ?", updated_since) if updated_since_filter.present?
+
+          if updated_since_filter.present?
+            scope = scope.includes(:delivery_partner, school: [:induction_coordinators])
+            scope = scope.where(partnerships: { updated_at: updated_since.. })
+              .or(scope.where(school: { updated_at: updated_since.. }))
+              .or(scope.where(delivery_partner: { updated_at: updated_since.. }))
+              .or(scope.where(school: { users: { updated_at: updated_since.. } }))
+          end
+
           scope = scope.where(partnerships: { delivery_partner: [delivery_partner_id_filter] }) if delivery_partner_id_filter.present?
           scope
         end

--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -7,6 +7,14 @@ weight: 8
 
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
 
+## 9 October 2023
+
+The DfE has released a change to the `updated_at` functionality of the [ECFPartnershipAttributes](/api-reference/reference-v3.html#schema-ecfpartnershipattributes).
+
+Now, when a user (for example, a school induction tutor) challenges a partnership, the date and time of this change will populate the `updated_at` field of the partnership.
+
+In this way, providers may rely on the `updated_since` filter to identify if the partnership has been challenged since their most recent call to the API.
+
 ## 6 October 2023
 
 In the sandbox environment, the DfE has added experimental fields to API v3 documentation intended to make it simpler for lead providers to identify and manage deduped participants.

--- a/spec/serializers/api/v3/ecf/partnership_serializer_spec.rb
+++ b/spec/serializers/api/v3/ecf/partnership_serializer_spec.rb
@@ -60,10 +60,6 @@ module Api
             )
           end
 
-          it "returns the partnership updated_at timestamp" do
-            expect(subject.serializable_hash[:data][:attributes][:updated_at]).to eq(partnership.updated_at.rfc3339)
-          end
-
           context "when partnership active" do
             it "returns an active status" do
               expect(subject.serializable_hash[:data][:attributes][:status]).to eq("active")
@@ -91,6 +87,62 @@ module Api
 
             it "returns the challenged_at timestamp" do
               expect(subject.serializable_hash[:data][:attributes][:challenged_at]).to eq(partnership.challenged_at)
+            end
+          end
+
+          context "updated_at attribute" do
+            let!(:latest_updated_at) { 5.hours.ago }
+
+            before do
+              [
+                partnership,
+                school,
+                delivery_partner,
+                partnership.school.induction_coordinators.first,
+              ].each do |rec|
+                rec.update!(updated_at: 2.days.ago)
+              end
+            end
+
+            context "with latest partnership.updated_at" do
+              before do
+                partnership.update!(updated_at: latest_updated_at)
+                school.update!(updated_at: 2.days.ago)
+              end
+
+              it "returns the correct updated_at timestamp" do
+                expect(subject.serializable_hash[:data][:attributes][:updated_at]).to eq(latest_updated_at.rfc3339)
+              end
+            end
+
+            context "with latest school.updated_at" do
+              before do
+                partnership.school.update!(updated_at: latest_updated_at)
+              end
+
+              it "returns the correct updated_at timestamp" do
+                expect(subject.serializable_hash[:data][:attributes][:updated_at]).to eq(latest_updated_at.rfc3339)
+              end
+            end
+
+            context "with latest delivery_partner.updated_at" do
+              before do
+                partnership.delivery_partner.update!(updated_at: latest_updated_at)
+              end
+
+              it "returns the correct updated_at timestamp" do
+                expect(subject.serializable_hash[:data][:attributes][:updated_at]).to eq(latest_updated_at.rfc3339)
+              end
+            end
+
+            context "with induction_coordinator_profiles.first.updated_at" do
+              before do
+                partnership.school.induction_coordinators.first.update!(updated_at: latest_updated_at)
+              end
+
+              it "returns the correct updated_at timestamp" do
+                expect(subject.serializable_hash[:data][:attributes][:updated_at]).to eq(latest_updated_at.rfc3339)
+              end
             end
           end
         end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-2470

### Changes proposed in this pull request

* Updated `Api::V3::ECF::PartnershipSerializer`
* Updated `Api::V3::ECF::PartnershipsQuery`
* Updated release notes

### Guidance to review

