### PR TITLE
[CPDLP-2553] Raise an error when a completed declaration outcome fails to create

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -14,6 +14,7 @@ module Api
     rescue_from ActiveRecord::RecordNotUnique, with: :bad_request_response
     rescue_from ActiveRecord::RecordInvalid, with: :invalid_transition
     rescue_from Api::Errors::InvalidTransitionError, with: :invalid_transition
+    rescue_from Api::Errors::InvalidParticipantOutcomeError, with: :invalid_transition
     rescue_from Api::Errors::InvalidDatetimeError, with: :invalid_updated_since_response
     rescue_from Api::Errors::InvalidTrainingStatusError, with: :invalid_training_status_response
     rescue_from Pagy::VariableError, with: :invalid_pagination_response

--- a/app/controllers/api/errors/invalid_participant_outcome_error.rb
+++ b/app/controllers/api/errors/invalid_participant_outcome_error.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Api
+  module Errors
+    class InvalidParticipantOutcomeError < StandardError; end
+  end
+end

--- a/app/services/record_declaration.rb
+++ b/app/services/record_declaration.rb
@@ -47,7 +47,7 @@ class RecordDeclaration
 
       declaration_attempt.update!(participant_declaration:)
 
-      create_participant_outcome
+      create_participant_outcome!
     end
 
     participant_declaration
@@ -241,15 +241,21 @@ private
     has_passed.to_s == "true" ? "passed" : "failed"
   end
 
-  def create_participant_outcome
+  def create_participant_outcome!
     return unless validate_has_passed?
 
-    NPQ::CreateParticipantOutcome.new(
+    service = NPQ::CreateParticipantOutcome.new(
       cpd_lead_provider:,
       course_identifier:,
       participant_external_id: participant_identity.user_id,
       completion_date: declaration_date,
       state: participant_outcome_state,
-    ).call
+    )
+
+    if service.valid?
+      service.call
+    else
+      raise Api::Errors::InvalidParticipantOutcomeError, I18n.t(:cannot_create_completed_declaration)
+    end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,6 +42,7 @@ en:
   invalid_transition: "Invalid action"
   invalid_page_parameters: "The '#/page[page]' and '#/page[per_page]' parameter values must be a valid number (equal and more than 1)"
   cannot_change_cohort: "The property '#/cohort' cannot be changed"
+  cannot_create_completed_declaration: "Could not create completed declaration. Contact the DfE for support."
   invalid_participant: "Your update cannot be made as the '#/participant_id' is not recognised. Check participant details and try again."
   invalid_identifier: "The entered '#/course_identifier' is not recognised for the given participant. Check details and try again."
   invalid_declaration_type: "The property '#/declaration_type' must be available for '#/course_identifier'"

--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -7,6 +7,10 @@ weight: 8
 
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
 
+## 30 October 2023
+
+Lead providers will now see a 422 error code if a `completed` declaration outcome fails. In such instances, you'll be prompted to contact us for support.
+
 ## 17 October 2023
 
 Lead providers can now test the new `participant_id_changes` feature in the sandbox.

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -624,6 +624,20 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
             expect(ParticipantOutcome::NPQ.count).to eql(1)
           end
         end
+
+        context "when CreateParticipantOutcome service class is invalid" do
+          let(:has_passed) { true }
+
+          before do
+            allow_any_instance_of(NPQ::CreateParticipantOutcome).to receive(:valid?).and_return(false)
+          end
+
+          it "returns 422" do
+            post "/api/v1/participant-declarations", params: params.to_json
+            expect(response.status).to eq 422
+            expect(response.body).to eq({ errors: [{ title: "Invalid action", detail: I18n.t(:cannot_create_completed_declaration) }] }.to_json)
+          end
+        end
       end
     end
 

--- a/spec/requests/api/v2/participant_declarations_spec.rb
+++ b/spec/requests/api/v2/participant_declarations_spec.rb
@@ -320,6 +320,20 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
             expect(ParticipantOutcome::NPQ.count).to eql(1)
           end
         end
+
+        context "when CreateParticipantOutcome service class is invalid" do
+          let(:has_passed) { true }
+
+          before do
+            allow_any_instance_of(NPQ::CreateParticipantOutcome).to receive(:valid?).and_return(false)
+          end
+
+          it "returns 422" do
+            post "/api/v2/participant-declarations", params: params.to_json
+            expect(response.status).to eq 422
+            expect(response.body).to eq({ errors: [{ title: "Invalid action", detail: I18n.t(:cannot_create_completed_declaration) }] }.to_json)
+          end
+        end
       end
     end
 

--- a/spec/requests/api/v3/participant_declarations_spec.rb
+++ b/spec/requests/api/v3/participant_declarations_spec.rb
@@ -542,6 +542,20 @@ RSpec.describe "API Participant Declarations", type: :request do
             expect(ParticipantOutcome::NPQ.count).to eql(1)
           end
         end
+
+        context "when CreateParticipantOutcome service class is invalid" do
+          let(:has_passed) { true }
+
+          before do
+            allow_any_instance_of(NPQ::CreateParticipantOutcome).to receive(:valid?).and_return(false)
+          end
+
+          it "returns 422" do
+            post "/api/v3/participant-declarations", params: params.to_json
+            expect(response.status).to eq 422
+            expect(response.body).to eq({ errors: [{ title: "Invalid action", detail: I18n.t(:cannot_create_completed_declaration) }] }.to_json)
+          end
+        end
       end
     end
   end

--- a/spec/services/record_declaration_spec.rb
+++ b/spec/services/record_declaration_spec.rb
@@ -534,6 +534,18 @@ RSpec.describe RecordDeclaration do
           end
         end
       end
+
+      context "when CreateParticipantOutcome service class is invalid" do
+        before do
+          allow_any_instance_of(NPQ::CreateParticipantOutcome).to receive(:valid?).and_return(false)
+        end
+
+        it "raises an InvalidParticipantOutcomeError" do
+          expect(ParticipantDeclaration::NPQ.completed.count).to be(0)
+          expect { service.call }.to raise_error(Api::Errors::InvalidParticipantOutcomeError)
+          expect(ParticipantDeclaration::NPQ.completed.count).to be(0)
+        end
+      end
     end
 
     context "when lead provider has no contract for the cohort and course" do


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-2553](https://dfedigital.atlassian.net/browse/CPDLP-2553)

Completed declaration should error when outcome fails to create.

### Changes proposed in this pull request

Raise an error when a completed declaration outcome fails to create.

[CPDLP-2553]: https://dfedigital.atlassian.net/browse/CPDLP-2553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