### PR TITLE
CST-2075:  New mentors can be linked to the school's previous providers

### DIFF
--- a/app/forms/schools/add_participants/transfer_wizard.rb
+++ b/app/forms/schools/add_participants/transfer_wizard.rb
@@ -31,7 +31,6 @@ module Schools
         return do_not_join_school_programme! if continue_current_programme?
         return true if [lead_provider, delivery_partner].all? &&
           (lead_provider != existing_lead_provider || delivery_partner != existing_delivery_partner)
-        return false if [current_cohort_lead_provider, current_cohort_delivery_partner].any?(&:blank?)
         return false unless current_providers_training_on_participant_cohort?
 
         (current_cohort_lead_provider != existing_lead_provider ||

--- a/app/forms/schools/add_participants/wizard_steps/cannot_add_mentor_to_providers_step.rb
+++ b/app/forms/schools/add_participants/wizard_steps/cannot_add_mentor_to_providers_step.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Schools
+  module AddParticipants
+    module WizardSteps
+      class CannotAddMentorToProvidersStep < CannotAddStep
+      end
+    end
+  end
+end

--- a/app/forms/schools/add_participants/wizard_steps/choose_mentor_step.rb
+++ b/app/forms/schools/add_participants/wizard_steps/choose_mentor_step.rb
@@ -25,6 +25,8 @@ module Schools
             end
           elsif wizard.needs_to_confirm_appropriate_body?
             :confirm_appropriate_body
+          elsif wizard.needs_to_choose_partnership?
+            :choose_partnership
           else
             :check_answers
           end

--- a/app/forms/schools/add_participants/wizard_steps/choose_partnership_step.rb
+++ b/app/forms/schools/add_participants/wizard_steps/choose_partnership_step.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module Schools
+  module AddParticipants
+    module WizardSteps
+      class ChoosePartnershipStep < ::WizardStep
+        attr_accessor :providers
+
+        validates :providers,
+                  inclusion: { in: %w[current_providers previous_providers other_providers] }
+
+        def self.permitted_params
+          %i[
+            providers
+          ]
+        end
+
+        def choices
+          options = Array(current_providers_choice)
+          options << previous_providers_choice if previous_providers_choice?
+          options << other_providers_choice if options.present?
+
+          options
+        end
+
+        def next_step
+          if wizard.providers_chosen?
+            :check_answers
+          else
+            :cannot_add_mentor_to_providers
+          end
+        end
+
+      private
+
+        def current_providers_choice
+          if current_providers_names
+            OpenStruct.new(id: :current_providers, name: current_providers_names)
+          end
+        end
+
+        def current_providers_names
+          return if [wizard.lead_provider, wizard.delivery_partner].any?(&:blank?)
+
+          @current_providers_names ||= "#{wizard.lead_provider&.name} with #{wizard.delivery_partner&.name}"
+        end
+
+        def previous_providers_names
+          return if [wizard.previous_cohort_lead_provider, wizard.previous_cohort_delivery_partner].any?(&:blank?)
+
+          @previous_providers_names ||= "#{wizard.previous_cohort_lead_provider&.name} with #{wizard.previous_cohort_delivery_partner&.name}"
+        end
+
+        def previous_providers_choice
+          if previous_providers_names
+            OpenStruct.new(id: :previous_providers, name: previous_providers_names)
+          end
+        end
+
+        def previous_providers_choice?
+          return false if previous_providers_names == current_providers_names
+
+          wizard.previous_providers_training_on_current_cohort?
+        end
+
+        def other_providers_choice
+          OpenStruct.new(id: :other_providers, name: "Other training providers")
+        end
+      end
+    end
+  end
+end

--- a/app/forms/schools/add_participants/wizard_steps/confirm_appropriate_body_step.rb
+++ b/app/forms/schools/add_participants/wizard_steps/confirm_appropriate_body_step.rb
@@ -17,7 +17,11 @@ module Schools
         end
 
         def next_step
-          :check_answers
+          if wizard.needs_to_choose_partnership?
+            :choose_partnership
+          else
+            :check_answers
+          end
         end
       end
     end

--- a/app/forms/schools/add_participants/wizard_steps/email_step.rb
+++ b/app/forms/schools/add_participants/wizard_steps/email_step.rb
@@ -37,6 +37,8 @@ module Schools
             :choose_mentor
           elsif wizard.needs_to_confirm_appropriate_body?
             :confirm_appropriate_body
+          elsif wizard.needs_to_choose_partnership?
+            :choose_partnership
           else
             :check_answers
           end

--- a/app/forms/schools/add_participants/wizard_steps/join_school_programme_step.rb
+++ b/app/forms/schools/add_participants/wizard_steps/join_school_programme_step.rb
@@ -16,7 +16,7 @@ module Schools
         end
 
         def choices
-          options = [default_participant_cohort_choice].compact
+          options = Array(default_participant_cohort_choice)
           options << default_current_cohort_choice if default_current_cohort_choice?
           options << other_providers_choice if options.present?
 

--- a/app/forms/schools/add_participants/wizard_steps/start_term_step.rb
+++ b/app/forms/schools/add_participants/wizard_steps/start_term_step.rb
@@ -23,6 +23,8 @@ module Schools
             :choose_mentor
           elsif wizard.needs_to_confirm_appropriate_body?
             :confirm_appropriate_body
+          elsif wizard.needs_to_choose_partnership?
+            :choose_partnership
           else
             :check_answers
           end

--- a/app/forms/schools/add_participants/wizard_steps/yourself_step.rb
+++ b/app/forms/schools/add_participants/wizard_steps/yourself_step.rb
@@ -29,6 +29,8 @@ module Schools
             :choose_mentor
           elsif wizard.needs_to_confirm_appropriate_body?
             :confirm_appropriate_body
+          elsif wizard.needs_to_choose_partnership?
+            :choose_partnership
           else
             :check_answers
           end

--- a/app/services/early_career_teachers/create.rb
+++ b/app/services/early_career_teachers/create.rb
@@ -22,10 +22,10 @@ module EarlyCareerTeachers
           **ect_attributes,
         )
 
