### PR TITLE
Warn on Redis::TimeoutError

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,7 +48,13 @@ Rails.application.configure do
                            connect_timeout: 30, # Defaults to 20 seconds
                            reconnect_attempts: 1, # Defaults to 0
                            error_handler: lambda { |method:, returning:, exception:|
-                                            Sentry.capture_exception(exception, tags: { method:, returning: })
+                                            # We get a few timeout errors/day from Redis; it may be that the cache is
+                                            # under heavy load, but we don't want to be alerted about it.
+                                            if exception.instance_of?(Redis::TimeoutError)
+                                              Rails.logger.warn("Redis timeout error #{exception}")
+                                            else
+                                              Sentry.capture_exception(exception, tags: { method:, returning: })
+                                            end
                                           },
                        }
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -49,7 +49,13 @@ Rails.application.configure do
                            connect_timeout: 30, # Defaults to 20 seconds
                            reconnect_attempts: 1, # Defaults to 0
                            error_handler: lambda { |method:, returning:, exception:|
-                                            Sentry.capture_exception(exception, tags: { method:, returning: })
+                                            # We get a few timeout errors/day from Redis; it may be that the cache is
+                                            # under heavy load, but we don't want to be alerted about it.
+                                            if exception.instance_of?(Redis::TimeoutError)
+                                              Rails.logger.warn("Redis timeout error #{exception}")
+                                            else
+                                              Sentry.capture_exception(exception, tags: { method:, returning: })
+                                            end
                                           },
                        }
 


### PR DESCRIPTION
We get a few timeout errors/day; it may be that the Redis cache is under heavy load, but we don't want to be alerted about it (Rails will silently treat this as a cache-miss, so not user-facing).

Looking into the metrics on our cache Redis instance the latency is higher than our queue Redis instance, but its still sub 200ms when we get these errors and our read/write timeout is set to 1s (Rails default). We can't really explain why we are seeing the timeouts but its only ~6/day. 

When we have an alerting solution in place we could look to monitor the warning and raise an alert if we hit an unexpected threshold of these.

We could also try bumping the Redis cache from Standard-C1 to Standard-C3, which would upgrade the network performance from "Low" to "Moderate" (but is 3x the cost).