### PR TITLE
Add make command to unlock terraform state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,13 @@ terraform-plan: terraform-init
 terraform-destroy: terraform-init
 	terraform -chdir=terraform/aks destroy -var-file workspace_variables/${DEPLOY_ENV}.tfvars.json ${AUTO_APPROVE}
 
+
+## DOCKER_IMAGE=fake-image make review terraform-unlock PULL_REQUEST_NUMBER=4169 LOCK_ID=123456
+## DOCKER_IMAGE=fake-image make staging terraform-unlock LOCK_ID=123456
+.PHONY: terraform-unlock
+terraform-unlock: terraform-init
+	terraform -chdir=terraform/aks force-unlock ${LOCK_ID}
+
 enable-maintenance:
 	cf target -s ${SPACE}
 	cd service_unavailable_page && cf push


### PR DESCRIPTION
### Context

Sometimes the terraform state locks and we need to release the lock.This can be done in the portal but good to have a make command as well

- Ticket: n/a

### Changes proposed in this pull request
Add make command to unlock a terraform state.

The command unfortunately will require a docker image attached for now as the step `terraform-init` requires it, however we can add a fake string, see examples below

### Guidance to review

```
## DOCKER_IMAGE=fake-image make review terraform-unlock PULL_REQUEST_NUMBER=4169 LOCK_ID=123456
## DOCKER_IMAGE=fake-image make staging terraform-unlock LOCK_ID=123456
```