### PR TITLE
[CST-852] Allow admins to edit appropriate body (DRAFT)

### DIFF
--- a/app/components/admin/schools/cohort_component.html.erb
+++ b/app/components/admin/schools/cohort_component.html.erb
@@ -32,6 +32,12 @@
               row.with_action(text: "Change", visually_hidden_text: "training programme",  href: change_programme_href)
             end
           end
+
+          summary_list.with_row do |row|
+            row.with_key(text: "Appropriate body")
+            row.with_value(text: school_cohort&.appropriate_body&.name || "No appropriate body")
+            row.with_action(text: "Change", visually_hidden_text: "appropriate body", href: change_appropriate_body_href)
+          end
         end
       %>
     <% end %>
@@ -59,6 +65,7 @@
           summary_list.with_row do |row|
             row.with_key(text: "Appropriate body")
             row.with_value(text: school_cohort&.appropriate_body&.name || "No appropriate body")
+            row.with_action(text: "Change", visually_hidden_text: "appropriate body", href: change_appropriate_body_href)
           end
         end
       end

--- a/app/components/admin/schools/cohort_component.rb
+++ b/app/components/admin/schools/cohort_component.rb
@@ -81,6 +81,10 @@ module Admin
         admin_school_change_programme_path(id: school_cohort.start_year, school_id: school.slug)
       end
 
+      def change_appropriate_body_href
+        admin_school_change_appropriate_body_path(school.id, school_cohort.id)
+      end
+
     private
 
       def induction_programme_choice

--- a/app/components/admin/schools/partnership_component.html.erb
+++ b/app/components/admin/schools/partnership_component.html.erb
@@ -8,6 +8,7 @@
     summary_list.with_row do |row|
       row.with_key(text: "Appropriate body")
       row.with_value(text: appropriate_body_name || "None")
+      row.with_action(text: "Change", visually_hidden_text: "appropriate body", href: change_appropriate_body_href)
     end
 
     summary_list.with_row do |row|

--- a/app/components/admin/schools/partnership_component.rb
+++ b/app/components/admin/schools/partnership_component.rb
@@ -28,6 +28,10 @@ module Admin
         partnership.delivery_partner.name
       end
 
+      def change_appropriate_body_href
+        admin_school_change_appropriate_body_path(school.id, school_cohort.id)
+      end
+
     private
 
       def visually_hidden(text)

--- a/app/controllers/admin/schools/cohorts/change_appropriate_body_controller.rb
+++ b/app/controllers/admin/schools/cohorts/change_appropriate_body_controller.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Admin
+  module Schools
+    module Cohorts
+      class ChangeAppropriateBodyController < ::Admin::BaseController
+        skip_after_action :verify_authorized
+        skip_after_action :verify_policy_scoped
+        before_action :set_school_and_cohort, :set_school_cohort, :set_appropriate_body_options
+
+        def show
+          @change_appropriate_body_form = form_from_school_cohort
+        end
+
+        def update
+          @change_appropriate_body_form = Admin::ChangeAppropriateBodyForm.new(params.require(:admin_change_appropriate_body_form).permit(:appropriate_body, :teaching_school_hub_id))
+
+          if @change_appropriate_body_form.valid?
+            # TODO: update appropriate body
+            redirect_to admin_school_cohorts_path(@school)
+          else
+            render :show
+          end
+        end
+
+        private
+
+        def form_from_school_cohort
+          if @school_cohort.appropriate_body&.body_type == 'teaching_school_hub'
+            Admin::ChangeAppropriateBodyForm.new(
+              appropriate_body: 'teaching_school_hub',
+              teaching_school_hub_id: @school_cohort.appropriate_body_id
+            )
+          else
+            Admin::ChangeAppropriateBodyForm.new(
+              appropriate_body: @school_cohort.appropriate_body_id
+            )
+          end
+        end
+
+        def set_appropriate_body_options
+          @national_appropriate_bodies = AppropriateBody.where(body_type: 'national').active_in_year(@school_cohort.cohort.start_year)
+          @teaching_school_hubs = AppropriateBody.where(body_type: 'teaching_school_hub').active_in_year(@school_cohort.cohort.start_year)
+        end
+
+        def set_school_and_cohort
+          @school = ::School.friendly.find params[:school_id]
+          @cohort = ::Cohort.find_by start_year: params[:id]
+        end
+
+        def set_school_cohort
+          @school_cohort ||= @school.school_cohorts.find(params[:id])
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/admin/schools/cohorts/change_appropriate_body_controller.rb
+++ b/app/controllers/admin/schools/cohorts/change_appropriate_body_controller.rb
@@ -23,24 +23,24 @@ module Admin
           end
         end
 
-        private
+      private
 
         def form_from_school_cohort
-          if @school_cohort.appropriate_body&.body_type == 'teaching_school_hub'
+          if @school_cohort.appropriate_body&.body_type == "teaching_school_hub"
             Admin::ChangeAppropriateBodyForm.new(
-              appropriate_body: 'teaching_school_hub',
-              teaching_school_hub_id: @school_cohort.appropriate_body_id
+              appropriate_body: "teaching_school_hub",
+              teaching_school_hub_id: @school_cohort.appropriate_body_id,
             )
           else
             Admin::ChangeAppropriateBodyForm.new(
-              appropriate_body: @school_cohort.appropriate_body_id
+              appropriate_body: @school_cohort.appropriate_body_id,
             )
           end
         end
 
         def set_appropriate_body_options
