### PR TITLE
Accurate cohort seeds

### DIFF
--- a/db/data/cohorts/cohorts.csv
+++ b/db/data/cohorts/cohorts.csv
@@ -1,5 +1,5 @@
-start-year,registration-start-date,academic-year-start-date,npq-registration-start-date
-2020,2020/05/10,2020/09/01,
-2021,2021/05/10,2021/09/01,
-2022,2022/05/10,2022/09/01,
-2023,2023/05/10,2023/09/01,2023/04/03
+start-year,registration-start-date,academic-year-start-date,npq-registration-start-date,automatic-assignment-period-end-date
+2020,2020/05/10,2020/09/01,,2021/03/31
+2021,2021/05/10,2021/09/01,,2022/03/31
+2022,2022/05/10,2022/09/01,,2023/03/31
+2023,2023/06/05,2023/09/01,2023/04/03,2024/03/31

--- a/db/data/schedules/schedules.csv
+++ b/db/data/schedules/schedules.csv
@@ -1,338 +1,342 @@
 type,schedule-identifier,schedule-name,schedule-cohort-year,milestone-name,milestone-declaration-type,milestone-start-date,milestone-date,milestone-payment-date
-ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 1 - Participant Start,started,01/09/2021,,01/09/2021
-ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 2 - Retention Point 1,retained-1,01/09/2021,,01/09/2021
-ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 3 - Retention Point 2,retained-2,01/09/2021,,01/09/2021
-ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 4 - Retention Point 3,retained-3,01/09/2021,,01/09/2021
-ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 5 - Retention Point 4,retained-4,01/09/2021,,01/09/2021
-ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 6 - Participant Completion,completed,01/09/2021,,01/09/2021
-ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 1 - Participant Start,started,01/01/2022,,01/01/2022
-ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 2 - Retention Point 1,retained-1,01/01/2022,,01/01/2022
-ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 3 - Retention Point 2,retained-2,01/01/2022,,01/01/2022
-ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 4 - Retention Point 3,retained-3,01/01/2022,,01/01/2022
-ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 5 - Retention Point 4,retained-4,01/01/2022,,01/01/2022
-ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 6 - Participant Completion,completed,01/01/2022,,01/01/2022
-ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 1 - Participant Start,started,01/04/2022,,01/04/2022
-ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 2 - Retention Point 1,retained-1,01/04/2022,,01/04/2022
-ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 3 - Retention Point 2,retained-2,01/04/2022,,01/04/2022
-ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 4 - Retention Point 3,retained-3,01/04/2022,,01/04/2022
-ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 5 - Retention Point 4,retained-4,01/04/2022,,01/04/2022
-ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 6 - Participant Completion,completed,01/04/2022,,01/04/2022
-ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 1 - Participant Start,started,01/09/2022,,01/09/2022
-ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 2 - Retention Point 1,retained-1,01/09/2022,,01/09/2022
-ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 3 - Retention Point 2,retained-2,01/09/2022,,01/09/2022
-ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 4 - Retention Point 3,retained-3,01/09/2022,,01/09/2022
-ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 5 - Retention Point 4,retained-4,01/09/2022,,01/09/2022
-ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 6 - Participant Completion,completed,01/09/2022,,01/09/2022
-ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 1 - Participant Start,started,01/01/2023,,01/01/2023
-ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 2 - Retention Point 1,retained-1,01/01/2023,,01/01/2023
-ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 3 - Retention Point 2,retained-2,01/01/2023,,01/01/2023
-ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 4 - Retention Point 3,retained-3,01/01/2023,,01/01/2023
-ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 5 - Retention Point 4,retained-4,01/01/2023,,01/01/2023
-ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 6 - Participant Completion,completed,01/01/2023,,01/01/2023
-ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 1 - Participant Start,started,01/04/2023,,01/04/2023
-ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 2 - Retention Point 1,retained-1,01/04/2023,,01/04/2023
-ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 3 - Retention Point 2,retained-2,01/04/2023,,01/04/2023
-ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 4 - Retention Point 3,retained-3,01/04/2023,,01/04/2023
-ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 5 - Retention Point 4,retained-4,01/04/2023,,01/04/2023
-ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 6 - Participant Completion,completed,01/04/2023,,01/04/2023
-ecf_reduced,ecf-reduced-september,ECF Reduced September,2021,Output 1 - Participant Start,started,01/09/2021,,01/09/2021
-ecf_reduced,ecf-reduced-september,ECF Reduced September,2021,Output 2 - Retention Point 1,retained-1,01/09/2021,,01/09/2021
-ecf_reduced,ecf-reduced-september,ECF Reduced September,2021,Output 3 - Retention Point 2,retained-2,01/09/2021,,01/09/2021
-ecf_reduced,ecf-reduced-september,ECF Reduced September,2021,Output 4 - Retention Point 3,retained-3,01/09/2021,,01/09/2021
-ecf_reduced,ecf-reduced-september,ECF Reduced September,2021,Output 5 - Retention Point 4,retained-4,01/09/2021,,01/09/2021
-ecf_reduced,ecf-reduced-september,ECF Reduced September,2021,Output 6 - Participant Completion,completed,01/09/2021,,01/09/2021
-ecf_reduced,ecf-reduced-january,ECF Reduced January,2021,Output 1 - Participant Start,started,01/01/2022,,01/01/2022
-ecf_reduced,ecf-reduced-january,ECF Reduced January,2021,Output 2 - Retention Point 1,retained-1,01/01/2022,,01/01/2022
-ecf_reduced,ecf-reduced-january,ECF Reduced January,2021,Output 3 - Retention Point 2,retained-2,01/01/2022,,01/01/2022
-ecf_reduced,ecf-reduced-january,ECF Reduced January,2021,Output 4 - Retention Point 3,retained-3,01/01/2022,,01/01/2022
-ecf_reduced,ecf-reduced-january,ECF Reduced January,2021,Output 5 - Retention Point 4,retained-4,01/01/2022,,01/01/2022
-ecf_reduced,ecf-reduced-january,ECF Reduced January,2021,Output 6 - Participant Completion,completed,01/01/2022,,01/01/2022
-ecf_reduced,ecf-reduced-april,ECF Reduced April,2021,Output 1 - Participant Start,started,01/04/2022,,01/04/2022
-ecf_reduced,ecf-reduced-april,ECF Reduced April,2021,Output 2 - Retention Point 1,retained-1,01/04/2022,,01/04/2022
-ecf_reduced,ecf-reduced-april,ECF Reduced April,2021,Output 3 - Retention Point 2,retained-2,01/04/2022,,01/04/2022
-ecf_reduced,ecf-reduced-april,ECF Reduced April,2021,Output 4 - Retention Point 3,retained-3,01/04/2022,,01/04/2022
-ecf_reduced,ecf-reduced-april,ECF Reduced April,2021,Output 5 - Retention Point 4,retained-4,01/04/2022,,01/04/2022
-ecf_reduced,ecf-reduced-april,ECF Reduced April,2021,Output 6 - Participant Completion,completed,01/04/2022,,01/04/2022
-ecf_reduced,ecf-reduced-september,ECF Reduced September,2022,Output 1 - Participant Start,started,01/09/2022,,01/09/2022
-ecf_reduced,ecf-reduced-september,ECF Reduced September,2022,Output 2 - Retention Point 1,retained-1,01/09/2022,,01/09/2022
-ecf_reduced,ecf-reduced-september,ECF Reduced September,2022,Output 3 - Retention Point 2,retained-2,01/09/2022,,01/09/2022
-ecf_reduced,ecf-reduced-september,ECF Reduced September,2022,Output 4 - Retention Point 3,retained-3,01/09/2022,,01/09/2022
-ecf_reduced,ecf-reduced-september,ECF Reduced September,2022,Output 5 - Retention Point 4,retained-4,01/09/2022,,01/09/2022
-ecf_reduced,ecf-reduced-september,ECF Reduced September,2022,Output 6 - Participant Completion,completed,01/09/2022,,01/09/2022
-ecf_reduced,ecf-reduced-january,ECF Reduced January,2022,Output 1 - Participant Start,started,01/01/2023,,01/01/2023
-ecf_reduced,ecf-reduced-january,ECF Reduced January,2022,Output 2 - Retention Point 1,retained-1,01/01/2023,,01/01/2023
-ecf_reduced,ecf-reduced-january,ECF Reduced January,2022,Output 3 - Retention Point 2,retained-2,01/01/2023,,01/01/2023
-ecf_reduced,ecf-reduced-january,ECF Reduced January,2022,Output 4 - Retention Point 3,retained-3,01/01/2023,,01/01/2023
-ecf_reduced,ecf-reduced-january,ECF Reduced January,2022,Output 5 - Retention Point 4,retained-4,01/01/2023,,01/01/2023
-ecf_reduced,ecf-reduced-january,ECF Reduced January,2022,Output 6 - Participant Completion,completed,01/01/2023,,01/01/2023
-ecf_reduced,ecf-reduced-april,ECF Reduced April,2022,Output 1 - Participant Start,started,01/04/2023,,01/04/2023
-ecf_reduced,ecf-reduced-april,ECF Reduced April,2022,Output 2 - Retention Point 1,retained-1,01/04/2023,,01/04/2023
-ecf_reduced,ecf-reduced-april,ECF Reduced April,2022,Output 3 - Retention Point 2,retained-2,01/04/2023,,01/04/2023
-ecf_reduced,ecf-reduced-april,ECF Reduced April,2022,Output 4 - Retention Point 3,retained-3,01/04/2023,,01/04/2023
-ecf_reduced,ecf-reduced-april,ECF Reduced April,2022,Output 5 - Retention Point 4,retained-4,01/04/2023,,01/04/2023
-ecf_reduced,ecf-reduced-april,ECF Reduced April,2022,Output 6 - Participant Completion,completed,01/04/2023,,01/04/2023
-ecf_replacement,ecf-replacement-september,ECF Replacement September,2021,Output 1 - Participant Start,started,01/09/2021,,01/09/2021
-ecf_replacement,ecf-replacement-september,ECF Replacement September,2021,Output 2 - Retention Point 1,retained-1,01/09/2021,,01/09/2021
-ecf_replacement,ecf-replacement-september,ECF Replacement September,2021,Output 3 - Retention Point 2,retained-2,01/09/2021,,01/09/2021
-ecf_replacement,ecf-replacement-september,ECF Replacement September,2021,Output 4 - Retention Point 3,retained-3,01/09/2021,,01/09/2021
-ecf_replacement,ecf-replacement-september,ECF Replacement September,2021,Output 5 - Retention Point 4,retained-4,01/09/2021,,01/09/2021
-ecf_replacement,ecf-replacement-september,ECF Replacement September,2021,Output 6 - Participant Completion,completed,01/09/2021,,01/09/2021
-ecf_replacement,ecf-replacement-january,ECF Replacement January,2021,Output 1 - Participant Start,started,01/01/2022,,01/01/2022
-ecf_replacement,ecf-replacement-january,ECF Replacement January,2021,Output 2 - Retention Point 1,retained-1,01/01/2022,,01/01/2022
-ecf_replacement,ecf-replacement-january,ECF Replacement January,2021,Output 3 - Retention Point 2,retained-2,01/01/2022,,01/01/2022
-ecf_replacement,ecf-replacement-january,ECF Replacement January,2021,Output 4 - Retention Point 3,retained-3,01/01/2022,,01/01/2022
-ecf_replacement,ecf-replacement-january,ECF Replacement January,2021,Output 5 - Retention Point 4,retained-4,01/01/2022,,01/01/2022
-ecf_replacement,ecf-replacement-january,ECF Replacement January,2021,Output 6 - Participant Completion,completed,01/01/2022,,01/01/2022
-ecf_replacement,ecf-replacement-april,ECF Replacement April,2021,Output 1 - Participant Start,started,01/04/2022,,01/04/2022
-ecf_replacement,ecf-replacement-april,ECF Replacement April,2021,Output 2 - Retention Point 1,retained-1,01/04/2022,,01/04/2022
-ecf_replacement,ecf-replacement-april,ECF Replacement April,2021,Output 3 - Retention Point 2,retained-2,01/04/2022,,01/04/2022
-ecf_replacement,ecf-replacement-april,ECF Replacement April,2021,Output 4 - Retention Point 3,retained-3,01/04/2022,,01/04/2022
-ecf_replacement,ecf-replacement-april,ECF Replacement April,2021,Output 5 - Retention Point 4,retained-4,01/04/2022,,01/04/2022
-ecf_replacement,ecf-replacement-april,ECF Replacement April,2021,Output 6 - Participant Completion,completed,01/04/2022,,01/04/2022
-ecf_replacement,ecf-replacement-september,ECF Replacement September,2022,Output 1 - Participant Start,started,01/09/2022,,01/09/2022
-ecf_replacement,ecf-replacement-september,ECF Replacement September,2022,Output 2 - Retention Point 1,retained-1,01/09/2022,,01/09/2022
-ecf_replacement,ecf-replacement-september,ECF Replacement September,2022,Output 3 - Retention Point 2,retained-2,01/09/2022,,01/09/2022
-ecf_replacement,ecf-replacement-september,ECF Replacement September,2022,Output 4 - Retention Point 3,retained-3,01/09/2022,,01/09/2022
-ecf_replacement,ecf-replacement-september,ECF Replacement September,2022,Output 5 - Retention Point 4,retained-4,01/09/2022,,01/09/2022
-ecf_replacement,ecf-replacement-september,ECF Replacement September,2022,Output 6 - Participant Completion,completed,01/09/2022,,01/09/2022
-ecf_replacement,ecf-replacement-january,ECF Replacement January,2022,Output 1 - Participant Start,started,01/01/2023,,01/01/2023
-ecf_replacement,ecf-replacement-january,ECF Replacement January,2022,Output 2 - Retention Point 1,retained-1,01/01/2023,,01/01/2023
-ecf_replacement,ecf-replacement-january,ECF Replacement January,2022,Output 3 - Retention Point 2,retained-2,01/01/2023,,01/01/2023
-ecf_replacement,ecf-replacement-january,ECF Replacement January,2022,Output 4 - Retention Point 3,retained-3,01/01/2023,,01/01/2023
-ecf_replacement,ecf-replacement-january,ECF Replacement January,2022,Output 5 - Retention Point 4,retained-4,01/01/2023,,01/01/2023
-ecf_replacement,ecf-replacement-january,ECF Replacement January,2022,Output 6 - Participant Completion,completed,01/01/2023,,01/01/2023
-ecf_replacement,ecf-replacement-april,ECF Replacement April,2022,Output 1 - Participant Start,started,01/04/2023,,01/04/2023
-ecf_replacement,ecf-replacement-april,ECF Replacement April,2022,Output 2 - Retention Point 1,retained-1,01/04/2023,,01/04/2023
-ecf_replacement,ecf-replacement-april,ECF Replacement April,2022,Output 3 - Retention Point 2,retained-2,01/04/2023,,01/04/2023
-ecf_replacement,ecf-replacement-april,ECF Replacement April,2022,Output 4 - Retention Point 3,retained-3,01/04/2023,,01/04/2023
-ecf_replacement,ecf-replacement-april,ECF Replacement April,2022,Output 5 - Retention Point 4,retained-4,01/04/2023,,01/04/2023
-ecf_replacement,ecf-replacement-april,ECF Replacement April,2022,Output 6 - Participant Completion,completed,01/04/2023,,01/04/2023
-ecf_standard,ecf-standard-september,ECF Standard September,2021,Output 1 - Participant Start,started,01/09/2021,30/11/2021,30/11/2021
-ecf_standard,ecf-standard-september,ECF Standard September,2021,Output 2 - Retention Point 1,retained-1,01/09/2021,31/01/2022,28/02/2022
-ecf_standard,ecf-standard-september,ECF Standard September,2021,Output 3 - Retention Point 2,retained-2,01/02/2022,30/04/2022,31/05/2022
-ecf_standard,ecf-standard-september,ECF Standard September,2021,Output 4 - Retention Point 3,retained-3,01/05/2022,30/09/2022,31/10/2022
-ecf_standard,ecf-standard-september,ECF Standard September,2021,Output 5 - Retention Point 4,retained-4,01/10/2022,31/01/2023,28/02/2023
-ecf_standard,ecf-standard-september,ECF Standard September,2021,Output 6 - Participant Completion,completed,01/02/2023,30/04/2023,31/05/2023
-ecf_standard,ecf-standard-january,ECF Standard January,2021,Output 1 - Participant Start,started,01/12/2021,31/01/2022,28/02/2022
-ecf_standard,ecf-standard-january,ECF Standard January,2021,Output 2 - Retention Point 1,retained-1,01/02/2022,30/04/2022,31/05/2022
-ecf_standard,ecf-standard-january,ECF Standard January,2021,Output 3 - Retention Point 2,retained-2,01/05/2022,30/09/2022,31/10/2022
-ecf_standard,ecf-standard-january,ECF Standard January,2021,Output 4 - Retention Point 3,retained-3,01/10/2022,31/01/2023,28/02/2023
-ecf_standard,ecf-standard-january,ECF Standard January,2021,Output 5 - Retention Point 4,retained-4,01/02/2023,30/04/2023,31/05/2023
-ecf_standard,ecf-standard-january,ECF Standard January,2021,Output 6 - Participant Completion,completed,01/02/2023,31/10/2023,30/11/2023
-ecf_standard,ecf-standard-april,ECF Standard April,2021,Output 1 - Participant Start,started,01/03/2022,30/04/2022,31/05/2022
-ecf_standard,ecf-standard-april,ECF Standard April,2021,Output 2 - Retention Point 1,retained-1,01/06/2022,30/09/2022,31/10/2022
-ecf_standard,ecf-standard-april,ECF Standard April,2021,Output 3 - Retention Point 2,retained-2,01/11/2022,31/01/2023,28/02/2023
-ecf_standard,ecf-standard-april,ECF Standard April,2021,Output 4 - Retention Point 3,retained-3,01/03/2023,30/04/2023,31/05/2023
-ecf_standard,ecf-standard-april,ECF Standard April,2021,Output 5 - Retention Point 4,retained-4,01/06/2023,31/10/2023,30/11/2023
-ecf_standard,ecf-standard-april,ECF Standard April,2021,Output 6 - Participant Completion,completed,01/12/2023,31/01/2024,28/02/2024
-ecf_standard,ecf-standard-september,ECF Standard September,2022,Output 1 - Participant Start,started,01/06/2022,31/12/2022,30/11/2022
-ecf_standard,ecf-standard-september,ECF Standard September,2022,Output 2 - Retention Point 1,retained-1,01/01/2023,31/03/2023,30/04/2023
-ecf_standard,ecf-standard-september,ECF Standard September,2022,Output 3 - Retention Point 2,retained-2,01/04/2023,31/07/2023,31/08/2023
-ecf_standard,ecf-standard-september,ECF Standard September,2022,Output 4 - Retention Point 3,retained-3,01/08/2023,31/12/2023,31/01/2024
-ecf_standard,ecf-standard-september,ECF Standard September,2022,Output 5 - Retention Point 4,retained-4,01/01/2024,31/03/2024,30/04/2024
-ecf_standard,ecf-standard-september,ECF Standard September,2022,Output 6 - Participant Completion,completed,01/04/2024,31/07/2024,31/08/2024
-ecf_standard,ecf-standard-january,ECF Standard January,2022,Output 1 - Participant Start,started,01/01/2023,31/03/2023,30/04/2023
-ecf_standard,ecf-standard-january,ECF Standard January,2022,Output 2 - Retention Point 1,retained-1,01/04/2023,31/07/2023,31/08/2023
-ecf_standard,ecf-standard-january,ECF Standard January,2022,Output 3 - Retention Point 2,retained-2,01/08/2023,31/12/2023,31/01/2024
-ecf_standard,ecf-standard-january,ECF Standard January,2022,Output 4 - Retention Point 3,retained-3,01/01/2024,31/03/2024,30/04/2024
-ecf_standard,ecf-standard-january,ECF Standard January,2022,Output 5 - Retention Point 4,retained-4,01/04/2024,31/07/2024,31/08/2024
-ecf_standard,ecf-standard-january,ECF Standard January,2022,Output 6 - Participant Completion,completed,01/08/2024,31/12/2024,31/01/2025
-ecf_standard,ecf-standard-april,ECF Standard April,2022,Output 1 - Participant Start,started,01/04/2023,31/07/2023,31/08/2023
-ecf_standard,ecf-standard-april,ECF Standard April,2022,Output 2 - Retention Point 1,retained-1,01/08/2023,31/12/2023,31/01/2024
-ecf_standard,ecf-standard-april,ECF Standard April,2022,Output 3 - Retention Point 2,retained-2,01/01/2024,31/03/2024,30/04/2024
-ecf_standard,ecf-standard-april,ECF Standard April,2022,Output 4 - Retention Point 3,retained-3,01/04/2024,31/07/2024,31/08/2024
-ecf_standard,ecf-standard-april,ECF Standard April,2022,Output 5 - Retention Point 4,retained-4,01/08/2024,31/12/2024,31/01/2025
-ecf_standard,ecf-standard-april,ECF Standard April,2022,Output 6 - Participant Completion,completed,01/01/2025,31/03/2025,30/04/2025
-npq_aso,npq-aso-november,NPQ ASO November,2021,Output 1 - Participant Start,started,01/11/2021,,01/11/2021
-npq_aso,npq-aso-november,NPQ ASO November,2021,Output 2 - Retention Point 1,retained-1,01/11/2021,,01/11/2021
-npq_aso,npq-aso-november,NPQ ASO November,2021,Output 3 - Retention Point 2,retained-2,01/11/2021,,01/11/2021
-npq_aso,npq-aso-november,NPQ ASO November,2021,Output 4 - Participant Completion,completed,01/11/2021,,01/11/2021
-npq_aso,npq-aso-december,NPQ ASO December,2021,Output 1 - Participant Start,started,01/12/2021,,01/12/2021
-npq_aso,npq-aso-december,NPQ ASO December,2021,Output 2 - Retention Point 1,retained-1,01/12/2021,,01/12/2021
-npq_aso,npq-aso-december,NPQ ASO December,2021,Output 3 - Retention Point 2,retained-2,01/12/2021,,01/12/2021
-npq_aso,npq-aso-december,NPQ ASO December,2021,Output 4 - Participant Completion,completed,01/12/2021,,01/12/2021
-npq_aso,npq-aso-march,NPQ ASO March,2021,Output 1 - Participant Start,started,01/03/2022,,01/03/2022
-npq_aso,npq-aso-march,NPQ ASO March,2021,Output 2 - Retention Point 1,retained-1,01/03/2022,,01/03/2022
-npq_aso,npq-aso-march,NPQ ASO March,2021,Output 3 - Retention Point 2,retained-2,01/03/2022,,01/03/2022
-npq_aso,npq-aso-march,NPQ ASO March,2021,Output 4 - Participant Completion,completed,01/03/2022,,01/03/2022
-npq_aso,npq-aso-june,NPQ ASO June,2021,Output 1 - Participant Start,started,01/06/2022,,01/06/2022
-npq_aso,npq-aso-june,NPQ ASO June,2021,Output 2 - Retention Point 1,retained-1,01/06/2022,,01/06/2022
-npq_aso,npq-aso-june,NPQ ASO June,2021,Output 3 - Retention Point 2,retained-2,01/06/2022,,01/06/2022
-npq_aso,npq-aso-june,NPQ ASO June,2021,Output 4 - Participant Completion,completed,01/06/2022,,01/06/2022
-npq_ehco,npq-ehco-june,NPQ EHCO June,2021,Output 1 - Participant Start,started,01/06/2022,,01/06/2022
-npq_ehco,npq-ehco-june,NPQ EHCO June,2021,Output 2 - Retention Point 1,retained-1,01/06/2022,,01/06/2022
-npq_ehco,npq-ehco-june,NPQ EHCO June,2021,Output 3 - Retention Point 2,retained-2,01/06/2022,,01/06/2022
-npq_ehco,npq-ehco-june,NPQ EHCO June,2021,Output 4 - Participant Completion,completed,01/06/2022,,01/06/2022
-npq_ehco,npq-ehco-november,NPQ EHCO November,2022,Output 1 - Participant Start,started,01/11/2022,,01/11/2022
-npq_ehco,npq-ehco-november,NPQ EHCO November,2022,Output 2 - Retention Point 1,retained-1,01/11/2022,,01/11/2022
-npq_ehco,npq-ehco-november,NPQ EHCO November,2022,Output 3 - Retention Point 2,retained-2,01/11/2022,,01/11/2022
-npq_ehco,npq-ehco-november,NPQ EHCO November,2022,Output 4 - Participant Completion,completed,01/11/2022,,01/11/2022
-npq_ehco,npq-ehco-december,NPQ EHCO December,2022,Output 1 - Participant Start,started,01/12/2022,,01/12/2022
-npq_ehco,npq-ehco-december,NPQ EHCO December,2022,Output 2 - Retention Point 1,retained-1,01/12/2022,,01/12/2022
-npq_ehco,npq-ehco-december,NPQ EHCO December,2022,Output 3 - Retention Point 2,retained-2,01/12/2022,,01/12/2022
-npq_ehco,npq-ehco-december,NPQ EHCO December,2022,Output 4 - Participant Completion,completed,01/12/2022,,01/12/2022
-npq_ehco,npq-ehco-march,NPQ EHCO March,2022,Output 1 - Participant Start,started,01/03/2023,,01/03/2023
-npq_ehco,npq-ehco-march,NPQ EHCO March,2022,Output 2 - Retention Point 1,retained-1,01/03/2023,,01/03/2023
-npq_ehco,npq-ehco-march,NPQ EHCO March,2022,Output 3 - Retention Point 2,retained-2,01/03/2023,,01/03/2023
-npq_ehco,npq-ehco-march,NPQ EHCO March,2022,Output 4 - Participant Completion,completed,01/03/2023,,01/03/2023
-npq_ehco,npq-ehco-june,NPQ EHCO June,2022,Output 1 - Participant Start,started,01/06/2023,,01/06/2023
-npq_ehco,npq-ehco-june,NPQ EHCO June,2022,Output 2 - Retention Point 1,retained-1,01/06/2023,,01/06/2023
-npq_ehco,npq-ehco-june,NPQ EHCO June,2022,Output 3 - Retention Point 2,retained-2,01/06/2023,,01/06/2023
-npq_ehco,npq-ehco-june,NPQ EHCO June,2022,Output 4 - Participant Completion,completed,01/06/2023,,01/06/2023
-npq_ehco,npq-ehco-november,NPQ EHCO November,2023,Output 1 - Participant Start,started,01/11/2023,,01/11/2023
-npq_ehco,npq-ehco-november,NPQ EHCO November,2023,Output 2 - Retention Point 1,retained-1,01/11/2023,,01/11/2023
-npq_ehco,npq-ehco-november,NPQ EHCO November,2023,Output 3 - Retention Point 2,retained-2,01/11/2023,,01/11/2023
-npq_ehco,npq-ehco-november,NPQ EHCO November,2023,Output 4 - Participant Completion,completed,01/11/2023,,01/11/2023
-npq_ehco,npq-ehco-december,NPQ EHCO December,2023,Output 1 - Participant Start,started,01/12/2023,,01/12/2023
-npq_ehco,npq-ehco-december,NPQ EHCO December,2023,Output 2 - Retention Point 1,retained-1,01/12/2023,,01/12/2023
-npq_ehco,npq-ehco-december,NPQ EHCO December,2023,Output 3 - Retention Point 2,retained-2,01/12/2023,,01/12/2023
-npq_ehco,npq-ehco-december,NPQ EHCO December,2023,Output 4 - Participant Completion,completed,01/12/2023,,01/12/2023
-npq_ehco,npq-ehco-march,NPQ EHCO March,2023,Output 1 - Participant Start,started,01/03/2024,,01/03/2024
-npq_ehco,npq-ehco-march,NPQ EHCO March,2023,Output 2 - Retention Point 1,retained-1,01/03/2024,,01/03/2024
-npq_ehco,npq-ehco-march,NPQ EHCO March,2023,Output 3 - Retention Point 2,retained-2,01/03/2024,,01/03/2024
-npq_ehco,npq-ehco-march,NPQ EHCO March,2023,Output 4 - Participant Completion,completed,01/03/2024,,01/03/2024
-npq_ehco,npq-ehco-june,NPQ EHCO June,2023,Output 1 - Participant Start,started,01/06/2024,,01/06/2024
-npq_ehco,npq-ehco-june,NPQ EHCO June,2023,Output 2 - Retention Point 1,retained-1,01/06/2024,,01/06/2024
-npq_ehco,npq-ehco-june,NPQ EHCO June,2023,Output 3 - Retention Point 2,retained-2,01/06/2024,,01/06/2024
-npq_ehco,npq-ehco-june,NPQ EHCO June,2023,Output 4 - Participant Completion,completed,01/06/2024,,01/06/2024
-npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2021,Output 1 - Participant Start,started,01/11/2021,,01/11/2021
-npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2021,Output 2 - Retention Point 1,retained-1,01/11/2021,,01/11/2021
-npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2021,Output 3 - Retention Point 2,retained-2,01/11/2021,,01/11/2021
-npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2021,Output 4 - Participant Completion,completed,01/11/2021,,01/11/2021
-npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2021,Output 1 - Participant Start,started,01/01/2022,,01/01/2022
-npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2021,Output 2 - Retention Point 1,retained-1,01/01/2022,,01/01/2022
-npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2021,Output 3 - Retention Point 2,retained-2,01/01/2022,,01/01/2022
-npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2021,Output 4 - Participant Completion,completed,01/01/2022,,01/01/2022
-npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2022,Output 1 - Participant Start,started,01/11/2022,,01/11/2022
-npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2022,Output 2 - Retention Point 1,retained-1,01/11/2022,,01/11/2022
-npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2022,Output 3 - Retention Point 2,retained-2,01/11/2022,,01/11/2022
-npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2022,Output 4 - Participant Completion,completed,01/11/2022,,01/11/2022
-npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2022,Output 1 - Participant Start,started,01/01/2023,,01/01/2023
-npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2022,Output 2 - Retention Point 1,retained-1,01/01/2023,,01/01/2023
-npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2022,Output 3 - Retention Point 2,retained-2,01/01/2023,,01/01/2023
-npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2022,Output 4 - Participant Completion,completed,01/01/2023,,01/01/2023
-npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2023,Output 1 - Participant Start,started,01/11/2023,,01/11/2023
-npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2023,Output 2 - Retention Point 1,retained-1,01/11/2023,,01/11/2023
-npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2023,Output 3 - Retention Point 2,retained-2,01/11/2023,,01/11/2023
-npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2023,Output 4 - Participant Completion,completed,01/11/2023,,01/11/2023
-npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2023,Output 1 - Participant Start,started,01/01/2024,,01/01/2024
-npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2023,Output 2 - Retention Point 1,retained-1,01/01/2024,,01/01/2024
-npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2023,Output 3 - Retention Point 2,retained-2,01/01/2024,,01/01/2024
-npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2023,Output 4 - Participant Completion,completed,01/01/2024,,01/01/2024
-npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2021,Output 1 - Participant Start,started,01/11/2021,,01/11/2021
-npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2021,Output 2 - Retention Point 1,retained-1,01/11/2021,,01/11/2021
-npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2021,Output 3 - Participant Completion,completed,01/11/2021,,01/11/2021
-npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2021,Output 1 - Participant Start,started,01/01/2022,,01/01/2022
-npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2021,Output 2 - Retention Point 1,retained-1,01/01/2022,,01/01/2022
-npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2021,Output 3 - Participant Completion,completed,01/01/2022,,01/01/2022
-npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2022,Output 1 - Participant Start,started,01/11/2022,,01/11/2022
-npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2022,Output 2 - Retention Point 1,retained-1,01/11/2022,,01/11/2022
-npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2022,Output 3 - Participant Completion,completed,01/11/2022,,01/11/2022
-npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2022,Output 1 - Participant Start,started,01/01/2023,,01/01/2023
-npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2022,Output 2 - Retention Point 1,retained-1,01/01/2023,,01/01/2023
-npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2022,Output 3 - Participant Completion,completed,01/01/2023,,01/01/2023
-npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2023,Output 1 - Participant Start,started,01/11/2023,,01/11/2023
-npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2023,Output 2 - Retention Point 1,retained-1,01/11/2023,,01/11/2023
-npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2023,Output 3 - Participant Completion,completed,01/11/2023,,01/11/2023
-npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2023,Output 1 - Participant Start,started,01/01/2024,,01/01/2024
-npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2023,Output 2 - Retention Point 1,retained-1,01/01/2024,,01/01/2024
-npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2023,Output 3 - Participant Completion,completed,01/01/2024,,01/01/2024
-ecf_standard,ecf-standard-september,ECF Standard September,2023,Output 1 - Participant Start,started,01/06/2023,31/12/2023,30/11/2023
-ecf_standard,ecf-standard-september,ECF Standard September,2023,Output 2 - Retention Point 1,retained-1,01/01/2024,31/03/2024,30/04/2024
-ecf_standard,ecf-standard-september,ECF Standard September,2023,Output 3 - Retention Point 2,retained-2,01/04/2024,31/07/2024,31/08/2024
-ecf_standard,ecf-standard-september,ECF Standard September,2023,Output 4 - Retention Point 3,retained-3,01/08/2024,31/12/2024,31/01/2025
-ecf_standard,ecf-standard-september,ECF Standard September,2023,Output 5 - Retention Point 4,retained-4,01/01/2025,31/03/2025,30/04/2025
-ecf_standard,ecf-standard-september,ECF Standard September,2023,Output 6 - Participant Completion,completed,01/04/2025,31/07/2025,31/08/2025
-ecf_standard,ecf-standard-january,ECF Standard January,2023,Output 1 - Participant Start,started,01/01/2024,31/03/2024,30/04/2024
-ecf_standard,ecf-standard-january,ECF Standard January,2023,Output 2 - Retention Point 1,retained-1,01/04/2024,31/07/2024,31/08/2024
-ecf_standard,ecf-standard-january,ECF Standard January,2023,Output 3 - Retention Point 2,retained-2,01/08/2024,31/12/2024,31/01/2025
-ecf_standard,ecf-standard-january,ECF Standard January,2023,Output 4 - Retention Point 3,retained-3,01/01/2025,31/03/2025,30/04/2025
-ecf_standard,ecf-standard-january,ECF Standard January,2023,Output 5 - Retention Point 4,retained-4,01/04/2025,31/07/2025,31/08/2025
-ecf_standard,ecf-standard-january,ECF Standard January,2023,Output 6 - Participant Completion,completed,01/08/2025,31/12/2025,31/01/2026
-ecf_standard,ecf-standard-april,ECF Standard April,2023,Output 1 - Participant Start,started,01/04/2024,31/07/2024,31/08/2024
-ecf_standard,ecf-standard-april,ECF Standard April,2023,Output 2 - Retention Point 1,retained-1,01/08/2024,31/12/2024,31/01/2025
-ecf_standard,ecf-standard-april,ECF Standard April,2023,Output 3 - Retention Point 2,retained-2,01/01/2025,31/03/2025,30/04/2025
-ecf_standard,ecf-standard-april,ECF Standard April,2023,Output 4 - Retention Point 3,retained-3,01/04/2025,31/07/2025,31/08/2025
-ecf_standard,ecf-standard-april,ECF Standard April,2023,Output 5 - Retention Point 4,retained-4,01/08/2025,31/12/2025,31/01/2026
-ecf_standard,ecf-standard-april,ECF Standard April,2023,Output 6 - Participant Completion,completed,01/01/2026,31/03/2026,30/04/2026
-ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 1 - Participant Start,started,01/09/2023,,01/09/2023
-ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 2 - Retention Point 1,retained-1,01/09/2023,,01/09/2023
-ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 3 - Retention Point 2,retained-2,01/09/2023,,01/09/2023
-ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 4 - Retention Point 3,retained-3,01/09/2023,,01/09/2023
-ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 5 - Retention Point 4,retained-4,01/09/2023,,01/09/2023
-ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 6 - Participant Completion,completed,01/09/2023,,01/09/2023
-ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 1 - Participant Start,started,01/01/2024,,01/01/2024
-ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 2 - Retention Point 1,retained-1,01/01/2024,,01/01/2024
-ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 3 - Retention Point 2,retained-2,01/01/2024,,01/01/2024
-ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 4 - Retention Point 3,retained-3,01/01/2024,,01/01/2024
-ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 5 - Retention Point 4,retained-4,01/01/2024,,01/01/2024
-ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 6 - Participant Completion,completed,01/01/2024,,01/01/2024
-ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 1 - Participant Start,started,01/04/2024,,01/04/2024
-ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 2 - Retention Point 1,retained-1,01/04/2024,,01/04/2024
-ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 3 - Retention Point 2,retained-2,01/04/2024,,01/04/2024
-ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 4 - Retention Point 3,retained-3,01/04/2024,,01/04/2024
-ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 5 - Retention Point 4,retained-4,01/04/2024,,01/04/2024
-ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 6 - Participant Completion,completed,01/04/2024,,01/04/2024
-ecf_reduced,ecf-reduced-september,ECF Reduced September,2023,Output 1 - Participant Start,started,01/09/2023,,01/09/2023
-ecf_reduced,ecf-reduced-september,ECF Reduced September,2023,Output 2 - Retention Point 1,retained-1,01/09/2023,,01/09/2023
-ecf_reduced,ecf-reduced-september,ECF Reduced September,2023,Output 3 - Retention Point 2,retained-2,01/09/2023,,01/09/2023
-ecf_reduced,ecf-reduced-september,ECF Reduced September,2023,Output 4 - Retention Point 3,retained-3,01/09/2023,,01/09/2023
-ecf_reduced,ecf-reduced-september,ECF Reduced September,2023,Output 5 - Retention Point 4,retained-4,01/09/2023,,01/09/2023
-ecf_reduced,ecf-reduced-september,ECF Reduced September,2023,Output 6 - Participant Completion,completed,01/09/2023,,01/09/2023
-ecf_reduced,ecf-reduced-january,ECF Reduced January,2023,Output 1 - Participant Start,started,01/01/2024,,01/01/2024
-ecf_reduced,ecf-reduced-january,ECF Reduced January,2023,Output 2 - Retention Point 1,retained-1,01/01/2024,,01/01/2024
-ecf_reduced,ecf-reduced-january,ECF Reduced January,2023,Output 3 - Retention Point 2,retained-2,01/01/2024,,01/01/2024
-ecf_reduced,ecf-reduced-january,ECF Reduced January,2023,Output 4 - Retention Point 3,retained-3,01/01/2024,,01/01/2024
-ecf_reduced,ecf-reduced-january,ECF Reduced January,2023,Output 5 - Retention Point 4,retained-4,01/01/2024,,01/01/2024
-ecf_reduced,ecf-reduced-january,ECF Reduced January,2023,Output 6 - Participant Completion,completed,01/01/2024,,01/01/2024
-ecf_reduced,ecf-reduced-april,ECF Reduced April,2023,Output 1 - Participant Start,started,01/04/2024,,01/04/2024
-ecf_reduced,ecf-reduced-april,ECF Reduced April,2023,Output 2 - Retention Point 1,retained-1,01/04/2024,,01/04/2024
-ecf_reduced,ecf-reduced-april,ECF Reduced April,2023,Output 3 - Retention Point 2,retained-2,01/04/2024,,01/04/2024
-ecf_reduced,ecf-reduced-april,ECF Reduced April,2023,Output 4 - Retention Point 3,retained-3,01/04/2024,,01/04/2024
-ecf_reduced,ecf-reduced-april,ECF Reduced April,2023,Output 5 - Retention Point 4,retained-4,01/04/2024,,01/04/2024
-ecf_reduced,ecf-reduced-april,ECF Reduced April,2023,Output 6 - Participant Completion,completed,01/04/2024,,01/04/2024
-ecf_replacement,ecf-replacement-september,ECF Replacement September,2023,Output 1 - Participant Start,started,01/09/2023,,01/09/2023
-ecf_replacement,ecf-replacement-september,ECF Replacement September,2023,Output 2 - Retention Point 1,retained-1,01/09/2023,,01/09/2023
-ecf_replacement,ecf-replacement-september,ECF Replacement September,2023,Output 3 - Retention Point 2,retained-2,01/09/2023,,01/09/2023
-ecf_replacement,ecf-replacement-september,ECF Replacement September,2023,Output 4 - Retention Point 3,retained-3,01/09/2023,,01/09/2023
-ecf_replacement,ecf-replacement-september,ECF Replacement September,2023,Output 5 - Retention Point 4,retained-4,01/09/2023,,01/09/2023
-ecf_replacement,ecf-replacement-september,ECF Replacement September,2023,Output 6 - Participant Completion,completed,01/09/2023,,01/09/2023
-ecf_replacement,ecf-replacement-january,ECF Replacement January,2023,Output 1 - Participant Start,started,01/01/2024,,01/01/2024
-ecf_replacement,ecf-replacement-january,ECF Replacement January,2023,Output 2 - Retention Point 1,retained-1,01/01/2024,,01/01/2024
-ecf_replacement,ecf-replacement-january,ECF Replacement January,2023,Output 3 - Retention Point 2,retained-2,01/01/2024,,01/01/2024
-ecf_replacement,ecf-replacement-january,ECF Replacement January,2023,Output 4 - Retention Point 3,retained-3,01/01/2024,,01/01/2024
-ecf_replacement,ecf-replacement-january,ECF Replacement January,2023,Output 5 - Retention Point 4,retained-4,01/01/2024,,01/01/2024
-ecf_replacement,ecf-replacement-january,ECF Replacement January,2023,Output 6 - Participant Completion,completed,01/01/2024,,01/01/2024
-ecf_replacement,ecf-replacement-april,ECF Replacement April,2023,Output 1 - Participant Start,started,01/04/2024,,01/04/2024
-ecf_replacement,ecf-replacement-april,ECF Replacement April,2023,Output 2 - Retention Point 1,retained-1,01/04/2024,,01/04/2024
-ecf_replacement,ecf-replacement-april,ECF Replacement April,2023,Output 3 - Retention Point 2,retained-2,01/04/2024,,01/04/2024
-ecf_replacement,ecf-replacement-april,ECF Replacement April,2023,Output 4 - Retention Point 3,retained-3,01/04/2024,,01/04/2024
-ecf_replacement,ecf-replacement-april,ECF Replacement April,2023,Output 5 - Retention Point 4,retained-4,01/04/2024,,01/04/2024
-ecf_replacement,ecf-replacement-april,ECF Replacement April,2023,Output 6 - Participant Completion,completed,01/04/2024,,01/04/2024
-ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 7 - Extended Point 1,extended-1,01/09/2021,,01/09/2021
-ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 8 - Extended Point 2,extended-2,01/09/2021,,01/09/2021
-ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 9 - Extended Point 3,extended-3,01/09/2021,,01/09/2021
-ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 7 - Extended Point 1,extended-1,01/01/2022,,01/01/2022
-ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 8 - Extended Point 2,extended-2,01/01/2022,,01/01/2022
-ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 9 - Extended Point 3,extended-3,01/01/2022,,01/01/2022
-ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 7 - Extended Point 1,extended-1,01/04/2022,,01/04/2022
-ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 8 - Extended Point 2,extended-2,01/04/2022,,01/04/2022
-ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 9 - Extended Point 3,extended-3,01/04/2022,,01/04/2022
-ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 7 - Extended Point 1,extended-1,01/09/2022,,01/09/2022
-ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 8 - Extended Point 2,extended-2,01/09/2022,,01/09/2022
-ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 9 - Extended Point 3,extended-3,01/09/2022,,01/09/2022
-ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 7 - Extended Point 1,extended-1,01/01/2023,,01/01/2023
-ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 8 - Extended Point 2,extended-2,01/01/2023,,01/01/2023
-ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 9 - Extended Point 3,extended-3,01/01/2023,,01/01/2023
-ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 7 - Extended Point 1,extended-1,01/04/2023,,01/04/2023
-ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 8 - Extended Point 2,extended-2,01/04/2023,,01/04/2023
-ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 9 - Extended Point 3,extended-3,01/04/2023,,01/04/2023
-ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 7 - Extended Point 1,extended-1,01/09/2023,,01/09/2023
-ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 8 - Extended Point 2,extended-2,01/09/2023,,01/09/2023
-ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 9 - Extended Point 3,extended-3,01/09/2023,,01/09/2023
-ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 7 - Extended Point 1,extended-1,01/01/2024,,01/01/2024
-ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 8 - Extended Point 2,extended-2,01/01/2024,,01/01/2024
-ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 9 - Extended Point 3,extended-3,01/01/2024,,01/01/2024
-ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 7 - Extended Point 1,extended-1,01/04/2024,,01/04/2024
-ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 8 - Extended Point 2,extended-2,01/04/2024,,01/04/2024
-ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 9 - Extended Point 3,extended-3,01/04/2024,,01/04/2024
+npq_ehco,npq-ehco-june,NPQ EHCO June,2023,Output 1 - Participant Start,started,2024-06-01,,2024-06-01
+npq_ehco,npq-ehco-june,NPQ EHCO June,2023,Output 2 - Retention Point 1,retained-1,2024-06-01,,2024-06-01
+npq_ehco,npq-ehco-june,NPQ EHCO June,2023,Output 3 - Retention Point 2,retained-2,2024-06-01,,2024-06-01
+npq_ehco,npq-ehco-june,NPQ EHCO June,2023,Output 4 - Participant Completion,completed,2024-06-01,,2024-06-01
+ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 1 - Participant Start,started,2023-09-01,,2023-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 2 - Retention Point 1,retained-1,2023-09-01,,2023-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 3 - Retention Point 2,retained-2,2023-09-01,,2023-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 4 - Retention Point 3,retained-3,2023-09-01,,2023-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 5 - Retention Point 4,retained-4,2023-09-01,,2023-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 6 - Participant Completion,completed,2023-09-01,,2023-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 7 - Extended Point 1,extended-1,2023-09-01,,2023-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 8 - Extended Point 2,extended-2,2023-09-01,,2023-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 9 - Extended Point 3,extended-3,2023-09-01,,2023-09-01
+ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 1 - Participant Start,started,2024-01-01,,2024-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 2 - Retention Point 1,retained-1,2024-01-01,,2024-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 3 - Retention Point 2,retained-2,2024-01-01,,2024-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 4 - Retention Point 3,retained-3,2024-01-01,,2024-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 5 - Retention Point 4,retained-4,2024-01-01,,2024-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 6 - Participant Completion,completed,2024-01-01,,2024-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 7 - Extended Point 1,extended-1,2024-01-01,,2024-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 8 - Extended Point 2,extended-2,2024-01-01,,2024-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 9 - Extended Point 3,extended-3,2024-01-01,,2024-01-01
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2021,Output 1 - Participant Start,started,2022-04-01,,2022-04-01
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2021,Output 2 - Retention Point 1,retained-1,2022-04-01,,2022-04-01
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2021,Output 3 - Retention Point 2,retained-2,2022-04-01,,2022-04-01
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2021,Output 4 - Retention Point 3,retained-3,2022-04-01,,2022-04-01
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2021,Output 5 - Retention Point 4,retained-4,2022-04-01,,2022-04-01
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2021,Output 6 - Participant Completion,completed,2022-04-01,,2022-04-01
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2022,Output 1 - Participant Start,started,2022-09-01,,2022-09-01
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2022,Output 2 - Retention Point 1,retained-1,2022-09-01,,2022-09-01
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2022,Output 3 - Retention Point 2,retained-2,2022-09-01,,2022-09-01
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2022,Output 4 - Retention Point 3,retained-3,2022-09-01,,2022-09-01
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2022,Output 5 - Retention Point 4,retained-4,2022-09-01,,2022-09-01
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2022,Output 6 - Participant Completion,completed,2022-09-01,,2022-09-01
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2022,Output 1 - Participant Start,started,2023-01-01,,2023-01-01
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2022,Output 2 - Retention Point 1,retained-1,2023-01-01,,2023-01-01
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2022,Output 3 - Retention Point 2,retained-2,2023-01-01,,2023-01-01
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2022,Output 4 - Retention Point 3,retained-3,2023-01-01,,2023-01-01
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2022,Output 5 - Retention Point 4,retained-4,2023-01-01,,2023-01-01
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2022,Output 6 - Participant Completion,completed,2023-01-01,,2023-01-01
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2022,Output 1 - Participant Start,started,2023-04-01,,2023-04-01
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2022,Output 2 - Retention Point 1,retained-1,2023-04-01,,2023-04-01
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2022,Output 3 - Retention Point 2,retained-2,2023-04-01,,2023-04-01
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2022,Output 4 - Retention Point 3,retained-3,2023-04-01,,2023-04-01
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2022,Output 5 - Retention Point 4,retained-4,2023-04-01,,2023-04-01
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2022,Output 6 - Participant Completion,completed,2023-04-01,,2023-04-01
+npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2022,Output 1 - Participant Start,started,2022-10-01,,2022-11-01
+npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2022,Output 2 - Retention Point 1,retained-1,2022-10-01,,2022-11-01
+npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2022,Output 3 - Participant Completion,completed,2022-10-01,,2022-11-01
+ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 1 - Participant Start,started,2022-09-01,,2022-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 2 - Retention Point 1,retained-1,2022-09-01,,2022-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 3 - Retention Point 2,retained-2,2022-09-01,,2022-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 4 - Retention Point 3,retained-3,2022-09-01,,2022-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 5 - Retention Point 4,retained-4,2022-09-01,,2022-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 6 - Participant Completion,completed,2022-09-01,,2022-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 7 - Extended Point 1,extended-1,2022-09-01,,2022-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 8 - Extended Point 2,extended-2,2022-09-01,,2022-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 9 - Extended Point 3,extended-3,2022-09-01,,2022-09-01
+ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 1 - Participant Start,started,2023-01-01,,2023-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 2 - Retention Point 1,retained-1,2023-01-01,,2023-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 3 - Retention Point 2,retained-2,2023-01-01,,2023-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 4 - Retention Point 3,retained-3,2023-01-01,,2023-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 5 - Retention Point 4,retained-4,2023-01-01,,2023-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 6 - Participant Completion,completed,2023-01-01,,2023-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 7 - Extended Point 1,extended-1,2023-01-01,,2023-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 8 - Extended Point 2,extended-2,2023-01-01,,2023-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 9 - Extended Point 3,extended-3,2023-01-01,,2023-01-01
+npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2022,Output 1 - Participant Start,started,2022-10-01,,2022-11-01
+npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2022,Output 2 - Retention Point 1,retained-1,2022-10-01,,2022-11-01
+npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2022,Output 3 - Retention Point 2,retained-2,2022-10-01,,2022-11-01
+npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2022,Output 4 - Participant Completion,completed,2022-10-01,,2022-11-01
+ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 1 - Participant Start,started,2023-04-01,,2023-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 2 - Retention Point 1,retained-1,2023-04-01,,2023-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 3 - Retention Point 2,retained-2,2023-04-01,,2023-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 4 - Retention Point 3,retained-3,2023-04-01,,2023-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 5 - Retention Point 4,retained-4,2023-04-01,,2023-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 6 - Participant Completion,completed,2023-04-01,,2023-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 7 - Extended Point 1,extended-1,2023-04-01,,2023-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 8 - Extended Point 2,extended-2,2023-04-01,,2023-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 9 - Extended Point 3,extended-3,2023-04-01,,2023-04-01
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2022,Output 1 - Participant Start,started,2022-09-01,,2022-09-01
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2022,Output 2 - Retention Point 1,retained-1,2022-09-01,,2022-09-01
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2022,Output 3 - Retention Point 2,retained-2,2022-09-01,,2022-09-01
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2022,Output 4 - Retention Point 3,retained-3,2022-09-01,,2022-09-01
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2022,Output 5 - Retention Point 4,retained-4,2022-09-01,,2022-09-01
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2022,Output 6 - Participant Completion,completed,2022-09-01,,2022-09-01
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2022,Output 1 - Participant Start,started,2023-01-01,,2023-01-01
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2022,Output 2 - Retention Point 1,retained-1,2023-01-01,,2023-01-01
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2022,Output 3 - Retention Point 2,retained-2,2023-01-01,,2023-01-01
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2022,Output 4 - Retention Point 3,retained-3,2023-01-01,,2023-01-01
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2022,Output 5 - Retention Point 4,retained-4,2023-01-01,,2023-01-01
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2022,Output 6 - Participant Completion,completed,2023-01-01,,2023-01-01
+ecf_standard,ecf-standard-january,ECF Standard January,2022,Output 1 - Participant Start,started,2023-01-01,2023-03-31,2023-04-30
+ecf_standard,ecf-standard-january,ECF Standard January,2022,Output 2 - Retention Point 1,retained-1,2023-04-01,2023-07-31,2023-08-31
+ecf_standard,ecf-standard-january,ECF Standard January,2022,Output 3 - Retention Point 2,retained-2,2023-08-01,2023-12-31,2024-01-31
+ecf_standard,ecf-standard-january,ECF Standard January,2022,Output 4 - Retention Point 3,retained-3,2024-01-01,2024-03-31,2024-04-30
+ecf_standard,ecf-standard-january,ECF Standard January,2022,Output 5 - Retention Point 4,retained-4,2024-04-01,2024-07-31,2024-08-31
+ecf_standard,ecf-standard-january,ECF Standard January,2022,Output 6 - Participant Completion,completed,2024-08-01,2024-12-31,2025-01-31
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2022,Output 1 - Participant Start,started,2023-04-01,,2023-04-01
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2022,Output 2 - Retention Point 1,retained-1,2023-04-01,,2023-04-01
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2022,Output 3 - Retention Point 2,retained-2,2023-04-01,,2023-04-01
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2022,Output 4 - Retention Point 3,retained-3,2023-04-01,,2023-04-01
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2022,Output 5 - Retention Point 4,retained-4,2023-04-01,,2023-04-01
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2022,Output 6 - Participant Completion,completed,2023-04-01,,2023-04-01
+npq_ehco,npq-ehco-june,NPQ EHCO June,2022,Output 1 - Participant Start,started,2023-06-01,,2023-06-01
+npq_ehco,npq-ehco-june,NPQ EHCO June,2022,Output 2 - Retention Point 1,retained-1,2023-06-01,,2023-06-01
+npq_ehco,npq-ehco-june,NPQ EHCO June,2022,Output 3 - Retention Point 2,retained-2,2023-06-01,,2023-06-01
+npq_ehco,npq-ehco-june,NPQ EHCO June,2022,Output 4 - Participant Completion,completed,2023-06-01,,2023-06-01
+npq_ehco,npq-ehco-june,NPQ EHCO June,2022,Output 1 - Participant Start,started,2023-06-01,,2023-06-01
+npq_ehco,npq-ehco-june,NPQ EHCO June,2022,Output 2 - Retention Point 1,retained-1,2023-06-01,,2023-06-01
+npq_ehco,npq-ehco-june,NPQ EHCO June,2022,Output 3 - Retention Point 2,retained-2,2023-06-01,,2023-06-01
+npq_ehco,npq-ehco-june,NPQ EHCO June,2022,Output 4 - Participant Completion,completed,2023-06-01,,2023-06-01
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2021,Output 1 - Participant Start,started,2022-01-01,,2022-01-01
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2021,Output 2 - Retention Point 1,retained-1,2022-01-01,,2022-01-01
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2021,Output 3 - Retention Point 2,retained-2,2022-01-01,,2022-01-01
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2021,Output 4 - Retention Point 3,retained-3,2022-01-01,,2022-01-01
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2021,Output 5 - Retention Point 4,retained-4,2022-01-01,,2022-01-01
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2021,Output 6 - Participant Completion,completed,2022-01-01,,2022-01-01
+ecf_standard,ecf-standard-april,ECF Standard April,2022,Output 1 - Participant Start,started,2023-04-01,2023-07-31,2023-08-31
+ecf_standard,ecf-standard-april,ECF Standard April,2022,Output 2 - Retention Point 1,retained-1,2023-08-01,2023-12-31,2024-01-31
+ecf_standard,ecf-standard-april,ECF Standard April,2022,Output 3 - Retention Point 2,retained-2,2024-01-01,2024-03-31,2024-04-30
+ecf_standard,ecf-standard-april,ECF Standard April,2022,Output 4 - Retention Point 3,retained-3,2024-04-01,2024-07-31,2024-08-31
+ecf_standard,ecf-standard-april,ECF Standard April,2022,Output 5 - Retention Point 4,retained-4,2024-08-01,2024-12-31,2025-01-31
+ecf_standard,ecf-standard-april,ECF Standard April,2022,Output 6 - Participant Completion,completed,2025-01-01,2025-03-31,2025-04-30
+npq_ehco,npq-ehco-march,NPQ EHCO March,2022,Output 1 - Participant Start,started,2023-03-01,,2023-03-01
+npq_ehco,npq-ehco-march,NPQ EHCO March,2022,Output 2 - Retention Point 1,retained-1,2023-03-01,,2023-03-01
+npq_ehco,npq-ehco-march,NPQ EHCO March,2022,Output 3 - Retention Point 2,retained-2,2023-03-01,,2023-03-01
+npq_ehco,npq-ehco-march,NPQ EHCO March,2022,Output 4 - Participant Completion,completed,2023-03-01,,2023-03-01
+npq_ehco,npq-ehco-march,NPQ EHCO March,2022,Output 1 - Participant Start,started,2023-03-01,,2023-03-01
+npq_ehco,npq-ehco-march,NPQ EHCO March,2022,Output 2 - Retention Point 1,retained-1,2023-03-01,,2023-03-01
+npq_ehco,npq-ehco-march,NPQ EHCO March,2022,Output 3 - Retention Point 2,retained-2,2023-03-01,,2023-03-01
+npq_ehco,npq-ehco-march,NPQ EHCO March,2022,Output 4 - Participant Completion,completed,2023-03-01,,2023-03-01
+ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 1 - Participant Start,started,2022-04-01,,2022-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 2 - Retention Point 1,retained-1,2022-04-01,,2022-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 3 - Retention Point 2,retained-2,2022-04-01,,2022-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 4 - Retention Point 3,retained-3,2022-04-01,,2022-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 5 - Retention Point 4,retained-4,2022-04-01,,2022-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 6 - Participant Completion,completed,2022-04-01,,2022-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 7 - Extended Point 1,extended-1,2022-04-01,,2022-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 8 - Extended Point 2,extended-2,2022-04-01,,2022-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 9 - Extended Point 3,extended-3,2022-04-01,,2022-04-01
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2021,Output 1 - Participant Start,started,2022-01-01,,2022-01-01
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2021,Output 2 - Retention Point 1,retained-1,2022-01-01,,2022-01-01
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2021,Output 3 - Retention Point 2,retained-2,2022-01-01,,2022-01-01
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2021,Output 4 - Retention Point 3,retained-3,2022-01-01,,2022-01-01
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2021,Output 5 - Retention Point 4,retained-4,2022-01-01,,2022-01-01
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2021,Output 6 - Participant Completion,completed,2022-01-01,,2022-01-01
+npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2022,Output 1 - Participant Start,started,2023-01-01,,2023-01-01
+npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2022,Output 2 - Retention Point 1,retained-1,2023-01-01,,2023-01-01
+npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2022,Output 3 - Retention Point 2,retained-2,2023-01-01,,2023-01-01
+npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2022,Output 4 - Participant Completion,completed,2023-01-01,,2023-01-01
+npq_ehco,npq-ehco-december,NPQ EHCO December,2022,Output 1 - Participant Start,started,2022-12-01,,2022-12-01
+npq_ehco,npq-ehco-december,NPQ EHCO December,2022,Output 2 - Retention Point 1,retained-1,2022-12-01,,2022-12-01
+npq_ehco,npq-ehco-december,NPQ EHCO December,2022,Output 3 - Retention Point 2,retained-2,2022-12-01,,2022-12-01
+npq_ehco,npq-ehco-december,NPQ EHCO December,2022,Output 4 - Participant Completion,completed,2022-12-01,,2022-12-01
+npq_ehco,npq-ehco-december,NPQ EHCO December,2022,Output 1 - Participant Start,started,2022-12-01,,2022-12-01
+npq_ehco,npq-ehco-december,NPQ EHCO December,2022,Output 2 - Retention Point 1,retained-1,2022-12-01,,2022-12-01
+npq_ehco,npq-ehco-december,NPQ EHCO December,2022,Output 3 - Retention Point 2,retained-2,2022-12-01,,2022-12-01
+npq_ehco,npq-ehco-december,NPQ EHCO December,2022,Output 4 - Participant Completion,completed,2022-12-01,,2022-12-01
+npq_ehco,npq-ehco-june,NPQ EHCO June,2021,Output 1 - Participant Start,started,2022-06-01,,2022-06-01
+npq_ehco,npq-ehco-june,NPQ EHCO June,2021,Output 2 - Retention Point 1,retained-1,2022-06-01,,2022-06-01
+npq_ehco,npq-ehco-june,NPQ EHCO June,2021,Output 3 - Retention Point 2,retained-2,2022-06-01,,2022-06-01
+npq_ehco,npq-ehco-june,NPQ EHCO June,2021,Output 4 - Participant Completion,completed,2022-06-01,,2022-06-01
+ecf_standard,ecf-standard-september,ECF Standard September,2022,Output 1 - Participant Start,started,2022-06-01,2022-12-31,2022-11-30
+ecf_standard,ecf-standard-september,ECF Standard September,2022,Output 2 - Retention Point 1,retained-1,2023-01-01,2023-03-31,2023-04-30
+ecf_standard,ecf-standard-september,ECF Standard September,2022,Output 3 - Retention Point 2,retained-2,2023-04-01,2023-07-31,2023-08-31
+ecf_standard,ecf-standard-september,ECF Standard September,2022,Output 4 - Retention Point 3,retained-3,2023-08-01,2023-12-31,2024-01-31
+ecf_standard,ecf-standard-september,ECF Standard September,2022,Output 5 - Retention Point 4,retained-4,2024-01-01,2024-03-31,2024-04-30
+ecf_standard,ecf-standard-september,ECF Standard September,2022,Output 6 - Participant Completion,completed,2024-04-01,2024-07-31,2024-08-31
+npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2023,Output 1 - Participant Start,started,2023-10-01,,2023-11-01
+npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2023,Output 2 - Retention Point 1,retained-1,2023-10-01,,2023-11-01
+npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2023,Output 3 - Retention Point 2,retained-2,2023-10-01,,2023-11-01
+npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2023,Output 4 - Participant Completion,completed,2023-10-01,,2023-11-01
+npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2022,Output 1 - Participant Start,started,2023-01-01,,2023-01-01
+npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2022,Output 2 - Retention Point 1,retained-1,2023-01-01,,2023-01-01
+npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2022,Output 3 - Participant Completion,completed,2023-01-01,,2023-01-01
+npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2023,Output 1 - Participant Start,started,2024-01-01,,2024-01-01
+npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2023,Output 2 - Retention Point 1,retained-1,2024-01-01,,2024-01-01
+npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2023,Output 3 - Retention Point 2,retained-2,2024-01-01,,2024-01-01
+npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2023,Output 4 - Participant Completion,completed,2024-01-01,,2024-01-01
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2021,Output 1 - Participant Start,started,2021-09-01,,2021-09-01
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2021,Output 2 - Retention Point 1,retained-1,2021-09-01,,2021-09-01
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2021,Output 3 - Retention Point 2,retained-2,2021-09-01,,2021-09-01
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2021,Output 4 - Retention Point 3,retained-3,2021-09-01,,2021-09-01
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2021,Output 5 - Retention Point 4,retained-4,2021-09-01,,2021-09-01
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2021,Output 6 - Participant Completion,completed,2021-09-01,,2021-09-01
+npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2023,Output 1 - Participant Start,started,2023-10-01,,2023-11-01
+npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2023,Output 2 - Retention Point 1,retained-1,2023-10-01,,2023-11-01
+npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2023,Output 3 - Participant Completion,completed,2023-10-01,,2023-11-01
+npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2023,Output 1 - Participant Start,started,2024-01-01,,2024-01-01
+npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2023,Output 2 - Retention Point 1,retained-1,2024-01-01,,2024-01-01
+npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2023,Output 3 - Participant Completion,completed,2024-01-01,,2024-01-01
+ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 1 - Participant Start,started,2021-09-01,,2021-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 2 - Retention Point 1,retained-1,2021-09-01,,2021-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 3 - Retention Point 2,retained-2,2021-09-01,,2021-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 4 - Retention Point 3,retained-3,2021-09-01,,2021-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 5 - Retention Point 4,retained-4,2021-09-01,,2021-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 6 - Participant Completion,completed,2021-09-01,,2021-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 7 - Extended Point 1,extended-1,2021-09-01,,2021-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 8 - Extended Point 2,extended-2,2021-09-01,,2021-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 9 - Extended Point 3,extended-3,2021-09-01,,2021-09-01
+ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 1 - Participant Start,started,2022-01-01,,2022-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 2 - Retention Point 1,retained-1,2022-01-01,,2022-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 3 - Retention Point 2,retained-2,2022-01-01,,2022-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 4 - Retention Point 3,retained-3,2022-01-01,,2022-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 5 - Retention Point 4,retained-4,2022-01-01,,2022-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 6 - Participant Completion,completed,2022-01-01,,2022-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 7 - Extended Point 1,extended-1,2022-01-01,,2022-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 8 - Extended Point 2,extended-2,2022-01-01,,2022-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 9 - Extended Point 3,extended-3,2022-01-01,,2022-01-01
+npq_ehco,npq-ehco-november,NPQ EHCO November,2022,Output 1 - Participant Start,started,2022-10-01,,2022-11-01
+npq_ehco,npq-ehco-november,NPQ EHCO November,2022,Output 2 - Retention Point 1,retained-1,2022-10-01,,2022-11-01
+npq_ehco,npq-ehco-november,NPQ EHCO November,2022,Output 3 - Retention Point 2,retained-2,2022-10-01,,2022-11-01
+npq_ehco,npq-ehco-november,NPQ EHCO November,2022,Output 4 - Participant Completion,completed,2022-10-01,,2022-11-01
+npq_ehco,npq-ehco-november,NPQ EHCO November,2022,Output 1 - Participant Start,started,2022-10-01,,2022-11-01
+npq_ehco,npq-ehco-november,NPQ EHCO November,2022,Output 2 - Retention Point 1,retained-1,2022-10-01,,2022-11-01
+npq_ehco,npq-ehco-november,NPQ EHCO November,2022,Output 3 - Retention Point 2,retained-2,2022-10-01,,2022-11-01
+npq_ehco,npq-ehco-november,NPQ EHCO November,2022,Output 4 - Participant Completion,completed,2022-10-01,,2022-11-01
+npq_ehco,npq-ehco-november,NPQ EHCO November,2023,Output 1 - Participant Start,started,2023-11-01,,2023-11-01
+npq_ehco,npq-ehco-november,NPQ EHCO November,2023,Output 2 - Retention Point 1,retained-1,2023-11-01,,2023-11-01
+npq_ehco,npq-ehco-november,NPQ EHCO November,2023,Output 3 - Retention Point 2,retained-2,2023-11-01,,2023-11-01
+npq_ehco,npq-ehco-november,NPQ EHCO November,2023,Output 4 - Participant Completion,completed,2023-11-01,,2023-11-01
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2021,Output 1 - Participant Start,started,2022-04-01,,2022-04-01
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2021,Output 2 - Retention Point 1,retained-1,2022-04-01,,2022-04-01
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2021,Output 3 - Retention Point 2,retained-2,2022-04-01,,2022-04-01
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2021,Output 4 - Retention Point 3,retained-3,2022-04-01,,2022-04-01
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2021,Output 5 - Retention Point 4,retained-4,2022-04-01,,2022-04-01
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2021,Output 6 - Participant Completion,completed,2022-04-01,,2022-04-01
+npq_ehco,npq-ehco-december,NPQ EHCO December,2023,Output 1 - Participant Start,started,2023-12-01,,2023-12-01
+npq_ehco,npq-ehco-december,NPQ EHCO December,2023,Output 2 - Retention Point 1,retained-1,2023-12-01,,2023-12-01
+npq_ehco,npq-ehco-december,NPQ EHCO December,2023,Output 3 - Retention Point 2,retained-2,2023-12-01,,2023-12-01
+npq_ehco,npq-ehco-december,NPQ EHCO December,2023,Output 4 - Participant Completion,completed,2023-12-01,,2023-12-01
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2021,Output 1 - Participant Start,started,2021-09-01,,2021-09-01
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2021,Output 2 - Retention Point 1,retained-1,2021-09-01,,2021-09-01
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2021,Output 3 - Retention Point 2,retained-2,2021-09-01,,2021-09-01
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2021,Output 4 - Retention Point 3,retained-3,2021-09-01,,2021-09-01
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2021,Output 5 - Retention Point 4,retained-4,2021-09-01,,2021-09-01
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2021,Output 6 - Participant Completion,completed,2021-09-01,,2021-09-01
+npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2021,Output 1 - Participant Start,started,2022-01-01,,2022-01-01
+npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2021,Output 2 - Retention Point 1,retained-1,2022-01-01,,2022-01-01
+npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2021,Output 3 - Retention Point 2,retained-2,2022-01-01,,2022-01-01
+npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2021,Output 4 - Participant Completion,completed,2022-01-01,,2022-01-01
+npq_ehco,npq-ehco-march,NPQ EHCO March,2023,Output 1 - Participant Start,started,2024-03-01,,2024-03-01
+npq_ehco,npq-ehco-march,NPQ EHCO March,2023,Output 2 - Retention Point 1,retained-1,2024-03-01,,2024-03-01
+npq_ehco,npq-ehco-march,NPQ EHCO March,2023,Output 3 - Retention Point 2,retained-2,2024-03-01,,2024-03-01
+npq_ehco,npq-ehco-march,NPQ EHCO March,2023,Output 4 - Participant Completion,completed,2024-03-01,,2024-03-01
+ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 1 - Participant Start,started,2024-04-01,,2024-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 2 - Retention Point 1,retained-1,2024-04-01,,2024-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 3 - Retention Point 2,retained-2,2024-04-01,,2024-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 4 - Retention Point 3,retained-3,2024-04-01,,2024-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 5 - Retention Point 4,retained-4,2024-04-01,,2024-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 6 - Participant Completion,completed,2024-04-01,,2024-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 7 - Extended Point 1,extended-1,2024-04-01,,2024-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 8 - Extended Point 2,extended-2,2024-04-01,,2024-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 9 - Extended Point 3,extended-3,2024-04-01,,2024-04-01
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2023,Output 1 - Participant Start,started,2023-09-01,,2023-09-01
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2023,Output 2 - Retention Point 1,retained-1,2023-09-01,,2023-09-01
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2023,Output 3 - Retention Point 2,retained-2,2023-09-01,,2023-09-01
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2023,Output 4 - Retention Point 3,retained-3,2023-09-01,,2023-09-01
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2023,Output 5 - Retention Point 4,retained-4,2023-09-01,,2023-09-01
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2023,Output 6 - Participant Completion,completed,2023-09-01,,2023-09-01
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2023,Output 1 - Participant Start,started,2024-01-01,,2024-01-01
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2023,Output 2 - Retention Point 1,retained-1,2024-01-01,,2024-01-01
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2023,Output 3 - Retention Point 2,retained-2,2024-01-01,,2024-01-01
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2023,Output 4 - Retention Point 3,retained-3,2024-01-01,,2024-01-01
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2023,Output 5 - Retention Point 4,retained-4,2024-01-01,,2024-01-01
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2023,Output 6 - Participant Completion,completed,2024-01-01,,2024-01-01
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2023,Output 1 - Participant Start,started,2024-04-01,,2024-04-01
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2023,Output 2 - Retention Point 1,retained-1,2024-04-01,,2024-04-01
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2023,Output 3 - Retention Point 2,retained-2,2024-04-01,,2024-04-01
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2023,Output 4 - Retention Point 3,retained-3,2024-04-01,,2024-04-01
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2023,Output 5 - Retention Point 4,retained-4,2024-04-01,,2024-04-01
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2023,Output 6 - Participant Completion,completed,2024-04-01,,2024-04-01
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2023,Output 1 - Participant Start,started,2023-09-01,,2023-09-01
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2023,Output 2 - Retention Point 1,retained-1,2023-09-01,,2023-09-01
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2023,Output 3 - Retention Point 2,retained-2,2023-09-01,,2023-09-01
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2023,Output 4 - Retention Point 3,retained-3,2023-09-01,,2023-09-01
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2023,Output 5 - Retention Point 4,retained-4,2023-09-01,,2023-09-01
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2023,Output 6 - Participant Completion,completed,2023-09-01,,2023-09-01
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2023,Output 1 - Participant Start,started,2024-01-01,,2024-01-01
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2023,Output 2 - Retention Point 1,retained-1,2024-01-01,,2024-01-01
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2023,Output 3 - Retention Point 2,retained-2,2024-01-01,,2024-01-01
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2023,Output 4 - Retention Point 3,retained-3,2024-01-01,,2024-01-01
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2023,Output 5 - Retention Point 4,retained-4,2024-01-01,,2024-01-01
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2023,Output 6 - Participant Completion,completed,2024-01-01,,2024-01-01
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2023,Output 1 - Participant Start,started,2024-04-01,,2024-04-01
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2023,Output 2 - Retention Point 1,retained-1,2024-04-01,,2024-04-01
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2023,Output 3 - Retention Point 2,retained-2,2024-04-01,,2024-04-01
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2023,Output 4 - Retention Point 3,retained-3,2024-04-01,,2024-04-01
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2023,Output 5 - Retention Point 4,retained-4,2024-04-01,,2024-04-01
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2023,Output 6 - Participant Completion,completed,2024-04-01,,2024-04-01
+ecf_standard,ecf-standard-september,ECF Standard September,2021,Output 1 - Participant Start,started,2021-09-01,2021-11-30,2021-11-30
+ecf_standard,ecf-standard-september,ECF Standard September,2021,Output 2 - Retention Point 1,retained-1,2021-09-01,2022-01-31,2022-02-28
+ecf_standard,ecf-standard-september,ECF Standard September,2021,Output 3 - Retention Point 2,retained-2,2022-02-01,2022-04-30,2022-05-31
+ecf_standard,ecf-standard-september,ECF Standard September,2021,Output 4 - Retention Point 3,retained-3,2022-05-01,2022-09-30,2022-10-31
+ecf_standard,ecf-standard-september,ECF Standard September,2021,Output 5 - Retention Point 4,retained-4,2022-10-01,2023-01-31,2023-02-28
+ecf_standard,ecf-standard-september,ECF Standard September,2021,Output 6 - Participant Completion,completed,2023-02-01,2023-04-30,2023-05-31
+ecf_standard,ecf-standard-september,ECF Standard September,2021,Output 1 - Participant Start,started,2021-09-01,2021-11-30,2021-11-30
+ecf_standard,ecf-standard-september,ECF Standard September,2021,Output 2 - Retention Point 1,retained-1,2021-09-01,2022-01-31,2022-02-28
+ecf_standard,ecf-standard-september,ECF Standard September,2021,Output 3 - Retention Point 2,retained-2,2022-02-01,2022-04-30,2022-05-31
+ecf_standard,ecf-standard-september,ECF Standard September,2021,Output 4 - Retention Point 3,retained-3,2022-05-01,2022-09-30,2022-10-31
+ecf_standard,ecf-standard-september,ECF Standard September,2021,Output 5 - Retention Point 4,retained-4,2022-10-01,2023-01-31,2023-02-28
+ecf_standard,ecf-standard-september,ECF Standard September,2021,Output 6 - Participant Completion,completed,2023-02-01,2023-04-30,2023-05-31
+ecf_standard,ecf-standard-september,ECF Standard September,2023,Output 1 - Participant Start,started,2023-06-01,2023-12-31,2023-11-30
+ecf_standard,ecf-standard-september,ECF Standard September,2023,Output 2 - Retention Point 1,retained-1,2024-01-01,2024-03-31,2024-04-30
+ecf_standard,ecf-standard-september,ECF Standard September,2023,Output 3 - Retention Point 2,retained-2,2024-04-01,2024-07-31,2024-08-31
+ecf_standard,ecf-standard-september,ECF Standard September,2023,Output 4 - Retention Point 3,retained-3,2024-08-01,2024-12-31,2025-01-31
+ecf_standard,ecf-standard-september,ECF Standard September,2023,Output 5 - Retention Point 4,retained-4,2025-01-01,2025-03-31,2025-04-30
+ecf_standard,ecf-standard-september,ECF Standard September,2023,Output 6 - Participant Completion,completed,2025-04-01,2025-07-31,2025-08-31
+ecf_standard,ecf-standard-january,ECF Standard January,2023,Output 1 - Participant Start,started,2024-01-01,2024-03-31,2024-04-30
+ecf_standard,ecf-standard-january,ECF Standard January,2023,Output 2 - Retention Point 1,retained-1,2024-04-01,2024-07-31,2024-08-31
+ecf_standard,ecf-standard-january,ECF Standard January,2023,Output 3 - Retention Point 2,retained-2,2024-08-01,2024-12-31,2025-01-31
+ecf_standard,ecf-standard-january,ECF Standard January,2023,Output 4 - Retention Point 3,retained-3,2025-01-01,2025-03-31,2025-04-30
+ecf_standard,ecf-standard-january,ECF Standard January,2023,Output 5 - Retention Point 4,retained-4,2025-04-01,2025-07-31,2025-08-31
+ecf_standard,ecf-standard-january,ECF Standard January,2023,Output 6 - Participant Completion,completed,2025-08-01,2025-12-31,2026-01-31
+ecf_standard,ecf-standard-april,ECF Standard April,2023,Output 1 - Participant Start,started,2024-04-01,2024-07-31,2024-08-31
+ecf_standard,ecf-standard-april,ECF Standard April,2023,Output 2 - Retention Point 1,retained-1,2024-08-01,2024-12-31,2025-01-31
+ecf_standard,ecf-standard-april,ECF Standard April,2023,Output 3 - Retention Point 2,retained-2,2025-01-01,2025-03-31,2025-04-30
+ecf_standard,ecf-standard-april,ECF Standard April,2023,Output 4 - Retention Point 3,retained-3,2025-04-01,2025-07-31,2025-08-31
+ecf_standard,ecf-standard-april,ECF Standard April,2023,Output 5 - Retention Point 4,retained-4,2025-08-01,2025-12-31,2026-01-31
+ecf_standard,ecf-standard-april,ECF Standard April,2023,Output 6 - Participant Completion,completed,2026-01-01,2026-03-31,2026-04-30
+npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2021,Output 1 - Participant Start,started,2021-11-01,,2021-11-01
+npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2021,Output 2 - Retention Point 1,retained-1,2021-11-01,,2021-11-01
+npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2021,Output 3 - Participant Completion,completed,2021-11-01,,2021-11-01
+ecf_standard,ecf-standard-january,ECF Standard January,2021,Output 1 - Participant Start,started,2021-12-01,2022-01-31,2022-02-28
+ecf_standard,ecf-standard-january,ECF Standard January,2021,Output 2 - Retention Point 1,retained-1,2022-02-01,2022-04-30,2022-05-31
+ecf_standard,ecf-standard-january,ECF Standard January,2021,Output 3 - Retention Point 2,retained-2,2022-05-01,2022-09-30,2022-10-31
+ecf_standard,ecf-standard-january,ECF Standard January,2021,Output 4 - Retention Point 3,retained-3,2022-10-01,2023-01-31,2023-02-28
+ecf_standard,ecf-standard-january,ECF Standard January,2021,Output 5 - Retention Point 4,retained-4,2023-02-01,2023-04-30,2023-05-31
+ecf_standard,ecf-standard-january,ECF Standard January,2021,Output 1 - Participant Start,started,2021-12-01,2022-01-31,2022-02-28
+ecf_standard,ecf-standard-january,ECF Standard January,2021,Output 2 - Retention Point 1,retained-1,2022-02-01,2022-04-30,2022-05-31
+ecf_standard,ecf-standard-january,ECF Standard January,2021,Output 3 - Retention Point 2,retained-2,2022-05-01,2022-09-30,2022-10-31
+ecf_standard,ecf-standard-january,ECF Standard January,2021,Output 4 - Retention Point 3,retained-3,2022-10-01,2023-01-31,2023-02-28
+ecf_standard,ecf-standard-january,ECF Standard January,2021,Output 5 - Retention Point 4,retained-4,2023-02-01,2023-04-30,2023-05-31
+npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2021,Output 1 - Participant Start,started,2021-11-01,,2021-11-01
+npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2021,Output 2 - Retention Point 1,retained-1,2021-11-01,,2021-11-01
+npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2021,Output 3 - Retention Point 2,retained-2,2021-11-01,,2021-11-01
+npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2021,Output 4 - Participant Completion,completed,2021-11-01,,2021-11-01
+npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2021,Output 1 - Participant Start,started,2022-01-01,,2022-01-01
+npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2021,Output 2 - Retention Point 1,retained-1,2022-01-01,,2022-01-01
+npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2021,Output 3 - Participant Completion,completed,2022-01-01,,2022-01-01

