### PR TITLE
[CST-2067] Include more participants in the no longer training search view

### DIFF
--- a/app/models/induction_record.rb
+++ b/app/models/induction_record.rb
@@ -63,7 +63,7 @@ class InductionRecord < ApplicationRecord
   scope :transferred, -> { leaving_induction_status.merge(end_date_in_past) }
 
   scope :current_or_transferring_in, -> { current.or(transferring_in) }
-  scope :school_dashboard_relevant, -> { completed_induction_status.or(current).or(transferring_in).or(transferred).or(withdrawn_induction_status) }
+  scope :school_dashboard_relevant, -> { completed_induction_status.or(current).or(transferring_in).or(transferred).or(withdrawn_induction_status).or(training_status_withdrawn).or(training_status_deferred) }
 
   scope :ects, -> { joins(:participant_profile).merge(ParticipantProfile.ects) }
   scope :mentors, -> { joins(:participant_profile).merge(ParticipantProfile.mentors) }
@@ -195,8 +195,8 @@ class InductionRecord < ApplicationRecord
     leaving_induction_status? && end_date.present? && end_date.past?
   end
 
-  def deferred_or_transferred?
-    training_status_deferred? || transferred?
+  def deferred_or_transferred_or_withdrawn?
+    training_status_deferred? || transferred? || training_status_withdrawn? || withdrawn_induction_status?
   end
 
   def transferring_in?

--- a/app/services/dashboard/participants.rb
+++ b/app/services/dashboard/participants.rb
@@ -131,7 +131,7 @@ module Dashboard
         .select(&:ect?)
         .each do |induction_record|
           next completed_induction_ect(induction_record) if induction_record.completed_induction_status?
-          next no_longer_training_ect(induction_record) if induction_record.deferred_or_transferred? || induction_record.withdrawn_induction_status?
+          next no_longer_training_ect(induction_record) if induction_record.deferred_or_transferred_or_withdrawn?
           next orphan_ect(induction_record) if induction_record.mentor_profile_id.blank?
 
           currently_training_ect(induction_record)
@@ -146,7 +146,7 @@ module Dashboard
       induction_records
         .reject(&:ect?)
         .each do |induction_record|
-          next no_longer_training_mentor(induction_record) if induction_record.deferred_or_transferred? || induction_record.withdrawn_induction_status?
+          next no_longer_training_mentor(induction_record) if induction_record.deferred_or_transferred_or_withdrawn?
 
           @active_mentors << dashboard_participant(induction_record.participant_profile_id, induction_record:)
         end

--- a/spec/features/schools/participant_dashboard/no_longer_training_participants_spec.rb
+++ b/spec/features/schools/participant_dashboard/no_longer_training_participants_spec.rb
@@ -16,14 +16,16 @@ RSpec.describe "Manage currently training participants", js: true do
     and_i_have_added_a_training_ect_with_mentor
     and_i_have_added_an_eligible_ect_without_mentor
     and_i_have_added_a_deferred_ect
+    and_i_have_added_an_ect_with_withdrawn_training
+    and_i_have_added_an_ect_with_withdrawn_induction_status
     and_i_am_signed_in_as_an_induction_coordinator
     and_i_click(Cohort.current.description)
     given_i_am_taken_to_the_induction_dashboard
 
     when_i_navigate_to_participants_dashboard
-    then_i_see_the_participants_filter_with_counts(currently_training: 4, no_longer_training: 1)
+    then_i_see_the_participants_filter_with_counts(currently_training: 4, no_longer_training: 3)
 
-    when_i_filter_by("No longer training (1)")
+    when_i_filter_by("No longer training (3)")
     then_i_see_the_participants_filtered_by("No Longer Training")
     and_i_see_mentors_not_training_and_ects_not_being_trained_sorted_by_name
 

--- a/spec/features/schools/participants/update_participants_details_spec.rb
+++ b/spec/features/schools/participants/update_participants_details_spec.rb
@@ -110,6 +110,7 @@ RSpec.describe "Changing participant details from the dashboard", type: :feature
     and_i_click(Cohort.current.description)
 
     when_i_navigate_to_participants_dashboard
