### PR TITLE
[CST-1778] Fix the participant breadcrumbs in the admin pages

### DIFF
--- a/app/controllers/admin/participants/change_log_controller.rb
+++ b/app/controllers/admin/participants/change_log_controller.rb
@@ -13,8 +13,9 @@ module Admin::Participants
 
   private
 
+    # Get the school from the induction record for ECTs and from the participant profile for NPQs
     def school
-      @school ||= @participant_profile.school
+      @school ||= @participant_profile.latest_induction_record&.school || @participant_profile.school
     end
   end
 end

--- a/app/controllers/admin/participants/cohorts_controller.rb
+++ b/app/controllers/admin/participants/cohorts_controller.rb
@@ -15,8 +15,9 @@ module Admin::Participants
 
   private
 
+    # Get the school from the induction record for ECTs and from the participant profile for NPQs
     def school
-      @school ||= @participant_profile.school
+      @school ||= @participant_profile.latest_induction_record&.school || @participant_profile.school
     end
   end
 end

--- a/app/controllers/admin/participants/declaration_history_controller.rb
+++ b/app/controllers/admin/participants/declaration_history_controller.rb
@@ -15,8 +15,9 @@ module Admin::Participants
 
   private
 
+    # Get the school from the induction record for ECTs and from the participant profile for NPQs
     def school
-      @school ||= @participant_profile.school
+      @school ||= @participant_profile.latest_induction_record&.school || @participant_profile.school
     end
   end
 end

--- a/app/controllers/admin/participants/details_controller.rb
+++ b/app/controllers/admin/participants/details_controller.rb
@@ -12,8 +12,9 @@ module Admin::Participants
 
   private
 
+    # Get the school from the induction record for ECTs and from the participant profile for NPQs
     def school
-      @school ||= @participant_profile.school
+      @school ||= @participant_profile.latest_induction_record&.school || @participant_profile.school
     end
   end
 end

--- a/app/controllers/admin/participants/history_controller.rb
+++ b/app/controllers/admin/participants/history_controller.rb
@@ -15,8 +15,9 @@ module Admin::Participants
 
   private
 
+    # Get the school from the induction record for ECTs and from the participant profile for NPQs
     def school
-      @school ||= @participant_profile.school
+      @school ||= @participant_profile.latest_induction_record&.school || @participant_profile.school
     end
   end
 end

--- a/app/controllers/admin/participants/identities_controller.rb
+++ b/app/controllers/admin/participants/identities_controller.rb
@@ -15,8 +15,9 @@ module Admin::Participants
 
   private
 
+    # Get the school from the induction record for ECTs and from the participant profile for NPQs
     def school
-      @school ||= @participant_profile.school
+      @school ||= @participant_profile.latest_induction_record&.school || @participant_profile.school
     end
   end
 end

--- a/app/controllers/admin/participants/induction_records_controller.rb
+++ b/app/controllers/admin/participants/induction_records_controller.rb
@@ -39,8 +39,9 @@ module Admin::Participants
       @induction_record = @participant_profile.induction_records.find(params[:induction_record_id])
     end
 
+    # Get the school from the induction record for ECTs and from the participant profile for NPQs
     def school
-      @school ||= @participant_profile.school
+      @school ||= @participant_profile.latest_induction_record&.school || @participant_profile.school
     end
 
     def induction_params

--- a/app/controllers/admin/participants/school_controller.rb
+++ b/app/controllers/admin/participants/school_controller.rb
@@ -15,8 +15,9 @@ module Admin::Participants
 
   private
 
+    # Get the school from the induction record for ECTs and from the participant profile for NPQs
     def school
-      @school ||= @participant_profile.school
+      @school ||= @participant_profile.latest_induction_record&.school || @participant_profile.school
     end
   end
 end

--- a/app/controllers/admin/participants/statuses_controller.rb
+++ b/app/controllers/admin/participants/statuses_controller.rb
@@ -15,8 +15,9 @@ module Admin::Participants
 
   private
 
+    # Get the school from the induction record for ECTs and from the participant profile for NPQs
     def school
-      @school ||= @participant_profile.school
+      @school ||= @participant_profile.latest_induction_record&.school || @participant_profile.school
     end
   end
 end

--- a/app/controllers/admin/participants/validation_data_controller.rb
+++ b/app/controllers/admin/participants/validation_data_controller.rb
@@ -32,8 +32,9 @@ module Admin::Participants
 
   private
 
+    # Get the school from the induction record for ECTs and from the participant profile for NPQs
     def school
-      @school ||= @participant_profile.school
+      @school ||= @participant_profile.latest_induction_record&.school || @participant_profile.school
     end
 
     def validate_participant!


### PR DESCRIPTION
### Context

- Ticket: CST-1778

We want to display the participants' school in the Admin breadcrumbs from the Induction Records when they are ECTs and from their participant profile when they are NPQs.

### Changes proposed in this pull request
- Update the admin participant controllers to set the school according to the participant's profile type

### Guidance to review

