### PR TITLE
Enable Redis as Rails.cache in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,8 +42,15 @@ Rails.application.configure do
   config.force_ssl = true
   config.session_store :cookie_store, key: "_early_career_framework_session", secure: true, expire_after: 2.weeks
 
-  # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :redis_cache_store,
+                       {
+                         url: ENV["REDIS_CACHE_URL"],
+                           connect_timeout: 30, # Defaults to 20 seconds
+                           reconnect_attempts: 1, # Defaults to 0
+                           error_handler: lambda { |method:, returning:, exception:|
+                                            Sentry.capture_exception(exception, tags: { method:, returning: })
+                                          },
+                       }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   config.active_job.queue_adapter = :sidekiq

--- a/config/environments/sandbox.rb
+++ b/config/environments/sandbox.rb
@@ -44,11 +44,10 @@ Rails.application.configure do
   config.force_ssl = true
   config.session_store :cookie_store, key: "_early_career_framework_session", secure: true, expire_after: 2.weeks
 
-  # Use a different cache store in production.
+  # Mirrors the production cache store.
   config.cache_store = :redis_cache_store,
                        {
                          url: ENV["REDIS_CACHE_URL"],
-                           pool_size: ENV.fetch("RAILS_MAX_THREADS", 5),
                            connect_timeout: 30, # Defaults to 20 seconds
                            reconnect_attempts: 1, # Defaults to 0
                            error_handler: lambda { |method:, returning:, exception:|

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -42,11 +42,10 @@ Rails.application.configure do
   config.force_ssl = true
   config.session_store :cookie_store, key: "_early_career_framework_session", secure: true, expire_after: 2.weeks
 
-  # Use a different cache store in production.
+  # Mirrors the production cache store.
   config.cache_store = :redis_cache_store,
                        {
                          url: ENV["REDIS_CACHE_URL"],
-                           pool_size: ENV.fetch("RAILS_MAX_THREADS", 5),
                            connect_timeout: 30, # Defaults to 20 seconds
                            reconnect_attempts: 1, # Defaults to 0
                            error_handler: lambda { |method:, returning:, exception:|


### PR DESCRIPTION
We have this enabeld in sandbox/staging already and it appears to be behaving.

Use default Redis `pool_size`.