### PR TITLE
[Bug-fix] Fix method name used in view

### DIFF
--- a/app/views/schools/add_participants/_transferring_ect_or_mentor_answers.html.erb
+++ b/app/views/schools/add_participants/_transferring_ect_or_mentor_answers.html.erb
@@ -107,7 +107,7 @@
           <% row.with_action(text: "Change",
                              visually_hidden_text: "training programme",
                              href: form.change_path_for(step: :continue_current_programme)) %>
-        <% elsif form.needs_to_choose_school_programme %>
+        <% elsif form.needs_to_choose_school_programme? %>
           <% row.with_action(text: "Change",
                              visually_hidden_text: "training programme",
                              href: form.change_path_for(step: :join_school_programme)) %>


### PR DESCRIPTION
### Context

Spotted an error occurring in Sentry related to a bad method name. Call was missing the `?` at the end of the method name