+    when_i_filter_by("No longer training (1)")
     when_i_click_on_the_participants_name "Sally Teacher"
     then_i_am_taken_to_view_details_page
     and_it_should_not_allow_a_sit_to_edit_the_participant_details

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -6,7 +6,7 @@ module ManageTrainingSteps
   # Given_steps
 
   def given_there_is_a_school_that_has_chosen_fip_and_partnered
-    @cohort = Cohort.current || create(:cohort, :current)
+    @cohort = Cohort.current
     @school = create(:school, name: "Fip School")
     @school_cohort = create(:school_cohort, school: @school, cohort: @cohort, induction_programme_choice: "full_induction_programme")
     @induction_programme = create(:induction_programme, :fip, school_cohort: @school_cohort, partnership: nil)
@@ -357,6 +357,26 @@ module ManageTrainingSteps
                                               induction_programme: @induction_programme,
                                               start_date: 2.months.from_now)
     @induction_record.update!(training_status: :deferred)
+  end
+
+  def and_i_have_added_an_ect_with_withdrawn_training
+    user = create(:user, full_name: "Withdrawn training participant")
+    teacher_profile = create(:teacher_profile, user:)
+    @withdrawn_training_participant = create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, teacher_profile:, school_cohort: @school_cohort, training_status: :withdrawn)
+    @induction_record = Induction::Enrol.call(participant_profile: @withdrawn_training_participant,
+                                              induction_programme: @induction_programme,
+                                              start_date: 2.months.from_now)
+    @induction_record.update!(training_status: :withdrawn)
+  end
+
+  def and_i_have_added_an_ect_with_withdrawn_induction_status
+    user = create(:user, full_name: "Withdrawn training participant")
+    teacher_profile = create(:teacher_profile, user:)
+    @withdrawn_induction_status_participant = create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, teacher_profile:, school_cohort: @school_cohort, status: :withdrawn)
+    @induction_record = Induction::Enrol.call(participant_profile: @withdrawn_induction_status_participant,
+                                              induction_programme: @induction_programme,
+                                              start_date: 2.months.from_now)
+    @induction_record.update!(induction_status: :withdrawn)
   end
 
   def and_my_ects_have_completed_their_induction

--- a/spec/services/dashboard/participants_spec.rb
+++ b/spec/services/dashboard/participants_spec.rb
@@ -23,6 +23,12 @@ RSpec.describe Dashboard::Participants do
       .build
       .add_induction_record(induction_programme: transfer_1.induction_programme_from, training_status: :deferred)
   end
+  let!(:withdrawn_training_record) do
+    NewSeeds::Scenarios::Participants::Ects::Ect
+      .new(school_cohort: ect_1_induction_record_1.school_cohort)
+      .build
+      .add_induction_record(induction_programme: transfer_1.induction_programme_from, training_status: :withdrawn)
+  end
   # TODO: copied from NewSeeds::Scenarios::Participants::TrainingRecordStates#ect_on_fip_transferred as they are not yet set up to receive a school cohort
   let!(:transferred_induction_record) do
     transferred_to_school_cohort = NewSeeds::Scenarios::Schools::School.new.build
@@ -65,7 +71,7 @@ RSpec.describe Dashboard::Participants do
     end
 
     it "returns a unique entry per ect mentor not mentoring or ects not training" do
-      expect(subject).to contain_exactly(deferred_induction_record, withdrawn_induction_record, transferred_induction_record)
+      expect(subject).to contain_exactly(deferred_induction_record, withdrawn_induction_record, transferred_induction_record, withdrawn_training_record)
     end
   end
 end


### PR DESCRIPTION
### Context

- Ticket: CST-2067

The No longer training search view in the school pages should also include participants with withdrawn or deferred training and withdrawn induction status

### Changes proposed in this pull request
- Update the `InductionRecord.school_dashboard_relevant` scope return withdrawn or deferred participants
- Update the Dashboard::Participants service to include participants with those statuses when processing the ECTs and Mentors

### Guidance to review
Find schools with participants with withdrawn training, withdrawn induction and deferred training and confirm they are displayed in the "No longer training" search view when you are in the "Manage mentors and ECTs" school page