--- a/db/new_seeds/base/add_cohorts.rb
+++ b/db/new_seeds/base/add_cohorts.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
-# Cohort 2020
-cohort_2020 = FactoryBot.create(:seed_cohort, start_year: 2020)
+Rails.logger.info("Importing cohorts")
 
-# Ensures Cohort.next is always created
-academic_year_start_month = cohort_2020.academic_year_start_date.month
+Importers::CreateCohort.new(path_to_csv: Rails.root.join("db/data/cohorts/cohorts.csv")).call
+
+# Ensure Cohort.next is always created
+academic_year_start_month = Cohort.find_by(start_year: 2020).academic_year_start_date.month
 next_cohort_start_year = Date.current.year + (Date.current.month < academic_year_start_month ? 0 : 1)
-(2021..next_cohort_start_year).to_a.each { |start_year| FactoryBot.create(:seed_cohort, start_year:) }
+FactoryBot.create(:seed_cohort, start_year: next_cohort_start_year) if Cohort.find_by(start_year: next_cohort_start_year).nil?

--- a/db/new_seeds/base/add_npq_courses.rb
+++ b/db/new_seeds/base/add_npq_courses.rb
@@ -53,8 +53,10 @@
     identifier: "npq-leading-literacy",
   },
   {
+    # this is the production uuid for npq-leading-primary-mathematics in case we want it to be the same like the others
+    # "id": "7866f853-064f-44b4-9287-20b9993452d6",
     id: "6f81f1ab-5c4e-445d-9363-0f91149c87db",
-    name: "NPQ for Leading Primary Mathematics (NPQLPM)",
+    name: "NPQ Leading Primary Mathematics (NPQLPM)",
     identifier: "npq-leading-primary-mathematics",
   },
 ].each do |hash|

