### PR TITLE
CST-2012: allow admin users to edit the training status of CIP participants

### DIFF
--- a/app/controllers/admin/participants/induction_records_controller.rb
+++ b/app/controllers/admin/participants/induction_records_controller.rb
@@ -44,7 +44,7 @@ module Admin::Participants
         set_success_message(heading: "The induction records has been updated")
         redirect_to admin_participant_induction_records_path(@participant_profile)
       else
-        flash.now[:notice] = { heading: "The induction records could not be updated" }
+        flash.now[:alert] = "The induction records could not be updated"
         render "admin/participants/induction_records/edit_training_status"
       end
     end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -106,8 +106,8 @@ module AdminHelper
 
   def training_statuses
     [
-      OpenStruct.new(id: "deferred", value: "deferred"),
-      OpenStruct.new(id: "withdrawn", value: "withdrawn"),
+      OpenStruct.new(id: "deferred", value: "Deferred"),
+      OpenStruct.new(id: "withdrawn", value: "Withdrawn"),
     ]
   end
 end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -103,4 +103,11 @@ module AdminHelper
       "unknown"
     end
   end
+
+  def training_statuses
+    [
+      OpenStruct.new(id: "deferred", value: "deferred"),
+      OpenStruct.new(id: "withdrawn", value: "withdrawn"),
+    ]
+  end
 end

--- a/app/policies/induction_record_policy.rb
+++ b/app/policies/induction_record_policy.rb
@@ -33,6 +33,10 @@ class InductionRecordPolicy < ApplicationPolicy
     school_induction_coordinator? && record.current?
   end
 
+  def change_training_status?
+    admin? && record.enrolled_in_cip?
+  end
+
   def validate?
     admin?
   end
@@ -48,6 +52,9 @@ class InductionRecordPolicy < ApplicationPolicy
 
   alias_method :edit_preferred_email?, :change_preferred_email?
   alias_method :update_preferred_email?, :change_preferred_email?
+
+  alias_method :edit_training_status?, :change_training_status?
+  alias_method :update_training_status?, :change_training_status?
 
   alias_method :withdraw_record?, :destroy?
   alias_method :remove?, :destroy?

--- a/app/presenters/admin/participant_presenter.rb
+++ b/app/presenters/admin/participant_presenter.rb
@@ -3,88 +3,64 @@
 class Admin::ParticipantPresenter
   attr_reader :participant_profile
 
-  delegate :id,
-           :user,
-           :participant_identity,
-           :training_status,
-           :status,
-           :notes,
-           :notes?,
-           :ect?,
-           :mentor?,
-           :ecf_participant_validation_data,
-           :ecf_participant_eligibility,
-           :teacher_profile,
-           to: :participant_profile
-
-  delegate :full_name, :email, :participant_identities, to: :user
-  delegate :user_id, to: :participant_identity
-  delegate :trn, to: :teacher_profile
-  delegate :enrolled_in_fip?, to: :relevant_induction_record
-
   def initialize(participant_profile)
     @participant_profile = participant_profile
   end
 
-  def relevant_induction_record
-    @relevant_induction_record ||= Induction::FindBy.new(participant_profile:).call
+  def all_induction_records
+    induction_records
   end
 
-  def school_cohort
-    relevant_induction_record&.school_cohort
-  end
+  delegate :appropriate_body, to: :school_cohort, allow_nil: true
 
-  def school
-    school_cohort&.school
-  end
+  # appropriate_body_name
+  delegate :name, to: :appropriate_body, allow_nil: true, prefix: true
 
   def cohort
     relevant_cohort_location = relevant_induction_record&.school_cohort || relevant_induction_record&.schedule || participant_profile
     relevant_cohort_location.cohort
   end
 
-  def start_year
-    cohort&.start_year
+  def declarations
+    @declarations ||= @participant_profile
+                        .participant_declarations
+                        .includes(:cpd_lead_provider, :delivery_partner)
+                        .order(created_at: :desc)
   end
 
-  def school_name
-    school&.name
+  delegate :delivery_partner_name, to: :relevant_induction_record, allow_nil: true
+  delegate :ect?, to: :participant_profile
+  delegate :ecf_participant_eligibility, to: :participant_profile
+  delegate :ecf_participant_validation_data, to: :participant_profile
+
+  def eligibility_data
+    @eligibility_data = ::EligibilityPresenter.new(@participant_profile.ecf_participant_eligibility)
   end
 
