### PR TITLE
[CST-2037] Add schools queries for automated comms

### DIFF
--- a/app/queries/schools/that_have_not_added_participants_query.rb
+++ b/app/queries/schools/that_have_not_added_participants_query.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Schools
+  class ThatHaveNotAddedParticipantsQuery < BaseService
+    def call
+      schools_to_include.where(id: school_cohorts_that_have_not_added_participants.select(:school_id))
+    end
+
+    attr_reader :cohort, :school_type_codes
+
+    def initialize(cohort: nil, school_type_codes: [])
+      @cohort = cohort
+      @school_type_codes = school_type_codes
+    end
+
+    def schools_to_include
+      scope = School.currently_open.in_england
+      return scope if school_type_codes.blank?
+
+      scope.where(school_type_code: school_type_codes)
+    end
+
+    def school_cohorts_that_have_not_added_participants
+      scope = SchoolCohort
+        .where(induction_programme_choice: %w[full_induction_programme core_induction_programme])
+        .where.missing(:induction_records)
+
+      return scope if cohort.blank?
+
+      scope.joins(:cohort).where(cohort:)
+    end
+  end
+end

--- a/app/queries/schools/that_ran_fip_last_year_but_have_not_engaged_query.rb
+++ b/app/queries/schools/that_ran_fip_last_year_but_have_not_engaged_query.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Schools
+  class ThatRanFipLastYearButHaveNotEngagedQuery < BaseService
+    def call
+      schools_to_include.merge(schools_that_ran_fip_last_year).merge(schools_that_have_not_engaged)
+    end
+
+    attr_reader :cohort, :school_type_codes
+
+    def initialize(cohort:, school_type_codes: [])
+      @cohort = cohort
+      @school_type_codes = school_type_codes
+    end
+
+    def schools_to_include
+      scope = School.currently_open.in_england
+      return scope if school_type_codes.blank?
+
+      scope.where(school_type_code: school_type_codes)
+    end
+
+    def schools_that_ran_fip_last_year
+      School
+        .joins(:school_cohorts)
+        .merge(SchoolCohort.full_induction_programme.where(cohort: cohort.previous))
+    end
+
+    def schools_that_have_not_engaged
+      School.where.not(id: SchoolCohort.where(cohort:).select(:school_id))
+    end
+  end
+end

--- a/app/queries/schools/unpartnered_last_year_and_have_not_partnered_this_year_query.rb
+++ b/app/queries/schools/unpartnered_last_year_and_have_not_partnered_this_year_query.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Schools
+  class UnpartneredLastYearAndHaveNotPartneredThisYearQuery < BaseService
+    def call
+      schools_to_include
+        .where(id: unpartnered_schools_this_cohort)
+        .where(id: unpartnered_schools_last_cohort)
+        .or(schools_to_include.where(id: schools_that_did_not_choose_fip_last_year))
+    end
+
+    attr_reader :cohort, :school_type_codes
+
+    def initialize(cohort:, school_type_codes: [])
+      @cohort = cohort
+      @school_type_codes = school_type_codes
+    end
+
+    def schools_to_include
+      scope = School.currently_open.in_england
+      return scope if school_type_codes.blank?
+
+      scope.where(school_type_code: school_type_codes)
+    end
+
+    def unpartnered_schools_this_cohort
+      Schools::UnpartneredQuery.call(cohort:, school_type_codes:)
+    end
+
+    def unpartnered_schools_last_cohort
+      Schools::UnpartneredQuery.call(cohort: cohort.previous, school_type_codes:)
+    end
+
+    def schools_that_did_not_choose_fip_last_year
+      School.joins(:school_cohorts)
+        .where(school_cohorts: { cohort: cohort.previous })
+        .where.not(school_cohorts: { induction_programme_choice: "full_induction_programme" })
+    end
+  end
+end