--- a/db/new_seeds/base/add_schedules.rb
+++ b/db/new_seeds/base/add_schedules.rb
@@ -3,3 +3,138 @@
 Rails.logger.info("Importing schedules")
 
 Importers::CreateSchedule.new(path_to_csv: Rails.root.join("db/data/schedules/schedules.csv")).call
+
+# Ensure Cohort.next always has NPQ schedules that can be used
+if Finance::Schedule.find_by(cohort: Cohort.next, schedule_identifier: "npq-ehco-november").nil?
+  next_start_year = Cohort.next.start_year
+  csv = Tempfile.new("data.csv")
+
+  csv.write "type,schedule-identifier,schedule-name,schedule-cohort-year,milestone-name,milestone-declaration-type,milestone-start-date,milestone-date,milestone-payment-date"
+  csv.write "\n"
+
+  csv.write "npq_ehco,npq-ehco-november,NPQ EHCO November,#{next_start_year},Output 1 - Participant Start,started,01/11/#{next_start_year},,01/11/#{next_start_year}"
+  csv.write "npq_ehco,npq-ehco-november,NPQ EHCO November,#{next_start_year},Output 2 - Retention Point 1,retained-1,01/11/#{next_start_year},,01/11/#{next_start_year}"
+  csv.write "npq_ehco,npq-ehco-november,NPQ EHCO November,#{next_start_year},Output 3 - Retention Point 2,retained-2,01/11/#{next_start_year},,01/11/#{next_start_year}"
+  csv.write "npq_ehco,npq-ehco-november,NPQ EHCO November,#{next_start_year},Output 4 - Participant Completion,completed,01/11/#{next_start_year},,01/11/#{next_start_year}"
+
+  csv.close
+
+  Importers::CreateSchedule.new(path_to_csv: csv.path).call
+end
+
+if Finance::Schedule.find_by(cohort: Cohort.next, schedule_identifier: "npq-ehco-december").nil?
+  next_start_year = Cohort.next.start_year
+  csv = Tempfile.new("data.csv")
+
+  csv.write "type,schedule-identifier,schedule-name,schedule-cohort-year,milestone-name,milestone-declaration-type,milestone-start-date,milestone-date,milestone-payment-date"
+  csv.write "\n"
+
+  csv.write "npq_ehco,npq-ehco-december,NPQ EHCO December,#{next_start_year},Output 1 - Participant Start,started,01/12/#{next_start_year},,01/12/#{next_start_year}"
+  csv.write "npq_ehco,npq-ehco-december,NPQ EHCO December,#{next_start_year},Output 2 - Retention Point 1,retained-1,01/12/#{next_start_year},,01/12/#{next_start_year}"
+  csv.write "npq_ehco,npq-ehco-december,NPQ EHCO December,#{next_start_year},Output 3 - Retention Point 2,retained-2,01/12/#{next_start_year},,01/12/#{next_start_year}"
+  csv.write "npq_ehco,npq-ehco-december,NPQ EHCO December,#{next_start_year},Output 4 - Participant Completion,completed,01/12/#{next_start_year},,01/12/#{next_start_year}"
+
+  csv.close
+
+  Importers::CreateSchedule.new(path_to_csv: csv.path).call
+end
+
+if Finance::Schedule.find_by(cohort: Cohort.next, schedule_identifier: "npq-ehco-march").nil?
+  next_start_year = Cohort.next.start_year
+  csv = Tempfile.new("data.csv")
+
+  csv.write "type,schedule-identifier,schedule-name,schedule-cohort-year,milestone-name,milestone-declaration-type,milestone-start-date,milestone-date,milestone-payment-date"
+  csv.write "\n"
+
+  csv.write "npq_ehco,npq-ehco-march,NPQ EHCO March,#{next_start_year},Output 1 - Participant Start,started,01/03/#{next_start_year + 1},,01/03/#{next_start_year + 1}"
+  csv.write "npq_ehco,npq-ehco-march,NPQ EHCO March,#{next_start_year},Output 2 - Retention Point 1,retained-1,01/03/#{next_start_year + 1},,01/03/#{next_start_year + 1}"
+  csv.write "npq_ehco,npq-ehco-march,NPQ EHCO March,#{next_start_year},Output 3 - Retention Point 2,retained-2,01/03/#{next_start_year + 1},,01/03/#{next_start_year + 1}"
+  csv.write "npq_ehco,npq-ehco-march,NPQ EHCO March,#{next_start_year},Output 4 - Participant Completion,completed,01/03/#{next_start_year + 1},,01/03/#{next_start_year + 1}"
+
+  csv.close
+
+  Importers::CreateSchedule.new(path_to_csv: csv.path).call
+end
+
+if Finance::Schedule.find_by(cohort: Cohort.next, schedule_identifier: "npq-ehco-june").nil?
+  next_start_year = Cohort.next.start_year
+  csv = Tempfile.new("data.csv")
+
+  csv.write "type,schedule-identifier,schedule-name,schedule-cohort-year,milestone-name,milestone-declaration-type,milestone-start-date,milestone-date,milestone-payment-date"
+  csv.write "\n"
+
+  csv.write "npq_ehco,npq-ehco-june,NPQ EHCO June,#{next_start_year},Output 1 - Participant Start,started,01/06/#{next_start_year + 1},,01/06/#{next_start_year + 1}"
+  csv.write "npq_ehco,npq-ehco-june,NPQ EHCO June,#{next_start_year},Output 2 - Retention Point 1,retained-1,01/06/#{next_start_year + 1},,01/06/#{next_start_year + 1}"
+  csv.write "npq_ehco,npq-ehco-june,NPQ EHCO June,#{next_start_year},Output 3 - Retention Point 2,retained-2,01/06/#{next_start_year + 1},,01/06/#{next_start_year + 1}"
+  csv.write "npq_ehco,npq-ehco-june,NPQ EHCO June,#{next_start_year},Output 4 - Participant Completion,completed,01/06/#{next_start_year + 1},,01/06/#{next_start_year + 1}"
+
+  csv.close
+
+  Importers::CreateSchedule.new(path_to_csv: csv.path).call
+end
+
+if Finance::Schedule.find_by(cohort: Cohort.next, schedule_identifier: "npq-leadership-autumn").nil?
+  next_start_year = Cohort.next.start_year
+  csv = Tempfile.new("data.csv")
+
+  csv.write "type,schedule-identifier,schedule-name,schedule-cohort-year,milestone-name,milestone-declaration-type,milestone-start-date,milestone-date,milestone-payment-date"
+  csv.write "\n"
+
+  csv.write "npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,#{next_start_year},Output 1 - Participant Start,started,01/11/#{next_start_year},,01/11/#{next_start_year}"
+  csv.write "npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,#{next_start_year},Output 2 - Retention Point 1,retained-1,01/11/#{next_start_year},,01/11/#{next_start_year}"
+  csv.write "npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,#{next_start_year},Output 3 - Retention Point 2,retained-2,01/11/#{next_start_year},,01/11/#{next_start_year}"
+  csv.write "npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,#{next_start_year},Output 4 - Participant Completion,completed,01/11/#{next_start_year},,01/11/#{next_start_year}"
+
+  csv.close
+
+  Importers::CreateSchedule.new(path_to_csv: csv.path).call
+end
+
+if Finance::Schedule.find_by(cohort: Cohort.next, schedule_identifier: "npq-leadership-spring").nil?
+  next_start_year = Cohort.next.start_year
+  csv = Tempfile.new("data.csv")
+
+  csv.write "type,schedule-identifier,schedule-name,schedule-cohort-year,milestone-name,milestone-declaration-type,milestone-start-date,milestone-date,milestone-payment-date"
+  csv.write "\n"
+
+  csv.write "npq_leadership,npq-leadership-spring,NPQ Leadership Spring,#{next_start_year},Output 1 - Participant Start,started,01/01/#{next_start_year + 1},,01/01/#{next_start_year + 1}"
+  csv.write "npq_leadership,npq-leadership-spring,NPQ Leadership Spring,#{next_start_year},Output 2 - Retention Point 1,retained-1,01/01/#{next_start_year + 1},,01/01/#{next_start_year + 1}"
+  csv.write "npq_leadership,npq-leadership-spring,NPQ Leadership Spring,#{next_start_year},Output 3 - Retention Point 2,retained-2,01/01/#{next_start_year + 1},,01/01/#{next_start_year + 1}"
+  csv.write "npq_leadership,npq-leadership-spring,NPQ Leadership Spring,#{next_start_year},Output 4 - Participant Completion,completed,01/01/#{next_start_year + 1},,01/01/#{next_start_year + 1}"
+
+  csv.close
+
+  Importers::CreateSchedule.new(path_to_csv: csv.path).call
+end
+
+if Finance::Schedule.find_by(cohort: Cohort.next, schedule_identifier: "npq-specialist-autumn").nil?
+  next_start_year = Cohort.next.start_year
+  csv = Tempfile.new("data.csv")
+
+  csv.write "type,schedule-identifier,schedule-name,schedule-cohort-year,milestone-name,milestone-declaration-type,milestone-start-date,milestone-date,milestone-payment-date"
+  csv.write "\n"
+
+  csv.write "npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,#{next_start_year},Output 1 - Participant Start,started,01/11/#{next_start_year},,01/11/#{next_start_year}"
+  csv.write "npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,#{next_start_year},Output 2 - Retention Point 1,retained-1,01/11/#{next_start_year},,01/11/#{next_start_year}"
+  csv.write "npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,#{next_start_year},Output 3 - Participant Completion,completed,01/11/#{next_start_year},,01/11/#{next_start_year}"
+
+  csv.close
+
+  Importers::CreateSchedule.new(path_to_csv: csv.path).call
+end
+
+if Finance::Schedule.find_by(cohort: Cohort.next, schedule_identifier: "npq-specialist-spring").nil?
+  next_start_year = Cohort.next.start_year
+  csv = Tempfile.new("data.csv")
+
+  csv.write "type,schedule-identifier,schedule-name,schedule-cohort-year,milestone-name,milestone-declaration-type,milestone-start-date,milestone-date,milestone-payment-date"
+  csv.write "\n"
+
+  csv.write "npq_specialist,npq-specialist-spring,NPQ Specialist Spring,#{next_start_year},Output 1 - Participant Start,started,01/01/#{next_start_year + 1},,01/01/#{next_start_year + 1}"
+  csv.write "npq_specialist,npq-specialist-spring,NPQ Specialist Spring,#{next_start_year},Output 2 - Retention Point 1,retained-1,01/01/#{next_start_year + 1},,01/01/#{next_start_year + 1}"
+  csv.write "npq_specialist,npq-specialist-spring,NPQ Specialist Spring,#{next_start_year},Output 3 - Participant Completion,completed,01/01/#{next_start_year + 1},,01/01/#{next_start_year + 1}"
+
+  csv.close
+
+  Importers::CreateSchedule.new(path_to_csv: csv.path).call
+end

