### PR TITLE
[CST-2026] Display the materials supplier in Admin and Schools pages

### DIFF
--- a/app/components/admin/schools/cohort_component.html.erb
+++ b/app/components/admin/schools/cohort_component.html.erb
@@ -51,9 +51,9 @@
 
         if cip?
           summary_list.with_row do |row|
-            row.with_key(text: "Materials")
+            row.with_key(text: "Materials supplier")
             row.with_value(text: materials)
-            row.with_action(text: "Change", visually_hidden_text: "materials", href: change_materials_href)
+            row.with_action(text: "Change", visually_hidden_text: "materials suplier", href: change_materials_href)
           end
 
           summary_list.with_row do |row|

--- a/app/views/admin/participants/school/show.html.erb
+++ b/app/views/admin/participants/school/show.html.erb
@@ -49,14 +49,21 @@
       row.with_value(text: render(StatusTags::SchoolParticipantStatusTag.new(participant_profile: @participant_presenter.participant_profile, school: @participant_presenter.school)))
     end
 
-    sl.with_row do |row|
-      row.with_key(text: "Lead provider")
-      row.with_value(text: @participant_presenter.school_lead_provider_name)
-    end
+    if @participant_presenter.relevant_induction_record&.enrolled_in_fip?
+      sl.with_row do |row|
+        row.with_key(text: "Lead provider")
+        row.with_value(text: @participant_presenter.school_lead_provider_name)
+      end
 
-    sl.with_row do |row|
-      row.with_key(text: "Delivery partner")
-      row.with_value(text: @participant_presenter.school_delivery_partner_name)
+      sl.with_row do |row|
+        row.with_key(text: "Delivery partner")
+        row.with_value(text: @participant_presenter.school_delivery_partner_name)
+      end
+    elsif @participant_presenter.relevant_induction_record&.enrolled_in_cip?
+      sl.with_row do |row|
+        row.with_key(text: "Materials supplier")
+        row.with_value(text: @participant_presenter.relevant_induction_record.core_induction_programme_name)
+      end
     end
 
     sl.with_row do |row|

--- a/app/views/admin/participants/statuses/show.html.erb
+++ b/app/views/admin/participants/statuses/show.html.erb
@@ -31,38 +31,52 @@
   end %>
 <% end %>
 
-<h2 class="govuk-heading-m">Lead provider</h2>
-<% if @participant_presenter.lead_provider_name.blank? %>
-  <p>No lead provider details for <%= @participant_presenter.full_name %>.</p>
-<% else %>
-  <%= govuk_summary_list(actions: true) do |sl|
-    sl.with_row do |row|
-      row.with_key(text: "Name")
-      row.with_value(text: @participant_presenter.lead_provider_name)
-    end
+<% if @participant_presenter.relevant_induction_record&.enrolled_in_fip? %>
+  <h2 class="govuk-heading-m">Lead provider</h2>
+  <% if @participant_presenter.lead_provider_name.blank? %>
+    <p>No lead provider details for <%= @participant_presenter.full_name %>.</p>
+  <% else %>
+    <%= govuk_summary_list(actions: true) do |sl|
+      sl.with_row do |row|
+        row.with_key(text: "Name")
+        row.with_value(text: @participant_presenter.lead_provider_name)
+      end
 
-    sl.with_row do |row|
-      row.with_key(text: "Training record state")
-      row.with_value(text: govuk_tag(text: @participant_presenter.relevant_induction_record&.training_status || "No Induction Record Found", colour: "grey"))
-    end
-  end %>
-<% end %>
+      sl.with_row do |row|
+        row.with_key(text: "Training record state")
+        row.with_value(text: govuk_tag(text: @participant_presenter.relevant_induction_record&.training_status || "No Induction Record Found", colour: "grey"))
+      end
+    end %>
+  <% end %>
 
-<h2 class="govuk-heading-m">Delivery partner</h2>
-<% if @participant_presenter.delivery_partner_name.blank? %>
-  <p>No delivery partner details for <%= @participant_presenter.full_name %>.</p>
-<% else %>
-  <%= govuk_summary_list(actions: true) do |sl|
-    sl.with_row do |row|
-      row.with_key(text: "Name")
-      row.with_value(text: @participant_presenter.delivery_partner_name)
-    end
+  <h2 class="govuk-heading-m">Delivery partner</h2>
+  <% if @participant_presenter.delivery_partner_name.blank? %>
+    <p>No delivery partner details for <%= @participant_presenter.full_name %>.</p>
+  <% else %>
+    <%= govuk_summary_list(actions: true) do |sl|
+      sl.with_row do |row|
+        row.with_key(text: "Name")
+        row.with_value(text: @participant_presenter.delivery_partner_name)
+      end
 
-    sl.with_row do |row|
-      row.with_key(text: "Training record state")
-      row.with_value(text: render(StatusTags::DeliveryPartnerParticipantStatusTag.new(participant_profile: @participant_presenter.participant_profile, delivery_partner: @participant_presenter.school_cohort&.delivery_partner)))
-    end
-  end %>
+      sl.with_row do |row|
+        row.with_key(text: "Training record state")
+        row.with_value(text: render(StatusTags::DeliveryPartnerParticipantStatusTag.new(participant_profile: @participant_presenter.participant_profile, delivery_partner: @participant_presenter.school_cohort&.delivery_partner)))
+      end
+    end %>
+  <% end %>
+<% elsif @participant_presenter.relevant_induction_record&.enrolled_in_cip? %>
+  <h2 class="govuk-heading-m">Materials supplier</h2>
+  <% if @participant_presenter.relevant_induction_record.core_induction_programme_name.blank? %>
+  <p>No materials supplier for <%= @participant_presenter.full_name %>.</p>
+  <% else %>
+    <%= govuk_summary_list(actions: true) do |sl|
+      sl.with_row do |row|
+        row.with_key(text: "Name")
+        row.with_value(text: @participant_presenter.relevant_induction_record.core_induction_programme_name)
+      end
+    end %>
+  <% end %>
 <% end %>
 
 <h2 class="govuk-heading-m">Appropriate body</h2>

