### PR TITLE
[CPDLP-2468] UCL Deduping: Surface new deduped data in participants A…

### DIFF
--- a/app/controllers/api/v3/ecf/participants_controller.rb
+++ b/app/controllers/api/v3/ecf/participants_controller.rb
@@ -43,8 +43,8 @@ module Api
 
         def ecf_participant_params
           params
-            .with_defaults(sort: "", filter: { cohort: "", updated_since: "", training_status: "" })
-            .permit(:id, :sort, filter: %i[cohort updated_since training_status])
+            .with_defaults(sort: "", filter: { cohort: "", updated_since: "", training_status: "", from_participant_id: "" })
+            .permit(:id, :sort, filter: %i[cohort updated_since training_status from_participant_id])
         end
 
         def ecf_participant_query

--- a/app/controllers/api/v3/npq_participants_controller.rb
+++ b/app/controllers/api/v3/npq_participants_controller.rb
@@ -22,8 +22,8 @@ module Api
 
       def npq_participant_params
         params
-          .with_defaults(sort: "", filter: { updated_since: "", training_status: "" })
-          .permit(:id, :sort, filter: %i[updated_since training_status])
+          .with_defaults(sort: "", filter: { updated_since: "", training_status: "", from_participant_id: "" })
+          .permit(:id, :sort, filter: %i[updated_since training_status from_participant_id])
       end
 
       def serializer_class

--- a/app/serializers/api/v3/ecf/participant_serializer.rb
+++ b/app/serializers/api/v3/ecf/participant_serializer.rb
@@ -141,6 +141,16 @@ module Api
             }
           }.compact
         end
+
+        attribute(:participant_id_changes, if: -> { FeatureFlag.active?(:participant_id_changes) }) do |object|
+          (object.participant_id_changes || []).map do |c|
+            {
+              from_participant_id: c.from_participant_id,
+              to_participant_id: c.to_participant_id,
+              changed_at: c.created_at.rfc3339,
+            }
+          end
+        end
       end
     end
   end

--- a/app/serializers/api/v3/npq_participant_serializer.rb
+++ b/app/serializers/api/v3/npq_participant_serializer.rb
@@ -78,6 +78,16 @@ module Api
           }
         }.compact
       end
+
+      attribute(:participant_id_changes, if: -> { FeatureFlag.active?(:participant_id_changes) }) do |object|
+        (object.participant_id_changes || []).map do |c|
+          {
+            from_participant_id: c.from_participant_id,
+            to_participant_id: c.to_participant_id,
+            changed_at: c.created_at.rfc3339,
+          }
+        end
+      end
     end
   end
 end

--- a/app/services/api/v3/ecf/participants_query.rb
+++ b/app/services/api/v3/ecf/participants_query.rb
@@ -20,10 +20,12 @@ module Api
                     .select("users.id", "users.created_at", "users.updated_at")
                     .joins(participant_profiles: :induction_records)
                     .joins("JOIN (#{latest_induction_records_join.to_sql}) AS latest_induction_records_join ON latest_induction_records_join.latest_id = induction_records.id")
+                    .left_joins(:participant_id_changes)
                     .order(sort_order(default: :created_at, model: User))
                     .distinct
           scope = scope.where(users: { updated_at: updated_since.. }) if updated_since_filter.present?
           scope = scope.where(induction_records: { training_status: }) if training_status.present?
+          scope = scope.where(participant_id_changes: { from_participant_id: }) if from_participant_id.present?
           scope
         end
 
@@ -41,7 +43,7 @@ module Api
 
           User
             .select("users.*")
-            .includes(:participant_identities, :teacher_profile, participant_profiles: [:participant_profile_states, :schedule, :teacher_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, { induction_records: [:preferred_identity, :schedule, :delivery_partner, :participant_profile, { mentor_profile: :participant_identity, induction_programme: [school_cohort: %i[school cohort]] }] }])
+            .includes(:participant_identities, :teacher_profile, :participant_id_changes, participant_profiles: [:participant_profile_states, :schedule, :teacher_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, { induction_records: [:preferred_identity, :schedule, :delivery_partner, :participant_profile, { mentor_profile: :participant_identity, induction_programme: [school_cohort: %i[school cohort]] }] }])
             .from("(#{sub_query.to_sql}) as users")
             .order(sort_order(default: "participant_profiles_induction_records.created_at ASC", model: User))
             .distinct
