### PR TITLE
Enable Redis for Rails.cache in sandbox/staging

### DIFF
--- a/config/environments/sandbox.rb
+++ b/config/environments/sandbox.rb
@@ -45,7 +45,16 @@ Rails.application.configure do
   config.session_store :cookie_store, key: "_early_career_framework_session", secure: true, expire_after: 2.weeks
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :redis_cache_store,
+                       {
+                         url: ENV["REDIS_CACHE_URL"],
+                           pool_size: ENV.fetch("RAILS_MAX_THREADS", 5),
+                           connect_timeout: 30, # Defaults to 20 seconds
+                           reconnect_attempts: 1, # Defaults to 0
+                           error_handler: lambda { |method:, returning:, exception:|
+                                            Sentry.capture_exception(exception, tags: { method:, returning: })
+                                          },
+                       }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -43,7 +43,16 @@ Rails.application.configure do
   config.session_store :cookie_store, key: "_early_career_framework_session", secure: true, expire_after: 2.weeks
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :redis_cache_store,
+                       {
+                         url: ENV["REDIS_CACHE_URL"],
+                           pool_size: ENV.fetch("RAILS_MAX_THREADS", 5),
+                           connect_timeout: 30, # Defaults to 20 seconds
+                           reconnect_attempts: 1, # Defaults to 0
+                           error_handler: lambda { |method:, returning:, exception:|
+                                            Sentry.capture_exception(exception, tags: { method:, returning: })
+                                          },
+                       }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   config.active_job.queue_adapter = :sidekiq


### PR DESCRIPTION
Switching to the Redis cache in sandbox and staging so we can test it ahead of rolling out to production.