--- a/app/views/schools/participants/show.html.erb
+++ b/app/views/schools/participants/show.html.erb
@@ -109,6 +109,14 @@
             DfE accredited materials
           </dd>
         </div>
+        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
+          <dt class="govuk-summary-list__key">
+            Materials supplier
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= @induction_record.core_induction_programme_name %>
+          </dd>
+        </div>
       <% end %>
 
       <% if @induction_record.enrolled_in_fip? %>

--- a/spec/features/scenarios/participants/ect_doing_cip/after_cohort_transfer_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_cip/after_cohort_transfer_spec.rb
@@ -159,7 +159,7 @@ RSpec.feature "ECT doing CIP: after cohort transfer", type: :feature do
     expect(participant_training).to have_school_name school.name
     expect(participant_training).to have_school_urn school.urn
     expect(participant_training).to have_school_record_state school_record_state
-    expect(participant_training).to have_lead_provider lead_provider_name
+    expect(participant_training).to have_materials_supplier cip_material_provider
   end
 
   scenario "A DfE finance user can locate the record for the ECT" do

--- a/spec/features/scenarios/participants/ect_doing_cip/in_training_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_cip/in_training_spec.rb
@@ -141,7 +141,7 @@ RSpec.feature "ECT doing CIP: in training", type: :feature do
     expect(participant_training).to have_school_name school.name
     expect(participant_training).to have_school_urn school.urn
     expect(participant_training).to have_school_record_state school_record_state
-    expect(participant_training).to have_lead_provider lead_provider_name
+    expect(participant_training).to have_materials_supplier cip_material_provider
   end
 
   scenario "A DfE finance user can locate the record for the ECT" do

--- a/spec/features/scenarios/participants/ect_doing_cip/no_validation_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_cip/no_validation_spec.rb
@@ -141,7 +141,7 @@ RSpec.feature "ECT doing CIP: no validation", type: :feature do
     expect(participant_training).to have_school_name school.name
     expect(participant_training).to have_school_urn school.urn
     expect(participant_training).to have_school_record_state school_record_state
-    expect(participant_training).to have_lead_provider lead_provider_name
+    expect(participant_training).to have_materials_supplier cip_material_provider
   end
 
   scenario "A DfE finance user can locate the record for the ECT" do

--- a/spec/features/scenarios/participants/ect_doing_cip/no_validation_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_cip/no_validation_spec.rb
@@ -87,6 +87,7 @@ RSpec.feature "ECT doing CIP: no validation", type: :feature do
     expect(participant_details).to have_email participant_email
     expect(participant_details).to have_full_name participant_full_name
     expect(participant_details).to have_status school_record_state
+    expect(participant_details).to have_materials_supplier cip_material_provider
   end
 
   scenario "The current appropriate body can locate a record for the ECT", :skip do

--- a/spec/support/features/pages/admin_support/admin_support_participant_training.rb
+++ b/spec/support/features/pages/admin_support/admin_support_participant_training.rb
@@ -12,6 +12,10 @@ module Pages
       element_has_content? self, "Cohort: #{start_year}"
     end
 
+    def has_materials_supplier?(material_supplier)
+      element_has_content? self, "Materials supplier#{material_supplier}"
+    end
+
     def has_school_name?(school_name)
       element_has_content? self, "School name#{school_name}"
     end

--- a/spec/support/features/pages/schools/school_participant_details_page.rb
+++ b/spec/support/features/pages/schools/school_participant_details_page.rb
@@ -28,5 +28,9 @@ module Pages
       element_has_content? self, "Status #{status}"
     end
     alias_method :confirm_status, :has_status?
+
+    def has_materials_supplier?(material_supplier)
+      element_has_content? self, "Materials supplier #{material_supplier}"
+    end
   end
 end

--- a/spec/support/features/steps/changes_of_circumstance_steps.rb
+++ b/spec/support/features/steps/changes_of_circumstance_steps.rb
@@ -552,7 +552,12 @@ module Steps
 
       school = find_school_for_sit "New SIT"
       participant_training.has_school_name? school.name
-      participant_training.has_materials_supplier? ""
+
+      if scenario.new_programme == "FIP"
+        participant_training.has_lead_provider? scenario.new_lead_provider_name
+      elsif scenario.new_programme == "CIP"
+        participant_training.has_materials_supplier? ""
+      end
 
       sign_out
     end

--- a/spec/support/features/steps/changes_of_circumstance_steps.rb
+++ b/spec/support/features/steps/changes_of_circumstance_steps.rb
@@ -552,7 +552,7 @@ module Steps
 
       school = find_school_for_sit "New SIT"
       participant_training.has_school_name? school.name
-      participant_training.has_lead_provider? scenario.new_lead_provider_name
+      participant_training.has_materials_supplier? ""
 
       sign_out
     end


### PR DESCRIPTION
### Context

- Ticket: CST-2026

We want to display the materials supplier in the following pages for CIP participants:
- Admin Training page
- Admin Statuses page
- Schools participant page

### Changes proposed in this pull request
- Update the views to display the Materials supplier or the LP/DP info based on their CIP/FIP enrollment

### Guidance to review
Check all three pages are displaying:
- the Materials supplier when participants are on CIP
- the LP/DP info when participants are on FIP