@@ -54,6 +56,10 @@ module Api
       private
 
         attr_accessor :lead_provider, :params
+
+        def from_participant_id
+          filter[:from_participant_id].to_s
+        end
 
         def latest_induction_records_join
           super

--- a/app/services/api/v3/npq_participants_query.rb
+++ b/app/services/api/v3/npq_participants_query.rb
@@ -17,16 +17,23 @@ module Api
       def participants
         scope = npq_lead_provider
           .npq_participants
-          .includes(:teacher_profile, npq_profiles: [:npq_course, :participant_profile_states, :participant_identity, { schedule: [:cohort], npq_application: [npq_lead_provider: :cpd_lead_provider] }])
+          .includes(:teacher_profile, :participant_id_changes, npq_profiles: [:npq_course, :participant_profile_states, :participant_identity, { schedule: [:cohort], npq_application: [npq_lead_provider: :cpd_lead_provider] }])
           .order(sort_order(default: "npq_profiles.created_at ASC", model: User))
           .distinct
         scope = scope.where("users.updated_at > ?", updated_since) if updated_since_filter.present?
         scope = scope.where(npq_profiles: { training_status: }) if training_status.present?
+        scope = scope.where(participant_id_changes: { from_participant_id: }) if from_participant_id.present?
         scope
       end
 
       def participant
         npq_lead_provider.npq_participants.find(params[:id])
+      end
+
+    private
+
+      def from_participant_id
+        filter[:from_participant_id].to_s
       end
     end
   end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -24,6 +24,7 @@ class FeatureFlag
     prevent_2023_ect_registrations
     cohortless_dashboard
     school_participant_status_language
+    participant_id_changes
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).index_with { |name|

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -1,7 +1,5 @@
 ---
 :shared:
-  :completion_candidates:
-    - participant_profile_id
   :versions:
   - id
   - item_type
@@ -294,11 +292,11 @@
   - code
   - name
   :lead_provider_profiles:
-  - id
   - user_id
   - lead_provider_id
   - created_at
   - updated_at
+  - id
   - discarded_at
   :lead_provider_cips:
   - id
@@ -308,11 +306,11 @@
   - created_at
   - updated_at
   :induction_coordinator_profiles_schools:
-  - id
   - induction_coordinator_profile_id
   - school_id
   - created_at
   - updated_at
+  - id
   :finance_profiles:
   - id
   - user_id
@@ -409,6 +407,8 @@
   - name
   - created_at
   - updated_at
+  :completion_candidates:
+  - participant_profile_id
   :call_off_contracts:
   - id
   - version

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -1,5 +1,7 @@
 ---
 :shared:
+  :completion_candidates:
+    - participant_profile_id
   :versions:
   - id
   - item_type
@@ -292,11 +294,11 @@
   - code
   - name
   :lead_provider_profiles:
+  - id
   - user_id
   - lead_provider_id
   - created_at
   - updated_at
-  - id
   - discarded_at
   :lead_provider_cips:
   - id
@@ -306,11 +308,11 @@
   - created_at
   - updated_at
   :induction_coordinator_profiles_schools:
+  - id
   - induction_coordinator_profile_id
   - school_id
   - created_at
   - updated_at
-  - id
   :finance_profiles:
   - id
   - user_id
@@ -407,8 +409,6 @@
   - name
   - created_at
   - updated_at
-  :completion_candidates:
-  - participant_profile_id
   :call_off_contracts:
   - id
   - version

--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -7,6 +7,14 @@ weight: 8
 
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
 
+## 17 October 2023
+
+Lead providers can now test the new `participant_id_changes` feature in the sandbox.
+
+The DfE welcomes feedback and intends to deploy the change to the production environment as soon as possible.
+
+Further detail on the change is available in the release note of [6 October 2023](/api-reference/release-notes.html#6-october-2023).
+
 ## 16 October 2023
 
 We've removed the `started-in-error` option from the [ECFWithdrawal schemas](/api-reference/reference-v3.html#schema-ecfwithdrawal) in all versions of the API.

--- a/spec/docs/v3/ecf_participants_spec.rb
+++ b/spec/docs/v3/ecf_participants_spec.rb
@@ -2,7 +2,7 @@
 
 require "swagger_helper"
 
-describe "API", type: :request, swagger_doc: "v3/api_spec.json" do
+describe "API", type: :request, swagger_doc: "v3/api_spec.json", with_feature_flags: { participant_id_changes: "active" } do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
   let(:school) { create(:school) }
   let(:cohort) { create(:cohort, :current) }

--- a/spec/docs/v3/npq_participants_spec.rb
+++ b/spec/docs/v3/npq_participants_spec.rb
@@ -2,7 +2,7 @@
 
 require "swagger_helper"
 
-describe "API", type: :request, swagger_doc: "v3/api_spec.json" do
+describe "API", type: :request, swagger_doc: "v3/api_spec.json", with_feature_flags: { participant_id_changes: "active" } do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_npq_lead_provider) }
   let(:npq_lead_provider) { cpd_lead_provider.npq_lead_provider }
   let(:npq_course) { create(:npq_course, identifier: "npq-senior-leadership") }

