### PR TITLE
Save request_body in ApiRequest for PUT requests

### DIFF
--- a/app/jobs/api_request_job.rb
+++ b/app/jobs/api_request_job.rb
@@ -49,9 +49,7 @@ private
   end
 
   def request_body(request_data)
-    if request_data[:method] == "POST"
-      return if request_data[:body].blank?
-
+    if request_data[:body].present?
       JSON.parse(request_data[:body])
     else
       request_data[:params]

--- a/spec/jobs/api_request_job_spec.rb
+++ b/spec/jobs/api_request_job_spec.rb
@@ -74,6 +74,16 @@ RSpec.describe ApiRequestJob do
     expect(ApiRequest.find_by(request_path: "/api/v1/bar").request_body).to eq("foo" => "meh")
   end
 
+  it "saves request data from PUT requests" do
+    described_class.new.perform({
+      body: { "foo" => "meh" }.to_json,
+      path: "/api/v1/bar",
+      method: "PUT",
+    }, {}, 500, Time.zone.now)
+
+    expect(ApiRequest.find_by(request_path: "/api/v1/bar").request_body).to eq("foo" => "meh")
+  end
+
   it "records when POST data is not valid JSON" do
     described_class.new.perform({
       body: "This is not JSON",


### PR DESCRIPTION
### Context

Currently we only persist the request body for POST requests. Going forward, if there is a request body in the payload we want to persist it in the `ApiRequest` model.

### Changes proposed in this pull request

- Save request_body in ApiRequest for PUT requests

### Guidance to review

