### PR TITLE
[CPDLP-2545] NPQ Maths - As an SRM I want to view NPQ Maths on the NPQ statement

### DIFF
--- a/app/assets/stylesheets/lead_providers/statements.scss
+++ b/app/assets/stylesheets/lead_providers/statements.scss
@@ -187,3 +187,14 @@
     }
   }
 }
+
+.app-application__standalone-course {
+  margin: 40px 20px;
+
+  .govuk-warning-text__icon {
+    margin-top: 7px;
+  }
+  .govuk-warning-text__text {
+    margin-left: 10px;
+  }
+}

--- a/app/controllers/finance/npq/statements_controller.rb
+++ b/app/controllers/finance/npq/statements_controller.rb
@@ -8,10 +8,19 @@ module Finance
         @cpd_lead_provider = @npq_lead_provider.cpd_lead_provider
         @statement         = @cpd_lead_provider.npq_lead_provider.statements.find(params[:id])
         @statements        = @npq_lead_provider.statements.upto_current.order(payment_date: :desc)
+
         @npq_contracts     = @npq_lead_provider.npq_contracts.where(
           version: @statement.contract_version,
           cohort: @statement.cohort,
+          special_course: false,
         ).order(course_identifier: :asc)
+
+        @npq_special_contracts = @npq_lead_provider.npq_contracts.where(
+          version: @statement.contract_version,
+          cohort: @statement.cohort,
+          special_course: true,
+        ).order(course_identifier: :asc)
+
         @calculator = StatementCalculator.new(statement: @statement)
         set_important_message(title: t("finance.statements.payment_authorisations.banner.title"), content: t("finance.statements.payment_authorisations.banner.content", statement_marked_as_paid_at: @statement.marked_as_paid_at.strftime("%-I:%M%P on %-e %b %Y"))) if authorising_for_payment_banner_visible?(@statement)
       end

--- a/app/services/finance/npq/statement_calculator.rb
+++ b/app/services/finance/npq/statement_calculator.rb
@@ -109,6 +109,7 @@ module Finance
           .npq_contracts
           .where(version: statement.contract_version)
           .where(cohort: statement.cohort)
+          .where(special_course: false)
           .order(course_identifier: :asc)
       end
 

--- a/app/views/finance/npq/statements/show.html.erb
+++ b/app/views/finance/npq/statements/show.html.erb
@@ -9,6 +9,19 @@
 
     <%= render Finance::Statements::NPQStatementSelector.new(current_statement: @statement, cohorts: Cohort.where(start_year: 2021..)) %>
 
+    <% if @npq_special_contracts.any? %>
+      <div class="govuk-warning-text app-application__standalone-course">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-warning-text__assistive">Warning</span>
+          <%= @npq_special_contracts.map{|c| t(c.course_identifier, scope: "npq_courses") }.join(", ") %>
+          has standalone payments.
+          <br/>
+          <%= govuk_link_to "View payments for this course", '#standalone_payments' %>
+        </strong>
+      </div>
+    <% end %>
+
     <div class="app-application__panel__summary">
       <div class="govuk-!-margin-right-4">
         <h4 class="govuk-heading-l govuk-!-margin-bottom-2"><%= t("finance.totals") %></h4>
@@ -152,11 +165,22 @@
       <div class="moj-filter-layout__content">
         <% @npq_contracts.each do |npq_contract| %>
           <%= render Finance::NPQ::PaymentOverviews::Course.new(statement: @statement, contract: npq_contract) %>
-
-          <br>
+          <br/>
         <% end %>
       </div>
     </div>
+
+    <% if @npq_special_contracts.any? %>
+      <h4 id="standalone_payments" class="govuk-heading-l govuk-!-margin-top-9 govuk-!-margin-bottom-7">Standalone payments</h4>
+      <div class="app-application__panel">
+        <div class="moj-filter-layout__content">
+          <% @npq_special_contracts.each do |npq_contract| %>
+            <%= render Finance::NPQ::PaymentOverviews::Course.new(statement: @statement, contract: npq_contract) %>
+            <br/>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
   </div>
 
   <%= render Finance::NPQ::PaymentOverviews::ContractInfo.new(@npq_contracts, @npq_lead_provider) %>

--- a/spec/factories/participant_declaration.rb
+++ b/spec/factories/participant_declaration.rb
@@ -54,10 +54,13 @@ FactoryBot.define do
       params[:evidence_held] = "other" if declaration_type != "started"
 
       if participant_profile.is_a?(ParticipantProfile::NPQ)
-        create(:npq_contract,
-               npq_lead_provider: cpd_lead_provider.npq_lead_provider,
-               cohort: participant_profile.npq_application.cohort,
-               npq_course: participant_profile.npq_application.npq_course)
+        opts = {
+          npq_lead_provider: cpd_lead_provider.npq_lead_provider,
+          cohort: participant_profile.npq_application.cohort,
+          npq_course: participant_profile.npq_application.npq_course,
+          version: "1.0",
+        }
+        NPQContract.find_by(opts) || create(:npq_contract, opts)
       end
 
       service = RecordDeclaration.new(params)

--- a/spec/features/finance/npq/statement_spec.rb
+++ b/spec/features/finance/npq/statement_spec.rb
@@ -85,11 +85,38 @@ RSpec.describe "Show NPQ statement", :js do
     end
   end
 
