### PR TITLE
[CST-1988] Display the correct page when SITs adding already enrolled participants with completed induction

### DIFF
--- a/app/forms/schools/add_participants/who_to_add_wizard.rb
+++ b/app/forms/schools/add_participants/who_to_add_wizard.rb
@@ -90,6 +90,10 @@ module Schools
         already_enrolled_at_school? && existing_induction_record.active_induction_status? && existing_induction_record.training_status_active?
       end
 
+      def already_enrolled_at_school_and_completed?
+        already_enrolled_at_school? && existing_induction_record.completed_induction_status?
+      end
+
       def already_enrolled_at_school_but_leaving?
         already_enrolled_at_school? && existing_induction_record.leaving_induction_status?
       end

--- a/app/forms/schools/add_participants/wizard_steps/who_to_add_participant_checks.rb
+++ b/app/forms/schools/add_participants/wizard_steps/who_to_add_participant_checks.rb
@@ -18,7 +18,7 @@ module Schools
             cohort_checks
           elsif adding_an_ect_profile_to_a_mentor?
             :cannot_add_ect_because_already_a_mentor
-          elsif wizard.already_enrolled_at_school_and_training?
+          elsif wizard.already_enrolled_at_school_and_training? || wizard.already_enrolled_at_school_and_completed?
             :cannot_add_already_enrolled_at_school
           elsif wizard.already_enrolled_at_school_but_leaving?
             :cannot_add_already_enrolled_at_school_but_leaving

--- a/spec/forms/schools/add_participants/wizard_steps/date_of_birth_step_spec.rb
+++ b/spec/forms/schools/add_participants/wizard_steps/date_of_birth_step_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe Schools::AddParticipants::WizardSteps::DateOfBirthStep, type: :mo
     let(:already_enrolled_at_school_but_leaving) { false }
     let(:already_enrolled_at_school_but_withdrawn) { false }
     let(:already_enrolled_at_school_but_deferred) { false }
+    let(:already_at_school_and_completed) { false }
 
     before do
       allow(wizard).to receive(:participant_exists?).and_return(participant_exists)
@@ -57,6 +58,7 @@ RSpec.describe Schools::AddParticipants::WizardSteps::DateOfBirthStep, type: :mo
       allow(wizard).to receive(:mentor_participant?).and_return(mentor)
       allow(wizard).to receive(:existing_participant_is_a_different_type?).and_return(different_type)
       allow(wizard).to receive(:already_enrolled_at_school_and_training?).and_return(already_at_school_and_training)
+      allow(wizard).to receive(:already_enrolled_at_school_and_completed?).and_return(already_at_school_and_completed)
       allow(wizard).to receive(:already_enrolled_at_school_but_leaving?).and_return(already_enrolled_at_school_but_leaving)
       allow(wizard).to receive(:already_enrolled_at_school_but_withdrawn?).and_return(already_enrolled_at_school_but_withdrawn)
       allow(wizard).to receive(:already_enrolled_at_school_but_deferred?).and_return(already_enrolled_at_school_but_deferred)
@@ -158,6 +160,14 @@ RSpec.describe Schools::AddParticipants::WizardSteps::DateOfBirthStep, type: :mo
           end
 
           context "when the participant is training" do
+            let(:already_at_school_and_training) { true }
+
+            it "returns :cannot_add_already_enrolled_at_school" do
+              expect(step.next_step).to eql :cannot_add_already_enrolled_at_school
+            end
+          end
+
+          context "when the participant is completed" do
             let(:already_at_school_and_training) { true }
 
             it "returns :cannot_add_already_enrolled_at_school" do

--- a/spec/forms/schools/add_participants/wizard_steps/nino_step_spec.rb
+++ b/spec/forms/schools/add_participants/wizard_steps/nino_step_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Schools::AddParticipants::WizardSteps::NinoStep, type: :model do
     let(:already_enrolled_at_school_but_leaving) { false }
     let(:already_enrolled_at_school_but_withdrawn) { false }
     let(:already_enrolled_at_school_but_deferred) { false }
+    let(:already_at_school_and_completed) { false }
     let(:different_name) { false }
     let(:found_dqt_record) { false }
     let(:sit_mentor) { false }
@@ -38,6 +39,7 @@ RSpec.describe Schools::AddParticipants::WizardSteps::NinoStep, type: :model do
       allow(wizard).to receive(:ect_participant?).and_return(ect_participant)
       allow(wizard).to receive(:mentor_participant?).and_return(mentor_participant)
       allow(wizard).to receive(:already_enrolled_at_school_and_training?).and_return(already_enrolled_at_school_and_training)
+      allow(wizard).to receive(:already_enrolled_at_school_and_completed?).and_return(already_at_school_and_completed)
       allow(wizard).to receive(:already_enrolled_at_school_but_leaving?).and_return(already_enrolled_at_school_but_leaving)
       allow(wizard).to receive(:already_enrolled_at_school_but_withdrawn?).and_return(already_enrolled_at_school_but_withdrawn)
       allow(wizard).to receive(:already_enrolled_at_school_but_deferred?).and_return(already_enrolled_at_school_but_deferred)


### PR DESCRIPTION
### Context

- Ticket: CST-1988

#4083 introduced a bug redirecting the SITs who are trying to add completed participants to the wrong page. It should redirect them to `cannot-add-already-enrolled-at-school` page. 

This is a follow up fix.

### Changes proposed in this pull request
- Add a method to check if the participant is completed and use it in the `existing_participant_checks` that decides what's the next step is

### Guidance to review

