### PR TITLE
[CST-2058] Enable super user admins to activate the participants induction statuses

### DIFF
--- a/app/controllers/admin/participants/change_induction_status_controller.rb
+++ b/app/controllers/admin/participants/change_induction_status_controller.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Admin::Participants
+  class ChangeInductionStatusController < Admin::BaseController
+    before_action :retrieve_participant_profile
+
+    def edit; end
+
+    def confirm_induction_status
+      @participant_profile = retrieve_participant_profile
+      @relevant_induction_record = Induction::FindBy.new(participant_profile: @participant_profile).call
+
+      update_the_participant_profile unless @participant_profile.active_record?
+      update_the_induction_record if %w[withdrawn leaving].include?(@relevant_induction_record&.induction_status)
+
+      flash[:success] = {
+        title: "Induction status changed successfully",
+        content: "#{@participant_profile.user.full_name}'s induction status was changed to active",
+      }
+
+      redirect_to(admin_participant_statuses_path(@participant_profile))
+    end
+
+  private
+
+    def retrieve_participant_profile
+      @participant_profile =
+        policy_scope(ParticipantProfile).find(params[:participant_id]).tap do |participant_profile|
+          authorize participant_profile, policy_class: participant_profile.policy_class
+        end
+    end
+
+    def update_the_participant_profile
+      @participant_profile.update(status: :active)
+    end
+
+    def update_the_induction_record
+      induction_record_changes = { induction_status: :active }
+      induction_record_changes[:school_transfer] = true if @relevant_induction_record&.leaving_induction_status?
+
+      Induction::ChangeInductionRecord.call(
+        induction_record: @relevant_induction_record,
+        changes: induction_record_changes,
+      )
+    end
+  end
+end

--- a/app/controllers/admin/participants/change_induction_status_controller.rb
+++ b/app/controllers/admin/participants/change_induction_status_controller.rb
@@ -7,11 +7,7 @@ module Admin::Participants
     def edit; end
 
     def confirm_induction_status
-      @participant_profile = retrieve_participant_profile
-      @relevant_induction_record = Induction::FindBy.new(participant_profile: @participant_profile).call
-
-      update_the_participant_profile unless @participant_profile.active_record?
-      update_the_induction_record if %w[withdrawn leaving].include?(@relevant_induction_record&.induction_status)
+      Induction::InductionStatusesActivator.call(participant_profile: @participant_profile)
 
       flash[:success] = {
         title: "Induction status changed successfully",
@@ -28,20 +24,6 @@ module Admin::Participants
         policy_scope(ParticipantProfile).find(params[:participant_id]).tap do |participant_profile|
           authorize participant_profile, policy_class: participant_profile.policy_class
         end
-    end
-
-    def update_the_participant_profile
-      @participant_profile.update(status: :active)
-    end
-
-    def update_the_induction_record
-      induction_record_changes = { induction_status: :active }
-      induction_record_changes[:school_transfer] = true if @relevant_induction_record&.leaving_induction_status?
-
-      Induction::ChangeInductionRecord.call(
-        induction_record: @relevant_induction_record,
-        changes: induction_record_changes,
-      )
     end
   end
 end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -110,4 +110,9 @@ module AdminHelper
       OpenStruct.new(id: "withdrawn", value: "Withdrawn"),
     ]
   end
+
+  def allowed_to_change_induction_status?(participant_presenter)
+    policy(participant_presenter.participant_profile).edit_induction_status? &&
+      %w[withdrawn leaving].include?(participant_presenter.relevant_induction_record&.induction_status)
+  end
 end

--- a/app/policies/participant_profile_policy.rb
+++ b/app/policies/participant_profile_policy.rb
@@ -13,7 +13,12 @@ class ParticipantProfilePolicy < ApplicationPolicy
     super_user_only
   end
 
+  def edit_induction_status?
+    super_user_only
+  end
+
   alias_method :edit_cohort?, :change_cohort?
+  alias_method :confirm_induction_status?, :edit_induction_status?
   alias_method :update_cohort?, :change_cohort?
 
   alias_method :withdraw_record?, :destroy?

--- a/app/services/induction/induction_statuses_activator.rb
+++ b/app/services/induction/induction_statuses_activator.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class Induction::InductionStatusesActivator < BaseService
+  def call
+    ActiveRecord::Base.transaction do
+      update_the_induction_record if induction_record_needs_correction?
+      update_the_participant_profile if profile_needs_correction?
+    end
+  end
+
+private
+
+  attr_reader :participant_profile, :induction_record
+
+  def initialize(participant_profile:)
+    @participant_profile = participant_profile
+    @induction_record = Induction::FindBy.new(participant_profile:).call
+  end
+
+  def update_the_participant_profile
+    participant_profile.update(status: :active)
+  end
+
+  def update_the_induction_record
+    changes = { induction_status: :active }
+    changes[:school_transfer] = true if induction_record&.leaving_induction_status?
+
+    Induction::ChangeInductionRecord.call(
+      induction_record:,
+      changes:,
+    )
+  end
+
+  def induction_record_needs_correction?
+    %w[withdrawn leaving].include?(induction_record&.induction_status)
+  end
+
+  def profile_needs_correction?
+    %w[withdrawn].include?(participant_profile.status)
+  end
+end