-          @national_appropriate_bodies = AppropriateBody.where(body_type: 'national').active_in_year(@school_cohort.cohort.start_year)
-          @teaching_school_hubs = AppropriateBody.where(body_type: 'teaching_school_hub').active_in_year(@school_cohort.cohort.start_year)
+          @national_appropriate_bodies = AppropriateBody.where(body_type: "national").active_in_year(@school_cohort.cohort.start_year)
+          @teaching_school_hubs = AppropriateBody.where(body_type: "teaching_school_hub").active_in_year(@school_cohort.cohort.start_year)
         end
 
         def set_school_and_cohort

--- a/app/controllers/admin/schools/cohorts/change_appropriate_body_controller.rb
+++ b/app/controllers/admin/schools/cohorts/change_appropriate_body_controller.rb
@@ -49,7 +49,7 @@ module Admin
         end
 
         def set_school_cohort
-          @school_cohort ||= @school.school_cohorts.find(params[:id])
+          @school_cohort = @school.school_cohorts.find(params[:id])
         end
       end
     end

--- a/app/forms/admin/change_appropriate_body_form.rb
+++ b/app/forms/admin/change_appropriate_body_form.rb
@@ -1,0 +1,15 @@
+class Admin::ChangeAppropriateBodyForm
+  include ActiveModel::Model
+
+  attr_accessor :appropriate_body, :teaching_school_hub_id
+
+  validates :appropriate_body, presence: true
+  validates :teaching_school_hub_id, presence: true, if: :teaching_school_hub?
+
+  private
+
+  def teaching_school_hub?
+    appropriate_body == 'teaching_school_hub'
+  end
+
+end

--- a/app/forms/admin/change_appropriate_body_form.rb
+++ b/app/forms/admin/change_appropriate_body_form.rb
@@ -6,10 +6,9 @@ class Admin::ChangeAppropriateBodyForm
   validates :appropriate_body, presence: true
   validates :teaching_school_hub_id, presence: true, if: :teaching_school_hub?
 
-  private
+private
 
   def teaching_school_hub?
-    appropriate_body == 'teaching_school_hub'
+    appropriate_body == "teaching_school_hub"
   end
-
 end

--- a/app/forms/admin/change_appropriate_body_form.rb
+++ b/app/forms/admin/change_appropriate_body_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Admin::ChangeAppropriateBodyForm
   include ActiveModel::Model
 

--- a/app/views/admin/schools/cohorts/change_appropriate_body/show.html.erb
+++ b/app/views/admin/schools/cohorts/change_appropriate_body/show.html.erb
@@ -1,0 +1,33 @@
+<% title = "Who is the appropriate body for their #{@school_cohort.cohort.start_year} programme?" %>
+<% content_for :title, title %>
+<% content_for :before_content, govuk_back_link(
+  text: "Back",
+  href: admin_school_cohorts_path) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <%= form_for @change_appropriate_body_form, url: admin_school_change_appropriate_body_path(@school, @school_cohort), method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <span class="govuk-caption-l"><%= @school.name %></span>
+      <%= f.govuk_radio_buttons_fieldset(:appropriate_body, legend: { size: 'l', text: title }, hint: {text: "This will change the default for any new ECTs registered, but will not affect any existing ECTs" }) do %>
+        <% @national_appropriate_bodies.each_with_index do |appropriate_body, index| %>
+          <%= f.govuk_radio_button :appropriate_body, appropriate_body.id, label: { text: appropriate_body.name }, link_errors: (index == 0) %>
+        <% end %>
+
+        <%= f.govuk_radio_divider %>
+        <%= f.govuk_radio_button :appropriate_body, 'teaching_school_hub', label: { text: 'A teaching school hub' } do %>
+          <%= f.govuk_collection_select(:teaching_school_hub_id,
+              @teaching_school_hubs,
+              :id,
+              :name,
+              label: { text: "Teaching school hub", size: 's' },
+              options: { include_blank: true },
+              class: "autocomplete") %>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_submit "Continue" %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/admin/induction_choice_form.yml
+++ b/config/locales/admin/induction_choice_form.yml
@@ -14,3 +14,13 @@ en:
         design_our_own: "design and deliver their own programme based on the Early Career Framework (ECF)"
         school_funded_fip: "use a training provider funded by their school."
         no_early_career_teachers: "opt out of notifications because they don’t expect to have any early career teachers starting in %{cohort}"
+
+  activemodel:
+    errors:
+      models:
+        admin/change_appropriate_body_form:
+          attributes:
+            appropriate_body:
+              blank: "Select appropriate body"
+            teaching_school_hub_id:
+              blank: "Select teaching school hub"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -294,6 +294,7 @@ Rails.application.routes.draw do
           resource :change_training_materials, only: %i[show update], path: "change-training-materials", controller: "schools/cohorts/change_training_materials" do
             post :confirm
           end
+          resource :change_appropriate_body, only: %i[show update], path: "appropriate-body", controller: "schools/cohorts/change_appropriate_body"
         end
       end
       resources :partnerships, only: [] do


### PR DESCRIPTION
This allows admins to change the appropriate body for a school’s academic year cohort without having to impersonate the induction tutor.

**Note:** this is just a design for now, but I thought I’d see if it’d be quicker to mockup within the production code, as the prototype doesn't contain any admin views.

## Admin cohort view

<img width="985" alt="Screenshot 2023-10-24 at 12 53 19" src="https://github.com/DFE-Digital/early-careers-framework/assets/30665/27e5f7e0-c22a-4e6b-be2a-51ea8ea777f5">

### Change appropriate body form

(This is all on a single form, using a conditional-reveal for the Teaching School Hub option)

<img width="978" alt="Screenshot 2023-10-24 at 13 00 00" src="https://github.com/DFE-Digital/early-careers-framework/assets/30665/fb6d0451-2da8-46b1-95fd-61e9eca63767">