--- a/app/queries/schools/unpartnered_query.rb
+++ b/app/queries/schools/unpartnered_query.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Schools
+  class UnpartneredQuery < BaseService
+    def call
+      schools_to_include
+        .merge(schools_that_chose_fip)
+        .merge(schools_without_a_partnership)
+    end
+
+    attr_reader :cohort, :school_type_codes
+
+    def initialize(cohort:, school_type_codes: [])
+      @cohort = cohort
+      @school_type_codes = school_type_codes
+    end
+
+    def schools_to_include
+      scope = School.currently_open.in_england
+      return scope if school_type_codes.blank?
+
+      scope.where(school_type_code: school_type_codes)
+    end
+
+    def schools_without_a_partnership
+      School.where.not(id: Partnership.active.where(cohort:).select(:school_id))
+    end
+
+    def schools_that_chose_fip
+      School.joins(:school_cohorts).merge(SchoolCohort.full_induction_programme.where(cohort:))
+    end
+  end
+end

--- a/app/services/bulk_mailers/school_reminder_comms.rb
+++ b/app/services/bulk_mailers/school_reminder_comms.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+module BulkMailers
+  class SchoolReminderComms
+    SCHOOL_TYPES_TO_INCLUDE = [1, 2, 3, 5, 6, 7, 8, 12, 28, 33, 34, 35, 36, 40, 44].freeze
+
+    attr_reader :cohort, :dry_run
+
+    # Set dry_run = true to just return the number of emails that would be sent but don't send any emails
+    def initialize(cohort:, dry_run: false)
+      @cohort = cohort
+      @dry_run = dry_run
+    end
+
+    def contact_sits_that_need_to_assign_mentors
+      email_count = 0
+
+      Schools::WithEctsWithNoMentorQuery
+        .call(cohort:, school_type_codes: SCHOOL_TYPES_TO_INCLUDE)
+        .joins(:induction_coordinator_profiles)
+        .includes(:induction_coordinator_profiles)
+        .find_each do |school|
+          school.induction_coordinator_profiles.each do |induction_coordinator|
+            email_count += 1
+            next if dry_run
+
+            SchoolMailer.with(school:, induction_coordinator:).remind_sit_to_assign_mentors_to_ects_email.deliver_later
+          end
+        end
+
+      email_count
+    end
+
+    def contact_sits_that_have_not_added_participants
+      email_count = 0
+
+      # this could send a lot of email at the cohort start and may break Notify limits
+      # numbers should be checked before running this (dry_run = true) and maybe changes made/different approach to batch these
+      Schools::ThatHaveNotAddedParticipantsQuery
+        .call(cohort:, school_type_codes: SCHOOL_TYPES_TO_INCLUDE)
+        .joins(:induction_coordinator_profiles)
+        .includes(:induction_coordinator_profiles)
+        .find_each do |school|
+          school.induction_coordinator_profiles.each do |induction_coordinator|
+            email_count += 1
+            next if dry_run
+
+            SchoolMailer.with(school:, induction_coordinator:).remind_sit_to_add_ects_and_mentors_email.deliver_later
+          end
+        end
+
+      email_count
+    end
+
+    def contact_sits_that_have_not_engaged
+      email_count = 0
+
+      # this could send a lot of email at the cohort start and may break Notify limits
+      # numbers should be checked before running this (dry_run = true) and maybe changes made/different approach to batch these
+      Schools::ThatRanFipLastYearButHaveNotEngagedQuery
+        .call(cohort:, school_type_codes: SCHOOL_TYPES_TO_INCLUDE)
+        .joins(:induction_coordinator_profiles)
+        .includes(:induction_coordinator_profiles)
+        .find_each do |school|
+          school.induction_coordinator_profiles.each do |induction_coordinator|
+            email_count += 1
+            next if dry_run
+
+            sit_user = induction_coordinator.user
+            SchoolMailer.with(sit_user:, nomination_link: nomination_url(email: sit_user.email, school:))
+              .launch_ask_sit_to_report_school_training_details
+              .deliver_later
+          end
+        end
+
+      email_count
+    end
+
+    def contact_schools_without_a_sit_that_have_not_engaged
+      email_count = 0
+
+      Schools::ThatRanFipLastYearButHaveNotEngagedQuery
+        .call(cohort:, school_type_codes: SCHOOL_TYPES_TO_INCLUDE)
+        .where.missing(:induction_coordinator_profiles)
+        .find_each do |school|
+          gias_contact_email = school.primary_contact_email || school.secondary_contact_email
+
+          if gias_contact_email.blank?
+            Rails.logger.info("No GIAS contact for #{school.name_and_urn}")
+            next
+          end
+
+          email_count += 1
+          next if dry_run
+
+          SchoolMailer.with(school:, gias_contact_email:, opt_in_out_link: opt_in_out_url(email: gias_contact_email, school:))
+            .launch_ask_gias_contact_to_report_school_training_details
+            .deliver_later
+        end
+
+      email_count
+    end
+
+  private
+
+    def nomination_token(email:, school:)
+      NominationEmail.create_nomination_email(sent_at: Time.zone.now, sent_to: email, school:).token
+    end
+
+    def nomination_url(email:, school:)
+      Rails.application.routes.url_helpers.start_nominate_induction_coordinator_url(token: nomination_token(email:, school:),
+                                                                                    host: Rails.application.config.domain)
+    end
+
+    def opt_in_out_url(email:, school:)
+      Rails.application.routes.url_helpers.choose_how_to_continue_url(token: nomination_token(email:, school:),
+                                                                      host: Rails.application.config.domain)
+    end
+  end
+end

