### PR TITLE
Remove the banner around completed ECTs

### DIFF
--- a/app/views/schools/participants/index.html.erb
+++ b/app/views/schools/participants/index.html.erb
@@ -3,17 +3,6 @@
 <% content_for :before_content, govuk_breadcrumbs(breadcrumbs: breadcrumbs(@school)) %>
 
 <div class="govuk-grid-row">
-  <% if participants_count(@school.school_cohorts) > 0 %>
-    <div class="govuk-width-container">
-      <%= render GovukComponent::NotificationBannerComponent.new(title_text: 'Important', classes: 'govuk-!-margin-top-0 govuk-!-margin-bottom-5', html_attributes: { data: { test: "notification-banner" } }) do |banner| %>
-        <p class="govuk-notification-banner__heading">Do not remove ECTs or mentors who have completed their induction
-          and training.</p>
-        <p class="govuk-notification-banner__heading">Your appropriate body and provider will confirm this with us soon,
-          and we’ll update their records.</p>
-      <% end %>
-    </div>
-  <% end %>
-
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-l"><%= @school.name %></span>
     <h1 class="govuk-heading-l">Manage mentors and ECTs</h1>

--- a/spec/features/schools/participant_dashboard/manage_fip_partnered_participants_spec.rb
+++ b/spec/features/schools/participant_dashboard/manage_fip_partnered_participants_spec.rb
@@ -9,28 +9,6 @@ RSpec.describe "Manage FIP partnered participants with no change of circumstance
   context "inactive change of circumstances flag" do
     it_behaves_like "manage fip participants example"
   end
-
-  context "Completed participants banner" do
-    context "when school has participants" do
-      scenario "the banner is displayed" do
-        given_there_is_a_school_that_has_chosen_fip_and_partnered
-        and_i_have_added_a_contacted_for_info_mentor
-        and_i_have_added_an_eligible_ect_with_mentor
-        and_i_am_signed_in_as_an_induction_coordinator
-        and_i_click("Manage mentors and ECTs")
-        then_i_see_the_complete_participants_banner
-      end
-    end
-
-    context "when school has no participants" do
-      scenario "The banner is not displayed" do
-        given_there_is_a_school_that_has_chosen_fip_and_partnered
-        and_i_am_signed_in_as_an_induction_coordinator
-        and_i_click("Manage mentors and ECTs")
-        then_i_do_not_see_the_complete_participants_banner
-      end
-    end
-  end
 end
 
 RSpec.describe "Manage FIP partnered participants with change of circumstances", js: true, with_feature_flags: { eligibility_notifications: "active" } do

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -1314,14 +1314,6 @@ module ManageTrainingSteps
     then_i_see_the_tab_for_the_cohort(2022)
   end
 
-  def then_i_see_the_complete_participants_banner
-    expect(page).to have_text("Do not remove ECTs or mentors who have completed their induction and training.")
-  end
-
-  def then_i_do_not_see_the_complete_participants_banner
-    expect(page).not_to have_text("Do not remove ECTs or mentors who have completed their induction and training.")
-  end
-
   def then_i_am_on_the_what_we_need_to_know_page
     expect(page).to have_text("Tell us if any new ECTs or mentors will start training at your school in the 2022 to 2023 academic year")
   end


### PR DESCRIPTION
### Context

We can remove this banner, now that we are pulling the completed induction status for ECTs from the DQT database and reflecting this in our interface.

Removing this banner improve the visibility of other information in the service, and avoids users from having to read information unnecessarily. 

🗂️  [Jira ticket](https://dfedigital.atlassian.net/browse/CST-1998)  [Second Jira ticket](https://dfedigital.atlassian.net/browse/CST-2100)

### Screenshots

#### Before

<img width="1203" alt="Screenshot 2023-11-02 at 15 50 52" src="https://github.com/DFE-Digital/early-careers-framework/assets/30665/29530224-3311-4570-8ed4-d4942674d392">

#### After

<img width="1203" alt="Screenshot 2023-11-02 at 15 51 02" src="https://github.com/DFE-Digital/early-careers-framework/assets/30665/beaf545c-e544-4a90-9af1-8409f709f1df">