--- a/spec/requests/api/v3/ecf/participants_spec.rb
+++ b/spec/requests/api/v3/ecf/participants_spec.rb
@@ -162,6 +162,29 @@ RSpec.describe "API ECF Participants", type: :request, with_feature_flags: { par
           }))
         end
 
+        context "with filter from_participant_id" do
+          let(:partnership) { create(:partnership, lead_provider:, cohort: cohort_2021) }
+          let(:participant_profile) { create(:ect_participant_profile) }
+          let(:induction_programme) { create(:induction_programme, :fip, partnership:) }
+          let(:induction_record) { create(:induction_record, induction_programme:, participant_profile:) }
+          let(:user) { induction_record.user }
+
+          let!(:participant_id_change1) { create(:participant_id_change, to_participant: user, user:) }
+          let(:from_participant_id) { participant_id_change1.from_participant_id }
+
+          it "returns matching users when filtering by from_participant_id" do
+            get "/api/v3/participants/ecf", params: { filter: { from_participant_id: } }
+
+            expect(parsed_response["data"].size).to eq(1)
+          end
+
+          it "returns empty array if from_participant_id does not exist" do
+            get "/api/v3/participants/ecf", params: { filter: { from_participant_id: "doesnotexist" } }
+
+            expect(parsed_response["data"].size).to eq(0)
+          end
+        end
+
         context "when updated_since parameter is supplied" do
           it "returns users changed since the updated_since parameter" do
             get "/api/v3/participants/ecf", params: { filter: { updated_since: 1.day.ago.iso8601 } }

--- a/spec/requests/api/v3/ecf/participants_spec.rb
+++ b/spec/requests/api/v3/ecf/participants_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "API ECF Participants", type: :request do
+RSpec.describe "API ECF Participants", type: :request, with_feature_flags: { participant_id_changes: "active" } do
   let(:cohort_2021) { Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021) }
   let(:cpd_lead_provider) { create(:cpd_lead_provider, lead_provider:) }
   let(:lead_provider)     { create(:lead_provider) }
@@ -100,6 +100,7 @@ RSpec.describe "API ECF Participants", type: :request do
               :teacher_reference_number,
               :updated_at,
               :ecf_enrolments,
+              :participant_id_changes,
             ).exactly)
         end
 
@@ -310,6 +311,7 @@ RSpec.describe "API ECF Participants", type: :request do
                 "created_at": early_career_teacher_profile.created_at.rfc3339,
                 "induction_end_date": "2022-01-12",
               }],
+              "participant_id_changes": [],
             },
           },
         })

--- a/spec/requests/api/v3/npq_participants_spec.rb
+++ b/spec/requests/api/v3/npq_participants_spec.rb
@@ -107,6 +107,24 @@ RSpec.describe "NPQ Participants API", type: :request do
             expect(parsed_response["data"].size).to eq(3)
           end
 
+          context "with filter from_participant_id" do
+            let(:user) { create(:npq_participant_profile, npq_lead_provider:, npq_course:, training_status: :withdrawn).user }
+            let!(:participant_id_change1) { create(:participant_id_change, to_participant: user, user:) }
+            let(:from_participant_id) { participant_id_change1.from_participant_id }
+
+            it "returns matching users when filtering by from_participant_id" do
+              get "/api/v3/participants/npq", params: { filter: { from_participant_id: } }
+
+              expect(parsed_response["data"].size).to eq(1)
+            end
+
+            it "returns empty array if from_participant_id does not exist" do
+              get "/api/v3/participants/npq", params: { filter: { from_participant_id: "doesnotexist" } }
+
+              expect(parsed_response["data"].size).to eq(0)
+            end
+          end
+
           context "with invalid filter of a string" do
             it "returns an error" do
               get "/api/v3/participants/npq", params: { filter: 2.days.ago.iso8601 }

