### PR TITLE
[CPDLP-2402] Add the schedule identifier as a parameter into the api accept NPQ application endpoints

### DIFF
--- a/app/controllers/api/v1/npq_applications_controller.rb
+++ b/app/controllers/api/v1/npq_applications_controller.rb
@@ -33,7 +33,7 @@ module Api
       end
 
       def accept
-        service = ::NPQ::Application::Accept.new(npq_application:)
+        service = ::NPQ::Application::Accept.new({ npq_application: }.merge(accept_npq_application_params["attributes"] || {}))
 
         render_from_service(service, json_serializer_class)
       end
@@ -67,6 +67,14 @@ module Api
 
       def npq_application
         @npq_application ||= npq_lead_provider.npq_applications.includes(:cohort, :npq_course, participant_identity: [:user]).find(params[:id])
+      end
+
+      def accept_npq_application_params
+        params
+          .require(:data)
+          .permit(:type, attributes: %i[schedule_identifier])
+      rescue ActionController::ParameterMissing
+        {}
       end
     end
   end

--- a/app/serializers/api/v1/npq_application_serializer.rb
+++ b/app/serializers/api/v1/npq_application_serializer.rb
@@ -75,6 +75,10 @@ module Api
       attribute :teacher_catchment_country
       attribute :itt_provider
       attribute :lead_mentor
+
+      attribute(:schedule_identifier) do |object|
+        object.profile&.schedule&.schedule_identifier
+      end
     end
   end
 end

--- a/spec/services/npq/application/accept_spec.rb
+++ b/spec/services/npq/application/accept_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe NPQ::Application::Accept do
     let(:trn) { rand(1_000_000..9_999_999).to_s }
     let(:user) { create(:user) }
     let(:identity) { create(:participant_identity, user:) }
-    let(:npq_course) { create(:npq_course, identifier: "npq-senior-leadership") }
+    let(:npq_course) { create(:npq_leadership_course, identifier: "npq-senior-leadership") }
     let(:npq_lead_provider) { create(:npq_lead_provider) }
 
     let(:npq_application) do
@@ -290,6 +290,51 @@ RSpec.describe NPQ::Application::Accept do
           subject.call
           npq_application.reload
           expect(npq_application.user.teacher_profile.trn).to be_blank
+        end
+      end
+
+      context "when the schedule identifier is present in the params" do
+        let(:params) do
+          {
+            npq_application:,
+            schedule_identifier:,
+          }
+        end
+        let(:schedule_identifier) { "npq-leadership-spring" }
+
+        it "creates teacher and participant profile" do
+          expect { service.call }
+            .to change(TeacherProfile, :count).by(1)
+            .and change(ParticipantProfile::NPQ, :count).by(1)
+        end
+
+        it "creates participant profile correctly" do
+          subject.call
+
+          profile = user.teacher_profile.npq_profiles.first
+
+          expect(profile.schedule).to eql(Finance::Schedule::NPQ.where(schedule_identifier:, cohort: cohort_2021).first)
+          expect(profile.npq_course).to eql(npq_application.npq_course)
+          expect(profile.teacher_profile).to eql(user.teacher_profile)
+          expect(profile.user).to eql(user)
+          expect(profile.school_urn).to eql(npq_application.school_urn)
+          expect(profile.school_ukprn).to eql(npq_application.school_ukprn)
+        end
+
+        context "when schedule identifier is not valid for the npq course" do
+          let(:schedule_identifier) { "npq-specialist-spring" }
+
+          it "does not create neither teacher nor participant profile" do
+            expect { service.call }
+              .to change(TeacherProfile, :count).by(0)
+              .and change(ParticipantProfile::NPQ, :count).by(0)
+          end
+
+          it "is invalid and returns an error message" do
+            is_expected.to be_invalid
+
+            expect(service.errors.messages_for(:schedule_identifier)).to include("Selected schedule is not valid for the course")
+          end
         end
       end
     end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-2402

Providers want to pick which schedule when accepting an NPQ application, so they can have participants on the right schedule.

### Changes proposed in this pull request

Add the schedule identifier as a parameter into the api accept NPQ application endpoints.