### PR TITLE
Output super user status on admin page

### DIFF
--- a/app/views/admin/administrators/administrators/index.html.erb
+++ b/app/views/admin/administrators/administrators/index.html.erb
@@ -6,6 +6,7 @@
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header">Name</th>
       <th scope="col" class="govuk-table__header">Email</th>
+      <th scope="col" class="govuk-table__header">Super User?</th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
@@ -13,6 +14,7 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__cell" data-test="edit-admin-link"><%= govuk_link_to administrator.full_name, edit_admin_administrator_path(administrator) %></td>
         <td class="govuk-table__cell"><%= administrator.email %></td>
+        <td class="govuk-table__cell"><%= boolean_red_green_tag(administrator.super_user?) %></td>
       </tr>
     <% end %>
   </tbody>


### PR DESCRIPTION
### Context

Useful information for providing guidance

### Changes proposed in this pull request

- Add super user info to admin page


![Screenshot 2023-10-17 at 16 57 21](https://github.com/DFE-Digital/early-careers-framework/assets/1465268/71d0a6a0-c6da-420f-a29f-452fe2657269)