--- a/spec/requests/api/v3/npq_participants_spec.rb
+++ b/spec/requests/api/v3/npq_participants_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "NPQ Participants API", type: :request do
 
   before { default_headers[:Authorization] = bearer_token }
 
-  describe "GET /api/v3/participants/npq" do
+  describe "GET /api/v3/participants/npq", with_feature_flags: { participant_id_changes: "active" } do
     context "when authorized" do
       let(:npq_application) { npq_applications.sample }
       let(:npq_course)      { npq_application.npq_course }
@@ -56,6 +56,7 @@ RSpec.describe "NPQ Participants API", type: :request do
               :teacher_reference_number,
               :updated_at,
               :npq_enrolments,
+              :participant_id_changes,
             ).exactly)
         end
 
@@ -190,7 +191,7 @@ RSpec.describe "NPQ Participants API", type: :request do
     end
   end
 
-  describe "GET /api/v3/participants/npq/:id" do
+  describe "GET /api/v3/participants/npq/:id", with_feature_flags: { participant_id_changes: "active" } do
     let(:npq_application) { create(:npq_application, :accepted, :with_started_declaration, npq_lead_provider:) }
     let(:npq_participant) { npq_application.profile }
 
@@ -227,6 +228,7 @@ RSpec.describe "NPQ Participants API", type: :request do
             :teacher_reference_number,
             :updated_at,
             :npq_enrolments,
+            :participant_id_changes,
           ).exactly)
       end
     end

--- a/spec/serializers/api/v3/ecf/participant_serializer_spec.rb
+++ b/spec/serializers/api/v3/ecf/participant_serializer_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 module Api
   module V3
     module ECF
-      RSpec.describe ParticipantSerializer do
+      RSpec.describe ParticipantSerializer, with_feature_flags: { participant_id_changes: "active" } do
         describe "serialization" do
           let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
           let(:school) { create(:school) }
@@ -56,6 +56,7 @@ module Api
                       induction_end_date: "2022-01-12",
                     },
                   ],
+                participant_id_changes: [],
               },
             ])
           end
@@ -139,6 +140,48 @@ module Api
 
               it "selects the latest induction record correctly" do
                 expect(result[:data][0][:attributes][:ecf_enrolments][0][:email]).to eq(latest_induction_record.preferred_identity.email)
+              end
+            end
+          end
+
+          describe "participant_id_changes" do
+            context "when there are no participant_id_changes" do
+              it "should returne empty array" do
+                expect(result[:data][0][:attributes][:participant_id_changes]).to eql([])
+              end
+            end
+
+            context "when there is one participant_id_changes" do
+              let!(:participant_id_change) { create(:participant_id_change, user: participant, to_participant: participant) }
+
+              it "should returns participant id change" do
+                expect(result[:data][0][:attributes][:participant_id_changes]).to eql([
+                  {
+                    from_participant_id: participant_id_change.from_participant_id,
+                    to_participant_id: participant_id_change.to_participant_id,
+                    changed_at: participant_id_change.created_at.rfc3339,
+                  },
+                ])
+              end
+            end
+
+            context "when there are multiple participant_id_changes" do
+              let!(:participant_id_change1) { create(:participant_id_change, user: participant, to_participant: participant) }
+              let!(:participant_id_change2) { create(:participant_id_change, user: participant, to_participant: participant) }
+
+              it "should returns participant id changes" do
+                expect(result[:data][0][:attributes][:participant_id_changes]).to eql([
+                  {
+                    from_participant_id: participant_id_change2.from_participant_id,
+                    to_participant_id: participant_id_change2.to_participant_id,
+                    changed_at: participant_id_change2.created_at.rfc3339,
+                  },
+                  {
+                    from_participant_id: participant_id_change1.from_participant_id,
+                    to_participant_id: participant_id_change1.to_participant_id,
+                    changed_at: participant_id_change1.created_at.rfc3339,
+                  },
+                ])
               end
             end
           end

--- a/spec/services/api/v3/ecf/participants_query_spec.rb
+++ b/spec/services/api/v3/ecf/participants_query_spec.rb
@@ -97,6 +97,23 @@ RSpec.describe Api::V3::ECF::ParticipantsQuery do
       end
     end
 