-  def school_urn
-    school&.urn
+  def eligibility_status?
+    eligibility_data.eligible_status?
   end
 
-  def school_friendly_id
-    school&.friendly_id
-  end
+  delegate :email, to: :user
+  delegate :enrolled_in_fip?, to: :relevant_induction_record
+  delegate :full_name, to: :user
 
-  def school_lead_provider_name
-    school_cohort&.lead_provider&.name
-  end
-
-  def school_delivery_partner_name
-    school_cohort&.delivery_partner&.name
-  end
-
-  def lead_provider_name
-    relevant_induction_record&.lead_provider_name
-  end
-
-  def delivery_partner_name
-    relevant_induction_record&.delivery_partner_name
-  end
-
-  def appropriate_body_name
-    school_cohort&.appropriate_body&.name
+  def has_mentor?
+    relevant_induction_record&.mentor&.present?
   end
 
   def historical_induction_records
     induction_records[1..].presence || []
   end
 
-  def all_induction_records
-    induction_records
+  delegate :id, to: :participant_profile
+
+  def induction_completion_date
+    if participant_profile.induction_completion_date
+      participant_profile.induction_completion_date.to_formatted_s(:govuk)
+    else
+      "Not yet recorded"
+    end
   end
 
   def induction_start_date
@@ -95,59 +71,76 @@ class Admin::ParticipantPresenter
     end
   end
 
-  def induction_completion_date
-    if participant_profile.induction_completion_date
-      participant_profile.induction_completion_date.to_formatted_s(:govuk)
-    else
-      "Not yet recorded"
-    end
-  end
-
-  def has_mentor?
-    relevant_induction_record&.mentor&.present?
-  end
-
   def is_mentor?
     mentor_profile.present?
   end
 
-  def mentor_profile
-    relevant_induction_record&.mentor_profile
+  delegate :lead_provider_name, to: :relevant_induction_record, allow_nil: true
+
+  def mentees_by_school
+    @mentees_by_school ||= ParticipantProfile::ECT
+                             .merge(InductionRecord.current)
+                             .joins(:induction_records)
+                             .where(induction_records: { mentor_profile_id: @participant_profile.id })
+                             .group_by(&:school)
   end
 
-  def mentor_full_name
-    mentor_profile&.full_name
+  # mentor_full_name
+  delegate :full_name, to: :mentor_profile, allow_nil: true, prefix: :mentor
+
+  delegate :mentor_profile, to: :relevant_induction_record, allow_nil: true
+  delegate :mentor?, to: :participant_profile
+  delegate :notes, to: :participant_profile
+  delegate :notes?, to: :participant_profile
+  delegate :participant_identities, to: :user
+  delegate :participant_identity, to: :participant_profile
+
+  def relevant_induction_record
+    @relevant_induction_record ||= Induction::FindBy.new(participant_profile:).call
   end
+
+  delegate :school, to: :school_cohort, allow_nil: true
+  delegate :school_cohort, to: :relevant_induction_record, allow_nil: true
+
+  # school_delivery_partner
+  delegate :delivery_partner, to: :school_cohort, allow_nil: true, prefix: :school
+
+  # school_delivery_partner_name
+  delegate :name, to: :school_delivery_partner, allow_nil: true, prefix: true
+
+  # school_friendly_id
+  delegate :friendly_id, to: :school, allow_nil: true, prefix: true
+
+  def school_latest_induction_record?(induction_record)
+    school_latest_induction_records.include?(induction_record)
+  end
+
+  # school_lead_provider
+  delegate :lead_provider, to: :school_cohort, allow_nil: true, prefix: :school
+
+  # school_lead_provider_name
+  delegate :name, to: :school_lead_provider, allow_nil: true, prefix: true
+
+  # school_name
+  delegate :name, to: :school, allow_nil: true, prefix: true
+
+  # school_urn
+  delegate :urn, to: :school, allow_nil: true, prefix: true
+
+  delegate :start_year, to: :cohort, allow_nil: true
+  delegate :status, to: :participant_profile
+  delegate :teacher_profile, to: :participant_profile
+  delegate :training_status, to: :participant_profile
+  delegate :trn, to: :teacher_profile
+  delegate :user, to: :participant_profile
+  delegate :user_id, to: :participant_identity
 
   def user_created_at
     user&.created_at&.to_date&.to_fs(:govuk)
   end
 
