### PR TITLE
Remove access restriction to ECF providers only

### DIFF
--- a/app/controllers/api/v3/participant_declarations_controller.rb
+++ b/app/controllers/api/v3/participant_declarations_controller.rb
@@ -103,7 +103,7 @@ module Api
       end
 
       def access_scope
-        LeadProviderApiToken.joins(cpd_lead_provider: [:lead_provider])
+        LeadProviderApiToken.joins(cpd_lead_provider: [:lead_provider]) + LeadProviderApiToken.joins(cpd_lead_provider: [:npq_lead_provider])
       end
 
       def serializer_class

--- a/app/services/api/v3/participant_declarations_query.rb
+++ b/app/services/api/v3/participant_declarations_query.rb
@@ -66,7 +66,9 @@ module Api
 
     private
 
-      delegate :lead_provider, to: :cpd_lead_provider
+      def lead_provider
+        cpd_lead_provider.lead_provider if cpd_lead_provider.respond_to?(:lead_provider)
+      end
 
       def declarations_scope
         scope = ParticipantDeclaration.for_lead_provider(cpd_lead_provider)
@@ -81,7 +83,8 @@ module Api
 
       def previous_declarations_scope
         scope = with_joins(ParticipantDeclaration)
-          .where(participant_profile: { induction_records: { induction_programme: { partnerships: { lead_provider_id: lead_provider.id } } } })
+        scope = scope
+          .where(participant_profile: { induction_records: { induction_programme: { partnerships: { lead_provider_id: lead_provider&.id } } } })
           .where(participant_profile: { induction_records: { induction_status: "active" } }) # only want induction records that are the winning latest ones
           .where(state: %w[submitted eligible payable paid])
 

--- a/spec/services/api/v3/participant_declarations_query_spec.rb
+++ b/spec/services/api/v3/participant_declarations_query_spec.rb
@@ -23,6 +23,11 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery do
   let(:delivery_partner2) { create(:delivery_partner) }
   let(:params) { {} }
 
+  let(:npq_only_lead_provider) { create(:cpd_lead_provider, :with_npq_lead_provider) }
+  let(:npq_lead_provider) { npq_only_lead_provider.npq_lead_provider }
+  let(:npq_application) { create(:npq_application, :accepted, :with_started_declaration, npq_lead_provider:) }
+  let!(:npq_participant_declarations) { npq_application.profile.participant_declarations }
+
   subject { described_class.new(cpd_lead_provider: cpd_lead_provider1, params:) }
 
   describe "#participant_declarations_for_pagination" do
@@ -201,6 +206,14 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery do
 
       it "returns no participant declarations" do
         expect(subject.participant_declarations_for_pagination.to_a).to be_empty
+      end
+    end
+
+    context "with npq only lead provider" do
+      subject { described_class.new(cpd_lead_provider: npq_only_lead_provider, params:) }
+
+      it "returns all participant declarations for that provider" do
+        expect(subject.participant_declarations_for_pagination.pluck(:id)).to eq(npq_participant_declarations.pluck(:id))
       end
     end
   end


### PR DESCRIPTION
### Context
NPQ only Providers are getting 403 errors when attempting to access declaration endpoints.
- Ticket: n/a

### Changes proposed in this pull request

Declarations endpoint serves both ECF and NPQ, so both providers require access. This being there means that only ECF providers have access to declarations which is not always the case.

### Guidance to review
Test with NPQ provider hitting declarations endpoint v3
