### PR TITLE
Ignore Terraform lockfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ bin/konduit.sh
 # Terraform
 *.tfstate
 *.tfstate.backup
+*.lock.hcl
 .terraform/environment
 terraform.tfplan
 terraform.tfstate


### PR DESCRIPTION
Prevent the accidental committing of Terraform's state/lock files.
