### PR TITLE
Avoid overpaying uplifts on statements

### DIFF
--- a/app/services/finance/ecf/statement_calculator.rb
+++ b/app/services/finance/ecf/statement_calculator.rb
@@ -159,11 +159,9 @@ module Finance
         previous_uplift_count = output_calculator.uplift_breakdown[:previous_count]
         previous_uplift_amount = previous_uplift_count * uplift_fee_per_declaration
 
-        delta_uplift_count = output_calculator.uplift_breakdown[:count]
-
         # uplift_clawback_deductions is a negative number so doing a double negative --
         # we're adding it back as we had subtracted from adjustments_total
-        delta_uplift_amount = delta_uplift_count * uplift_fee_per_declaration - uplift_clawback_deductions
+        delta_uplift_amount = uplift_count * uplift_fee_per_declaration - uplift_clawback_deductions
 
         available = [(statement.contract.uplift_cap - previous_uplift_amount), 0].max
 

--- a/spec/services/finance/ecf/output_calculator_spec.rb
+++ b/spec/services/finance/ecf/output_calculator_spec.rb
@@ -1120,7 +1120,7 @@ RSpec.describe Finance::ECF::OutputCalculator do
         end
       end
 
-      context "when the upper band limit is exceeded by previous statements" do
+      context "when the upper band limit is met by previous statements" do
         let(:max_billable_declarations) { first_statement.contract.bands.map(&:max).max }
 
         before do
@@ -1130,7 +1130,7 @@ RSpec.describe Finance::ECF::OutputCalculator do
 
         def setup_statement_one
           declarations = create_list(
-            :ect_participant_declaration, max_billable_declarations + 1,
+            :ect_participant_declaration, max_billable_declarations,
             state: :paid,
             pupil_premium_uplift: true
           )
@@ -1189,7 +1189,7 @@ RSpec.describe Finance::ECF::OutputCalculator do
         let(:statement_two_expectation) do
           {
             previous_count: 8,
-            count: 1,
+            count: 0,
             additions: 2,
             subtractions: 2,
           }


### PR DESCRIPTION
[Jira-2546](https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-2546)

### Context

We currently restrict the declaration payments to the defined upper band limit, but we do not restrict payments on uplifts.

Going forward we want to also restrict the uplift payments in the same way, such that when the number of uplift payments reaches the upper band limit we will not make any more uplifts payable (until refundable uplifts brings the available amount back within the upper band limit).

### Changes proposed in this pull request

- Avoid overpaying uplifts on statements

We do this by capping the `uplift_breakdown` values in the `OutputCalculator`.

For example:

> Upper band limit: 2

| Statement | Billable Amount | Refundable Amount | Uplift Breakdown                                                |
| --------- | --------------- | ----------------- | --------------------------------------------------------------- |
| A         | 3               | 0                 | available: 2, prev: 0, count: 2, additions: 2, subtractions: 0  |
| B         | 2               | 1                 | available: 1, prev: 2, count: 1, additions: 1, subtractions: 1  |
| C         | 0               | 2                 | available: 2, prev: 2, count: -2, additions: 0, subtractions: 2 |

### Guidance to review