-        ParticipantProfileState.create!(participant_profile: profile, cpd_lead_provider: school_cohort&.default_induction_programme&.lead_provider&.cpd_lead_provider)
-        if school_cohort.default_induction_programme.present?
+        ParticipantProfileState.create!(participant_profile: profile, cpd_lead_provider: induction_programme&.lead_provider&.cpd_lead_provider)
+        if induction_programme.present?
           Induction::Enrol.call(participant_profile: profile,
-                                induction_programme: school_cohort.default_induction_programme,
+                                induction_programme:,
                                 mentor_profile:,
                                 start_date:,
                                 appropriate_body_id:)
@@ -37,7 +37,7 @@ module EarlyCareerTeachers
 
   private
 
-    attr_reader :full_name, :email, :school_cohort, :mentor_profile_id, :start_date, :appropriate_body_id, :induction_start_date
+    attr_reader :full_name, :email, :induction_programme, :school_cohort, :mentor_profile_id, :start_date, :appropriate_body_id, :induction_start_date
 
     def initialize(full_name:, email:, school_cohort:, mentor_profile_id: nil, start_date: nil, appropriate_body_id: nil, induction_start_date: nil)
       @full_name = full_name
@@ -47,6 +47,7 @@ module EarlyCareerTeachers
       @start_date = start_date
       @appropriate_body_id = appropriate_body_id
       @induction_start_date = induction_start_date
+      @induction_programme = induction_programme || school_cohort.default_induction_programme
     end
 
     def ect_attributes

--- a/app/services/early_career_teachers/reactivate.rb
+++ b/app/services/early_career_teachers/reactivate.rb
@@ -10,13 +10,13 @@ module EarlyCareerTeachers
         update_participant_profile_email
 
         ParticipantProfileState.create!(participant_profile:,
-                                        cpd_lead_provider: school_cohort&.default_induction_programme&.lead_provider&.cpd_lead_provider)
+                                        cpd_lead_provider: induction_programme&.lead_provider&.cpd_lead_provider)
 
