### PR TITLE
Fix Cohort filter in V3 Participant declaration API

### DIFF
--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -7,6 +7,12 @@ weight: 8
 
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
 
+## 2 November 2023
+
+The DfE has released a fix for an issue which affected NPQ only providers using the v3 declarations endpoints. Some providers reported receiving 403 errors when attempting to POST or GET declarations. The issue was limited to v3. The fix has been released to sandbox and production environments.
+
+The fix also addresses an issue with the [cohort filter](/api-reference/reference-v3.html#schema-participantdeclarationsfilter), which is available for the declarations endpoint. Providers using the filter should now see that the response only returns NPQ and ECF declarations in the cohort specified. Previously, the filtering was inconsistent for NPQ declarations. The fix applies to production and sandbox environments.
+
 ## 30 October 2023
 
 Lead providers will now see a 422 error code if a `completed` declaration outcome fails. In such instances, you'll be prompted to contact us for support.

--- a/spec/services/api/v3/participant_declarations_query_spec.rb
+++ b/spec/services/api/v3/participant_declarations_query_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery do
       end
     end
 
-    context "with npq only lead provider" do
+    context "with NPQ only lead provider" do
       subject { described_class.new(cpd_lead_provider: npq_only_lead_provider, params:) }
 
       it "returns all participant declarations for that provider" do
@@ -235,6 +235,46 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery do
 
         it "returns all participant declarations for the specific cohort" do
           expect(subject.participant_declarations_for_pagination.pluck(:id)).to eq(npq_participant_declarations.pluck(:id))
+        end
+      end
+
+      context "with incorrect cohort filter" do
+        let(:params) { { filter: { cohort: "2017" } } }
+
+        it "returns no participant declarations" do
+          expect(subject.participant_declarations_for_pagination.to_a).to be_empty
+        end
+      end
+    end
+
+    context "with an NPQ and ECF lead provider" do
+      let(:cpd_lead_provider1) { create(:cpd_lead_provider, :with_lead_provider, :with_npq_lead_provider) }
+      let(:npq_lead_provider) { cpd_lead_provider1.npq_lead_provider }
+      let(:ecf_declarations) { [participant_declaration3, participant_declaration1, participant_declaration2] }
+
+      it "returns all participant declarations for that provider" do
+        expect(subject.participant_declarations_for_pagination.pluck(:id)).to match_array(npq_participant_declarations.pluck(:id) + ecf_declarations.map(&:id))
+      end
+
+      context "with cohort filter" do
+        let(:another_npq_application) { create(:npq_application, :accepted, :with_started_declaration, npq_lead_provider:, cohort: cohort2) }
+        let!(:npq_participant_declarations) { another_npq_application.profile.participant_declarations }
+
+        let(:cohort) { cohort2.start_year.to_s }
+        let(:params) { { filter: { cohort: } } }
+
+        it "returns all participant declarations for the specific cohort" do
+          expect(subject.participant_declarations_for_pagination.pluck(:id)).to match_array(npq_participant_declarations.pluck(:id) + [participant_declaration3.id])
+        end
+      end
+
+      context "with multiple cohort filter" do
+        let(:another_npq_application) { create(:npq_application, :accepted, :with_started_declaration, npq_lead_provider:, cohort: cohort2) }
+        let!(:npq_participant_declarations) { another_npq_application.profile.participant_declarations + npq_application.profile.participant_declarations }
+        let(:params) { { filter: { cohort: [cohort1.start_year, cohort2.start_year].join(",") } } }
+
+        it "returns all participant declarations for the specific cohort" do
+          expect(subject.participant_declarations_for_pagination.pluck(:id)).to match_array(npq_participant_declarations.pluck(:id) + ecf_declarations.map(&:id))
         end
       end
 

--- a/spec/services/api/v3/participant_declarations_query_spec.rb
+++ b/spec/services/api/v3/participant_declarations_query_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery do
 
   let(:npq_only_lead_provider) { create(:cpd_lead_provider, :with_npq_lead_provider) }
   let(:npq_lead_provider) { npq_only_lead_provider.npq_lead_provider }
-  let(:npq_application) { create(:npq_application, :accepted, :with_started_declaration, npq_lead_provider:) }
+  let(:npq_application) { create(:npq_application, :accepted, :with_started_declaration, npq_lead_provider:, cohort: cohort1) }
   let!(:npq_participant_declarations) { npq_application.profile.participant_declarations }
 
   subject { described_class.new(cpd_lead_provider: cpd_lead_provider1, params:) }
@@ -214,6 +214,36 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery do
 
       it "returns all participant declarations for that provider" do
         expect(subject.participant_declarations_for_pagination.pluck(:id)).to eq(npq_participant_declarations.pluck(:id))
+      end
+
+      context "with cohort filter" do
+        let(:another_npq_application) { create(:npq_application, :accepted, :with_started_declaration, npq_lead_provider:, cohort: cohort2) }
+        let!(:npq_participant_declarations) { another_npq_application.profile.participant_declarations }
+
+        let(:cohort) { cohort2.start_year.to_s }
+        let(:params) { { filter: { cohort: } } }
+
+        it "returns all participant declarations for the specific cohort" do
+          expect(subject.participant_declarations_for_pagination.pluck(:id)).to eq(npq_participant_declarations.pluck(:id))
+        end
+      end
+
+      context "with multiple cohort filter" do
+        let(:another_npq_application) { create(:npq_application, :accepted, :with_started_declaration, npq_lead_provider:, cohort: cohort2) }
+        let!(:npq_participant_declarations) { another_npq_application.profile.participant_declarations + npq_application.profile.participant_declarations }
+        let(:params) { { filter: { cohort: [cohort1.start_year, cohort2.start_year].join(",") } } }
+
+        it "returns all participant declarations for the specific cohort" do
+          expect(subject.participant_declarations_for_pagination.pluck(:id)).to eq(npq_participant_declarations.pluck(:id))
+        end
+      end
+
+      context "with incorrect cohort filter" do
+        let(:params) { { filter: { cohort: "2017" } } }
+
+        it "returns no participant declarations" do
+          expect(subject.participant_declarations_for_pagination.to_a).to be_empty
+        end
       end
     end
   end


### PR DESCRIPTION
### Context
We are only filtering by ECF cohorts in decalarations endpoint in v3. We need add support for NPQ
- Ticket: n/a

### Changes proposed in this pull request

- Support NPQ cohort filter in declarations endpoint
- Support both ECF and NPQ providers together and separately

### Guidance to review
Test with NPQ provider hitting declarations endpoint v3
