### PR TITLE
[CPDLP-2467] Dont allow duplicate participant_id_change entries

### DIFF
--- a/app/models/participant_id_change.rb
+++ b/app/models/participant_id_change.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ParticipantIdChange < ApplicationRecord
+  has_paper_trail
+
   belongs_to :user
 
   belongs_to :from_participant, class_name: "User"

--- a/app/services/identity/transfer.rb
+++ b/app/services/identity/transfer.rb
@@ -60,10 +60,10 @@ module Identity
     end
 
     def create_participant_id_change!
-      to_user.participant_id_changes.create!(from_participant: from_user, to_participant: to_user)
-
       # Move previous change history to new to_user
       from_user.participant_id_changes.update!(user: to_user)
+
+      to_user.participant_id_changes.find_or_create_by!(from_participant: from_user, to_participant: to_user)
     end
   end
 end

--- a/spec/models/participant_id_change_spec.rb
+++ b/spec/models/participant_id_change_spec.rb
@@ -3,6 +3,10 @@
 require "rails_helper"
 
 RSpec.describe ParticipantIdChange, type: :model do
+  it "enables paper trail" do
+    is_expected.to be_versioned
+  end
+
   describe "associations" do
     it { is_expected.to belong_to(:user).class_name("User") }
     it { is_expected.to belong_to(:from_participant).class_name("User") }

--- a/spec/services/identity/transfer_spec.rb
+++ b/spec/services/identity/transfer_spec.rb
@@ -147,6 +147,16 @@ RSpec.describe Identity::Transfer do
           expect(rec2.user).to eql(user2)
         end
       end
+
+      context "run transfer multiple times" do
+        it "should only create one participant_id_change" do
+          expect(ParticipantIdChange.count).to eql(0)
+          service.call(from_user: user1, to_user: user2)
+          expect(ParticipantIdChange.count).to eql(1)
+          service.call(from_user: user1, to_user: user2)
+          expect(ParticipantIdChange.count).to eql(1)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-2467

### Changes proposed in this pull request

* Added find or create for `participant_id_changes` to avoid duplicates
* Added paper trail to `ParticipantIdChange` model

### Guidance to review