-        if school_cohort.default_induction_programme.present?
+        if induction_programme.present?
           end_current_induction_record
 
           Induction::Enrol.call(participant_profile:,
-                                induction_programme: school_cohort.default_induction_programme,
+                                induction_programme:,
                                 mentor_profile:,
                                 start_date:,
                                 appropriate_body_id:,
@@ -29,7 +29,8 @@ module EarlyCareerTeachers
 
   private
 
-    attr_reader :participant_profile, :email, :school_cohort, :mentor_profile_id, :start_date, :appropriate_body_id, :induction_start_date
+    attr_reader :participant_profile, :email, :induction_programme, :school_cohort, :mentor_profile_id,
+                :start_date, :appropriate_body_id, :induction_start_date
 
     def initialize(participant_profile:, email:, school_cohort:, mentor_profile_id: nil, start_date: nil, appropriate_body_id: nil, induction_start_date: nil)
       @participant_profile = participant_profile
@@ -39,6 +40,7 @@ module EarlyCareerTeachers
       @start_date = start_date
       @appropriate_body_id = appropriate_body_id
       @induction_start_date = induction_start_date
+      @induction_programme = school_cohort.default_induction_programme
     end
 
     def mentor_profile

--- a/app/services/form_data/add_participant_store.rb
+++ b/app/services/form_data/add_participant_store.rb
@@ -125,6 +125,22 @@ module FormData
       get(:participant_profile)
     end
 
+    def providers
+      get(:providers)
+    end
+
+    def current_providers?
+      providers == "current_providers"
+    end
+
+    def previous_providers?
+      providers == "previous_providers"
+    end
+
+    def providers_chosen?
+      current_providers? || previous_providers?
+    end
+
     def was_withdrawn_participant?
       get(:was_withdrawn_participant) == true
     end

--- a/app/services/mentors/add_profile_to_ect.rb
+++ b/app/services/mentors/add_profile_to_ect.rb
@@ -20,11 +20,11 @@ module Mentors
         )
 
         ParticipantProfileState.create!(participant_profile: mentor_profile,
-                                        cpd_lead_provider: school_cohort&.default_induction_programme&.lead_provider&.cpd_lead_provider)
+                                        cpd_lead_provider: induction_programme&.lead_provider&.cpd_lead_provider)
 
-        if school_cohort.default_induction_programme.present?
+        if induction_programme.present?
           Induction::Enrol.call(participant_profile: mentor_profile,
-                                induction_programme: school_cohort.default_induction_programme,
+                                induction_programme:,
                                 preferred_email:,
                                 start_date:)
         end
@@ -39,10 +39,11 @@ module Mentors
 
   private
 
-    attr_reader :ect_profile, :preferred_email, :school_cohort, :start_date
+    attr_reader :ect_profile, :induction_programme, :preferred_email, :school_cohort, :start_date
 
-    def initialize(ect_profile:, school_cohort:, preferred_email: nil, start_date: nil)
+    def initialize(ect_profile:, induction_programme:, school_cohort:, preferred_email: nil, start_date: nil)
       @ect_profile = ect_profile
+      @induction_programme = induction_programme
       @preferred_email = preferred_email || ect_profile.participant_identity.email
       @start_date = start_date
       @school_cohort = school_cohort

--- a/app/services/mentors/create.rb
+++ b/app/services/mentors/create.rb
@@ -20,11 +20,11 @@ module Mentors
           participant_identity: Identity::Create.call(user:, email:),
         }.merge(mentor_attributes))
 
-        ParticipantProfileState.create!(participant_profile: mentor_profile, cpd_lead_provider: school_cohort&.default_induction_programme&.lead_provider&.cpd_lead_provider)
+        ParticipantProfileState.create!(participant_profile: mentor_profile, cpd_lead_provider: induction_programme&.lead_provider&.cpd_lead_provider)
 
-        if school_cohort.default_induction_programme.present?
+        if induction_programme.present?
           Induction::Enrol.call(participant_profile: mentor_profile,
-                                induction_programme: school_cohort.default_induction_programme,
+                                induction_programme:,
                                 start_date:)
         end
 
@@ -36,10 +36,11 @@ module Mentors
 
   private
 
-    attr_reader :full_name, :email, :school_cohort, :start_date
+    attr_reader :full_name, :email, :induction_programme, :school_cohort, :start_date
 
-    def initialize(full_name:, email:, school_cohort:, start_date: nil, **)
+    def initialize(full_name:, email:, school_cohort:, induction_programme: nil, start_date: nil, **)
       @full_name = full_name
+      @induction_programme = induction_programme || school_cohort.default_induction_programme
       @email = email
       @start_date = start_date
       @school_cohort = school_cohort

--- a/app/services/mentors/reactivate.rb
+++ b/app/services/mentors/reactivate.rb
@@ -9,13 +9,13 @@ module Mentors
         reactivate_participant_profile
         update_participant_profile_email
 
-        ParticipantProfileState.create!(participant_profile:, cpd_lead_provider: school_cohort&.default_induction_programme&.lead_provider&.cpd_lead_provider)
+        ParticipantProfileState.create!(participant_profile:, cpd_lead_provider: induction_programme&.lead_provider&.cpd_lead_provider)
 