--- a/app/services/bulk_mailers/school_reminder_comms.rb
+++ b/app/services/bulk_mailers/school_reminder_comms.rb
@@ -104,20 +104,14 @@ module BulkMailers
     def contact_sits_that_have_chosen_fip_but_not_partnered
       email_count = 0
 
-      Schools::ThatChoseFipButNotPartneredQuery
+      Schools::UnpartneredLastYearAndHaveNotPartneredThisYearQuery
         .call(cohort:, school_type_codes: SCHOOL_TYPES_TO_INCLUDE)
         .joins(:induction_coordinator_profiles)
-        .includes(:induction_coordinator_profiles)
         .find_each do |school|
-          school.induction_coordinator_profiles.each do |induction_coordinator|
-            email_count += 1
-            next if dry_run
+          email_count += 1
+          next if dry_run
 
-            sit_user = induction_coordinator.user
-            SchoolMailer.with(sit_user:, nomination_link: nomination_url(email: sit_user.email, school:))
-              .launch_ask_sit_to_report_school_training_details
-              .deliver_later
-          end
+          SchoolMailer.with(school:).sit_needs_to_chase_partnership.deliver_later
         end
 
       email_count

--- a/spec/factories/seeds/school_cohort_factory.rb
+++ b/spec/factories/seeds/school_cohort_factory.rb
@@ -10,6 +10,9 @@ FactoryBot.define do
 
     trait(:fip) { induction_programme_choice { "full_induction_programme" } }
     trait(:cip) { induction_programme_choice { "core_induction_programme" } }
+    trait(:no_early_career_teachers) { induction_programme_choice { "no_early_career_teachers" } }
+    trait(:design_our_own) { induction_programme_choice { "design_our_own" } }
+    trait(:school_funded_fip) { induction_programme_choice { "school_funded_fip" } }
 
     trait(:starting_in_2021) { cohort { create(:cohort, start_year: 2021) } }
     trait(:starting_in_2022) { cohort { create(:cohort, start_year: 2022) } }

