### PR TITLE
[CST-2076] Update the completed training tag description

### DIFF
--- a/app/components/status_tags/school_participant_status_tag.rb
+++ b/app/components/status_tags/school_participant_status_tag.rb
@@ -19,7 +19,7 @@ module StatusTags
     end
 
     def description
-      Array.wrap(t(:description, scope: translation_scope, contact_us: render(MailToSupportComponent.new("contact us")))).map(&:html_safe)
+      Array.wrap(t(:description, scope: translation_scope, contact_us:, appropriate_body_name:, induction_completion_date:)).map(&:html_safe)
     rescue I18n::MissingTranslationData
       []
     end
@@ -40,6 +40,18 @@ module StatusTags
 
     def record_state
       @record_state ||= DetermineTrainingRecordStateLegacy.call(participant_profile:, induction_record:, school:)&.record_state || :no_longer_involved
+    end
+
+    def appropriate_body_name
+      @induction_record&.appropriate_body_name || "Your appropriate body"
+    end
+
+    def induction_completion_date
+      @participant_profile&.induction_completion_date&.to_fs(:govuk)
+    end
+
+    def contact_us
+      render(MailToSupportComponent.new("contact us"))
     end
   end
 end

--- a/config/locales/status_tags/school_participant_status.yml
+++ b/config/locales/status_tags/school_participant_status.yml
@@ -190,5 +190,5 @@ en:
 
       completed_training:
         label: "TRAINING COMPLETED"
-        description: "We’ve confirmed this person is eligible for this programme. Once you choose a training provider, they’ll contact this person directly."
+        description: "%{appropriate_body_name} confirmed that this person completed their induction and training on %{induction_completion_date}"
         colour: "grey"

--- a/spec/components/status_tags/school_participant_status_tag_spec.rb
+++ b/spec/components/status_tags/school_participant_status_tag_spec.rb
@@ -16,9 +16,15 @@ RSpec.describe StatusTags::SchoolParticipantStatusTag, type: :component do
   I18n.t("status_tags.school_participant_status").each do |key, value|
     context "when :#{key} is the determined state" do
       before { allow(component).to receive(:record_state).and_return(key) }
+      let(:tag_description) do
+        Array.wrap(value[:description]).join("\n  ")
+        .gsub("%{contact_us}", "contact us\n")
+        .gsub("%{appropriate_body_name}", "Your appropriate body")
+        .gsub("%{induction_completion_date}", "")
+      end
 
       it { is_expected.to have_text value[:label] }
-      it { is_expected.to have_text Array.wrap(value[:description]).join("\n  ").gsub("%{contact_us}", "contact us\n") }
+      it { is_expected.to have_text tag_description }
     end
 
     it "includes :#{key} as a recognised record_state" do

--- a/spec/features/schools/participant_dashboard/completed_induction_participants_spec.rb
+++ b/spec/features/schools/participant_dashboard/completed_induction_participants_spec.rb
@@ -28,5 +28,6 @@ RSpec.describe "Manage currently training participants", js: true do
 
     when_i_click_on_the_participants_name "Eligible Without-mentor"
     then_i_am_taken_to_view_details_page
+    and_i_see_the_completion_status_tag
   end
 end

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -604,6 +604,10 @@ module ManageTrainingSteps
     Mentors::AddToSchool.call(mentor_profile: @no_qts_mentor, school: @school)
   end
 
+  def and_i_see_the_completion_status_tag
+    expect(page).to have_text("Your appropriate body confirmed that this person completed their induction and training on #{@eligible_ect_without_mentor.induction_completion_date.to_fs(:govuk)}")
+  end
+
   def and_it_should_not_allow_a_sit_to_edit_the_participant_details
     expect(page).not_to have_link("//a[text()='Change']")
   end


### PR DESCRIPTION
### Context

- Ticket: CST-2076

This PR updates the description of the completed training status tag with more context, so SITs can be confident that the ECT's induction completion has been recorded with DfE correctly.

### Changes proposed in this pull request
- Update the locale
- Update the status tag component to interpolate the necessary arguments for the tag's description

### Guidance to review
Visit the profile of a participant with `Completed` induction and confirm the new description is displayed correctly including the AB's name and the induction completion date. 

In case the participant has no appropriate body linked to their induction record, the default value `Your appropriate body` should be displayed instead of the AB's name.

![image](https://github.com/DFE-Digital/early-careers-framework/assets/333931/bebbb8e3-e424-4f50-aedf-749bda7d158b)