-        if school_cohort.default_induction_programme.present?
+        if induction_programme.present?
           end_current_induction_record
 
           Induction::Enrol.call(participant_profile:,
-                                induction_programme: school_cohort.default_induction_programme,
+                                induction_programme:,
                                 start_date:,
                                 preferred_email: email)
         end
@@ -28,10 +28,11 @@ module Mentors
 
   private
 
-    attr_reader :participant_profile, :email, :school_cohort, :start_date
+    attr_reader :participant_profile, :email, :induction_programme, :school_cohort, :start_date
 
-    def initialize(participant_profile:, email:, school_cohort:, start_date: nil, **)
+    def initialize(participant_profile:, induction_programme:, email:, school_cohort:, start_date: nil, **)
       @participant_profile = participant_profile
+      @induction_programme = induction_programme || school_cohort.default_induction_programme
       @email = email
       @start_date = start_date
       @school_cohort = school_cohort

--- a/app/views/schools/add_participants/_ect_or_mentor_answers.html.erb
+++ b/app/views/schools/add_participants/_ect_or_mentor_answers.html.erb
@@ -75,12 +75,12 @@
     <% end %>
   <% end %>
 
-  <% if form.show_default_induction_programme_details? %>
+  <% if form.chosen_lead_provider %>
     <% summary_list.with_row do |row| %>
       <% row.with_key { "Training with" } %>
       <% row.with_value do %>
