### PR TITLE
Reinstate DFE analytics to API controller

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -3,6 +3,8 @@
 module Api
   class ApiController < ActionController::API
     include ActionController::MimeResponds
+    include DfE::Analytics::Requests
+
     before_action :remove_charset
     rescue_from ActionController::ParameterMissing, with: :missing_parameter_response
     rescue_from ActionController::UnpermittedParameters, with: :unpermitted_parameter_response

--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -53,5 +53,5 @@ DfE::Analytics.configure do |config|
   # return the identifier for the user. This is useful for systems with
   # users that don't use the id field.
   #
-  # config.user_identifier = proc { |user| user&.id }
+  config.user_identifier = proc { |user| user&.id if user.respond_to?(:id) }
 end

--- a/spec/requests/dfe_analytics_spec.rb
+++ b/spec/requests/dfe_analytics_spec.rb
@@ -28,5 +28,17 @@ RSpec.describe "DfE Analytics", type: :request do
     it "does not send a web request event for GET /check" do
       expect { get check_path }.not_to have_sent_analytics_event_types(:web_request)
     end
+
+    context "with lead provider API requests" do
+      let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
+      let(:token)             { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider:) }
+      let(:bearer_token)      { "Bearer #{token}" }
+
+      it "sends DFE Analytics web request event" do
+        default_headers[:Authorization] = bearer_token
+
+        expect { get "/api/v3/participants/ecf" }.to have_sent_analytics_event_types(:web_request)
+      end
+    end
   end
 end

--- a/spec/requests/dfe_analytics_spec.rb
+++ b/spec/requests/dfe_analytics_spec.rb
@@ -40,5 +40,17 @@ RSpec.describe "DfE Analytics", type: :request do
         expect { get "/api/v3/participants/ecf" }.to have_sent_analytics_event_types(:web_request)
       end
     end
+
+    context "with NPQ registration application API requests" do
+      let!(:npq_application) { create(:npq_application) }
+      let(:token)             { NPQRegistrationApiToken.create_with_random_token! }
+      let(:bearer_token)      { "Bearer #{token}" }
+
+      it "sends DFE Analytics web request event" do
+        default_headers[:Authorization] = bearer_token
+
+        expect { get "/api/v1/npq-profiles/#{npq_application.id}" }.to have_sent_analytics_event_types(:web_request)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

Reinstate API requests as `web_request` in DfE Analytics
Adding this the first time https://github.com/DFE-Digital/early-careers-framework/pull/4080 caused issues in the NPQ reg application when querying our API due to the following https://dfe-teacher-services.sentry.io/issues/4519374530/?alert_rule_id=7310304&alert_type=issue&notification_uuid=d4ae4668-3d2a-4566-9ac2-0fe446909ca7&project=5748989&referrer=slack

Where DfE analytics expects a record as the current user, however the owner in NPQ reg APIs is a string.
We now override this check in the config to only check the user IF the user is a record.
- Ticket: n/a

### Changes proposed in this pull request
- Add dfe analytics to API controller to start tracking API requests in BQ events
- Add a custom user method in the config to not return anything if the user is not a record
- Add tests for both lead provider and NPQ API

### Guidance to review
We will test this with all APIs before merging
