### PR TITLE
Fix bug where blank uuid causes pg adapter to crash

### DIFF
--- a/app/controllers/api/v1/npq/application_synchronizations_controller.rb
+++ b/app/controllers/api/v1/npq/application_synchronizations_controller.rb
@@ -22,7 +22,11 @@ module Api
         # Remove this code once all application statuses have been migrated.
         def set_npq_applications
           ecf_ids = params[:ecf_ids].split(",")
-          @npq_applications = NPQApplication.where("updated_at >= ? OR id IN (?)", 1.week.ago, ecf_ids).select(:lead_provider_approval_status, :id, :participant_identity_id)
+
+          @npq_applications = NPQApplication
+            .where(id: ecf_ids)
+            .or(NPQApplication.where(updated_at: 1.week.ago..))
+            .select(:lead_provider_approval_status, :id, :participant_identity_id)
         end
       end
     end


### PR DESCRIPTION
This bug surfaced [in Sentry](https://dfe-teacher-services.sentry.io/issues/4567543977/?alert_rule_id=14507789&alert_type=issue&notification_uuid=7987324f-898d-4af6-954c-b7d87fc925c2&project=5748989&referrer=slack).

```
ERROR:  invalid input syntax for type uuid: "" (PG::InvalidTextRepresentation)
LINE 1: ...00000000','aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee','','fffff...
```

When building raw SQL 'in' clauses we bypass ActiveRecord's tidying of conditions. By default it will reject non-uuids from uuid fields:

```ruby
NPQApplication.where(id: ["", " ", "abc", "7411192c-c8a1-4306-b840-b932377db02c"]

=> "...WHERE \"npq_applications\".\"id\" IN ('7411192c-c8a1-4306-b840-b932377db02c')"
```

Rewriting this method to use the ActiveRecord directly gives us the same query but with additional safety.
