### PR TITLE
[CST-2074] Handle gracefully participants without induction records in the admin pages

### DIFF
--- a/app/presenters/admin/participant_presenter.rb
+++ b/app/presenters/admin/participant_presenter.rb
@@ -42,7 +42,7 @@ class Admin::ParticipantPresenter
   end
 
   delegate :email, to: :user
-  delegate :enrolled_in_fip?, to: :relevant_induction_record
+  delegate :enrolled_in_fip?, to: :relevant_induction_record, allow_nil: true
   delegate :full_name, to: :user
 
   def has_mentor?

--- a/spec/presenters/admin/participant_presenter_spec.rb
+++ b/spec/presenters/admin/participant_presenter_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe(Admin::ParticipantPresenter) do
     it { is_expected.to delegate_method(:ecf_participant_eligibility).to(:participant_profile) }
     it { is_expected.to delegate_method(:ecf_participant_validation_data).to(:participant_profile) }
     it { is_expected.to delegate_method(:email).to(:user) }
-    it { is_expected.to delegate_method(:enrolled_in_fip?).to(:relevant_induction_record) }
+    it { is_expected.to delegate_method(:enrolled_in_fip?).to(:relevant_induction_record).allow_nil }
     it { is_expected.to delegate_method(:full_name).to(:user) }
     it { is_expected.to delegate_method(:id).to(:participant_profile) }
     it { is_expected.to delegate_method(:lead_provider_name).to(:relevant_induction_record).allow_nil }


### PR DESCRIPTION
### Context

- Ticket: CST-2074

The `Admin::ParticipantPresenter` is rasing an exception in the Admin pages when participants have no induction records. That breaks the Admin pages and the support team can't see the participant profiles or troubleshoot issues.

The admin pages should handle this issue gracefully so the participant profiles are accessible.

### Changes proposed in this pull request
- Update the failing delegated method to return nil when there are no induction records

### Guidance to review