-  def mentees_by_school
-    @mentees_by_school ||= ParticipantProfile::ECT
-      .merge(InductionRecord.current)
-      .joins(:induction_records)
-      .where(induction_records: { mentor_profile_id: @participant_profile.id })
-      .group_by(&:school)
-  end
-
-  def declarations
-    @declarations ||= @participant_profile
-      .participant_declarations
-      .includes(:cpd_lead_provider, :delivery_partner)
-      .order(created_at: :desc)
-  end
-
   def validation_data
     @validation_data ||= ecf_participant_validation_data || ECFParticipantValidationData.new(participant_profile:)
-  end
-
-  def eligibility_data
-    @eligibility_data = ::EligibilityPresenter.new(@participant_profile.ecf_participant_eligibility)
-  end
-
-  def eligibility_status?
-    eligibility_data.eligible_status?
   end
 
 private
@@ -166,5 +159,13 @@ private
         mentor_profile: :user,
       )
       .order(start_date: :desc, created_at: :desc)
+  end
+
+  def school_latest_induction_records
+    @school_latest_induction_records ||= schools.map { |school| Induction::FindBy.call(participant_profile:, school:) }
+  end
+
+  def schools
+    @schools ||= School.find(induction_records.map(&:school_id).uniq)
   end
 end

--- a/app/views/admin/participants/induction_records/edit_training_status.html.erb
+++ b/app/views/admin/participants/induction_records/edit_training_status.html.erb
@@ -7,7 +7,7 @@
               training_statuses,
               :id,
               :value,
-              legend: { text: "Training status for #{@participant_profile.name} at #{@induction_record.school_name}", tag: 'h1', size: 'l' },
+              legend: { text: "Training status for #{@participant_profile.full_name} at #{@induction_record.school_name}", tag: 'h1', size: 'l' },
               options: { selected: @induction_record.training_status }) %>
       <%= f.govuk_submit "Save" %>
     <% end %>

--- a/app/views/admin/participants/induction_records/edit_training_status.html.erb
+++ b/app/views/admin/participants/induction_records/edit_training_status.html.erb
@@ -1,16 +1,15 @@
 <% content_for :before_content, govuk_back_link(text: "Back", href: admin_participant_path(@participant_profile)) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Change the training status for this participant at <%= @induction_record.school_name %></h1>
     <%= form_for @induction_record, url: update_training_status_admin_participant_induction_records_path(@participant_profile, @induction_record), method: :put do |f| %>
       <%= f.govuk_collection_radio_buttons(
               :training_status,
               training_statuses,
               :id,
               :value,
-              legend: { text: "Select training status", tag: 'h1', size: 'l' },
+              legend: { text: "Training status for #{@participant_profile.name} at #{@induction_record.school_name}", tag: 'h1', size: 'l' },
               options: { selected: @induction_record.training_status }) %>
-      <%= f.govuk_submit "Submit" %>
+      <%= f.govuk_submit "Save" %>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/participants/induction_records/edit_training_status.html.erb
+++ b/app/views/admin/participants/induction_records/edit_training_status.html.erb
@@ -1,0 +1,17 @@
+<% content_for :before_content, govuk_back_link(text: "Back", href: admin_participant_path(@participant_profile)) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Change the training status for this participant at <%= @induction_record.school_name %></h1>
+    <%= form_for @induction_record, url: update_training_status_admin_participant_induction_records_path(@participant_profile, @induction_record), method: :put do |f| %>
+      <%= f.govuk_collection_select :training_status,
+                                    training_statuses,
+                                    :id,
+                                    :value,
+                                    label: { text: "Select training status" },
+                                    options: { selected: @induction_record.training_status }
+      %>
+
+      <%= f.govuk_submit "Submit" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/participants/induction_records/edit_training_status.html.erb
+++ b/app/views/admin/participants/induction_records/edit_training_status.html.erb
@@ -3,14 +3,13 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Change the training status for this participant at <%= @induction_record.school_name %></h1>
     <%= form_for @induction_record, url: update_training_status_admin_participant_induction_records_path(@participant_profile, @induction_record), method: :put do |f| %>