--- a/app/views/admin/participants/change_induction_status/edit.html.erb
+++ b/app/views/admin/participants/change_induction_status/edit.html.erb
@@ -1,0 +1,24 @@
+<% content_for :before_content, govuk_back_link( text: "Back", href: admin_participant_statuses_path(@participant_profile)) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">New induction status for <%= @participant_profile.full_name %></h1>
+      <h3 class="govuk-heading-m">Relevant induction record</h3>
+      <%= govuk_summary_list do |sl|
+        sl.with_row do |row|
+          row.with_key(text: "induction status")
+          row.with_value(text: govuk_tag(text: "Active", colour: "grey"))
+        end
+      end %>
+
+      <h3 class="govuk-heading-m">Participant profile</h3>
+      <%= govuk_summary_list do |sl|
+        sl.with_row do |row|
+          row.with_key(text: "status")
+          row.with_value(text: govuk_tag(text: "Active", colour: "grey"))
+        end
+      end %>
+
+      <%= govuk_button_link_to "Confirm",  confirm_induction_status_admin_participant_change_induction_status_path %>
+  </div>
+</div>
+

--- a/app/views/admin/participants/statuses/show.html.erb
+++ b/app/views/admin/participants/statuses/show.html.erb
@@ -129,7 +129,7 @@ end %>
   sl.with_row do |row|
     row.with_key(text: "induction status")
     row.with_value(text: govuk_tag(text: @participant_presenter.relevant_induction_record&.induction_status || "No Induction Record Found", colour: "grey"))
