### PR TITLE
Display authorised for payment date in local timezone

### DIFF
--- a/app/views/finance/ecf/statements/show.html.erb
+++ b/app/views/finance/ecf/statements/show.html.erb
@@ -118,7 +118,7 @@
               <% if authorise_for_payment_button_visible?(@statement) %>
                 <%= button_to t("finance.statements.payment_authorisations.button"), new_finance_statement_payment_authorisation_path(@statement), method: :get, class: "govuk-button govuk-button--primary" %>
               <% elsif @statement.marked_as_paid? %>
-                <%= govuk_tag(text: t("finance.statements.payment_authorisations.tag.content", statement_marked_as_paid_at: @statement.marked_as_paid_at.strftime("%-I:%M%P on %-e %b %Y"))) %>
+                <%= govuk_tag(text: t("finance.statements.payment_authorisations.tag.content", statement_marked_as_paid_at: @statement.marked_as_paid_at.in_time_zone("London").strftime("%-I:%M%P on %-e %b %Y"))) %>
               <% else %>
                 &nbsp;
               <% end %>

--- a/app/views/finance/npq/statements/show.html.erb
+++ b/app/views/finance/npq/statements/show.html.erb
@@ -128,7 +128,7 @@
               <% if authorise_for_payment_button_visible?(@statement) %>
                 <%= button_to t("finance.statements.payment_authorisations.button"), new_finance_statement_payment_authorisation_path(@statement), method: :get, class: "govuk-button govuk-button--primary" %>
               <% elsif @statement.marked_as_paid? %>
-                <%= govuk_tag(text: t("finance.statements.payment_authorisations.tag.content", statement_marked_as_paid_at: @statement.marked_as_paid_at.strftime("%-I:%M%P on %-e %b %Y"))) %>
+                <%= govuk_tag(text: t("finance.statements.payment_authorisations.tag.content", statement_marked_as_paid_at: @statement.marked_as_paid_at.in_time_zone("London").strftime("%-I:%M%P on %-e %b %Y"))) %>
               <% else %>
                 &nbsp;
               <% end %>

--- a/spec/features/finance/ecf/statement_spec.rb
+++ b/spec/features/finance/ecf/statement_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "Show ECF statement", :js do
 
       when_i_visit_the_ecf_financial_statements_page
 
-      then_i_do_not_see("Authorised for payment at #{statement.marked_as_paid_at.strftime('%-I:%M%P on %-e %b %Y')}".upcase)
+      then_i_do_not_see("Authorised for payment at #{statement.marked_as_paid_at.in_time_zone('London').strftime('%-I:%M%P on %-e %b %Y')}".upcase)
     end
 
     scenario "successfully authorised", perform_jobs: true do
@@ -80,7 +80,7 @@ RSpec.describe "Show ECF statement", :js do
 
       when_i_visit_the_ecf_financial_statements_page
 
-      then_i_see("Authorised for payment at #{Finance::Statement.find(statement.id).marked_as_paid_at.strftime('%-I:%M%P on %-e %b %Y')}".upcase)
+      then_i_see("Authorised for payment at #{Finance::Statement.find(statement.id).marked_as_paid_at.in_time_zone('London').strftime('%-I:%M%P on %-e %b %Y')}".upcase)
     end
 
     scenario "missing doing assurance checks" do


### PR DESCRIPTION
### Context

We currently display the authorised for payment date in the same timezone that we store it in the database (UTC). Instead, we want to format the date and display it in the London timezone.

### Changes proposed in this pull request

- Display authorised for payment date in local timezone

This is a app-wide issue, however applying a 'fix all' solution of setting the time zone in the application config is risky (it would change it everywhere, including in our API serializers). Instead, we are going to fix this on a case-by-case basis by converting the dates into London timezone prior to formatting them.

### Guidance to review

If we find we are going to change this in lots of other places it may be be worth creating a date formatting service.