-        <%= tag.p(form.lead_provider.name, class: "govuk-body") if form.lead_provider.present? %>
-        <%= tag.p(form.delivery_partner.name, class: "govuk-body") if form.delivery_partner.present? %>
+        <%= tag.p(form.chosen_lead_provider.name, class: "govuk-body") %>
+        <%= tag.p(form.chosen_delivery_partner.name, class: "govuk-body") %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/schools/add_participants/cannot_add_mentor_to_providers.html.erb
+++ b/app/views/schools/add_participants/cannot_add_mentor_to_providers.html.erb
@@ -1,0 +1,23 @@
+<% title =  "You cannot add #{@wizard.full_name}" %>
+<% content_for :title, title %>
+
+<% content_for :before_content, govuk_back_link( text: "Back", href: wizard_back_link_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l"><%= @school.name %></span>
+    <h1 class="govuk-heading-l"><%= title %></h1>
+
+    <p class="govuk-body">Contact our support team to report the training provider for this mentor: <%= render MailToSupportComponent.new %></p>
+    <p class="govuk-body">Include <%= @wizard.possessive_name %>:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>full name</li>
+      <li>date of birth</li>
+      <li>teacher reference number (TRN)</li>
+      <li>school</li>
+      <li>chosen lead provider and delivery partner</li>
+    </ul>
+
+    <%= govuk_link_to "Return to your ECTs and mentors", @wizard.dashboard_path, no_visited_state: true %>
+  </div>
+</div>

--- a/app/views/schools/add_participants/choose_partnership.html.erb
+++ b/app/views/schools/add_participants/choose_partnership.html.erb
@@ -1,0 +1,23 @@
+<% title = "Who will #{@wizard.full_name} do their mentor training with?" %>
+
+<% content_for :title, title %>
+
+<% content_for :before_content, govuk_back_link(text: "Back", href: wizard_back_link_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l"><%= @school.name %></span>
+    <%= form_with model: @wizard.form, url: url_for(action: :update), scope: @wizard.form_scope, method: :put do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_collection_radio_buttons(
+          :providers,
+          @wizard.form.choices,
+          :id,
+          :name,
+          inline: false,
+          legend: { text: title, tag: 'h1', size: 'l' }) %>
+
+      <%= f.govuk_submit "Continue" %>
+    <% end %>
+  </div>
+</div>

--- a/spec/features/schools/participants/add_participants/add_ect_as_mentor_spec.rb
+++ b/spec/features/schools/participants/add_participants/add_ect_as_mentor_spec.rb
@@ -48,6 +48,10 @@ RSpec.describe "Add ECT as mentor", js: true do
 
     when_i_choose_summer_term_2023
     when_i_click_on_continue
+    then_i_am_taken_to_choose_mentor_partnership_page
+
+    when_i_choose_current_providers
+    and_i_click_on_continue
     then_i_am_taken_to_check_answers_page
 
     when_i_click_confirm_and_add

--- a/spec/features/schools/participants/add_participants/add_previously_withdrawn_mentor_spec.rb
+++ b/spec/features/schools/participants/add_participants/add_previously_withdrawn_mentor_spec.rb
@@ -71,7 +71,10 @@ RSpec.describe "Adding previously withdrawn Mentor", type: :feature, js: true do
 
       when_i_choose_summer_term_2023
       when_i_click_on_continue
+      then_i_am_taken_to_choose_mentor_partnership_page
 
+      when_i_choose_current_providers
+      when_i_click_on_continue
       then_i_am_taken_to_the_confirmation_page
       and_i_see_the_correct_details(joint_provider_details: true)
 
@@ -103,7 +106,10 @@ RSpec.describe "Adding previously withdrawn Mentor", type: :feature, js: true do
 
       when_i_choose_summer_term_2023
       when_i_click_on_continue
+      then_i_am_taken_to_choose_mentor_partnership_page
 
+      when_i_choose_current_providers
+      when_i_click_on_continue
       then_i_am_taken_to_the_confirmation_page
       and_i_see_the_correct_details(joint_provider_details: true)
 
@@ -132,7 +138,10 @@ RSpec.describe "Adding previously withdrawn Mentor", type: :feature, js: true do
 
       when_i_choose_summer_term_2023
       when_i_click_on_continue
+      then_i_am_taken_to_choose_mentor_partnership_page
 
+      when_i_choose_current_providers
+      when_i_click_on_continue
       then_i_am_taken_to_the_confirmation_page
       and_i_see_the_correct_details(joint_provider_details: true, expected_email: new_email)
 
@@ -159,7 +168,10 @@ RSpec.describe "Adding previously withdrawn Mentor", type: :feature, js: true do
 
       when_i_choose_summer_term_2023
       when_i_click_on_continue
+      then_i_am_taken_to_choose_mentor_partnership_page
 
+      when_i_choose_current_providers
+      when_i_click_on_continue
       then_i_am_taken_to_the_confirmation_page
       and_i_see_the_correct_details(joint_provider_details: true)
 
@@ -292,6 +304,10 @@ private
     expect(page).to have_content("Is this the appropriate body for George Mentor’s induction?")
   end
 
+  def then_i_am_taken_to_choose_mentor_partnership_page
+    expect(page).to have_selector("h1", text: "Who will George Mentor do their mentor training with?")
+  end
+
   def then_i_am_taken_to_the_confirmation_page
     expect(page).to have_content("Check your answers")
   end
@@ -378,5 +394,9 @@ private
 
   def when_i_click_on_continue
     click_on "Continue"
+  end
+
+  def when_i_choose_current_providers
+    choose option: "current_providers"
   end
 end

--- a/spec/features/schools/participants/add_participants/reporting_participants_with_trn_spec.rb
+++ b/spec/features/schools/participants/add_participants/reporting_participants_with_trn_spec.rb
@@ -157,6 +157,9 @@ RSpec.describe "Reporting participants with a known TRN", type: :feature, js: tr
       when_i_add_email_address_to_the_school_add_participant_wizard "Sally Teacher", participant_data[:email]
       then_the_page_is_accessible
 
+      when_i_choose_current_providers_on_the_school_add_participant_wizard
+      then_the_page_is_accessible
+
       when_i_confirm_and_add_on_the_school_add_participant_wizard
       then_the_page_is_accessible
 
@@ -183,6 +186,9 @@ RSpec.describe "Reporting participants with a known TRN", type: :feature, js: tr
       then_the_page_is_accessible
 
       when_i_choose_summer_term_on_the_school_add_participant_wizard
+      then_the_page_is_accessible
+
+      when_i_choose_current_providers_on_the_school_add_participant_wizard
       then_the_page_is_accessible
 
       when_i_confirm_and_add_on_the_school_add_participant_wizard

--- a/spec/features/schools/participants/add_participants/sit_add_ect_spec.rb
+++ b/spec/features/schools/participants/add_participants/sit_add_ect_spec.rb
@@ -89,6 +89,10 @@ RSpec.describe "SIT adding themself as ECT", js: true do
 
     when_i_choose_summer_term_2023
     and_i_click_on_continue
+    then_i_am_taken_to_choose_sit_partnership_page
+
+    when_i_choose_current_providers
+    and_i_click_on_continue
     then_i_am_taken_to_check_answers_page
 
     when_i_click_confirm_and_add

--- a/spec/features/schools/participants/add_participants/sit_add_mentor_spec.rb
+++ b/spec/features/schools/participants/add_participants/sit_add_mentor_spec.rb
@@ -50,6 +50,10 @@ RSpec.describe "SIT adding mentor", js: true do
 
     when_i_choose_summer_term_2023
     and_i_click_on_continue
+    then_i_am_taken_to_choose_sit_partnership_page
+
+    when_i_choose_current_providers
+    and_i_click_on_continue
     then_i_am_taken_to_check_answers_page
 
     when_i_click_confirm_and_add
@@ -112,7 +116,7 @@ RSpec.describe "SIT adding mentor", js: true do
     then_i_see_the_transferred_mentor_name
   end
 
-  scenario "Induction tutor adds a new mentor" do
+  scenario "Induction tutor adds a new mentor to current providers" do
     given_there_is_a_sit
 
     when_i_sign_in_as_sit
@@ -147,6 +151,10 @@ RSpec.describe "SIT adding mentor", js: true do
     then_i_am_taken_to_mentor_start_training_page
 
     when_i_choose_summer_term_2023
+    and_i_click_on_continue
+    then_i_am_taken_to_choose_mentor_partnership_page
+
+    when_i_choose_current_providers
     and_i_click_on_continue
     then_i_am_taken_to_check_answers_page
 

--- a/spec/features/schools/participants/add_participants/unhappy_path_can_validate_with_nino_spec.rb
+++ b/spec/features/schools/participants/add_participants/unhappy_path_can_validate_with_nino_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe "Add participants", js: true do
       and_i_confirm_details_and_continue_on_the_school_add_participant_wizard
       and_i_add_nino_to_the_school_add_participant_wizard @participant_data[:full_name], @participant_data[:nino]
       and_i_add_email_address_to_the_school_add_participant_wizard "Sally Teacher", @participant_data[:email]
+      and_i_choose_current_providers_on_the_school_add_participant_wizard
       and_i_confirm_and_add_on_the_school_add_participant_wizard
 
       then_i_am_on_the_school_add_participant_completed_page
@@ -68,6 +69,7 @@ RSpec.describe "Add participants", js: true do
       and_i_add_nino_to_the_school_add_participant_wizard @participant_data[:full_name], @participant_data[:nino]
       and_i_add_email_address_to_the_school_add_participant_wizard "Sally Teacher", @participant_data[:email]
       and_i_choose_summer_term_on_the_school_add_participant_wizard
+      and_i_choose_current_providers_on_the_school_add_participant_wizard
       and_i_confirm_and_add_on_the_school_add_participant_wizard
 
       then_i_am_on_the_school_add_participant_completed_page

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -656,6 +656,18 @@ module ManageTrainingSteps
 
   # When_steps
 
+  def when_i_choose_current_providers
+    choose option: "current_providers"
+  end
+
+  def when_i_choose_previous_providers
+    choose option: "previous_providers"
+  end
+
+  def when_i_choose_other_providers
+    choose option: "other_providers"
+  end
+
   def when_i_choose_summer_term_2023
     choose "Summer term 2023"
   end
@@ -1294,6 +1306,14 @@ module ManageTrainingSteps
 
   def then_i_am_taken_to_mentor_start_training_page
     expect(page).to have_selector("h1", text: "When will #{@participant_data[:full_name]} start their mentor training?")
+  end
+
+  def then_i_am_taken_to_choose_sit_partnership_page
+    expect(page).to have_selector("h1", text: "Who will #{@induction_coordinator_profile.full_name} do their mentor training with?")
+  end
+
+  def then_i_am_taken_to_choose_mentor_partnership_page
+    expect(page).to have_selector("h1", text: "Who will #{@participant_data[:full_name]} do their mentor training with?")
   end
 
   def then_i_am_taken_to_sit_mentor_start_training_page

--- a/spec/forms/schools/add_participants/wizard_steps/choose_mentor_step_spec.rb
+++ b/spec/forms/schools/add_participants/wizard_steps/choose_mentor_step_spec.rb
@@ -58,9 +58,18 @@ RSpec.describe Schools::AddParticipants::WizardSteps::ChooseMentorStep, type: :m
         end
       end
 
+      context "when a partnership needs to be chosen" do
+        it "should return choose_partnership" do
+          allow(wizard).to receive(:needs_to_confirm_appropriate_body?).and_return(false)
+          allow(wizard).to receive(:needs_to_choose_partnership?).and_return(true)
+          expect(step.next_step).to eql :choose_partnership
+        end
+      end
+
       context "when the school does not have an appropriate body set" do
         it "should return check_answers" do
           allow(wizard).to receive(:needs_to_confirm_appropriate_body?).and_return(false)
+          allow(wizard).to receive(:needs_to_choose_partnership?).and_return(false)
           expect(step.next_step).to eql :check_answers
         end
       end

--- a/spec/forms/schools/add_participants/wizard_steps/confirm_appropriate_body_step_spec.rb
+++ b/spec/forms/schools/add_participants/wizard_steps/confirm_appropriate_body_step_spec.rb
@@ -18,8 +18,24 @@ RSpec.describe Schools::AddParticipants::WizardSteps::ConfirmAppropriateBodyStep
   end
 
   describe "#next_step" do
-    it "should return check_answers" do
-      expect(step.next_step).to eql :check_answers
+    context "when a partnership needs to be chosen" do
+      before do
+        allow(wizard).to receive(:needs_to_choose_partnership?).and_return(true)
+      end
+
+      it "returns choose_partnership" do
+        expect(step.next_step).to eql :choose_partnership
+      end
+    end
+
+    context "when a partnership needs not to be chosen" do
+      before do
+        allow(wizard).to receive(:needs_to_choose_partnership?).and_return(false)
+      end
+
+      it "returns check_answers" do
+        expect(step.next_step).to eql :check_answers
+      end
     end
   end
 end

--- a/spec/forms/schools/add_participants/wizard_steps/email_step_spec.rb
+++ b/spec/forms/schools/add_participants/wizard_steps/email_step_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Schools::AddParticipants::WizardSteps::EmailStep, type: :model do
     let(:confirm_appropriate_body) { false }
     let(:sit_adding_themself_as_mentor) { false }
     let(:adding_yourself_as_ect) { false }
+    let(:choose_partnership) { false }
 
     before do
       allow(wizard).to receive(:email_in_use?).and_return(email_taken)
@@ -89,6 +90,7 @@ RSpec.describe Schools::AddParticipants::WizardSteps::EmailStep, type: :model do
       before do
         allow(wizard).to receive(:needs_to_confirm_start_term?).and_return(confirm_start_term)
         allow(wizard).to receive(:needs_to_confirm_appropriate_body?).and_return(confirm_appropriate_body)
+        allow(wizard).to receive(:needs_to_choose_partnership?).and_return(choose_partnership)
       end
 
       it "returns :check_answers" do
@@ -132,6 +134,14 @@ RSpec.describe Schools::AddParticipants::WizardSteps::EmailStep, type: :model do
 
         it "returns :cannot_add_yourself_as_ect" do
           expect(step.next_step).to eql :cannot_add_yourself_as_ect
+        end
+      end
+
+      context "when a partnership needs to be chosen" do
+        let(:choose_partnership) { true }
+
+        it "returns :choose_mentor" do
+          expect(step.next_step).to eql :choose_partnership
         end
       end
     end

--- a/spec/services/mentors/add_profile_to_ect_spec.rb
+++ b/spec/services/mentors/add_profile_to_ect_spec.rb
@@ -22,7 +22,11 @@ RSpec.describe Mentors::AddProfileToECT do
     }
   end
 
-  subject(:service_call) { described_class.call(ect_profile:, school_cohort: school_cohort_22, preferred_email:) }
+  subject(:service_call) do
+    described_class.call(ect_profile:,
+                         induction_programme: school_cohort_22.default_induction_programme,
+                         school_cohort: school_cohort_22, preferred_email:)
+  end
 
   before do
     allow(ParticipantValidationService).to receive(:validate).and_return(validation_result)

--- a/spec/services/mentors/reactivate_spec.rb
+++ b/spec/services/mentors/reactivate_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe Mentors::Reactivate do
     expect {
       described_class.call(
         email: user.email,
+        induction_programme:,
         participant_profile:,
         school_cohort:,
       )
@@ -58,6 +59,7 @@ RSpec.describe Mentors::Reactivate do
     expect {
       described_class.call(
         email: user.email,
+        induction_programme:,
         participant_profile:,
         school_cohort:,
       )
@@ -68,6 +70,7 @@ RSpec.describe Mentors::Reactivate do
     expect {
       described_class.call(
         email: user.email,
+        induction_programme:,
         participant_profile:,
         school_cohort:,
       )
@@ -79,6 +82,7 @@ RSpec.describe Mentors::Reactivate do
       expect {
         described_class.call(
           email: user.email,
+          induction_programme:,
           participant_profile:,
           school_cohort:,
         )
@@ -86,7 +90,7 @@ RSpec.describe Mentors::Reactivate do
     end
   end
 
-  context "when there is no default induction programme set" do
+  context "when there is no induction programme given" do
     before do
       school_cohort.update!(default_induction_programme: nil)
     end
@@ -95,6 +99,7 @@ RSpec.describe Mentors::Reactivate do
       expect {
         described_class.call(
           email: user.email,
+          induction_programme: nil,
           participant_profile:,
           school_cohort:,
         )
@@ -103,28 +108,28 @@ RSpec.describe Mentors::Reactivate do
   end
 
   it "has no uplift if the school has not uplift set" do
-    described_class.call(email: user.email, participant_profile:, school_cohort:)
+    described_class.call(email: user.email, induction_programme:, participant_profile:, school_cohort:)
     expect(participant_profile.reload.pupil_premium_uplift).to be(false)
     expect(participant_profile.sparsity_uplift).to be(false)
   end
 
   it "has only pupil_premium_uplift set when the school has only pupil_premium_uplift set" do
     school_cohort.update!(school: pupil_premium_school)
-    described_class.call(email: user.email, participant_profile:, school_cohort:)
+    described_class.call(email: user.email, induction_programme:, participant_profile:, school_cohort:)
     expect(participant_profile.reload.pupil_premium_uplift).to be(true)
     expect(participant_profile.sparsity_uplift).to be(false)
   end
 
   it "has only sparsity_uplift set when the school has only sparsity_uplift set" do
     school_cohort.update!(school: sparsity_school)
-    described_class.call(email: user.email, participant_profile:, school_cohort:)
+    described_class.call(email: user.email, induction_programme:, participant_profile:, school_cohort:)
     expect(participant_profile.reload.pupil_premium_uplift).to be(false)
     expect(participant_profile.sparsity_uplift).to be(true)
   end
 
   it "has both sparsity_uplift and pupil_premium_uplift set when the school has both pupil_premium_uplift and sparsity_uplift set" do
     school_cohort.update!(school: uplift_school)
-    described_class.call(email: user.email, participant_profile:, school_cohort:)
+    described_class.call(email: user.email, induction_programme:, participant_profile:, school_cohort:)
     expect(participant_profile.reload.pupil_premium_uplift).to be(true)
     expect(participant_profile.sparsity_uplift).to be(true)
   end
@@ -133,6 +138,7 @@ RSpec.describe Mentors::Reactivate do
     expect {
       described_class.call(
         email: user.email,
+        induction_programme:,
         participant_profile:,
         school_cohort:,
       )

--- a/spec/support/features/pages/schools/school_add_participant_wizard.rb
+++ b/spec/support/features/pages/schools/school_add_participant_wizard.rb
@@ -62,7 +62,7 @@ module Pages
       add_teacher_reference_number full_name, trn
       add_date_of_birth date_of_birth
       add_email_address full_name, email_address
-
+      maybe_choose_current_providers
       confirm_and_add
     end
 
@@ -138,6 +138,20 @@ module Pages
 
       self
     end
+
+    def maybe_choose_current_providers
+      choose_current_providers if has_selector?("[value='current_providers']")
+    end
+
+    # what values :current, :previous or :other
+    def choose_providers(what: :current)
+      choose option: "#{what}_providers", allow_label_click: true
+      click_on "Continue"
+
+      self
+    end
+
+    alias_method :choose_current_providers, :choose_providers
 
     def add_full_name(participant_name)
       # TODO: is this label correct? it is visually hidden, but pretty sure it should be proper english


### PR DESCRIPTION
### Context
At the moment, SITs who are registering a new mentor have to register them with the training provider that’s partnered with the school for the 2023 cohort.

However, quite often SITs want a mentor to be training with a different provider. A common use case is that the school is partnered with provider A for 2022, and provider B for 2023. The mentor is mentoring a 2022 participant, so the school want them to be training with provider A.

We therefore want to allow schools to register a mentor either with this year’s partnership, or last year’s partnership if it’s available.

- [Ticket](https://dfedigital.atlassian.net/browse/CST-2075)

### Changes proposed in this pull request
- Add new step at the end of the add_participant journey for SITs to choose the partnership where to sit the mentor in (school current default providers, school previous years default providers, other providers)
- Add new screen to send the SIT to support when they choose "other providers" for their mentor.


### Guidance to review