-    if policy(@participant_presenter.participant_profile).edit_induction_status? && ['withdrawn', 'leaving'].include?(@participant_presenter.relevant_induction_record&.induction_status)
+    if allowed_to_change_induction_status?(@participant_presenter)
       row.with_action(
         href: edit_admin_participant_change_induction_status_path(@participant_presenter.participant_profile),
         visually_hidden_text: "induction status"

--- a/app/views/admin/participants/statuses/show.html.erb
+++ b/app/views/admin/participants/statuses/show.html.erb
@@ -129,6 +129,12 @@ end %>
   sl.with_row do |row|
     row.with_key(text: "induction status")
     row.with_value(text: govuk_tag(text: @participant_presenter.relevant_induction_record&.induction_status || "No Induction Record Found", colour: "grey"))
+    if policy(@participant_presenter.participant_profile).edit_induction_status? && ['withdrawn', 'leaving'].include?(@participant_presenter.relevant_induction_record&.induction_status)
+      row.with_action(
+        href: edit_admin_participant_change_induction_status_path(@participant_presenter.participant_profile),
+        visually_hidden_text: "induction status"
+      )
+    end
   end
 
   sl.with_row do |row|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -361,6 +361,9 @@ Rails.application.routes.draw do
       resource :npq_change_email, only: %i[edit update], controller: "participants/npq/change_email"
 
       resource :change_induction_start_date, only: %i[edit update], controller: "participants/change_induction_start_date"
+      resource :change_induction_status, only: %i[edit], controller: "participants/change_induction_status" do
+        get :confirm_induction_status
+      end
 
       resource :school_transfer, path: "school-transfer", only: [], controller: "participants/school_transfer" do
         member do

--- a/spec/features/admin/participants/update_induction_status_to_active_spec.rb
+++ b/spec/features/admin/participants/update_induction_status_to_active_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require_relative "./participant_steps"
+
+RSpec.feature "Super user admins should be able to update participants induction status to active", js: true, rutabaga: false do
+  include ParticipantSteps
+
+  context "when super user admin" do
+    before do
+      given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
+      and_i_sign_in_as_a_super_user_admin
+      and_i_have_added_an_ect
+    end
+
+    scenario "A super user admin can change induction statuses from withdrawn to active" do
+      given_the_ect_has_withdrawn_induction_status
+      when_i_visit_the_satuses_page_for_participant @participant_profile_ect
+
+      and_i_click_on_change_induction_status
+      then_i_should_be_on_the_edit_induction_status_page
+
+      when_i_click_on_confirm
+      then_i_should_be_in_the_admin_participants_statuses_dashboard
+      and_a_new_induction_record_should_be_created
+      and_admin_should_be_shown_a_success_message
+      and_i_should_see_the_induction_statuses_are_active
+    end
+
+    scenario "A super user admin can change induction statuses from leaving to active" do
+      given_the_ect_has_leaving_induction_status
+      when_i_visit_the_satuses_page_for_participant @participant_profile_ect
+
+      and_i_click_on_change_induction_status
+      then_i_should_be_on_the_edit_induction_status_page
+
+      when_i_click_on_confirm
+      then_i_should_be_in_the_admin_participants_statuses_dashboard
+      and_admin_should_be_shown_a_success_message
+      and_i_should_see_the_induction_statuses_are_active
+      and_the_induction_record_should_have_school_transfer_true
+    end
+  end
+
+  context "when admin" do
+    before do
+      given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
+      given_i_sign_in_as_an_admin_user
+      and_i_have_added_an_ect
+    end
+
+    scenario "A super user admin can change induction statuses from withdrawn to active" do
+      given_the_ect_has_withdrawn_induction_status
+      when_i_visit_the_satuses_page_for_participant @participant_profile_ect
+      then_i_should_not_see_the_change_induction_status_link
+    end
+  end
+end

--- a/spec/policies/participant_profile_policy_spec.rb
+++ b/spec/policies/participant_profile_policy_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe ParticipantProfilePolicy, type: :policy do
     it { is_expected.to forbid_action(:show) }
     it { is_expected.to forbid_action(:destroy) }
     it { is_expected.to forbid_actions(%i[edit_cohort update_cohort]) }
+    it { is_expected.to forbid_actions(%i[edit_induction_status confirm_induction_status]) }
   end
 
   context "being a super user admin" do
@@ -30,6 +31,7 @@ RSpec.describe ParticipantProfilePolicy, type: :policy do
     let(:user) { scenario.user }
 
     it { is_expected.to permit_actions(%i[edit_cohort update_cohort]) }
+    it { is_expected.to permit_actions(%i[edit_induction_status confirm_induction_status]) }
   end
 
   describe described_class::Scope do

--- a/spec/services/induction/induction_statuses_activator_spec.rb
+++ b/spec/services/induction/induction_statuses_activator_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+RSpec.describe Induction::InductionStatusesActivator do
+  describe "#call" do
+    let(:induction_record) { create(:induction_record, induction_status:) }
+    let(:participant_profile) { induction_record.participant_profile }
+
+    subject(:service) { described_class }
+
+    describe ".call" do
+      before do
+        service.call(participant_profile:)
+      end
+
+      context "when participant's induction record has withdrawn induction status" do
+        let(:induction_status) { "withdrawn" }
+
+        it "creates a new inductιon record" do
+          expect(participant_profile.induction_records.count).to eq(2)
+        end
+
+        it "sets the inductιon record induction status and the participant status to active" do
+          expect(participant_profile.latest_induction_record.induction_status).to eq("active")
+          expect(participant_profile.status).to eq("active")
+        end
+      end
+
+      context "when participant's induction record has leaving induction status" do
+        let(:induction_status) { "leaving" }
+
+        it "creates a new inductιon record" do
+          expect(participant_profile.induction_records.count).to eq(2)
+        end
+
+        it "sets the inductιon record induction status and the participant status to active" do
+          expect(participant_profile.latest_induction_record.induction_status).to eq("active")
+          expect(participant_profile.status).to eq("active")
+        end
+
+        it "sets the inductιon record school transfer to true" do
+          expect(participant_profile.latest_induction_record.school_transfer).to be true
+        end
+      end
+
+      context "when participant's induction record has not withdrawn or leaving induction status" do
+        let(:induction_status) { "active" }
+
+        it "does not creates a new inductιon record" do
+          expect(participant_profile.induction_records.count).to eq(1)
+        end
+      end
+    end
+  end
+end

--- a/spec/support/features/user_helper.rb
+++ b/spec/support/features/user_helper.rb
@@ -36,6 +36,7 @@ module UserHelper
     visit users_confirm_sign_in_path(login_token: @logged_in_admin_user.login_token)
     click_button "Continue"
   end
+  alias_method :and_i_sign_in_as_a_super_user_admin, :given_i_sign_in_as_a_super_user_admin
 
   def given_i_sign_in_as_a_finance_user
     token = "test-finance-token-#{Time.zone.now.to_f}"


### PR DESCRIPTION
### Context

- Ticket: CST-2058

SITs withdraw participants or set them as leaving by mistake. 

We want to enable super user admins to set them back to active.
For the leaving ones, we also want the school transfer to be `true`. This will display to a provider as a transfer from school A, into school A.

### Changes proposed in this pull request
- Add a new service class with the logic required to set the `ParticipantProfile@status` and `InductionRecord@induction_status` to `active`
- Add a new admin page to display the new statuses with a button to confirm the changes
- Display conditionally a `Change` link in the Participant->Statuses page that leads to the new admin page

### Guidance to review
1. Go to the Admin pages as a super user admin
2. Find an active or completed ECF participant
3. Confirm there is no "Change" link in the "induction status" row as a super user admin, but not as regular admin
4. Set the induction status in their induction record to either "withdraw" or "leaving"
5. Go back to their Profile->Statuses page and confirm the "Change" link is there
6. Click "Change" to take you to the induction status activation page
7. Click "Confirm" to set the statuses to active and redirect you back to the Statuses page
8. Confirm both the `induction status` in the IR section and the `status` in the Profile section are "active"