--- a/spec/factories/seeds/cohort_factory.rb
+++ b/spec/factories/seeds/cohort_factory.rb
@@ -4,9 +4,9 @@ FactoryBot.define do
   factory(:seed_cohort, class: "Cohort") do
     sequence(:start_year) { Faker::Number.unique.between(from: 2050, to: 3025) }
 
-    registration_start_date { Date.new(start_year, 6, 5) }
-    academic_year_start_date { Date.new(start_year, 11, 1) }
-    automatic_assignment_period_end_date { Date.new(start_year + 1, 3, 31) }
+    registration_start_date { Date.new(start_year, 5, 10) }
+    academic_year_start_date { Date.new(start_year, 9, 1) }
+    automatic_assignment_period_end_date { Date.new(start_year + 1, 4, 3) }
 
     initialize_with do
       Cohort.find_by(start_year:) || new(**attributes)

--- a/spec/factories/seeds/cohort_factory.rb
+++ b/spec/factories/seeds/cohort_factory.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
 
     registration_start_date { Date.new(start_year, 5, 10) }
     academic_year_start_date { Date.new(start_year, 9, 1) }
-    automatic_assignment_period_end_date { Date.new(start_year + 1, 4, 3) }
+    automatic_assignment_period_end_date { Date.new(start_year + 1, 3, 31) }
 
     initialize_with do
       Cohort.find_by(start_year:) || new(**attributes)


### PR DESCRIPTION
### Context

Seeded environments break when adding NPQ Registration seeds. The seeds expect there to be schedules available for `Cohort.next` but at certain times of the year the "schedules.csv" will not have details of schedules for the cohort to add. This will cause the seed scripts to fail. 

The last solution to solve this issue was to push the `academic-year-start-date` into the future but, this has had the knock on effect of meaning that seed environments fail to make 2023 the current cohort like the production system does and means no seed schools have chosen FIP or partnered with anyone for the 2023 academic year.

### Changes proposed in this pull request

1. Use the "cohort.csv" to easily define the cohorts that are seeded - giving us the option to mimic production in a simple way
2. Ensure that Cohort seed defaults create a more realistic timeline
3. Ensure that the previous logic to ensure a `Cohort.next` runs with the default seed settings
4. Ensure that if a `Cohort.next` has been created that some default NPQ schedules and milestones are also created so that the NPQ registration seeds have something to reference