--- a/spec/queries/schools/that_have_not_added_participants_query_spec.rb
+++ b/spec/queries/schools/that_have_not_added_participants_query_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Schools::ThatHaveNotAddedParticipantsQuery do
+  describe "#call" do
+    let(:cohort) { create(:seed_cohort) }
+    let(:query_cohort) { nil }
+    let(:school_type_codes) { [] }
+
+    let(:school_cohort) { create(:seed_school_cohort, :fip, :with_school, cohort:) }
+    let(:induction_programme) { create(:seed_induction_programme, :fip, school_cohort:) }
+    let(:school) { school_cohort.school }
+
+    let(:participant_profile) { create(:seed_ect_participant_profile, :valid, school_cohort:) }
+
+    subject(:query_result) { described_class.call(cohort: query_cohort, school_type_codes:) }
+
+    context "when there are no cohorts without participants" do
+      let!(:induction_record) { create(:seed_induction_record, :valid, participant_profile:, induction_programme:) }
+
+      it "does not include the school" do
+        expect(query_result).not_to include(school)
+      end
+    end
+
+    context "when a cohort is supplied" do
+      context "and there are no participants in the cohort" do
+        let(:query_cohort) { cohort }
+
+        it "includes the school" do
+          expect(query_result).to include(school)
+        end
+      end
+
+      context "and there are participants in the cohort" do
+        let!(:induction_record) { create(:seed_induction_record, :valid, participant_profile:, induction_programme:) }
+        let(:query_cohort) { cohort }
+
+        it "does not include the school" do
+          expect(query_result).not_to include(school)
+        end
+      end
+
+      context "and there are active participants in a different cohort" do
+        let(:query_cohort) { create(:seed_cohort, start_year: cohort.start_year + 1) }
+        let!(:query_school_cohort) { create(:seed_school_cohort, :fip, school:, cohort: query_cohort) }
+
+        it "includes the school" do
+          expect(query_result).to include(school)
+        end
+      end
+    end
+
+    context "when school type codes are supplied" do
+      let(:school_type_codes) { [1, 2, 3] }
+
+      context "and the school matches one of the school types" do
+        before do
+          school.update!(school_type_code: 2)
+        end
+
+        context "when there are no cohorts without participants" do
+          let!(:induction_record) { create(:seed_induction_record, :valid, participant_profile:, induction_programme:) }
+
+          it "does not include the school" do
+            expect(query_result).not_to include(school)
+          end
+        end
+
+        context "when there are cohorts without participants" do
+          it "includes the school" do
+            expect(query_result).to include(school)
+          end
+        end
+      end
+
+      context "and the school does not match one of the school types" do
+        before do
+          school.update!(school_type_code: 5)
+        end
+
+        context "when there are no cohorts without participants" do
+          let!(:induction_record) { create(:seed_induction_record, :valid, participant_profile:, induction_programme:) }
+
+          it "does not include the school" do
+            expect(query_result).not_to include(school)
+          end
+        end
+
+        context "when there are cohorts without participants" do
+          it "does not include the school" do
+            expect(query_result).not_to include(school)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/queries/schools/that_ran_fip_last_year_but_have_not_engaged_query_spec.rb
+++ b/spec/queries/schools/that_ran_fip_last_year_but_have_not_engaged_query_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Schools::ThatRanFipLastYearButHaveNotEngagedQuery do
+  describe "#call" do
+    let(:cohort) { create(:seed_cohort) }
+    let(:query_cohort) { cohort.next || create(:seed_cohort, start_year: cohort.start_year + 1) }
+    let(:school_type_codes) { [] }
+
+    let(:school_cohort) { create(:seed_school_cohort, :fip, :with_school, cohort:) }
+    let!(:school) { school_cohort.school }
+
+    subject(:query_result) { described_class.call(cohort: query_cohort, school_type_codes:) }
+
+    context "when the school has not engaged" do
+      context "and the school ran a FIP programme the year before" do
+        it "includes the school" do
+          expect(query_result).to include(school)
+        end
+      end
+
+      context "and the school did not run a FIP programme the year before" do
+        let(:school_cohort) { create(:seed_school_cohort, :cip, :with_school, cohort:) }
+
+        it "does not include the school" do
+          expect(query_result).not_to include(school)
+        end
+      end
+    end
+
+    context "when the school has engaged" do
+      let!(:query_school_cohort) { create(:seed_school_cohort, :fip, school:, cohort: query_cohort) }
+
+      it "does not include the school" do
+        expect(query_result).not_to include(school)
+      end
+    end
+
+    context "when school type codes are supplied" do
+      let(:school_type_codes) { [1, 2, 3] }
+
+      context "and the school matches one of the school types" do
+        before do
+          school.update!(school_type_code: 2)
+        end
+
+        context "when the school has not engaged" do
+          context "and the school ran a FIP programme the year before" do
+            it "includes the school" do
+              expect(query_result).to include(school)
+            end
+          end
+
+          context "and the school did not run a FIP programme the year before" do
+            let(:school_cohort) { create(:seed_school_cohort, :cip, :with_school, cohort:) }
+
+            it "does not include the school" do
+              expect(query_result).not_to include(school)
+            end
+          end
+        end
+
+        context "when the school has engaged" do
+          let!(:query_school_cohort) { create(:seed_school_cohort, :fip, school:, cohort: query_cohort) }
+
+          it "does not include the school" do
+            expect(query_result).not_to include(school)
+          end
+        end
+      end
+
+      context "and the school does not match one of the school types" do
+        before do
+          school.update!(school_type_code: 5)
+        end
+
+        context "when the school has not engaged" do
+          context "and the school ran a FIP programme the year before" do
+            it "does not include the school" do
+              expect(query_result).not_to include(school)
+            end
+          end
+
+          context "and the school did not run a FIP programme the year before" do
+            let(:school_cohort) { create(:seed_school_cohort, :cip, :with_school, cohort:) }
+
+            it "does not include the school" do
+              expect(query_result).not_to include(school)
+            end
+          end
+        end
+
+        context "when the school has engaged" do
+          let!(:query_school_cohort) { create(:seed_school_cohort, :fip, school:, cohort: query_cohort) }
+
+          it "does not include the school" do
+            expect(query_result).not_to include(school)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/queries/schools/unpartnered_last_year_and_have_not_partnered_this_year_query_spec.rb
+++ b/spec/queries/schools/unpartnered_last_year_and_have_not_partnered_this_year_query_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Schools::UnpartneredLastYearAndHaveNotPartneredThisYearQuery do
+  describe "#call" do
+    let(:cohort) { create(:seed_cohort) }
+    let(:previous_cohort) { cohort.previous || create(:seed_cohort, start_year: cohort.start_year - 1) }
+    let(:query_cohort) { cohort }
+    let(:school_type_codes) { [] }
+
+    let(:school_cohort) { create(:seed_school_cohort, :fip, :with_school, cohort:) }
+    let!(:previous_school_cohort) { create(:seed_school_cohort, :fip, school:, cohort: previous_cohort) }
+    let!(:school) { school_cohort.school }
+
+    subject(:query_result) { described_class.call(cohort: query_cohort, school_type_codes:) }
+
+    context "when there are no active partnerships in the cohort" do
+      it "includes the school" do
+        expect(query_result).to include(school)
+      end
+    end
+
+    context "when there is an active partnership" do
+      let!(:partnership) { create(:seed_partnership, :valid, school:, cohort:) }
+
+      it "does not include the school" do
+        expect(query_result).not_to include(school)
+      end
+    end
+
+    context "when there is a challenged partnership" do
+      let!(:partnership) { create(:seed_partnership, :valid, :challenged, school:, cohort:) }
+
+      it "includes the school" do
+        expect(query_result).to include(school)
+      end
+    end
+
+    context "when there is a relationship" do
+      let!(:relationship) { create(:seed_partnership, :valid, relationship: true, school:, cohort:) }
+
+      it "does not include the school" do
+        expect(query_result).not_to include(school)
+      end
+    end
+
+    context "when there is an active partnership in the previous cohort" do
+      let!(:partnership) { create(:seed_partnership, :valid, school:, cohort: previous_cohort) }
+
+      it "does not include the school" do
+        expect(query_result).not_to include(school)
+      end
+    end
+
+    context "when the school is doing CIP" do
+      let(:school_cohort) { create(:seed_school_cohort, :cip, :with_school, cohort:) }
+
+      it "does not include the school" do
+        expect(query_result).not_to include(school)
+      end
+    end
+
+    context "when the school is not expecting ECTs" do
+      let(:school_cohort) { create(:seed_school_cohort, :no_early_career_teachers, :with_school, cohort:) }
+
+      it "does not include the school" do
+        expect(query_result).not_to include(school)
+      end
+    end
+
+    context "when the school is doing a school-funded FIP" do
+      let(:school_cohort) { create(:seed_school_cohort, :school_funded_fip, :with_school, cohort:) }
+
+      it "does not include the school" do
+        expect(query_result).not_to include(school)
+      end
+    end
+
+    context "when the school is doing DIY" do
+      let(:school_cohort) { create(:seed_school_cohort, :design_our_own, :with_school, cohort:) }
+
+      it "does not include the school" do
+        expect(query_result).not_to include(school)
+      end
+    end
+
+    context "when school type codes are supplied" do
+      let(:school_type_codes) { [1, 2, 3] }
+
+      context "and the school matches one of the school types" do
+        before do
+          school.update!(school_type_code: 2)
+        end
+
+        context "when there are no active partnerships in the cohort" do
+          it "includes the school" do
+            expect(query_result).to include(school)
+          end
+        end
+
+        context "when there is an active partnership in the previous cohort" do
+          let!(:partnership) { create(:seed_partnership, :valid, school:, cohort: previous_cohort) }
+
+          it "does not include the school" do
+            expect(query_result).not_to include(school)
+          end
+        end
+      end
+
+      context "and the school does not match one of the school types" do
+        before do
+          school.update!(school_type_code: 5)
+        end
+
+        context "when there are no active partnerships in the cohort" do
+          it "does not include the school" do
+            expect(query_result).not_to include(school)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/queries/schools/unpartnered_query_spec.rb
+++ b/spec/queries/schools/unpartnered_query_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Schools::UnpartneredQuery do
+  describe "#call" do
+    let(:cohort) { create(:seed_cohort) }
+    let(:query_cohort) { cohort }
+    let(:school_type_codes) { [] }
+
+    let(:school_cohort) { create(:seed_school_cohort, :fip, :with_school, cohort:) }
+    let!(:school) { school_cohort.school }
+
+    subject(:query_result) { described_class.call(cohort: query_cohort, school_type_codes:) }
+
+    context "when there are no active partnerships in the cohort" do
+      it "includes the school" do
+        expect(query_result).to include(school)
+      end
+    end
+
+    context "when there is an active partnership" do
+      let!(:partnership) { create(:seed_partnership, :valid, school:, cohort:) }
+
+      it "does not include the school" do
+        expect(query_result).not_to include(school)
+      end
+    end
+
+    context "when there is a challenged partnership" do
+      let!(:partnership) { create(:seed_partnership, :valid, :challenged, school:, cohort:) }
+
+      it "includes the school" do
+        expect(query_result).to include(school)
+      end
+    end
+
+    context "when there is a relationship" do
+      let!(:relationship) { create(:seed_partnership, :valid, relationship: true, school:, cohort:) }
+
+      it "does not include the school" do
+        expect(query_result).not_to include(school)
+      end
+    end
+
+    context "when there is an active partnership in a different cohort" do
+      let(:query_cohort) { cohort.next || create(:seed_cohort, start_year: cohort.start_year + 1) }
+      let!(:query_school_cohort) { create(:seed_school_cohort, :fip, school:, cohort: query_cohort) }
+      let!(:partnership) { create(:seed_partnership, :valid, school:, cohort:) }
+
+      it "includes the school" do
+        expect(query_result).to include(school)
+      end
+    end
+
+    context "when the school is doing CIP" do
+      let(:school_cohort) { create(:seed_school_cohort, :cip, :with_school, cohort:) }
+
+      it "does not include the school" do
+        expect(query_result).not_to include(school)
+      end
+    end
+
+    context "when the school is not expecting ECTs" do
+      let(:school_cohort) { create(:seed_school_cohort, :no_early_career_teachers, :with_school, cohort:) }
+
+      it "does not include the school" do
+        expect(query_result).not_to include(school)
+      end
+    end
+
+    context "when the school is doing a school-funded FIP" do
+      let(:school_cohort) { create(:seed_school_cohort, :school_funded_fip, :with_school, cohort:) }
+
+      it "does not include the school" do
+        expect(query_result).not_to include(school)
+      end
+    end
+
+    context "when the school is doing DIY" do
+      let(:school_cohort) { create(:seed_school_cohort, :design_our_own, :with_school, cohort:) }
+
+      it "does not include the school" do
+        expect(query_result).not_to include(school)
+      end
+    end
+
+    context "when school type codes are supplied" do
+      let(:school_type_codes) { [1, 2, 3] }
+
+      context "and the school matches one of the school types" do
+        before do
+          school.update!(school_type_code: 2)
+        end
+
+        context "when there are no active partnerships in the cohort" do
+          it "includes the school" do
+            expect(query_result).to include(school)
+          end
+        end
+      end
+
+      context "and the school does not match one of the school types" do
+        before do
+          school.update!(school_type_code: 5)
+        end
+
+        context "when there are no active partnerships in the cohort" do
+          it "does not include the school" do
+            expect(query_result).not_to include(school)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/bulk_mailers/school_reminder_comms_spec.rb
+++ b/spec/services/bulk_mailers/school_reminder_comms_spec.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BulkMailers::SchoolReminderComms, type: :mailer do
+  let(:cohort) { create(:seed_cohort) }
+  let(:query_cohort) { cohort }
+  let(:dry_run) { false }
+
+  let(:school_cohort) { create(:seed_school_cohort, :fip, :with_school, cohort:) }
+  let(:induction_programme) { create(:seed_induction_programme, :fip, school_cohort:) }
+  let(:school) { school_cohort.school }
+  let!(:sit_profile) { create(:seed_induction_coordinator_profiles_school, :valid, school:).induction_coordinator_profile }
+
+  subject(:service) { described_class.new(cohort: query_cohort, dry_run:) }
+
+  before do
+    school.update!(school_type_code: 1)
+  end
+
+  describe "#contact_sits_that_need_to_assign_mentors" do
+    let(:participant_profile) { create(:seed_ect_participant_profile, :valid, school_cohort:) }
+    let!(:eligibility) { create(:seed_ecf_participant_eligibility, participant_profile:) }
+    let(:mentor_profile) { nil }
+
+    let!(:induction_record) { create(:seed_induction_record, :valid, participant_profile:, induction_programme:, mentor_profile:) }
+
+    context "when a school has not assigned a mentor to an ECT" do
+      it "mails the induction coordinator" do
+        expect {
+          service.contact_sits_that_need_to_assign_mentors
+        }.to have_enqueued_mail(SchoolMailer, :remind_sit_to_assign_mentors_to_ects_email)
+          .with(params: { school:, induction_coordinator: sit_profile }, args: [])
+      end
+
+      context "when the dry_run flag is set" do
+        let(:dry_run) { true }
+
+        it "does not mail the induction coordinator" do
+          expect {
+            service.contact_sits_that_need_to_assign_mentors
+          }.not_to have_enqueued_mail
+        end
+
+        it "returns the count of emails that would be sent" do
+          expect(service.contact_sits_that_need_to_assign_mentors).to eq 1
+        end
+      end
+    end
+
+    context "when a school has no ECTs without mentors" do
+      let(:mentor_profile) { create(:seed_mentor_participant_profile, :valid, school_cohort:) }
+
+      it "does not mail the induction coordinator" do
+        expect {
+          service.contact_sits_that_need_to_assign_mentors
+        }.not_to have_enqueued_mail
+      end
+    end
+  end
+
+  describe "#contact_sits_that_have_not_added_participants" do
+    context "when a school has not added participants to this programme" do
+      it "mails the induction coordinator" do
+        expect {
+          service.contact_sits_that_have_not_added_participants
+        }.to have_enqueued_mail(SchoolMailer, :remind_sit_to_add_ects_and_mentors_email)
+          .with(params: { school:, induction_coordinator: sit_profile }, args: [])
+      end
+    end
+
+    context "when a school has added participants" do
+      let!(:induction_record) { create(:seed_induction_record, :valid, induction_programme:) }
+
+      it "does not mail the induction coordinator" do
+        expect {
+          service.contact_sits_that_have_not_added_participants
+        }.not_to have_enqueued_mail
+      end
+    end
+
+    context "when the dry_run flag is set" do
+      let(:dry_run) { true }
+
+      it "does not mail the induction coordinator" do
+        expect {
+          service.contact_sits_that_have_not_added_participants
+        }.not_to have_enqueued_mail
+      end
+
+      it "returns the count of emails that would be sent" do
+        expect(service.contact_sits_that_have_not_added_participants).to eq 1
+      end
+    end
+  end
+
+  describe "#contact_sits_that_have_not_engaged" do
+    context "when the school has not made a programme choice" do
+      context "and ran FIP last year" do
+        let(:nomination_link) { "http://nomination.example.com" }
+        let(:sit_user) { sit_profile.user }
+        let!(:query_cohort) { create(:seed_cohort, start_year: cohort.start_year + 1) }
+
+        before do
+          allow(service).to receive(:nomination_url).with(email: sit_user.email, school:).and_return(nomination_link)
+        end
+
+        it "mails the induction coordinator" do
+          expect {
+            service.contact_sits_that_have_not_engaged
+          }.to have_enqueued_mail(SchoolMailer, :launch_ask_sit_to_report_school_training_details)
+            .with(params: { sit_user: sit_profile.user, nomination_link: }, args: [])
+        end
+
+        context "when the dry_run flag is set" do
+          let(:dry_run) { true }
+
+          it "does not mail the induction coordinator" do
+            expect {
+              service.contact_sits_that_have_not_engaged
+            }.not_to have_enqueued_mail
+          end
+
+          it "returns the count of emails that would be sent" do
+            expect(service.contact_sits_that_have_not_engaged).to eq 1
+          end
+        end
+      end
+
+      context "and did not run FIP last year" do
+        let!(:school) { create(:seed_school, :valid) }
+
+        it "does not mail the induction coordinator" do
+          expect {
+            service.contact_sits_that_have_not_engaged
+          }.not_to have_enqueued_mail
+        end
+      end
+    end
+  end
+
+  describe "#contact_sits_that_have_chosen_fip_but_not_partnered" do
+    context "when the school has chosen fip but not partnered" do
+      let(:previous_cohort) { create(:seed_cohort, start_year: cohort.start_year - 1) }
+
+      context "and did not partner last year" do
+        let!(:previous_school_cohort) { create(:seed_school_cohort, :cip, school:, cohort: previous_cohort) }
+
+        it "mails the induction coordinator" do
+          expect {
+            service.contact_sits_that_have_chosen_fip_but_not_partnered
+          }.to have_enqueued_mail(SchoolMailer, :sit_needs_to_chase_partnership)
+            .with(params: { school: }, args: [])
+        end
+
+        context "when the dry_run flag is set" do
+          let(:dry_run) { true }
+
+          it "does not mail the induction coordinator" do
+            expect {
+              service.contact_sits_that_have_chosen_fip_but_not_partnered
+            }.not_to have_enqueued_mail
+          end
+
+          it "returns the count of emails that would be sent" do
+            expect(service.contact_sits_that_have_chosen_fip_but_not_partnered).to eq 1
+          end
+        end
+      end
+
+      context "and partnered last year" do
+        let!(:previous_school_cohort) { create(:seed_school_cohort, :fip, school:, cohort: previous_cohort) }
+        let!(:previous_partnership) { create(:seed_partnership, :valid, school:, cohort: previous_cohort) }
+
+        it "does not mail the induction coordinator" do
+          expect {
+            service.contact_sits_that_have_chosen_fip_but_not_partnered
+          }.not_to have_enqueued_mail
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: [https://dfedigital.atlassian.net/browse/CST-2037](https://dfedigital.atlassian.net/browse/CST-2037)

Add queries and service to collate and send regular chaser mails to SITs.  This should enable the main repetitive mails to be sent easily manually, the next steps will be to automate these with a schedule and UI

### Changes proposed in this pull request
Add queries to support selecting the correct schools to include in bulk mailing
Add a service to collate the schools from the queries and send the emails

### Guidance to review