+    describe "with from_participant_id filter" do
+      let(:params) { { filter: { from_participant_id: } } }
+
+      context "ID does not exist" do
+        let(:from_participant_id) { "doesnotexist" }
+        it { expect(subject.participants_for_pagination).to be_empty }
+      end
+
+      context "ID with a match" do
+        let!(:participant_id_change1) { create(:participant_id_change, to_participant: user, user:) }
+        let!(:participant_id_change2) { create(:participant_id_change, to_participant: another_user, user: another_user) }
+        let(:from_participant_id) { participant_id_change1.from_participant_id }
+
+        it { expect(subject.participants_for_pagination).to contain_exactly(user) }
+      end
+    end
+
     context "with ect becoming mentor" do
       let(:mentor_participant_profile) { create(:mentor_participant_profile, participant_identity: user.participant_identities.first, teacher_profile: participant_profile.teacher_profile) }
       let(:mentor_induction_programme) { create(:induction_programme, :fip, partnership:) }

--- a/spec/services/api/v3/npq_participants_query_spec.rb
+++ b/spec/services/api/v3/npq_participants_query_spec.rb
@@ -41,6 +41,24 @@ RSpec.describe Api::V3::NPQParticipantsQuery do
       end
     end
 
+    describe "from_participant_id filter" do
+      let(:params) { { filter: { from_participant_id: } } }
+
+      context "ID does not exist" do
+        let(:from_participant_id) { "doesnotexist" }
+        it { is_expected.to be_empty }
+      end
+
+      context "ID with a match" do
+        let!(:another_user) { create(:npq_participant_profile, npq_lead_provider:, npq_course:, training_status: :withdrawn).user }
+        let!(:participant_id_change1) { create(:participant_id_change, to_participant: user, user:) }
+        let!(:participant_id_change2) { create(:participant_id_change, to_participant: another_user, user: another_user) }
+        let(:from_participant_id) { participant_id_change1.from_participant_id }
+
+        it { is_expected.to contain_exactly(user) }
+      end
+    end
+
     describe "updated_since filter" do
       let!(:another_participant_profile) { create(:npq_participant_profile, npq_lead_provider:, npq_course:) }
       let(:params) { { filter: { updated_since: 1.day.ago.iso8601 } } }

--- a/swagger/v3/api_spec.json
+++ b/swagger/v3/api_spec.json
@@ -5684,6 +5684,7 @@
         "required": [
           "full_name",
           "npq_enrolments",
+          "participant_id_changes",
           "updated_at"
         ],
         "properties": {

--- a/swagger/v3/component_schemas/ECFParticipantAttributes.yml
+++ b/swagger/v3/component_schemas/ECFParticipantAttributes.yml
@@ -4,6 +4,7 @@ required:
   - full_name
   - updated_at
   - ecf_enrolments
+  - participant_id_changes
 properties:
   full_name:
     description: "The full name of this ECF participant"

--- a/swagger/v3/component_schemas/NPQParticipantAttributes.yml
+++ b/swagger/v3/component_schemas/NPQParticipantAttributes.yml
@@ -3,6 +3,7 @@ type: object
 required:
   - full_name
   - npq_enrolments
+  - participant_id_changes
   - updated_at
 properties:
   full_name:

--- a/swagger/v3/component_schemas/ParticipantIdChange.yml
+++ b/swagger/v3/component_schemas/ParticipantIdChange.yml
@@ -20,3 +20,7 @@ properties:
     type: string
     format: date-time
     example: "2021-05-31T02:22:32.000Z"
+example:
+  from_participant_id: "000a97ff-d2a9-4779-a397-9bfd9063072e"
+  to_participant_id: "000a97ff-d2a9-4779-a397-9bfd9063072e"
+  changed_at: "2021-05-31T02:22:32.000Z"


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-2468

### Changes proposed in this pull request

* Updated `Api::V3::ECF::ParticipantSerializer` to include `participant_id_changes`
* Updated `Api::V3::NPQParticipantSerializer` to include `participant_id_changes`
* Updated spec docs to make `participant_id_changes` a requirement
* New filter `from_participant_id` for ECF/NPQ participants endpoint
* Added feature flag `participant_id_changes`
* Updated release notes

### Guidance to review

