### PR TITLE
update provider application status logic to cater to historic applications

### DIFF
--- a/app/controllers/api/v1/npq/application_synchronizations_controller.rb
+++ b/app/controllers/api/v1/npq/application_synchronizations_controller.rb
@@ -15,24 +15,14 @@ module Api
           Api::V1::NPQ::ApplicationSynchronizationSerializer
         end
 
-        def updated_applications
-          NPQApplication.where("updated_at >= ?", 1.week.ago).select(:lead_provider_approval_status, :id, :participant_identity_id)
-        end
-
-        def applications_by_ids
-          ecf_ids = params[:ecf_ids].split(',')
-          remaining_applications_count = 1000 - NPQApplication.where("updated_at >= ?", 1.week.ago).count
-          applications_to_fetch_count = [remaining_applications_count, NPQApplication.count].min
-          if applications_to_fetch_count > 0
-            NPQApplication.where(id: ecf_ids).limit(applications_to_fetch_count).select(:lead_provider_approval_status, :id, :participant_identity_id)
-          end
-        end
-
         # TODO: This needs to be optimized.
         # It will work fine for now because we are fetching records
         # that have been change within a week.
+        # Added new piece of code for catered the nil values for record in npq
+        # Remove this code once all application statuses have been migrated.
         def set_npq_applications
-          @npq_applications = applications_by_ids + updated_applications
+          ecf_ids = params[:ecf_ids].split(",")
+          @npq_applications = NPQApplication.where("updated_at >= ? OR id IN (?)", 1.week.ago, ecf_ids).select(:lead_provider_approval_status, :id, :participant_identity_id)
         end
       end
     end

--- a/app/controllers/api/v1/npq/application_synchronizations_controller.rb
+++ b/app/controllers/api/v1/npq/application_synchronizations_controller.rb
@@ -15,11 +15,24 @@ module Api
           Api::V1::NPQ::ApplicationSynchronizationSerializer
         end
 
+        def updated_applications
+          NPQApplication.where("updated_at >= ?", 1.week.ago).select(:lead_provider_approval_status, :id, :participant_identity_id)
+        end
+
+        def applications_by_ids
+          ecf_ids = params[:ecf_ids].split(',')
+          remaining_applications_count = 1000 - NPQApplication.where("updated_at >= ?", 1.week.ago).count
+          applications_to_fetch_count = [remaining_applications_count, NPQApplication.count].min
+          if applications_to_fetch_count > 0
+            NPQApplication.where(id: ecf_ids).limit(applications_to_fetch_count).select(:lead_provider_approval_status, :id, :participant_identity_id)
+          end
+        end
+
         # TODO: This needs to be optimized.
         # It will work fine for now because we are fetching records
         # that have been change within a week.
         def set_npq_applications
-          @npq_applications = NPQApplication.where("updated_at >= ?", 1.week.ago).select(:lead_provider_approval_status, :id, :participant_identity_id)
+          @npq_applications = applications_by_ids + updated_applications
         end
       end
     end

--- a/spec/requests/api/v1/npq/application_synchronization/index_spec.rb
+++ b/spec/requests/api/v1/npq/application_synchronization/index_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "NPQ Application Status API", type: :request do
     it "returns correct jsonapi content" do
       @controller = Api::V1::NPQ::ApplicationSynchronizationsController.new
       @controller.params = { "@npq_applications": npq_application }
-      get "/api/v1/npq/application_synchronizations"
+      get "/api/v1/npq/application_synchronizations", params: { ecf_ids: SecureRandom.uuid }
       expect(parsed_response).to be_a(Hash)
       expect(parsed_response["attributes"]["id"]).to eq(npq_application.id.to_s)
       expect(parsed_response["attributes"]["lead_provider_approval_status"]).to eq(npq_application.lead_provider_approval_status)

--- a/spec/requests/api/v1/npq/application_synchronization/index_spec.rb
+++ b/spec/requests/api/v1/npq/application_synchronization/index_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe "NPQ Application Status API", type: :request do
   let(:cpd_lead_provider) { create(:cpd_lead_provider) }
   let(:token)             { NPQRegistrationApiToken.create_with_random_token!(cpd_lead_provider_id: cpd_lead_provider.id) }
   let(:bearer_token)      { "Bearer #{token}" }
-  let(:parsed_response) { JSON.parse(response.body)["data"]&.first }
+  let(:parsed_response)   { JSON.parse(response.body)["data"]&.first }
+  let(:ecf_ids)           { SecureRandom.uuid }
 
   before { default_headers[:Authorization] = bearer_token }
 
@@ -21,11 +22,12 @@ RSpec.describe "NPQ Application Status API", type: :request do
     it "returns correct jsonapi content" do
       @controller = Api::V1::NPQ::ApplicationSynchronizationsController.new
       @controller.params = { "@npq_applications": npq_application }
-      get "/api/v1/npq/application_synchronizations", params: { ecf_ids: SecureRandom.uuid }
+      get "/api/v1/npq/application_synchronizations", params: { ecf_ids: }
       expect(parsed_response).to be_a(Hash)
       expect(parsed_response["attributes"]["id"]).to eq(npq_application.id.to_s)
       expect(parsed_response["attributes"]["lead_provider_approval_status"]).to eq(npq_application.lead_provider_approval_status)
       expect(parsed_response["attributes"]["participant_outcome_state"]).to eq(state)
+      expect(request.query_parameters["ecf_ids"]).to eq(ecf_ids)
     end
   end
 end


### PR DESCRIPTION
### Context
update provider application status logic to cater to historic applications
### Ticket
https://dfedigital.atlassian.net/browse/CPDNPQ-1381

### Changes proposed in this pull request
Updated `app/controllers/api/v1/npq/application_synchronizations_controller.rb` to manage more then 1.week.ago applications. Added limit to safe from timeout error

