### PR TITLE
Remove sign-up path from link to support for ECTs

### DIFF
--- a/app/views/schools/core_programme/materials/success.html.erb
+++ b/app/views/schools/core_programme/materials/success.html.erb
@@ -9,10 +9,7 @@
             <strong><%= @cohort.description %></strong>
           <% end %>
 
-        <p class="govuk-body">To access the training materials:</p>
-
-        <p class="govuk-body">
-          Visit <%= govuk_link_to 'Support for early career teachers (opens in new tab)',
+        <p class="govuk-body">To access the training materials, visit <%= govuk_link_to 'Support for early career teachers (opens in new tab)',
               "https://support-for-early-career-teachers.education.gov.uk",
               target: "_blank",
               rel: "noopener noreferrer" %>.

--- a/app/views/schools/core_programme/materials/success.html.erb
+++ b/app/views/schools/core_programme/materials/success.html.erb
@@ -9,14 +9,14 @@
             <strong><%= @cohort.description %></strong>
           <% end %>
 
-          <p>To access the training materials:</p>
-          <ol class="govuk-list govuk-list--number govuk-!-margin-bottom-7">
-            <li>Visit <%= govuk_link_to 'Support for early career teachers (opens in new tab)',
-            "https://support-for-early-career-teachers.education.gov.uk/users/sign-up",
-            target: :_blank,
-            rel: "noopener noreferrer" %>.</li>
-            <li>Enter your email address to create a new account.</li>
-          </ol>
+        <p class="govuk-body">To access the training materials:</p>
+
+        <p class="govuk-body">
+          Visit <%= govuk_link_to 'Support for early career teachers (opens in new tab)',
+              "https://support-for-early-career-teachers.education.gov.uk",
+              target: "_blank",
+              rel: "noopener noreferrer" %>.
+        </p>
 
         <%= govuk_link_to "Return to manage your training", schools_dashboard_path(school_id: @school.slug) %>
 


### PR DESCRIPTION
This service was replaced with a static website that has no login functionality.

A potential improvement would be to link to the right provider, I guess by this point in the journey we know it. I couldn't work out how to make the leap from [core_induction_programme](https://github.com/DFE-Digital/early-careers-framework/blob/main/app/models/core_induction_programme.rb) to it though, because the model is bare. But at least now it won't just show a 404.
