### PR TITLE
Skip DfE analytics events for /check endpoint

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,7 @@ class ApplicationController < ActionController::Base
   before_action :previous_url_for_cookies_page, except: :check
   before_action :check_privacy_policy_accepted, except: :check
   before_action :set_sentry_user, except: :check, unless: :devise_controller?
+  skip_after_action :trigger_request_event, only: :check
 
   def check
     head :ok

--- a/spec/requests/dfe_analytics_spec.rb
+++ b/spec/requests/dfe_analytics_spec.rb
@@ -24,5 +24,9 @@ RSpec.describe "DfE Analytics", type: :request do
       Cohort.create!(start_year: 2005)
       expect(:create_entity).to have_been_enqueued_as_analytics_events
     end
+
+    it "does not send a web request event for GET /check" do
+      expect { get check_path }.not_to have_sent_analytics_event_types(:web_request)
+    end
   end
 end


### PR DESCRIPTION
We call this endpoint frequently and it just creates noise in dfe-analytics/other monitoring platforms.
