### PR TITLE
Upgrade to dfe-analytics 1.11.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -113,7 +113,7 @@ gem "rouge"
 
 gem "auto_strip_attributes", "~> 2.6"
 
-gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.11.0"
+gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.11.1"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/DFE-Digital/dfe-analytics.git
-  revision: efcd939fecbc64574a3e1d5d5efef7e14b65f39f
-  tag: v1.11.0
+  revision: 3ff7fa4f30a1250ac36a36d37c1f88087a3a0096
+  tag: v1.11.1
   specs:
-    dfe-analytics (1.11.0)
+    dfe-analytics (1.11.1)
       google-cloud-bigquery (~> 1.38)
       request_store_rails (~> 2)
 


### PR DESCRIPTION
This release fixes a problem we encountered when using DfE-analytics with [single-table inheritance](https://guides.rubyonrails.org/association_basics.html#single-table-inheritance-sti).
