### PR TITLE
[CST-2038] Check for email when attempting to reactivate a profile

### DIFF
--- a/app/forms/schools/add_participants/add_wizard.rb
+++ b/app/forms/schools/add_participants/add_wizard.rb
@@ -125,22 +125,8 @@ module Schools
         profile
       end
 
-      def existing_withdrawn_records(trn:)
-        lookup_trn = TeacherReferenceNumber.new(trn).formatted_trn
-        teacher_profile = TeacherProfile.find_by(trn: lookup_trn)
-        teacher_profile&.participant_profiles&.withdrawn_record || ParticipantProfile.none
-      end
-
-      def existing_withdrawn_ect(trn:)
-        existing_withdrawn_records(trn:).ects.first
-      end
-
-      def existing_withdrawn_mentor(trn:)
-        existing_withdrawn_records(trn:).mentors.first
-      end
-
       def reactivate_or_create_ect_profile
-        existing_profile = existing_withdrawn_ect(trn:)
+        existing_profile = ::Participants::WithdrawnProfileFinder.find(trn:, email:, type: :ect)
 
         if existing_profile
           args = participant_create_args.except(:full_name)
@@ -153,7 +139,7 @@ module Schools
       def reactivate_or_create_mentor_profile
         args = participant_create_args.except(:induction_start_date, :mentor_profile_id)
 
-        existing_profile = existing_withdrawn_mentor(trn:)
+        existing_profile = ::Participants::WithdrawnProfileFinder.find(trn:, email:, type: :mentor)
         if existing_profile
           args = args.except(:full_name)
           Mentors::Reactivate.call(participant_profile: existing_profile, **args)

--- a/app/services/participants/withdrawn_profile_finder.rb
+++ b/app/services/participants/withdrawn_profile_finder.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Participants
+  class WithdrawnProfileFinder
+    class << self
+      def find(trn:, email:, type:)
+        new(trn:, email:, type:).find
+      end
+    end
+
+    VALID_TYPES = %i[ect mentor].freeze
+
+    attr_reader :trn, :email, :type
+
+    def initialize(trn:, email:, type:)
+      @trn = trn
+      @email = email
+      @type = type
+      raise ArgumentError, "type must be one of: #{VALID_TYPES.join(',')}" unless VALID_TYPES.include?(@type)
+    end
+
+    def find
+      all.first
+    end
+
+  private
+
+    def filter_to_type(scope)
+      case type
+      when :ect
+        scope.ects
+      when :mentor
+        scope.mentors
+      end
+    end
+
+    def all
+      existing_withdrawn_record_by_trn(trn) ||
+        existing_withdrawn_record_by_email(email) ||
+        ParticipantProfile.none
+    end
+
+    def existing_withdrawn_record_by_trn(trn)
+      lookup_trn = TeacherReferenceNumber.new(trn).formatted_trn
+      teacher_profile = TeacherProfile.find_by(trn: lookup_trn)
+      withdrawn_records = teacher_profile&.participant_profiles&.withdrawn_record
+      filter_to_type(withdrawn_records) if withdrawn_records.present?
+    end
+
+    def existing_withdrawn_record_by_email(email)
+      user = Identity.find_user_by(email:)
+      withdrawn_records = user&.participant_profiles&.withdrawn_record
+      filter_to_type(withdrawn_records) if withdrawn_records.present?
+    end
+  end
+end

--- a/spec/features/schools/participants/add_participants/add_previously_withdrawn_mentor_spec.rb
+++ b/spec/features/schools/participants/add_participants/add_previously_withdrawn_mentor_spec.rb
@@ -82,6 +82,38 @@ RSpec.describe "Adding previously withdrawn Mentor", type: :feature, js: true do
     }.to_not change { ParticipantProfile.count }
   end
 
+  scenario "Adding a Mentor without validation data back to the school it was withdrawn from" do
+    participant_profile = add_and_remove_participant_from_school_cohort(previous_school_cohort)
+    participant_profile.teacher_profile.update!(trn: nil)
+    the_participant_profile_is_set_up_as_withdrawn_correctly(
+      participant_profile,
+      previous_school_cohort,
+      expected_trn: nil,
+    )
+
+    expect {
+      sign_in
+
+      when_i_go_to_add_new_ect_or_mentor_page
+      and_i_go_through_the_who_do_you_want_to_add_page
+      and_i_go_through_the_what_we_need_from_you_page
+
+      and_i_fill_in_all_info
+      then_i_am_taken_to_mentor_start_training_page
+
+      when_i_choose_summer_term_2023
+      when_i_click_on_continue
+
+      then_i_am_taken_to_the_confirmation_page
+      and_i_see_the_correct_details(joint_provider_details: true)
+
+      when_i_check_the_mentor_details
+      and_i_see_the_correct_details
+
+      and_the_participant_profile_is_set_up_correctly(participant_profile)
+    }.to_not change { ParticipantProfile.count }
+  end
+
   scenario "Adding a Mentor back to the school it was withdrawn from with a different email" do
     participant_profile = add_and_remove_participant_from_school_cohort(previous_school_cohort)
     the_participant_profile_is_set_up_as_withdrawn_correctly(participant_profile, previous_school_cohort)
@@ -283,7 +315,7 @@ private
     expect(page).to have_content("Contact them directly to check whether they need to be transferred to your school")
   end
 
-  def the_participant_profile_is_set_up_as_withdrawn_correctly(participant_profile, expected_school_cohort)
+  def the_participant_profile_is_set_up_as_withdrawn_correctly(participant_profile, expected_school_cohort, expected_trn: ect_trn)
     participant_profile.reload
     expected_cohort = expected_school_cohort.cohort
     expect([
@@ -305,7 +337,7 @@ private
       expected_school_cohort.id,
       nil,
       nil,
-      ect_trn,
+      expected_trn,
     ]
   end
 


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CST-2038

### Changes proposed in this pull request

When checking for existing profiles that may be reactivated the AddWizard will now also check for withdrawn profiles on user's matching the entered email if no TRN match is found.


