### PR TITLE
Fix link to sandbox NPQ participant login

### DIFF
--- a/app/views/sandbox/show.html.erb
+++ b/app/views/sandbox/show.html.erb
@@ -28,7 +28,7 @@
 
       <h2 class="govuk-heading-m">Impersonate ECF school induction tutors </h2>
       <p class="govuk-body">Impersonate a school induction tutor to see how they set up ECF-based training programmes and register Early Career Teachers (ECTs) and mentors to the service. </p>
-      
+
       <p class="govuk-body">Request induction tutor test access to the sandbox by emailing us on <%= render MailToSupportComponent.new %>.</p>
 
       <%= govuk_start_button(
@@ -47,7 +47,7 @@
 
       <%= govuk_start_button(
             text: 'Login to sandbox as an NPQ participant',
-            href: 'https://npq-registration-sandbox.london.cloudapps.digital',
+            href: 'https://npq-registration-sandbox-web.teacherservices.cloud/',
             ) %>
 
 


### PR DESCRIPTION
The old link is to GOVUK PaaS which is being decomissioned, the new one is to our new environment in Azure.
