### PR TITLE
[CST-2072] Display the correct providers in the Admin Participant training page

### DIFF
--- a/app/views/admin/participants/school/show.html.erb
+++ b/app/views/admin/participants/school/show.html.erb
@@ -52,12 +52,12 @@
     if @participant_presenter.relevant_induction_record&.enrolled_in_fip?
       sl.with_row do |row|
         row.with_key(text: "Lead provider")
-        row.with_value(text: @participant_presenter.school_lead_provider_name)
+        row.with_value(text: @participant_presenter.lead_provider_name)
       end
 
       sl.with_row do |row|
         row.with_key(text: "Delivery partner")
-        row.with_value(text: @participant_presenter.school_delivery_partner_name)
+        row.with_value(text: @participant_presenter.delivery_partner_name)
       end
     elsif @participant_presenter.relevant_induction_record&.enrolled_in_cip?
       sl.with_row do |row|


### PR DESCRIPTION
### Context

- Ticket: CST-2072

The current Participant training in the Admin pages displays the LP/DP from the default induction programme of the school cohort the participant is in. However the participant may be on one of the relationships insteadm which is reflected in their induction record.

This PR uses the relevant induction record of the participant to display the LP/DP correctly in their training admin page.

### Changes proposed in this pull request
- Update the view to use the presenter's `lead_provider_name` and `delivery_partner_name` methods instead of the school ones

### Guidance to review
- Visit the admin pages
- Pick a participant who's doing a FIP programme from a relationship (not the default induction programme of the school cohort)
- Confirm the LP/DP in their Training page is the correct and also the same that's in their induction record