-      <%= f.govuk_collection_select :training_status,
-                                    training_statuses,
-                                    :id,
-                                    :value,
-                                    label: { text: "Select training status" },
-                                    options: { selected: @induction_record.training_status }
-      %>
-
+      <%= f.govuk_collection_radio_buttons(
+              :training_status,
+              training_statuses,
+              :id,
+              :value,
+              legend: { text: "Select training status", tag: 'h1', size: 'l' },
+              options: { selected: @induction_record.training_status }) %>
       <%= f.govuk_submit "Submit" %>
     <% end %>
   </div>

--- a/app/views/admin/participants/induction_records/show.html.erb
+++ b/app/views/admin/participants/induction_records/show.html.erb
@@ -93,6 +93,13 @@
         sl.with_row do |row|
           row.with_key(text: "Training status")
           row.with_value(text: induction_record.training_status)
+          if policy(induction_record).edit_training_status? &&
+              @participant_presenter.school_latest_induction_record?(induction_record)
+            row.with_action(
+                href: edit_training_status_admin_participant_induction_records_path(@participant_profile, induction_record),
+                visually_hidden_text: "training status"
+            )
+          end
         end
 
         sl.with_row do |row|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -313,6 +313,8 @@ Rails.application.routes.draw do
         member do
           get ":induction_record_id/edit_preferred_email", action: :edit_preferred_email, as: :edit_preferred_email
           put ":induction_record_id/update_preferred_email", action: :update_preferred_email, as: :update_preferred_email
+          get ":induction_record_id/edit_training_status", action: :edit_training_status, as: :edit_training_status
+          put ":induction_record_id/update_training_status", action: :update_training_status, as: :update_training_status
         end
       end
       resource :cohorts, only: :show, controller: "participants/cohorts"

--- a/spec/presenters/admin/participant_presenter_spec.rb
+++ b/spec/presenters/admin/participant_presenter_spec.rb
@@ -24,24 +24,40 @@ RSpec.describe(Admin::ParticipantPresenter) do
   end
 
   describe "delegation" do
+    it { is_expected.to delegate_method(:appropriate_body).to(:school_cohort).allow_nil }
+    it { is_expected.to delegate_method(:name).to(:appropriate_body).with_prefix.allow_nil }
+    it { is_expected.to delegate_method(:delivery_partner_name).to(:relevant_induction_record).allow_nil }
+    it { is_expected.to delegate_method(:ect?).to(:participant_profile) }
+    it { is_expected.to delegate_method(:ecf_participant_eligibility).to(:participant_profile) }
+    it { is_expected.to delegate_method(:ecf_participant_validation_data).to(:participant_profile) }
+    it { is_expected.to delegate_method(:email).to(:user) }
+    it { is_expected.to delegate_method(:enrolled_in_fip?).to(:relevant_induction_record) }
+    it { is_expected.to delegate_method(:full_name).to(:user) }
     it { is_expected.to delegate_method(:id).to(:participant_profile) }
-    it { is_expected.to delegate_method(:participant_identity).to(:participant_profile) }
-    it { is_expected.to delegate_method(:training_status).to(:participant_profile) }
+    it { is_expected.to delegate_method(:lead_provider_name).to(:relevant_induction_record).allow_nil }
+    it { is_expected.to delegate_method(:full_name).to(:mentor_profile).with_prefix(:mentor).allow_nil }
+    it { is_expected.to delegate_method(:mentor_profile).to(:relevant_induction_record).allow_nil }
+    it { is_expected.to delegate_method(:mentor?).to(:participant_profile) }
     it { is_expected.to delegate_method(:notes).to(:participant_profile) }
     it { is_expected.to delegate_method(:notes?).to(:participant_profile) }
