### PR TITLE
[CPDLP-2476] Remove 'started-in-error' as a value from ecf withdraw reason options

### DIFF
--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -11,7 +11,6 @@ class ParticipantProfile::ECF < ParticipantProfile
     moved-school
     mentor-no-longer-being-mentor
     school-left-fip
-    started-in-error
     other
   ].freeze
 

--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -7,6 +7,10 @@ weight: 8
 
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
 
+## 12 October 2023
+
+The DfE has removed the possible value `started-in-error` from the [ECFWithdrawal](/api-reference/reference-v3.html#schema-ecfwithdrawal) object. Only NPQ participants may be withdrawn for this reason.
+
 ## 10 October 2023
 
 Lead providers integrated with v3 of the API can now view details of ECTs that have completed their induction.
@@ -27,7 +31,7 @@ In this way, providers may rely on the `updated_since` filter to identify if the
 
 ## 6 October 2023
 
-We’ve added experimental fields to the API v3 sandbox environment to make it simpler for lead providers to identify and manage deduped participants. 
+We’ve added experimental fields to the API v3 sandbox environment to make it simpler for lead providers to identify and manage deduped participants.
 
 We’ve [previously advised](/api-reference/release-notes.html#15-march-2023) of the possibility that participants may be registered as duplicates with multiple participant_ids.
 

--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -7,9 +7,11 @@ weight: 8
 
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
 
-## 12 October 2023
+## 11 October 2023
 
-The DfE has removed the possible value `started-in-error` from the [ECFWithdrawal](/api-reference/reference-v3.html#schema-ecfwithdrawal) object. Only NPQ participants may be withdrawn for this reason.
+We've removed the `started-in-error` option from the [ECFWithdrawal schemas](/api-reference/reference-v3.html#schema-ecfwithdrawal) in all versions of the API.
+
+Note that NPQ participants can still be withdrawn for this reason.
 
 ## 10 October 2023
 

--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -7,7 +7,7 @@ weight: 8
 
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
 
-## 11 October 2023
+## 16 October 2023
 
 We've removed the `started-in-error` option from the [ECFWithdrawal schemas](/api-reference/reference-v3.html#schema-ecfwithdrawal) in all versions of the API.
 

--- a/spec/services/npq/amend_participant_cohort_spec.rb
+++ b/spec/services/npq/amend_participant_cohort_spec.rb
@@ -70,7 +70,8 @@ RSpec.describe NPQ::AmendParticipantCohort, type: :model do
   end
 
   describe "#call" do
-    let(:npq_application) { create(:npq_application, cohort: cohort_current) }
+    let(:npq_course) { create(:npq_leadership_course) }
+    let(:npq_application) { create(:npq_application, cohort: cohort_current, npq_course:) }
 
     context "when invalid" do
       let(:target_cohort_start_year) {}
@@ -86,7 +87,7 @@ RSpec.describe NPQ::AmendParticipantCohort, type: :model do
       end
 
       context "when a profile is attached to an NPQ application" do
-        let(:npq_course) { create(:npq_course, identifier: "npq-leading-teaching") }
+        let(:npq_course) { create(:npq_leadership_course, identifier: "npq-leading-teaching") }
         let(:npq_application) { create(:npq_application, :accepted, cohort: cohort_current, npq_course:) }
 
         let(:source_schedule) { Finance::Schedule::NPQSpecialist.schedule_for(cohort: cohort_current) }

--- a/spec/services/npq/amend_participant_cohort_spec.rb
+++ b/spec/services/npq/amend_participant_cohort_spec.rb
@@ -3,9 +3,10 @@
 require "rails_helper"
 
 RSpec.describe NPQ::AmendParticipantCohort, type: :model do
-  let(:npq_application) { create(:npq_application, :accepted, cohort: cohort_previous) }
+  let(:npq_course) { create(:npq_leadership_course) }
+  let(:npq_application) { create(:npq_application, :accepted, cohort: cohort_previous, npq_course:) }
   let(:npq_application_id) { npq_application.id }
-  let!(:npq_contract) { create(:npq_contract, :npq_senior_leadership, cohort: cohort_previous, npq_lead_provider: npq_application.npq_lead_provider, npq_course: npq_application.npq_course) }
+  let!(:npq_contract) { create(:npq_contract, :npq_senior_leadership, cohort: cohort_previous, npq_lead_provider: npq_application.npq_lead_provider, npq_course:) }
 
   let!(:cohort_current) { Cohort.current }
   let(:cohort_previous) { Cohort.previous }

--- a/swagger/v3/api_spec.json
+++ b/swagger/v3/api_spec.json
@@ -4687,7 +4687,6 @@
               "moved-school",
               "mentor-no-longer-being-mentor",
               "school-left-fip",
-              "started-in-error",
               "other"
             ]
           },

--- a/swagger/v3/component_schemas/ECFWithdrawal.yml
+++ b/swagger/v3/component_schemas/ECFWithdrawal.yml
@@ -13,7 +13,6 @@ properties:
       - moved-school
       - mentor-no-longer-being-mentor
       - school-left-fip
-      - started-in-error
       - other
   date:
     description: The date and time the participant was withdrawn


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-2476

### Changes proposed in this pull request

A provider may not include the value `started-in-error` as a withdrawal_reason for any API version as well as drilldown.