+  context "Statement with a special course" do
+    scenario "Maths as special course" do
+      given_i_am_logged_in_as_a_finance_user
+      and_multiple_declarations_exist
+      and_multiple_declarations_exist_with_special_course
+
+      when_i_visit_the_npq_financial_statements_page
+
+      then_i_see("National professional qualifications (NPQs)")
+      and_i_see_special_course_warning
+      and_i_see_special_course_payment_overview
+    end
+
+    scenario "No special course" do
+      given_i_am_logged_in_as_a_finance_user
+      and_multiple_declarations_exist
+
+      when_i_visit_the_npq_financial_statements_page
+
+      then_i_do_not_see_special_course
+    end
+  end
+
   def when_i_visit_the_npq_financial_statements_page
     visit("/finance/npq/payment-overviews/#{npq_lead_provider.id}/statements/#{statement.id}")
   end
 
   def then_i_see(string)
+    expect(page).to have_content(string)
+  end
+
+  def and_i_see(string)
     expect(page).to have_content(string)
   end
 
@@ -107,6 +134,23 @@ RSpec.describe "Show NPQ statement", :js do
     end
   end
 
+  def and_multiple_declarations_exist_with_special_course
+    npq_maths_course = create(:npq_leadership_course, identifier: "npq-leading-primary-mathematics")
+
+    create(
+      :npq_contract,
+      npq_lead_provider:,
+      version: statement.contract_version,
+      cohort: statement.cohort,
+      course_identifier: npq_maths_course.identifier,
+      special_course: true,
+    )
+
+    travel_to statement.deadline_date do
+      create_list(:npq_participant_declaration, 7, :eligible, npq_course: npq_maths_course, cpd_lead_provider:)
+    end
+  end
+
   def and_i_see_authorise_for_payment_button
     expect(page).to have_button("Authorise for payment")
   end
@@ -117,5 +161,26 @@ RSpec.describe "Show NPQ statement", :js do
 
   def when_i_do_all_assurance_checks
     check("Yes, I'm ready to authorise this for payment", allow_label_click: true)
+  end
+
+  def and_i_see_special_course_warning
+    within ".govuk-warning-text" do
+      have_content("Warning Leading Primary Mathematics has standalone payments")
+      have_link("View payments for this course", href: "#standalone_payments")
+    end
+  end
+
+  def and_i_see_special_course_payment_overview
+    within "h4#standalone_payments" do
+      have_content("Standalone payments")
+    end
+    within "h4#standalone_payments + .app-application__panel section.app-application__card h2" do
+      have_content("Leading primary mathematics")
+    end
+  end
+
+  def then_i_do_not_see_special_course
+    expect(page).to_not have_button("Standalone payments")
+    expect(page).to_not have_link("View payments for this course")
   end
 end

--- a/spec/services/oneoffs/npq/set_special_course_for_npq_contracts_spec.rb
+++ b/spec/services/oneoffs/npq/set_special_course_for_npq_contracts_spec.rb
@@ -94,5 +94,64 @@ RSpec.describe Oneoffs::NPQ::SetSpecialCourseForNPQContracts do
       expect(new_npq_contract1.targeted_delivery_funding_per_participant).to eql(old_npq_contract1.targeted_delivery_funding_per_participant)
       expect(new_npq_contract1.special_course).to eql(true)
     end
+
+    context "when there are other non-special courses" do
+      let(:course_identifier_npqlt) { create(:npq_course, identifier: "npq-leading-teaching").identifier }
+      let!(:npq_contract_npqlt) do
+        create(
+          :npq_contract,
+          course_identifier: course_identifier_npqlt,
+          npq_lead_provider: npq_statement1.npq_lead_provider,
+          cohort: npq_statement1.cohort,
+          version: npq_statement1.contract_version,
+          special_course: false,
+        )
+      end
+
+      it "should create new npq_contract_npqlt with updated version to match statement1" do
+        expect(npq_statement1.reload.contract_version).to eql("0.0.1")
+        expect(NPQContract.where(course_identifier: course_identifier_npqlt).count).to eql(1)
+
+        subject.call
+
+        expect(npq_statement1.reload.contract_version).to eql("0.0.2")
+        expect(NPQContract.where(course_identifier: course_identifier_npqlt).count).to eql(2)
+        new_contract = NPQContract.where(course_identifier: course_identifier_npqlt).order(version: :desc).first
+        expect(new_contract.version).to eql("0.0.2")
+        expect(new_contract.special_course).to eql(false)
+      end
+    end
+
+    context "multiple statement with same npq_contract" do
+      let!(:npq_statement4) do
+        create(
+          :npq_statement,
+          cohort: npq_statement1.cohort,
+          contract_version: npq_statement1.contract_version,
+          cpd_lead_provider: npq_statement1.npq_lead_provider.cpd_lead_provider,
+          payment_date: "2023-10-25",
+        )
+      end
+
+      it "should create one new npq_contract" do
+        expect(Finance::Statement::NPQ.count).to eql(4)
+        expect(npq_statement1.reload.contract_version).to eql("0.0.1")
+        expect(npq_statement4.reload.contract_version).to eql("0.0.1")
+
+        expect(NPQContract.count).to eql(3)
+        expect(NPQContract.where(special_course: false).count).to eql(2)
+        expect(NPQContract.where(special_course: true).count).to eql(1)
+
+        subject.call
+
+        expect(Finance::Statement::NPQ.count).to eql(4)
+        expect(npq_statement1.reload.contract_version).to eql("0.0.2")
+        expect(npq_statement4.reload.contract_version).to eql("0.0.2")
+
+        expect(NPQContract.count).to eql(3 + 1)
+        expect(NPQContract.where(special_course: false).count).to eql(2)
+        expect(NPQContract.where(special_course: true).count).to eql(2)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-2545

### Changes proposed in this pull request

* Updated NPQ statement page to show `special_course=false`
* Include a new section "Standalone payments" that show `special_course=true`

### Guidance to review

