### PR TITLE
Prevent 'labeled' events from triggering deploys

### DIFF
--- a/.github/workflows/aks_deploy.yml
+++ b/.github/workflows/aks_deploy.yml
@@ -22,7 +22,6 @@ on:
     branches:
       - main
     types:
-      - labeled
       - synchronize
       - reopened
       - opened


### PR DESCRIPTION
We used to want to deploy when the 'deploy' label was added to PRs but changed that behaviour so they were always built. As a result we can remove the 'labeled' type triggering deploys because when multiple tags are added in succession multiple builds are triggerd.