-    it { is_expected.to delegate_method(:ect?).to(:participant_profile) }
-    it { is_expected.to delegate_method(:mentor?).to(:participant_profile) }
-    it { is_expected.to delegate_method(:ecf_participant_validation_data).to(:participant_profile) }
-    it { is_expected.to delegate_method(:ecf_participant_eligibility).to(:participant_profile) }
-    it { is_expected.to delegate_method(:teacher_profile).to(:participant_profile) }
-
-    it { is_expected.to delegate_method(:full_name).to(:user) }
-    it { is_expected.to delegate_method(:email).to(:user) }
     it { is_expected.to delegate_method(:participant_identities).to(:user) }
-
-    it { is_expected.to delegate_method(:user_id).to(:participant_identity) }
-
+    it { is_expected.to delegate_method(:participant_identity).to(:participant_profile) }
+    it { is_expected.to delegate_method(:school).to(:school_cohort).allow_nil }
+    it { is_expected.to delegate_method(:school_cohort).to(:relevant_induction_record).allow_nil }
+    it { is_expected.to delegate_method(:delivery_partner).to(:school_cohort).with_prefix(:school).allow_nil }
+    it { is_expected.to delegate_method(:name).to(:school_delivery_partner).with_prefix.allow_nil }
+    it { is_expected.to delegate_method(:friendly_id).to(:school).with_prefix.allow_nil }
+    it { is_expected.to delegate_method(:lead_provider).to(:school_cohort).with_prefix(:school).allow_nil }
+    it { is_expected.to delegate_method(:name).to(:school_lead_provider).with_prefix.allow_nil }
+    it { is_expected.to delegate_method(:name).to(:school).with_prefix.allow_nil }
+    it { is_expected.to delegate_method(:urn).to(:school).with_prefix.allow_nil }
+    it { is_expected.to delegate_method(:start_year).to(:cohort).allow_nil }
+    it { is_expected.to delegate_method(:status).to(:participant_profile) }
+    it { is_expected.to delegate_method(:teacher_profile).to(:participant_profile) }
+    it { is_expected.to delegate_method(:training_status).to(:participant_profile) }
     it { is_expected.to delegate_method(:trn).to(:teacher_profile) }
+    it { is_expected.to delegate_method(:user).to(:participant_profile) }
+    it { is_expected.to delegate_method(:user_id).to(:participant_identity) }
   end
 
   describe "methods" do
@@ -161,6 +177,24 @@ RSpec.describe(Admin::ParticipantPresenter) do
       describe "#all_induction_records" do
         it "returns all of the participant's induction records" do
           expect(subject.all_induction_records.pluck(:id)).to match_array(participant_profile.induction_records.pluck(:id))
+        end
+      end
+
+      describe "#school_latest_induction_record?" do
+        context "when the induction_record is the latest induction record of the participant on any school" do
+          let(:induction_record) { subject.all_induction_records.order(start_date: :desc).first }
+
+          it "returns true" do
+            expect(subject.school_latest_induction_record?(induction_record)).to be_truthy
+          end
+        end
+
+        context "when the induction_record is not the latest induction record of the participant on any school" do
+          let(:induction_record) { subject.all_induction_records.order(start_date: :desc).last }
+
+          it "returns false" do
+            expect(subject.school_latest_induction_record?(induction_record)).to be_falsey
+          end
         end
       end
 


### PR DESCRIPTION
### Context
When a FIP participant is no longer training, their provider sets training_status = withdrawn.

CIP participants, however, have no lead provider, so we have to find another way of indicating they’re no longer training.

We also use induction_status = withdrawn. However, at the moment this needs to be actioned by a dev, which is time-consuming.

We therefore want to add a facility for first line agents to change induction_status = withdrawn for CIPsters ONLY. Note that this will not affect their access to funding.

[Ticket](https://dfedigital.atlassian.net/browse/CST-2012)

### Changes proposed in this pull request
<img width="668" alt="276339403-cd90c39a-06b8-46f2-9fa1-782ef69d35b0" src="https://github.com/DFE-Digital/early-careers-framework/assets/264612/2a089865-970d-4601-a647-0560eb70dce9">

<img width="1331" alt="Screenshot 2023-10-26 at 12 12 07" src="https://github.com/DFE-Digital/early-careers-framework/assets/264612/e5ac59ff-311f-41be-bb3c-a4a71f44caf8">

### Guidance to review

