### PR TITLE
Revert Cohort time fix and ensure specs pass

### DIFF
--- a/db/data/cohorts/cohorts.csv
+++ b/db/data/cohorts/cohorts.csv
@@ -1,5 +1,5 @@
-start-year,registration-start-date,academic-year-start-date,npq-registration-start-date
-2020,2020/05/10,2020/09/01,
-2021,2021/05/10,2021/09/01,
-2022,2022/05/10,2022/09/01,
-2023,2023/05/10,2023/09/01,2023/04/03
+start-year,registration-start-date,academic-year-start-date,npq-registration-start-date,automatic-assignment-period-end-date
+2020,2020/05/10,2020/09/01,,2021/03/31
+2021,2021/05/10,2021/09/01,,2022/03/31
+2022,2022/05/10,2022/09/01,,2023/03/31
+2023,2023/06/05,2023/09/01,2023/04/03,2024/03/31

--- a/db/data/schedules/schedules.csv
+++ b/db/data/schedules/schedules.csv
@@ -1,148 +1,318 @@
 type,schedule-identifier,schedule-name,schedule-cohort-year,milestone-name,milestone-declaration-type,milestone-start-date,milestone-date,milestone-payment-date
-ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 1 - Participant Start,started,01/09/2021,,01/09/2021
-ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 2 - Retention Point 1,retained-1,01/09/2021,,01/09/2021
-ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 3 - Retention Point 2,retained-2,01/09/2021,,01/09/2021
-ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 4 - Retention Point 3,retained-3,01/09/2021,,01/09/2021
-ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 5 - Retention Point 4,retained-4,01/09/2021,,01/09/2021
-ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 6 - Participant Completion,completed,01/09/2021,,01/09/2021
-ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 1 - Participant Start,started,01/01/2022,,01/01/2022
-ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 2 - Retention Point 1,retained-1,01/01/2022,,01/01/2022
-ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 3 - Retention Point 2,retained-2,01/01/2022,,01/01/2022
-ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 4 - Retention Point 3,retained-3,01/01/2022,,01/01/2022
-ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 5 - Retention Point 4,retained-4,01/01/2022,,01/01/2022
-ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 6 - Participant Completion,completed,01/01/2022,,01/01/2022
-ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 1 - Participant Start,started,01/04/2022,,01/04/2022
-ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 2 - Retention Point 1,retained-1,01/04/2022,,01/04/2022
-ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 3 - Retention Point 2,retained-2,01/04/2022,,01/04/2022
-ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 4 - Retention Point 3,retained-3,01/04/2022,,01/04/2022
-ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 5 - Retention Point 4,retained-4,01/04/2022,,01/04/2022
-ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 6 - Participant Completion,completed,01/04/2022,,01/04/2022
-ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 1 - Participant Start,started,01/09/2022,,01/09/2022
-ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 2 - Retention Point 1,retained-1,01/09/2022,,01/09/2022
-ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 3 - Retention Point 2,retained-2,01/09/2022,,01/09/2022
-ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 4 - Retention Point 3,retained-3,01/09/2022,,01/09/2022
-ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 5 - Retention Point 4,retained-4,01/09/2022,,01/09/2022
-ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 6 - Participant Completion,completed,01/09/2022,,01/09/2022
-ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 1 - Participant Start,started,01/01/2023,,01/01/2023
-ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 2 - Retention Point 1,retained-1,01/01/2023,,01/01/2023
-ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 3 - Retention Point 2,retained-2,01/01/2023,,01/01/2023
-ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 4 - Retention Point 3,retained-3,01/01/2023,,01/01/2023
-ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 5 - Retention Point 4,retained-4,01/01/2023,,01/01/2023
-ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 6 - Participant Completion,completed,01/01/2023,,01/01/2023
-ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 1 - Participant Start,started,01/04/2023,,01/04/2023
-ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 2 - Retention Point 1,retained-1,01/04/2023,,01/04/2023
-ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 3 - Retention Point 2,retained-2,01/04/2023,,01/04/2023
-ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 4 - Retention Point 3,retained-3,01/04/2023,,01/04/2023
-ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 5 - Retention Point 4,retained-4,01/04/2023,,01/04/2023
-ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 6 - Participant Completion,completed,01/04/2023,,01/04/2023
-ecf_reduced,ecf-reduced-september,ECF Reduced September,2021,Output 1 - Participant Start,started,01/09/2021,,01/09/2021
-ecf_reduced,ecf-reduced-september,ECF Reduced September,2021,Output 2 - Retention Point 1,retained-1,01/09/2021,,01/09/2021
-ecf_reduced,ecf-reduced-september,ECF Reduced September,2021,Output 3 - Retention Point 2,retained-2,01/09/2021,,01/09/2021
-ecf_reduced,ecf-reduced-september,ECF Reduced September,2021,Output 4 - Retention Point 3,retained-3,01/09/2021,,01/09/2021
-ecf_reduced,ecf-reduced-september,ECF Reduced September,2021,Output 5 - Retention Point 4,retained-4,01/09/2021,,01/09/2021
-ecf_reduced,ecf-reduced-september,ECF Reduced September,2021,Output 6 - Participant Completion,completed,01/09/2021,,01/09/2021
-ecf_reduced,ecf-reduced-january,ECF Reduced January,2021,Output 1 - Participant Start,started,01/01/2022,,01/01/2022
-ecf_reduced,ecf-reduced-january,ECF Reduced January,2021,Output 2 - Retention Point 1,retained-1,01/01/2022,,01/01/2022
-ecf_reduced,ecf-reduced-january,ECF Reduced January,2021,Output 3 - Retention Point 2,retained-2,01/01/2022,,01/01/2022
-ecf_reduced,ecf-reduced-january,ECF Reduced January,2021,Output 4 - Retention Point 3,retained-3,01/01/2022,,01/01/2022
-ecf_reduced,ecf-reduced-january,ECF Reduced January,2021,Output 5 - Retention Point 4,retained-4,01/01/2022,,01/01/2022
-ecf_reduced,ecf-reduced-january,ECF Reduced January,2021,Output 6 - Participant Completion,completed,01/01/2022,,01/01/2022
-ecf_reduced,ecf-reduced-april,ECF Reduced April,2021,Output 1 - Participant Start,started,01/04/2022,,01/04/2022
-ecf_reduced,ecf-reduced-april,ECF Reduced April,2021,Output 2 - Retention Point 1,retained-1,01/04/2022,,01/04/2022
-ecf_reduced,ecf-reduced-april,ECF Reduced April,2021,Output 3 - Retention Point 2,retained-2,01/04/2022,,01/04/2022
-ecf_reduced,ecf-reduced-april,ECF Reduced April,2021,Output 4 - Retention Point 3,retained-3,01/04/2022,,01/04/2022
-ecf_reduced,ecf-reduced-april,ECF Reduced April,2021,Output 5 - Retention Point 4,retained-4,01/04/2022,,01/04/2022
-ecf_reduced,ecf-reduced-april,ECF Reduced April,2021,Output 6 - Participant Completion,completed,01/04/2022,,01/04/2022
-ecf_reduced,ecf-reduced-september,ECF Reduced September,2022,Output 1 - Participant Start,started,01/09/2022,,01/09/2022
-ecf_reduced,ecf-reduced-september,ECF Reduced September,2022,Output 2 - Retention Point 1,retained-1,01/09/2022,,01/09/2022
-ecf_reduced,ecf-reduced-september,ECF Reduced September,2022,Output 3 - Retention Point 2,retained-2,01/09/2022,,01/09/2022
-ecf_reduced,ecf-reduced-september,ECF Reduced September,2022,Output 4 - Retention Point 3,retained-3,01/09/2022,,01/09/2022
-ecf_reduced,ecf-reduced-september,ECF Reduced September,2022,Output 5 - Retention Point 4,retained-4,01/09/2022,,01/09/2022
-ecf_reduced,ecf-reduced-september,ECF Reduced September,2022,Output 6 - Participant Completion,completed,01/09/2022,,01/09/2022
-ecf_reduced,ecf-reduced-january,ECF Reduced January,2022,Output 1 - Participant Start,started,01/01/2023,,01/01/2023
-ecf_reduced,ecf-reduced-january,ECF Reduced January,2022,Output 2 - Retention Point 1,retained-1,01/01/2023,,01/01/2023
-ecf_reduced,ecf-reduced-january,ECF Reduced January,2022,Output 3 - Retention Point 2,retained-2,01/01/2023,,01/01/2023
-ecf_reduced,ecf-reduced-january,ECF Reduced January,2022,Output 4 - Retention Point 3,retained-3,01/01/2023,,01/01/2023
-ecf_reduced,ecf-reduced-january,ECF Reduced January,2022,Output 5 - Retention Point 4,retained-4,01/01/2023,,01/01/2023
-ecf_reduced,ecf-reduced-january,ECF Reduced January,2022,Output 6 - Participant Completion,completed,01/01/2023,,01/01/2023
-ecf_reduced,ecf-reduced-april,ECF Reduced April,2022,Output 1 - Participant Start,started,01/04/2023,,01/04/2023
-ecf_reduced,ecf-reduced-april,ECF Reduced April,2022,Output 2 - Retention Point 1,retained-1,01/04/2023,,01/04/2023
-ecf_reduced,ecf-reduced-april,ECF Reduced April,2022,Output 3 - Retention Point 2,retained-2,01/04/2023,,01/04/2023
-ecf_reduced,ecf-reduced-april,ECF Reduced April,2022,Output 4 - Retention Point 3,retained-3,01/04/2023,,01/04/2023
-ecf_reduced,ecf-reduced-april,ECF Reduced April,2022,Output 5 - Retention Point 4,retained-4,01/04/2023,,01/04/2023
-ecf_reduced,ecf-reduced-april,ECF Reduced April,2022,Output 6 - Participant Completion,completed,01/04/2023,,01/04/2023
-ecf_replacement,ecf-replacement-september,ECF Replacement September,2021,Output 1 - Participant Start,started,01/09/2021,,01/09/2021
-ecf_replacement,ecf-replacement-september,ECF Replacement September,2021,Output 2 - Retention Point 1,retained-1,01/09/2021,,01/09/2021
-ecf_replacement,ecf-replacement-september,ECF Replacement September,2021,Output 3 - Retention Point 2,retained-2,01/09/2021,,01/09/2021
-ecf_replacement,ecf-replacement-september,ECF Replacement September,2021,Output 4 - Retention Point 3,retained-3,01/09/2021,,01/09/2021
-ecf_replacement,ecf-replacement-september,ECF Replacement September,2021,Output 5 - Retention Point 4,retained-4,01/09/2021,,01/09/2021
-ecf_replacement,ecf-replacement-september,ECF Replacement September,2021,Output 6 - Participant Completion,completed,01/09/2021,,01/09/2021
-ecf_replacement,ecf-replacement-january,ECF Replacement January,2021,Output 1 - Participant Start,started,01/01/2022,,01/01/2022
-ecf_replacement,ecf-replacement-january,ECF Replacement January,2021,Output 2 - Retention Point 1,retained-1,01/01/2022,,01/01/2022
-ecf_replacement,ecf-replacement-january,ECF Replacement January,2021,Output 3 - Retention Point 2,retained-2,01/01/2022,,01/01/2022
-ecf_replacement,ecf-replacement-january,ECF Replacement January,2021,Output 4 - Retention Point 3,retained-3,01/01/2022,,01/01/2022
-ecf_replacement,ecf-replacement-january,ECF Replacement January,2021,Output 5 - Retention Point 4,retained-4,01/01/2022,,01/01/2022
-ecf_replacement,ecf-replacement-january,ECF Replacement January,2021,Output 6 - Participant Completion,completed,01/01/2022,,01/01/2022
-ecf_replacement,ecf-replacement-april,ECF Replacement April,2021,Output 1 - Participant Start,started,01/04/2022,,01/04/2022
-ecf_replacement,ecf-replacement-april,ECF Replacement April,2021,Output 2 - Retention Point 1,retained-1,01/04/2022,,01/04/2022
-ecf_replacement,ecf-replacement-april,ECF Replacement April,2021,Output 3 - Retention Point 2,retained-2,01/04/2022,,01/04/2022
-ecf_replacement,ecf-replacement-april,ECF Replacement April,2021,Output 4 - Retention Point 3,retained-3,01/04/2022,,01/04/2022
-ecf_replacement,ecf-replacement-april,ECF Replacement April,2021,Output 5 - Retention Point 4,retained-4,01/04/2022,,01/04/2022
-ecf_replacement,ecf-replacement-april,ECF Replacement April,2021,Output 6 - Participant Completion,completed,01/04/2022,,01/04/2022
-ecf_replacement,ecf-replacement-september,ECF Replacement September,2022,Output 1 - Participant Start,started,01/09/2022,,01/09/2022
-ecf_replacement,ecf-replacement-september,ECF Replacement September,2022,Output 2 - Retention Point 1,retained-1,01/09/2022,,01/09/2022
-ecf_replacement,ecf-replacement-september,ECF Replacement September,2022,Output 3 - Retention Point 2,retained-2,01/09/2022,,01/09/2022
-ecf_replacement,ecf-replacement-september,ECF Replacement September,2022,Output 4 - Retention Point 3,retained-3,01/09/2022,,01/09/2022
-ecf_replacement,ecf-replacement-september,ECF Replacement September,2022,Output 5 - Retention Point 4,retained-4,01/09/2022,,01/09/2022
-ecf_replacement,ecf-replacement-september,ECF Replacement September,2022,Output 6 - Participant Completion,completed,01/09/2022,,01/09/2022
-ecf_replacement,ecf-replacement-january,ECF Replacement January,2022,Output 1 - Participant Start,started,01/01/2023,,01/01/2023
-ecf_replacement,ecf-replacement-january,ECF Replacement January,2022,Output 2 - Retention Point 1,retained-1,01/01/2023,,01/01/2023
-ecf_replacement,ecf-replacement-january,ECF Replacement January,2022,Output 3 - Retention Point 2,retained-2,01/01/2023,,01/01/2023
-ecf_replacement,ecf-replacement-january,ECF Replacement January,2022,Output 4 - Retention Point 3,retained-3,01/01/2023,,01/01/2023
-ecf_replacement,ecf-replacement-january,ECF Replacement January,2022,Output 5 - Retention Point 4,retained-4,01/01/2023,,01/01/2023
-ecf_replacement,ecf-replacement-january,ECF Replacement January,2022,Output 6 - Participant Completion,completed,01/01/2023,,01/01/2023
-ecf_replacement,ecf-replacement-april,ECF Replacement April,2022,Output 1 - Participant Start,started,01/04/2023,,01/04/2023
-ecf_replacement,ecf-replacement-april,ECF Replacement April,2022,Output 2 - Retention Point 1,retained-1,01/04/2023,,01/04/2023
-ecf_replacement,ecf-replacement-april,ECF Replacement April,2022,Output 3 - Retention Point 2,retained-2,01/04/2023,,01/04/2023
-ecf_replacement,ecf-replacement-april,ECF Replacement April,2022,Output 4 - Retention Point 3,retained-3,01/04/2023,,01/04/2023
-ecf_replacement,ecf-replacement-april,ECF Replacement April,2022,Output 5 - Retention Point 4,retained-4,01/04/2023,,01/04/2023
-ecf_replacement,ecf-replacement-april,ECF Replacement April,2022,Output 6 - Participant Completion,completed,01/04/2023,,01/04/2023
-ecf_standard,ecf-standard-september,ECF Standard September,2021,Output 1 - Participant Start,started,01/09/2021,30/11/2021,30/11/2021
-ecf_standard,ecf-standard-september,ECF Standard September,2021,Output 2 - Retention Point 1,retained-1,01/09/2021,31/01/2022,28/02/2022
-ecf_standard,ecf-standard-september,ECF Standard September,2021,Output 3 - Retention Point 2,retained-2,01/02/2022,30/04/2022,31/05/2022
-ecf_standard,ecf-standard-september,ECF Standard September,2021,Output 4 - Retention Point 3,retained-3,01/05/2022,30/09/2022,31/10/2022
-ecf_standard,ecf-standard-september,ECF Standard September,2021,Output 5 - Retention Point 4,retained-4,01/10/2022,31/01/2023,28/02/2023
-ecf_standard,ecf-standard-september,ECF Standard September,2021,Output 6 - Participant Completion,completed,01/02/2023,30/04/2023,31/05/2023
-ecf_standard,ecf-standard-january,ECF Standard January,2021,Output 1 - Participant Start,started,01/12/2021,31/01/2022,28/02/2022
-ecf_standard,ecf-standard-january,ECF Standard January,2021,Output 2 - Retention Point 1,retained-1,01/02/2022,30/04/2022,31/05/2022
-ecf_standard,ecf-standard-january,ECF Standard January,2021,Output 3 - Retention Point 2,retained-2,01/05/2022,30/09/2022,31/10/2022
-ecf_standard,ecf-standard-january,ECF Standard January,2021,Output 4 - Retention Point 3,retained-3,01/10/2022,31/01/2023,28/02/2023
-ecf_standard,ecf-standard-january,ECF Standard January,2021,Output 5 - Retention Point 4,retained-4,01/02/2023,30/04/2023,31/05/2023
-ecf_standard,ecf-standard-january,ECF Standard January,2021,Output 6 - Participant Completion,completed,01/02/2023,31/10/2023,30/11/2023
-ecf_standard,ecf-standard-april,ECF Standard April,2021,Output 1 - Participant Start,started,01/03/2022,30/04/2022,31/05/2022
-ecf_standard,ecf-standard-april,ECF Standard April,2021,Output 2 - Retention Point 1,retained-1,01/06/2022,30/09/2022,31/10/2022
-ecf_standard,ecf-standard-april,ECF Standard April,2021,Output 3 - Retention Point 2,retained-2,01/11/2022,31/01/2023,28/02/2023
-ecf_standard,ecf-standard-april,ECF Standard April,2021,Output 4 - Retention Point 3,retained-3,01/03/2023,30/04/2023,31/05/2023
-ecf_standard,ecf-standard-april,ECF Standard April,2021,Output 5 - Retention Point 4,retained-4,01/06/2023,31/10/2023,30/11/2023
-ecf_standard,ecf-standard-april,ECF Standard April,2021,Output 6 - Participant Completion,completed,01/12/2023,31/01/2024,28/02/2024
-ecf_standard,ecf-standard-september,ECF Standard September,2022,Output 1 - Participant Start,started,01/06/2022,31/12/2022,30/11/2022
-ecf_standard,ecf-standard-september,ECF Standard September,2022,Output 2 - Retention Point 1,retained-1,01/01/2023,31/03/2023,30/04/2023
-ecf_standard,ecf-standard-september,ECF Standard September,2022,Output 3 - Retention Point 2,retained-2,01/04/2023,31/07/2023,31/08/2023
-ecf_standard,ecf-standard-september,ECF Standard September,2022,Output 4 - Retention Point 3,retained-3,01/08/2023,31/12/2023,31/01/2024
-ecf_standard,ecf-standard-september,ECF Standard September,2022,Output 5 - Retention Point 4,retained-4,01/01/2024,31/03/2024,30/04/2024
-ecf_standard,ecf-standard-september,ECF Standard September,2022,Output 6 - Participant Completion,completed,01/04/2024,31/07/2024,31/08/2024
-ecf_standard,ecf-standard-january,ECF Standard January,2022,Output 1 - Participant Start,started,01/01/2023,31/03/2023,30/04/2023
-ecf_standard,ecf-standard-january,ECF Standard January,2022,Output 2 - Retention Point 1,retained-1,01/04/2023,31/07/2023,31/08/2023
-ecf_standard,ecf-standard-january,ECF Standard January,2022,Output 3 - Retention Point 2,retained-2,01/08/2023,31/12/2023,31/01/2024
-ecf_standard,ecf-standard-january,ECF Standard January,2022,Output 4 - Retention Point 3,retained-3,01/01/2024,31/03/2024,30/04/2024
-ecf_standard,ecf-standard-january,ECF Standard January,2022,Output 5 - Retention Point 4,retained-4,01/04/2024,31/07/2024,31/08/2024
-ecf_standard,ecf-standard-january,ECF Standard January,2022,Output 6 - Participant Completion,completed,01/08/2024,31/12/2024,31/01/2025
-ecf_standard,ecf-standard-april,ECF Standard April,2022,Output 1 - Participant Start,started,01/04/2023,31/07/2023,31/08/2023
-ecf_standard,ecf-standard-april,ECF Standard April,2022,Output 2 - Retention Point 1,retained-1,01/08/2023,31/12/2023,31/01/2024
-ecf_standard,ecf-standard-april,ECF Standard April,2022,Output 3 - Retention Point 2,retained-2,01/01/2024,31/03/2024,30/04/2024
-ecf_standard,ecf-standard-april,ECF Standard April,2022,Output 4 - Retention Point 3,retained-3,01/04/2024,31/07/2024,31/08/2024
-ecf_standard,ecf-standard-april,ECF Standard April,2022,Output 5 - Retention Point 4,retained-4,01/08/2024,31/12/2024,31/01/2025
-ecf_standard,ecf-standard-april,ECF Standard April,2022,Output 6 - Participant Completion,completed,01/01/2025,31/03/2025,30/04/2025
+npq_ehco,npq-ehco-june,NPQ EHCO June,2023,Output 1 - Participant Start,started,2024-06-01,,2024-06-01
+npq_ehco,npq-ehco-june,NPQ EHCO June,2023,Output 2 - Retention Point 1,retained-1,2024-06-01,,2024-06-01
+npq_ehco,npq-ehco-june,NPQ EHCO June,2023,Output 3 - Retention Point 2,retained-2,2024-06-01,,2024-06-01
+npq_ehco,npq-ehco-june,NPQ EHCO June,2023,Output 4 - Participant Completion,completed,2024-06-01,,2024-06-01
+ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 1 - Participant Start,started,2023-09-01,,2023-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 2 - Retention Point 1,retained-1,2023-09-01,,2023-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 3 - Retention Point 2,retained-2,2023-09-01,,2023-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 4 - Retention Point 3,retained-3,2023-09-01,,2023-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 5 - Retention Point 4,retained-4,2023-09-01,,2023-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 6 - Participant Completion,completed,2023-09-01,,2023-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 7 - Extended Point 1,extended-1,2023-09-01,,2023-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 8 - Extended Point 2,extended-2,2023-09-01,,2023-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 9 - Extended Point 3,extended-3,2023-09-01,,2023-09-01
+ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 1 - Participant Start,started,2024-01-01,,2024-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 2 - Retention Point 1,retained-1,2024-01-01,,2024-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 3 - Retention Point 2,retained-2,2024-01-01,,2024-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 4 - Retention Point 3,retained-3,2024-01-01,,2024-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 5 - Retention Point 4,retained-4,2024-01-01,,2024-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 6 - Participant Completion,completed,2024-01-01,,2024-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 7 - Extended Point 1,extended-1,2024-01-01,,2024-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 8 - Extended Point 2,extended-2,2024-01-01,,2024-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 9 - Extended Point 3,extended-3,2024-01-01,,2024-01-01
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2021,Output 1 - Participant Start,started,2022-04-01,,2022-04-01
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2021,Output 2 - Retention Point 1,retained-1,2022-04-01,,2022-04-01
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2021,Output 3 - Retention Point 2,retained-2,2022-04-01,,2022-04-01
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2021,Output 4 - Retention Point 3,retained-3,2022-04-01,,2022-04-01
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2021,Output 5 - Retention Point 4,retained-4,2022-04-01,,2022-04-01
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2021,Output 6 - Participant Completion,completed,2022-04-01,,2022-04-01
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2022,Output 1 - Participant Start,started,2022-09-01,,2022-09-01
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2022,Output 2 - Retention Point 1,retained-1,2022-09-01,,2022-09-01
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2022,Output 3 - Retention Point 2,retained-2,2022-09-01,,2022-09-01
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2022,Output 4 - Retention Point 3,retained-3,2022-09-01,,2022-09-01
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2022,Output 5 - Retention Point 4,retained-4,2022-09-01,,2022-09-01
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2022,Output 6 - Participant Completion,completed,2022-09-01,,2022-09-01
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2022,Output 1 - Participant Start,started,2023-01-01,,2023-01-01
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2022,Output 2 - Retention Point 1,retained-1,2023-01-01,,2023-01-01
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2022,Output 3 - Retention Point 2,retained-2,2023-01-01,,2023-01-01
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2022,Output 4 - Retention Point 3,retained-3,2023-01-01,,2023-01-01
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2022,Output 5 - Retention Point 4,retained-4,2023-01-01,,2023-01-01
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2022,Output 6 - Participant Completion,completed,2023-01-01,,2023-01-01
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2022,Output 1 - Participant Start,started,2023-04-01,,2023-04-01
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2022,Output 2 - Retention Point 1,retained-1,2023-04-01,,2023-04-01
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2022,Output 3 - Retention Point 2,retained-2,2023-04-01,,2023-04-01
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2022,Output 4 - Retention Point 3,retained-3,2023-04-01,,2023-04-01
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2022,Output 5 - Retention Point 4,retained-4,2023-04-01,,2023-04-01
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2022,Output 6 - Participant Completion,completed,2023-04-01,,2023-04-01
+npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2022,Output 1 - Participant Start,started,2022-10-01,,2022-11-01
+npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2022,Output 2 - Retention Point 1,retained-1,2022-10-01,,2022-11-01
+npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2022,Output 3 - Participant Completion,completed,2022-10-01,,2022-11-01
+ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 1 - Participant Start,started,2022-09-01,,2022-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 2 - Retention Point 1,retained-1,2022-09-01,,2022-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 3 - Retention Point 2,retained-2,2022-09-01,,2022-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 4 - Retention Point 3,retained-3,2022-09-01,,2022-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 5 - Retention Point 4,retained-4,2022-09-01,,2022-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 6 - Participant Completion,completed,2022-09-01,,2022-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 7 - Extended Point 1,extended-1,2022-09-01,,2022-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 8 - Extended Point 2,extended-2,2022-09-01,,2022-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 9 - Extended Point 3,extended-3,2022-09-01,,2022-09-01
+ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 1 - Participant Start,started,2023-01-01,,2023-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 2 - Retention Point 1,retained-1,2023-01-01,,2023-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 3 - Retention Point 2,retained-2,2023-01-01,,2023-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 4 - Retention Point 3,retained-3,2023-01-01,,2023-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 5 - Retention Point 4,retained-4,2023-01-01,,2023-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 6 - Participant Completion,completed,2023-01-01,,2023-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 7 - Extended Point 1,extended-1,2023-01-01,,2023-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 8 - Extended Point 2,extended-2,2023-01-01,,2023-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 9 - Extended Point 3,extended-3,2023-01-01,,2023-01-01
+npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2022,Output 1 - Participant Start,started,2022-10-01,,2022-11-01
+npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2022,Output 2 - Retention Point 1,retained-1,2022-10-01,,2022-11-01
+npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2022,Output 3 - Retention Point 2,retained-2,2022-10-01,,2022-11-01
+npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2022,Output 4 - Participant Completion,completed,2022-10-01,,2022-11-01
+ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 1 - Participant Start,started,2023-04-01,,2023-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 2 - Retention Point 1,retained-1,2023-04-01,,2023-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 3 - Retention Point 2,retained-2,2023-04-01,,2023-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 4 - Retention Point 3,retained-3,2023-04-01,,2023-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 5 - Retention Point 4,retained-4,2023-04-01,,2023-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 6 - Participant Completion,completed,2023-04-01,,2023-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 7 - Extended Point 1,extended-1,2023-04-01,,2023-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 8 - Extended Point 2,extended-2,2023-04-01,,2023-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 9 - Extended Point 3,extended-3,2023-04-01,,2023-04-01
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2022,Output 1 - Participant Start,started,2022-09-01,,2022-09-01
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2022,Output 2 - Retention Point 1,retained-1,2022-09-01,,2022-09-01
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2022,Output 3 - Retention Point 2,retained-2,2022-09-01,,2022-09-01
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2022,Output 4 - Retention Point 3,retained-3,2022-09-01,,2022-09-01
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2022,Output 5 - Retention Point 4,retained-4,2022-09-01,,2022-09-01
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2022,Output 6 - Participant Completion,completed,2022-09-01,,2022-09-01
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2022,Output 1 - Participant Start,started,2023-01-01,,2023-01-01
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2022,Output 2 - Retention Point 1,retained-1,2023-01-01,,2023-01-01
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2022,Output 3 - Retention Point 2,retained-2,2023-01-01,,2023-01-01
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2022,Output 4 - Retention Point 3,retained-3,2023-01-01,,2023-01-01
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2022,Output 5 - Retention Point 4,retained-4,2023-01-01,,2023-01-01
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2022,Output 6 - Participant Completion,completed,2023-01-01,,2023-01-01
+ecf_standard,ecf-standard-january,ECF Standard January,2022,Output 1 - Participant Start,started,2023-01-01,2023-03-31,2023-04-30
+ecf_standard,ecf-standard-january,ECF Standard January,2022,Output 2 - Retention Point 1,retained-1,2023-04-01,2023-07-31,2023-08-31
+ecf_standard,ecf-standard-january,ECF Standard January,2022,Output 3 - Retention Point 2,retained-2,2023-08-01,2023-12-31,2024-01-31
+ecf_standard,ecf-standard-january,ECF Standard January,2022,Output 4 - Retention Point 3,retained-3,2024-01-01,2024-03-31,2024-04-30
+ecf_standard,ecf-standard-january,ECF Standard January,2022,Output 5 - Retention Point 4,retained-4,2024-04-01,2024-07-31,2024-08-31
+ecf_standard,ecf-standard-january,ECF Standard January,2022,Output 6 - Participant Completion,completed,2024-08-01,2024-12-31,2025-01-31
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2022,Output 1 - Participant Start,started,2023-04-01,,2023-04-01
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2022,Output 2 - Retention Point 1,retained-1,2023-04-01,,2023-04-01
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2022,Output 3 - Retention Point 2,retained-2,2023-04-01,,2023-04-01
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2022,Output 4 - Retention Point 3,retained-3,2023-04-01,,2023-04-01
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2022,Output 5 - Retention Point 4,retained-4,2023-04-01,,2023-04-01
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2022,Output 6 - Participant Completion,completed,2023-04-01,,2023-04-01
+npq_ehco,npq-ehco-june,NPQ EHCO June,2022,Output 1 - Participant Start,started,2023-06-01,,2023-06-01
+npq_ehco,npq-ehco-june,NPQ EHCO June,2022,Output 2 - Retention Point 1,retained-1,2023-06-01,,2023-06-01
+npq_ehco,npq-ehco-june,NPQ EHCO June,2022,Output 3 - Retention Point 2,retained-2,2023-06-01,,2023-06-01
+npq_ehco,npq-ehco-june,NPQ EHCO June,2022,Output 4 - Participant Completion,completed,2023-06-01,,2023-06-01
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2021,Output 1 - Participant Start,started,2022-01-01,,2022-01-01
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2021,Output 2 - Retention Point 1,retained-1,2022-01-01,,2022-01-01
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2021,Output 3 - Retention Point 2,retained-2,2022-01-01,,2022-01-01
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2021,Output 4 - Retention Point 3,retained-3,2022-01-01,,2022-01-01
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2021,Output 5 - Retention Point 4,retained-4,2022-01-01,,2022-01-01
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2021,Output 6 - Participant Completion,completed,2022-01-01,,2022-01-01
+ecf_standard,ecf-standard-april,ECF Standard April,2022,Output 1 - Participant Start,started,2023-04-01,2023-07-31,2023-08-31
+ecf_standard,ecf-standard-april,ECF Standard April,2022,Output 2 - Retention Point 1,retained-1,2023-08-01,2023-12-31,2024-01-31
+ecf_standard,ecf-standard-april,ECF Standard April,2022,Output 3 - Retention Point 2,retained-2,2024-01-01,2024-03-31,2024-04-30
+ecf_standard,ecf-standard-april,ECF Standard April,2022,Output 4 - Retention Point 3,retained-3,2024-04-01,2024-07-31,2024-08-31
+ecf_standard,ecf-standard-april,ECF Standard April,2022,Output 5 - Retention Point 4,retained-4,2024-08-01,2024-12-31,2025-01-31
+ecf_standard,ecf-standard-april,ECF Standard April,2022,Output 6 - Participant Completion,completed,2025-01-01,2025-03-31,2025-04-30
+npq_ehco,npq-ehco-march,NPQ EHCO March,2022,Output 1 - Participant Start,started,2023-03-01,,2023-03-01
+npq_ehco,npq-ehco-march,NPQ EHCO March,2022,Output 2 - Retention Point 1,retained-1,2023-03-01,,2023-03-01
+npq_ehco,npq-ehco-march,NPQ EHCO March,2022,Output 3 - Retention Point 2,retained-2,2023-03-01,,2023-03-01
+npq_ehco,npq-ehco-march,NPQ EHCO March,2022,Output 4 - Participant Completion,completed,2023-03-01,,2023-03-01
+ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 1 - Participant Start,started,2022-04-01,,2022-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 2 - Retention Point 1,retained-1,2022-04-01,,2022-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 3 - Retention Point 2,retained-2,2022-04-01,,2022-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 4 - Retention Point 3,retained-3,2022-04-01,,2022-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 5 - Retention Point 4,retained-4,2022-04-01,,2022-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 6 - Participant Completion,completed,2022-04-01,,2022-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 7 - Extended Point 1,extended-1,2022-04-01,,2022-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 8 - Extended Point 2,extended-2,2022-04-01,,2022-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 9 - Extended Point 3,extended-3,2022-04-01,,2022-04-01
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2021,Output 1 - Participant Start,started,2022-01-01,,2022-01-01
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2021,Output 2 - Retention Point 1,retained-1,2022-01-01,,2022-01-01
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2021,Output 3 - Retention Point 2,retained-2,2022-01-01,,2022-01-01
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2021,Output 4 - Retention Point 3,retained-3,2022-01-01,,2022-01-01
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2021,Output 5 - Retention Point 4,retained-4,2022-01-01,,2022-01-01
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2021,Output 6 - Participant Completion,completed,2022-01-01,,2022-01-01
+npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2022,Output 1 - Participant Start,started,2023-01-01,,2023-01-01
+npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2022,Output 2 - Retention Point 1,retained-1,2023-01-01,,2023-01-01
+npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2022,Output 3 - Retention Point 2,retained-2,2023-01-01,,2023-01-01
+npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2022,Output 4 - Participant Completion,completed,2023-01-01,,2023-01-01
+npq_ehco,npq-ehco-december,NPQ EHCO December,2022,Output 1 - Participant Start,started,2022-12-01,,2022-12-01
+npq_ehco,npq-ehco-december,NPQ EHCO December,2022,Output 2 - Retention Point 1,retained-1,2022-12-01,,2022-12-01
+npq_ehco,npq-ehco-december,NPQ EHCO December,2022,Output 3 - Retention Point 2,retained-2,2022-12-01,,2022-12-01
+npq_ehco,npq-ehco-december,NPQ EHCO December,2022,Output 4 - Participant Completion,completed,2022-12-01,,2022-12-01
+npq_ehco,npq-ehco-june,NPQ EHCO June,2021,Output 1 - Participant Start,started,2022-06-01,,2022-06-01
+npq_ehco,npq-ehco-june,NPQ EHCO June,2021,Output 2 - Retention Point 1,retained-1,2022-06-01,,2022-06-01
+npq_ehco,npq-ehco-june,NPQ EHCO June,2021,Output 3 - Retention Point 2,retained-2,2022-06-01,,2022-06-01
+npq_ehco,npq-ehco-june,NPQ EHCO June,2021,Output 4 - Participant Completion,completed,2022-06-01,,2022-06-01
+ecf_standard,ecf-standard-september,ECF Standard September,2022,Output 1 - Participant Start,started,2022-06-01,2022-12-31,2022-11-30
+ecf_standard,ecf-standard-september,ECF Standard September,2022,Output 2 - Retention Point 1,retained-1,2023-01-01,2023-03-31,2023-04-30
+ecf_standard,ecf-standard-september,ECF Standard September,2022,Output 3 - Retention Point 2,retained-2,2023-04-01,2023-07-31,2023-08-31
+ecf_standard,ecf-standard-september,ECF Standard September,2022,Output 4 - Retention Point 3,retained-3,2023-08-01,2023-12-31,2024-01-31
+ecf_standard,ecf-standard-september,ECF Standard September,2022,Output 5 - Retention Point 4,retained-4,2024-01-01,2024-03-31,2024-04-30
+ecf_standard,ecf-standard-september,ECF Standard September,2022,Output 6 - Participant Completion,completed,2024-04-01,2024-07-31,2024-08-31
+npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2023,Output 1 - Participant Start,started,2023-10-01,,2023-11-01
+npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2023,Output 2 - Retention Point 1,retained-1,2023-10-01,,2023-11-01
+npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2023,Output 3 - Retention Point 2,retained-2,2023-10-01,,2023-11-01
+npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2023,Output 4 - Participant Completion,completed,2023-10-01,,2023-11-01
+npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2022,Output 1 - Participant Start,started,2023-01-01,,2023-01-01
+npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2022,Output 2 - Retention Point 1,retained-1,2023-01-01,,2023-01-01
+npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2022,Output 3 - Participant Completion,completed,2023-01-01,,2023-01-01
+npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2023,Output 1 - Participant Start,started,2024-01-01,,2024-01-01
+npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2023,Output 2 - Retention Point 1,retained-1,2024-01-01,,2024-01-01
+npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2023,Output 3 - Retention Point 2,retained-2,2024-01-01,,2024-01-01
+npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2023,Output 4 - Participant Completion,completed,2024-01-01,,2024-01-01
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2021,Output 1 - Participant Start,started,2021-09-01,,2021-09-01
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2021,Output 2 - Retention Point 1,retained-1,2021-09-01,,2021-09-01
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2021,Output 3 - Retention Point 2,retained-2,2021-09-01,,2021-09-01
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2021,Output 4 - Retention Point 3,retained-3,2021-09-01,,2021-09-01
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2021,Output 5 - Retention Point 4,retained-4,2021-09-01,,2021-09-01
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2021,Output 6 - Participant Completion,completed,2021-09-01,,2021-09-01
+npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2023,Output 1 - Participant Start,started,2023-10-01,,2023-11-01
+npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2023,Output 2 - Retention Point 1,retained-1,2023-10-01,,2023-11-01
+npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2023,Output 3 - Participant Completion,completed,2023-10-01,,2023-11-01
+npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2023,Output 1 - Participant Start,started,2024-01-01,,2024-01-01
+npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2023,Output 2 - Retention Point 1,retained-1,2024-01-01,,2024-01-01
+npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2023,Output 3 - Participant Completion,completed,2024-01-01,,2024-01-01
+ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 1 - Participant Start,started,2021-09-01,,2021-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 2 - Retention Point 1,retained-1,2021-09-01,,2021-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 3 - Retention Point 2,retained-2,2021-09-01,,2021-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 4 - Retention Point 3,retained-3,2021-09-01,,2021-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 5 - Retention Point 4,retained-4,2021-09-01,,2021-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 6 - Participant Completion,completed,2021-09-01,,2021-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 7 - Extended Point 1,extended-1,2021-09-01,,2021-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 8 - Extended Point 2,extended-2,2021-09-01,,2021-09-01
+ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 9 - Extended Point 3,extended-3,2021-09-01,,2021-09-01
+ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 1 - Participant Start,started,2022-01-01,,2022-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 2 - Retention Point 1,retained-1,2022-01-01,,2022-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 3 - Retention Point 2,retained-2,2022-01-01,,2022-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 4 - Retention Point 3,retained-3,2022-01-01,,2022-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 5 - Retention Point 4,retained-4,2022-01-01,,2022-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 6 - Participant Completion,completed,2022-01-01,,2022-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 7 - Extended Point 1,extended-1,2022-01-01,,2022-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 8 - Extended Point 2,extended-2,2022-01-01,,2022-01-01
+ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 9 - Extended Point 3,extended-3,2022-01-01,,2022-01-01
+npq_ehco,npq-ehco-november,NPQ EHCO November,2022,Output 1 - Participant Start,started,2022-10-01,,2022-11-01
+npq_ehco,npq-ehco-november,NPQ EHCO November,2022,Output 2 - Retention Point 1,retained-1,2022-10-01,,2022-11-01
+npq_ehco,npq-ehco-november,NPQ EHCO November,2022,Output 3 - Retention Point 2,retained-2,2022-10-01,,2022-11-01
+npq_ehco,npq-ehco-november,NPQ EHCO November,2022,Output 4 - Participant Completion,completed,2022-10-01,,2022-11-01
+npq_ehco,npq-ehco-november,NPQ EHCO November,2023,Output 1 - Participant Start,started,2023-11-01,,2023-11-01
+npq_ehco,npq-ehco-november,NPQ EHCO November,2023,Output 2 - Retention Point 1,retained-1,2023-11-01,,2023-11-01
+npq_ehco,npq-ehco-november,NPQ EHCO November,2023,Output 3 - Retention Point 2,retained-2,2023-11-01,,2023-11-01
+npq_ehco,npq-ehco-november,NPQ EHCO November,2023,Output 4 - Participant Completion,completed,2023-11-01,,2023-11-01
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2021,Output 1 - Participant Start,started,2022-04-01,,2022-04-01
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2021,Output 2 - Retention Point 1,retained-1,2022-04-01,,2022-04-01
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2021,Output 3 - Retention Point 2,retained-2,2022-04-01,,2022-04-01
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2021,Output 4 - Retention Point 3,retained-3,2022-04-01,,2022-04-01
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2021,Output 5 - Retention Point 4,retained-4,2022-04-01,,2022-04-01
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2021,Output 6 - Participant Completion,completed,2022-04-01,,2022-04-01
+npq_ehco,npq-ehco-december,NPQ EHCO December,2023,Output 1 - Participant Start,started,2023-12-01,,2023-12-01
+npq_ehco,npq-ehco-december,NPQ EHCO December,2023,Output 2 - Retention Point 1,retained-1,2023-12-01,,2023-12-01
+npq_ehco,npq-ehco-december,NPQ EHCO December,2023,Output 3 - Retention Point 2,retained-2,2023-12-01,,2023-12-01
+npq_ehco,npq-ehco-december,NPQ EHCO December,2023,Output 4 - Participant Completion,completed,2023-12-01,,2023-12-01
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2021,Output 1 - Participant Start,started,2021-09-01,,2021-09-01
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2021,Output 2 - Retention Point 1,retained-1,2021-09-01,,2021-09-01
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2021,Output 3 - Retention Point 2,retained-2,2021-09-01,,2021-09-01
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2021,Output 4 - Retention Point 3,retained-3,2021-09-01,,2021-09-01
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2021,Output 5 - Retention Point 4,retained-4,2021-09-01,,2021-09-01
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2021,Output 6 - Participant Completion,completed,2021-09-01,,2021-09-01
+npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2021,Output 1 - Participant Start,started,2022-01-01,,2022-01-01
+npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2021,Output 2 - Retention Point 1,retained-1,2022-01-01,,2022-01-01
+npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2021,Output 3 - Retention Point 2,retained-2,2022-01-01,,2022-01-01
+npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2021,Output 4 - Participant Completion,completed,2022-01-01,,2022-01-01
+npq_ehco,npq-ehco-march,NPQ EHCO March,2023,Output 1 - Participant Start,started,2024-03-01,,2024-03-01
+npq_ehco,npq-ehco-march,NPQ EHCO March,2023,Output 2 - Retention Point 1,retained-1,2024-03-01,,2024-03-01
+npq_ehco,npq-ehco-march,NPQ EHCO March,2023,Output 3 - Retention Point 2,retained-2,2024-03-01,,2024-03-01
+npq_ehco,npq-ehco-march,NPQ EHCO March,2023,Output 4 - Participant Completion,completed,2024-03-01,,2024-03-01
+ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 1 - Participant Start,started,2024-04-01,,2024-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 2 - Retention Point 1,retained-1,2024-04-01,,2024-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 3 - Retention Point 2,retained-2,2024-04-01,,2024-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 4 - Retention Point 3,retained-3,2024-04-01,,2024-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 5 - Retention Point 4,retained-4,2024-04-01,,2024-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 6 - Participant Completion,completed,2024-04-01,,2024-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 7 - Extended Point 1,extended-1,2024-04-01,,2024-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 8 - Extended Point 2,extended-2,2024-04-01,,2024-04-01
+ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 9 - Extended Point 3,extended-3,2024-04-01,,2024-04-01
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2023,Output 1 - Participant Start,started,2023-09-01,,2023-09-01
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2023,Output 2 - Retention Point 1,retained-1,2023-09-01,,2023-09-01
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2023,Output 3 - Retention Point 2,retained-2,2023-09-01,,2023-09-01
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2023,Output 4 - Retention Point 3,retained-3,2023-09-01,,2023-09-01
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2023,Output 5 - Retention Point 4,retained-4,2023-09-01,,2023-09-01
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2023,Output 6 - Participant Completion,completed,2023-09-01,,2023-09-01
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2023,Output 1 - Participant Start,started,2024-01-01,,2024-01-01
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2023,Output 2 - Retention Point 1,retained-1,2024-01-01,,2024-01-01
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2023,Output 3 - Retention Point 2,retained-2,2024-01-01,,2024-01-01
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2023,Output 4 - Retention Point 3,retained-3,2024-01-01,,2024-01-01
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2023,Output 5 - Retention Point 4,retained-4,2024-01-01,,2024-01-01
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2023,Output 6 - Participant Completion,completed,2024-01-01,,2024-01-01
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2023,Output 1 - Participant Start,started,2024-04-01,,2024-04-01
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2023,Output 2 - Retention Point 1,retained-1,2024-04-01,,2024-04-01
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2023,Output 3 - Retention Point 2,retained-2,2024-04-01,,2024-04-01
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2023,Output 4 - Retention Point 3,retained-3,2024-04-01,,2024-04-01
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2023,Output 5 - Retention Point 4,retained-4,2024-04-01,,2024-04-01
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2023,Output 6 - Participant Completion,completed,2024-04-01,,2024-04-01
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2023,Output 1 - Participant Start,started,2023-09-01,,2023-09-01
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2023,Output 2 - Retention Point 1,retained-1,2023-09-01,,2023-09-01
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2023,Output 3 - Retention Point 2,retained-2,2023-09-01,,2023-09-01
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2023,Output 4 - Retention Point 3,retained-3,2023-09-01,,2023-09-01
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2023,Output 5 - Retention Point 4,retained-4,2023-09-01,,2023-09-01
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2023,Output 6 - Participant Completion,completed,2023-09-01,,2023-09-01
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2023,Output 1 - Participant Start,started,2024-01-01,,2024-01-01
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2023,Output 2 - Retention Point 1,retained-1,2024-01-01,,2024-01-01
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2023,Output 3 - Retention Point 2,retained-2,2024-01-01,,2024-01-01
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2023,Output 4 - Retention Point 3,retained-3,2024-01-01,,2024-01-01
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2023,Output 5 - Retention Point 4,retained-4,2024-01-01,,2024-01-01
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2023,Output 6 - Participant Completion,completed,2024-01-01,,2024-01-01
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2023,Output 1 - Participant Start,started,2024-04-01,,2024-04-01
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2023,Output 2 - Retention Point 1,retained-1,2024-04-01,,2024-04-01
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2023,Output 3 - Retention Point 2,retained-2,2024-04-01,,2024-04-01
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2023,Output 4 - Retention Point 3,retained-3,2024-04-01,,2024-04-01
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2023,Output 5 - Retention Point 4,retained-4,2024-04-01,,2024-04-01
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2023,Output 6 - Participant Completion,completed,2024-04-01,,2024-04-01
+ecf_standard,ecf-standard-september,ECF Standard September,2021,Output 1 - Participant Start,started,2021-09-01,2021-11-30,2021-11-30
+ecf_standard,ecf-standard-september,ECF Standard September,2021,Output 2 - Retention Point 1,retained-1,2021-09-01,2022-01-31,2022-02-28
+ecf_standard,ecf-standard-september,ECF Standard September,2021,Output 3 - Retention Point 2,retained-2,2022-02-01,2022-04-30,2022-05-31
+ecf_standard,ecf-standard-september,ECF Standard September,2021,Output 4 - Retention Point 3,retained-3,2022-05-01,2022-09-30,2022-10-31
+ecf_standard,ecf-standard-september,ECF Standard September,2021,Output 5 - Retention Point 4,retained-4,2022-10-01,2023-01-31,2023-02-28
+ecf_standard,ecf-standard-september,ECF Standard September,2021,Output 6 - Participant Completion,completed,2023-02-01,2023-04-30,2023-05-31
+ecf_standard,ecf-standard-september,ECF Standard September,2023,Output 1 - Participant Start,started,2023-06-01,2023-12-31,2023-11-30
+ecf_standard,ecf-standard-september,ECF Standard September,2023,Output 2 - Retention Point 1,retained-1,2024-01-01,2024-03-31,2024-04-30
+ecf_standard,ecf-standard-september,ECF Standard September,2023,Output 3 - Retention Point 2,retained-2,2024-04-01,2024-07-31,2024-08-31
+ecf_standard,ecf-standard-september,ECF Standard September,2023,Output 4 - Retention Point 3,retained-3,2024-08-01,2024-12-31,2025-01-31
+ecf_standard,ecf-standard-september,ECF Standard September,2023,Output 5 - Retention Point 4,retained-4,2025-01-01,2025-03-31,2025-04-30
+ecf_standard,ecf-standard-september,ECF Standard September,2023,Output 6 - Participant Completion,completed,2025-04-01,2025-07-31,2025-08-31
+ecf_standard,ecf-standard-january,ECF Standard January,2023,Output 1 - Participant Start,started,2024-01-01,2024-03-31,2024-04-30
+ecf_standard,ecf-standard-january,ECF Standard January,2023,Output 2 - Retention Point 1,retained-1,2024-04-01,2024-07-31,2024-08-31
+ecf_standard,ecf-standard-january,ECF Standard January,2023,Output 3 - Retention Point 2,retained-2,2024-08-01,2024-12-31,2025-01-31
+ecf_standard,ecf-standard-january,ECF Standard January,2023,Output 4 - Retention Point 3,retained-3,2025-01-01,2025-03-31,2025-04-30
+ecf_standard,ecf-standard-january,ECF Standard January,2023,Output 5 - Retention Point 4,retained-4,2025-04-01,2025-07-31,2025-08-31
+ecf_standard,ecf-standard-january,ECF Standard January,2023,Output 6 - Participant Completion,completed,2025-08-01,2025-12-31,2026-01-31
+ecf_standard,ecf-standard-april,ECF Standard April,2023,Output 1 - Participant Start,started,2024-04-01,2024-07-31,2024-08-31
+ecf_standard,ecf-standard-april,ECF Standard April,2023,Output 2 - Retention Point 1,retained-1,2024-08-01,2024-12-31,2025-01-31
+ecf_standard,ecf-standard-april,ECF Standard April,2023,Output 3 - Retention Point 2,retained-2,2025-01-01,2025-03-31,2025-04-30
+ecf_standard,ecf-standard-april,ECF Standard April,2023,Output 4 - Retention Point 3,retained-3,2025-04-01,2025-07-31,2025-08-31
+ecf_standard,ecf-standard-april,ECF Standard April,2023,Output 5 - Retention Point 4,retained-4,2025-08-01,2025-12-31,2026-01-31
+ecf_standard,ecf-standard-april,ECF Standard April,2023,Output 6 - Participant Completion,completed,2026-01-01,2026-03-31,2026-04-30
+npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2021,Output 1 - Participant Start,started,2021-11-01,,2021-11-01
+npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2021,Output 2 - Retention Point 1,retained-1,2021-11-01,,2021-11-01
+npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2021,Output 3 - Participant Completion,completed,2021-11-01,,2021-11-01
+ecf_standard,ecf-standard-january,ECF Standard January,2021,Output 1 - Participant Start,started,2021-12-01,2022-01-31,2022-02-28
+ecf_standard,ecf-standard-january,ECF Standard January,2021,Output 2 - Retention Point 1,retained-1,2022-02-01,2022-04-30,2022-05-31
+ecf_standard,ecf-standard-january,ECF Standard January,2021,Output 3 - Retention Point 2,retained-2,2022-05-01,2022-09-30,2022-10-31
+ecf_standard,ecf-standard-january,ECF Standard January,2021,Output 4 - Retention Point 3,retained-3,2022-10-01,2023-01-31,2023-02-28
+ecf_standard,ecf-standard-january,ECF Standard January,2021,Output 5 - Retention Point 4,retained-4,2023-02-01,2023-04-30,2023-05-31
+npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2021,Output 1 - Participant Start,started,2021-11-01,,2021-11-01
+npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2021,Output 2 - Retention Point 1,retained-1,2021-11-01,,2021-11-01
+npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2021,Output 3 - Retention Point 2,retained-2,2021-11-01,,2021-11-01
+npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2021,Output 4 - Participant Completion,completed,2021-11-01,,2021-11-01
+npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2021,Output 1 - Participant Start,started,2022-01-01,,2022-01-01
+npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2021,Output 2 - Retention Point 1,retained-1,2022-01-01,,2022-01-01
+npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2021,Output 3 - Participant Completion,completed,2022-01-01,,2022-01-01
 npq_aso,npq-aso-november,NPQ ASO November,2021,Output 1 - Participant Start,started,01/11/2021,,01/11/2021
 npq_aso,npq-aso-november,NPQ ASO November,2021,Output 2 - Retention Point 1,retained-1,01/11/2021,,01/11/2021
 npq_aso,npq-aso-november,NPQ ASO November,2021,Output 3 - Retention Point 2,retained-2,01/11/2021,,01/11/2021
@@ -159,180 +329,3 @@ npq_aso,npq-aso-june,NPQ ASO June,2021,Output 1 - Participant Start,started,01/0
 npq_aso,npq-aso-june,NPQ ASO June,2021,Output 2 - Retention Point 1,retained-1,01/06/2022,,01/06/2022
 npq_aso,npq-aso-june,NPQ ASO June,2021,Output 3 - Retention Point 2,retained-2,01/06/2022,,01/06/2022
 npq_aso,npq-aso-june,NPQ ASO June,2021,Output 4 - Participant Completion,completed,01/06/2022,,01/06/2022
-npq_ehco,npq-ehco-june,NPQ EHCO June,2021,Output 1 - Participant Start,started,01/06/2022,,01/06/2022
-npq_ehco,npq-ehco-june,NPQ EHCO June,2021,Output 2 - Retention Point 1,retained-1,01/06/2022,,01/06/2022
-npq_ehco,npq-ehco-june,NPQ EHCO June,2021,Output 3 - Retention Point 2,retained-2,01/06/2022,,01/06/2022
-npq_ehco,npq-ehco-june,NPQ EHCO June,2021,Output 4 - Participant Completion,completed,01/06/2022,,01/06/2022
-npq_ehco,npq-ehco-november,NPQ EHCO November,2022,Output 1 - Participant Start,started,01/11/2022,,01/11/2022
-npq_ehco,npq-ehco-november,NPQ EHCO November,2022,Output 2 - Retention Point 1,retained-1,01/11/2022,,01/11/2022
-npq_ehco,npq-ehco-november,NPQ EHCO November,2022,Output 3 - Retention Point 2,retained-2,01/11/2022,,01/11/2022
-npq_ehco,npq-ehco-november,NPQ EHCO November,2022,Output 4 - Participant Completion,completed,01/11/2022,,01/11/2022
-npq_ehco,npq-ehco-december,NPQ EHCO December,2022,Output 1 - Participant Start,started,01/12/2022,,01/12/2022
-npq_ehco,npq-ehco-december,NPQ EHCO December,2022,Output 2 - Retention Point 1,retained-1,01/12/2022,,01/12/2022
-npq_ehco,npq-ehco-december,NPQ EHCO December,2022,Output 3 - Retention Point 2,retained-2,01/12/2022,,01/12/2022
-npq_ehco,npq-ehco-december,NPQ EHCO December,2022,Output 4 - Participant Completion,completed,01/12/2022,,01/12/2022
-npq_ehco,npq-ehco-march,NPQ EHCO March,2022,Output 1 - Participant Start,started,01/03/2023,,01/03/2023
-npq_ehco,npq-ehco-march,NPQ EHCO March,2022,Output 2 - Retention Point 1,retained-1,01/03/2023,,01/03/2023
-npq_ehco,npq-ehco-march,NPQ EHCO March,2022,Output 3 - Retention Point 2,retained-2,01/03/2023,,01/03/2023
-npq_ehco,npq-ehco-march,NPQ EHCO March,2022,Output 4 - Participant Completion,completed,01/03/2023,,01/03/2023
-npq_ehco,npq-ehco-june,NPQ EHCO June,2022,Output 1 - Participant Start,started,01/06/2023,,01/06/2023
-npq_ehco,npq-ehco-june,NPQ EHCO June,2022,Output 2 - Retention Point 1,retained-1,01/06/2023,,01/06/2023
-npq_ehco,npq-ehco-june,NPQ EHCO June,2022,Output 3 - Retention Point 2,retained-2,01/06/2023,,01/06/2023
-npq_ehco,npq-ehco-june,NPQ EHCO June,2022,Output 4 - Participant Completion,completed,01/06/2023,,01/06/2023
-npq_ehco,npq-ehco-november,NPQ EHCO November,2023,Output 1 - Participant Start,started,01/11/2023,,01/11/2023
-npq_ehco,npq-ehco-november,NPQ EHCO November,2023,Output 2 - Retention Point 1,retained-1,01/11/2023,,01/11/2023
-npq_ehco,npq-ehco-november,NPQ EHCO November,2023,Output 3 - Retention Point 2,retained-2,01/11/2023,,01/11/2023
-npq_ehco,npq-ehco-november,NPQ EHCO November,2023,Output 4 - Participant Completion,completed,01/11/2023,,01/11/2023
-npq_ehco,npq-ehco-december,NPQ EHCO December,2023,Output 1 - Participant Start,started,01/12/2023,,01/12/2023
-npq_ehco,npq-ehco-december,NPQ EHCO December,2023,Output 2 - Retention Point 1,retained-1,01/12/2023,,01/12/2023
-npq_ehco,npq-ehco-december,NPQ EHCO December,2023,Output 3 - Retention Point 2,retained-2,01/12/2023,,01/12/2023
-npq_ehco,npq-ehco-december,NPQ EHCO December,2023,Output 4 - Participant Completion,completed,01/12/2023,,01/12/2023
-npq_ehco,npq-ehco-march,NPQ EHCO March,2023,Output 1 - Participant Start,started,01/03/2024,,01/03/2024
-npq_ehco,npq-ehco-march,NPQ EHCO March,2023,Output 2 - Retention Point 1,retained-1,01/03/2024,,01/03/2024
-npq_ehco,npq-ehco-march,NPQ EHCO March,2023,Output 3 - Retention Point 2,retained-2,01/03/2024,,01/03/2024
-npq_ehco,npq-ehco-march,NPQ EHCO March,2023,Output 4 - Participant Completion,completed,01/03/2024,,01/03/2024
-npq_ehco,npq-ehco-june,NPQ EHCO June,2023,Output 1 - Participant Start,started,01/06/2024,,01/06/2024
-npq_ehco,npq-ehco-june,NPQ EHCO June,2023,Output 2 - Retention Point 1,retained-1,01/06/2024,,01/06/2024
-npq_ehco,npq-ehco-june,NPQ EHCO June,2023,Output 3 - Retention Point 2,retained-2,01/06/2024,,01/06/2024
-npq_ehco,npq-ehco-june,NPQ EHCO June,2023,Output 4 - Participant Completion,completed,01/06/2024,,01/06/2024
-npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2021,Output 1 - Participant Start,started,01/11/2021,,01/11/2021
-npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2021,Output 2 - Retention Point 1,retained-1,01/11/2021,,01/11/2021
-npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2021,Output 3 - Retention Point 2,retained-2,01/11/2021,,01/11/2021
-npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2021,Output 4 - Participant Completion,completed,01/11/2021,,01/11/2021
-npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2021,Output 1 - Participant Start,started,01/01/2022,,01/01/2022
-npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2021,Output 2 - Retention Point 1,retained-1,01/01/2022,,01/01/2022
-npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2021,Output 3 - Retention Point 2,retained-2,01/01/2022,,01/01/2022
-npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2021,Output 4 - Participant Completion,completed,01/01/2022,,01/01/2022
-npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2022,Output 1 - Participant Start,started,01/11/2022,,01/11/2022
-npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2022,Output 2 - Retention Point 1,retained-1,01/11/2022,,01/11/2022
-npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2022,Output 3 - Retention Point 2,retained-2,01/11/2022,,01/11/2022
-npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2022,Output 4 - Participant Completion,completed,01/11/2022,,01/11/2022
-npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2022,Output 1 - Participant Start,started,01/01/2023,,01/01/2023
-npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2022,Output 2 - Retention Point 1,retained-1,01/01/2023,,01/01/2023
-npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2022,Output 3 - Retention Point 2,retained-2,01/01/2023,,01/01/2023
-npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2022,Output 4 - Participant Completion,completed,01/01/2023,,01/01/2023
-npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2023,Output 1 - Participant Start,started,01/11/2023,,01/11/2023
-npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2023,Output 2 - Retention Point 1,retained-1,01/11/2023,,01/11/2023
-npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2023,Output 3 - Retention Point 2,retained-2,01/11/2023,,01/11/2023
-npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,2023,Output 4 - Participant Completion,completed,01/11/2023,,01/11/2023
-npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2023,Output 1 - Participant Start,started,01/01/2024,,01/01/2024
-npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2023,Output 2 - Retention Point 1,retained-1,01/01/2024,,01/01/2024
-npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2023,Output 3 - Retention Point 2,retained-2,01/01/2024,,01/01/2024
-npq_leadership,npq-leadership-spring,NPQ Leadership Spring,2023,Output 4 - Participant Completion,completed,01/01/2024,,01/01/2024
-npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2021,Output 1 - Participant Start,started,01/11/2021,,01/11/2021
-npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2021,Output 2 - Retention Point 1,retained-1,01/11/2021,,01/11/2021
-npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2021,Output 3 - Participant Completion,completed,01/11/2021,,01/11/2021
-npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2021,Output 1 - Participant Start,started,01/01/2022,,01/01/2022
-npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2021,Output 2 - Retention Point 1,retained-1,01/01/2022,,01/01/2022
-npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2021,Output 3 - Participant Completion,completed,01/01/2022,,01/01/2022
-npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2022,Output 1 - Participant Start,started,01/11/2022,,01/11/2022
-npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2022,Output 2 - Retention Point 1,retained-1,01/11/2022,,01/11/2022
-npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2022,Output 3 - Participant Completion,completed,01/11/2022,,01/11/2022
-npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2022,Output 1 - Participant Start,started,01/01/2023,,01/01/2023
-npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2022,Output 2 - Retention Point 1,retained-1,01/01/2023,,01/01/2023
-npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2022,Output 3 - Participant Completion,completed,01/01/2023,,01/01/2023
-npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2023,Output 1 - Participant Start,started,01/11/2023,,01/11/2023
-npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2023,Output 2 - Retention Point 1,retained-1,01/11/2023,,01/11/2023
-npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2023,Output 3 - Participant Completion,completed,01/11/2023,,01/11/2023
-npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2023,Output 1 - Participant Start,started,01/01/2024,,01/01/2024
-npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2023,Output 2 - Retention Point 1,retained-1,01/01/2024,,01/01/2024
-npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2023,Output 3 - Participant Completion,completed,01/01/2024,,01/01/2024
-ecf_standard,ecf-standard-september,ECF Standard September,2023,Output 1 - Participant Start,started,01/06/2023,31/12/2023,30/11/2023
-ecf_standard,ecf-standard-september,ECF Standard September,2023,Output 2 - Retention Point 1,retained-1,01/01/2024,31/03/2024,30/04/2024
-ecf_standard,ecf-standard-september,ECF Standard September,2023,Output 3 - Retention Point 2,retained-2,01/04/2024,31/07/2024,31/08/2024
-ecf_standard,ecf-standard-september,ECF Standard September,2023,Output 4 - Retention Point 3,retained-3,01/08/2024,31/12/2024,31/01/2025
-ecf_standard,ecf-standard-september,ECF Standard September,2023,Output 5 - Retention Point 4,retained-4,01/01/2025,31/03/2025,30/04/2025
-ecf_standard,ecf-standard-september,ECF Standard September,2023,Output 6 - Participant Completion,completed,01/04/2025,31/07/2025,31/08/2025
-ecf_standard,ecf-standard-january,ECF Standard January,2023,Output 1 - Participant Start,started,01/01/2024,31/03/2024,30/04/2024
-ecf_standard,ecf-standard-january,ECF Standard January,2023,Output 2 - Retention Point 1,retained-1,01/04/2024,31/07/2024,31/08/2024
-ecf_standard,ecf-standard-january,ECF Standard January,2023,Output 3 - Retention Point 2,retained-2,01/08/2024,31/12/2024,31/01/2025
-ecf_standard,ecf-standard-january,ECF Standard January,2023,Output 4 - Retention Point 3,retained-3,01/01/2025,31/03/2025,30/04/2025
-ecf_standard,ecf-standard-january,ECF Standard January,2023,Output 5 - Retention Point 4,retained-4,01/04/2025,31/07/2025,31/08/2025
-ecf_standard,ecf-standard-january,ECF Standard January,2023,Output 6 - Participant Completion,completed,01/08/2025,31/12/2025,31/01/2026
-ecf_standard,ecf-standard-april,ECF Standard April,2023,Output 1 - Participant Start,started,01/04/2024,31/07/2024,31/08/2024
-ecf_standard,ecf-standard-april,ECF Standard April,2023,Output 2 - Retention Point 1,retained-1,01/08/2024,31/12/2024,31/01/2025
-ecf_standard,ecf-standard-april,ECF Standard April,2023,Output 3 - Retention Point 2,retained-2,01/01/2025,31/03/2025,30/04/2025
-ecf_standard,ecf-standard-april,ECF Standard April,2023,Output 4 - Retention Point 3,retained-3,01/04/2025,31/07/2025,31/08/2025
-ecf_standard,ecf-standard-april,ECF Standard April,2023,Output 5 - Retention Point 4,retained-4,01/08/2025,31/12/2025,31/01/2026
-ecf_standard,ecf-standard-april,ECF Standard April,2023,Output 6 - Participant Completion,completed,01/01/2026,31/03/2026,30/04/2026
-ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 1 - Participant Start,started,01/09/2023,,01/09/2023
-ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 2 - Retention Point 1,retained-1,01/09/2023,,01/09/2023
-ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 3 - Retention Point 2,retained-2,01/09/2023,,01/09/2023
-ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 4 - Retention Point 3,retained-3,01/09/2023,,01/09/2023
-ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 5 - Retention Point 4,retained-4,01/09/2023,,01/09/2023
-ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 6 - Participant Completion,completed,01/09/2023,,01/09/2023
-ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 1 - Participant Start,started,01/01/2024,,01/01/2024
-ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 2 - Retention Point 1,retained-1,01/01/2024,,01/01/2024
-ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 3 - Retention Point 2,retained-2,01/01/2024,,01/01/2024
-ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 4 - Retention Point 3,retained-3,01/01/2024,,01/01/2024
-ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 5 - Retention Point 4,retained-4,01/01/2024,,01/01/2024
-ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 6 - Participant Completion,completed,01/01/2024,,01/01/2024
-ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 1 - Participant Start,started,01/04/2024,,01/04/2024
-ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 2 - Retention Point 1,retained-1,01/04/2024,,01/04/2024
-ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 3 - Retention Point 2,retained-2,01/04/2024,,01/04/2024
-ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 4 - Retention Point 3,retained-3,01/04/2024,,01/04/2024
-ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 5 - Retention Point 4,retained-4,01/04/2024,,01/04/2024
-ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 6 - Participant Completion,completed,01/04/2024,,01/04/2024
-ecf_reduced,ecf-reduced-september,ECF Reduced September,2023,Output 1 - Participant Start,started,01/09/2023,,01/09/2023
-ecf_reduced,ecf-reduced-september,ECF Reduced September,2023,Output 2 - Retention Point 1,retained-1,01/09/2023,,01/09/2023
-ecf_reduced,ecf-reduced-september,ECF Reduced September,2023,Output 3 - Retention Point 2,retained-2,01/09/2023,,01/09/2023
-ecf_reduced,ecf-reduced-september,ECF Reduced September,2023,Output 4 - Retention Point 3,retained-3,01/09/2023,,01/09/2023
-ecf_reduced,ecf-reduced-september,ECF Reduced September,2023,Output 5 - Retention Point 4,retained-4,01/09/2023,,01/09/2023
-ecf_reduced,ecf-reduced-september,ECF Reduced September,2023,Output 6 - Participant Completion,completed,01/09/2023,,01/09/2023
-ecf_reduced,ecf-reduced-january,ECF Reduced January,2023,Output 1 - Participant Start,started,01/01/2024,,01/01/2024
-ecf_reduced,ecf-reduced-january,ECF Reduced January,2023,Output 2 - Retention Point 1,retained-1,01/01/2024,,01/01/2024
-ecf_reduced,ecf-reduced-january,ECF Reduced January,2023,Output 3 - Retention Point 2,retained-2,01/01/2024,,01/01/2024
-ecf_reduced,ecf-reduced-january,ECF Reduced January,2023,Output 4 - Retention Point 3,retained-3,01/01/2024,,01/01/2024
-ecf_reduced,ecf-reduced-january,ECF Reduced January,2023,Output 5 - Retention Point 4,retained-4,01/01/2024,,01/01/2024
-ecf_reduced,ecf-reduced-january,ECF Reduced January,2023,Output 6 - Participant Completion,completed,01/01/2024,,01/01/2024
-ecf_reduced,ecf-reduced-april,ECF Reduced April,2023,Output 1 - Participant Start,started,01/04/2024,,01/04/2024
-ecf_reduced,ecf-reduced-april,ECF Reduced April,2023,Output 2 - Retention Point 1,retained-1,01/04/2024,,01/04/2024
-ecf_reduced,ecf-reduced-april,ECF Reduced April,2023,Output 3 - Retention Point 2,retained-2,01/04/2024,,01/04/2024
-ecf_reduced,ecf-reduced-april,ECF Reduced April,2023,Output 4 - Retention Point 3,retained-3,01/04/2024,,01/04/2024
-ecf_reduced,ecf-reduced-april,ECF Reduced April,2023,Output 5 - Retention Point 4,retained-4,01/04/2024,,01/04/2024
-ecf_reduced,ecf-reduced-april,ECF Reduced April,2023,Output 6 - Participant Completion,completed,01/04/2024,,01/04/2024
-ecf_replacement,ecf-replacement-september,ECF Replacement September,2023,Output 1 - Participant Start,started,01/09/2023,,01/09/2023
-ecf_replacement,ecf-replacement-september,ECF Replacement September,2023,Output 2 - Retention Point 1,retained-1,01/09/2023,,01/09/2023
-ecf_replacement,ecf-replacement-september,ECF Replacement September,2023,Output 3 - Retention Point 2,retained-2,01/09/2023,,01/09/2023
-ecf_replacement,ecf-replacement-september,ECF Replacement September,2023,Output 4 - Retention Point 3,retained-3,01/09/2023,,01/09/2023
-ecf_replacement,ecf-replacement-september,ECF Replacement September,2023,Output 5 - Retention Point 4,retained-4,01/09/2023,,01/09/2023
-ecf_replacement,ecf-replacement-september,ECF Replacement September,2023,Output 6 - Participant Completion,completed,01/09/2023,,01/09/2023
-ecf_replacement,ecf-replacement-january,ECF Replacement January,2023,Output 1 - Participant Start,started,01/01/2024,,01/01/2024
-ecf_replacement,ecf-replacement-january,ECF Replacement January,2023,Output 2 - Retention Point 1,retained-1,01/01/2024,,01/01/2024
-ecf_replacement,ecf-replacement-january,ECF Replacement January,2023,Output 3 - Retention Point 2,retained-2,01/01/2024,,01/01/2024
-ecf_replacement,ecf-replacement-january,ECF Replacement January,2023,Output 4 - Retention Point 3,retained-3,01/01/2024,,01/01/2024
-ecf_replacement,ecf-replacement-january,ECF Replacement January,2023,Output 5 - Retention Point 4,retained-4,01/01/2024,,01/01/2024
-ecf_replacement,ecf-replacement-january,ECF Replacement January,2023,Output 6 - Participant Completion,completed,01/01/2024,,01/01/2024
-ecf_replacement,ecf-replacement-april,ECF Replacement April,2023,Output 1 - Participant Start,started,01/04/2024,,01/04/2024
-ecf_replacement,ecf-replacement-april,ECF Replacement April,2023,Output 2 - Retention Point 1,retained-1,01/04/2024,,01/04/2024
-ecf_replacement,ecf-replacement-april,ECF Replacement April,2023,Output 3 - Retention Point 2,retained-2,01/04/2024,,01/04/2024
-ecf_replacement,ecf-replacement-april,ECF Replacement April,2023,Output 4 - Retention Point 3,retained-3,01/04/2024,,01/04/2024
-ecf_replacement,ecf-replacement-april,ECF Replacement April,2023,Output 5 - Retention Point 4,retained-4,01/04/2024,,01/04/2024
-ecf_replacement,ecf-replacement-april,ECF Replacement April,2023,Output 6 - Participant Completion,completed,01/04/2024,,01/04/2024
-ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 7 - Extended Point 1,extended-1,01/09/2021,,01/09/2021
-ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 8 - Extended Point 2,extended-2,01/09/2021,,01/09/2021
-ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 9 - Extended Point 3,extended-3,01/09/2021,,01/09/2021
-ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 7 - Extended Point 1,extended-1,01/01/2022,,01/01/2022
-ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 8 - Extended Point 2,extended-2,01/01/2022,,01/01/2022
-ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 9 - Extended Point 3,extended-3,01/01/2022,,01/01/2022
-ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 7 - Extended Point 1,extended-1,01/04/2022,,01/04/2022
-ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 8 - Extended Point 2,extended-2,01/04/2022,,01/04/2022
-ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 9 - Extended Point 3,extended-3,01/04/2022,,01/04/2022
-ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 7 - Extended Point 1,extended-1,01/09/2022,,01/09/2022
-ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 8 - Extended Point 2,extended-2,01/09/2022,,01/09/2022
-ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 9 - Extended Point 3,extended-3,01/09/2022,,01/09/2022
-ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 7 - Extended Point 1,extended-1,01/01/2023,,01/01/2023
-ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 8 - Extended Point 2,extended-2,01/01/2023,,01/01/2023
-ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 9 - Extended Point 3,extended-3,01/01/2023,,01/01/2023
-ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 7 - Extended Point 1,extended-1,01/04/2023,,01/04/2023
-ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 8 - Extended Point 2,extended-2,01/04/2023,,01/04/2023
-ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 9 - Extended Point 3,extended-3,01/04/2023,,01/04/2023
-ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 7 - Extended Point 1,extended-1,01/09/2023,,01/09/2023
-ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 8 - Extended Point 2,extended-2,01/09/2023,,01/09/2023
-ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 9 - Extended Point 3,extended-3,01/09/2023,,01/09/2023
-ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 7 - Extended Point 1,extended-1,01/01/2024,,01/01/2024
-ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 8 - Extended Point 2,extended-2,01/01/2024,,01/01/2024
-ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 9 - Extended Point 3,extended-3,01/01/2024,,01/01/2024
-ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 7 - Extended Point 1,extended-1,01/04/2024,,01/04/2024
-ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 8 - Extended Point 2,extended-2,01/04/2024,,01/04/2024
-ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 9 - Extended Point 3,extended-3,01/04/2024,,01/04/2024

--- a/db/new_seeds/base/add_cohorts.rb
+++ b/db/new_seeds/base/add_cohorts.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
-# Cohort 2020
-cohort_2020 = FactoryBot.create(:seed_cohort, start_year: 2020)
+Rails.logger.info("Importing cohorts")
 
-# Ensures Cohort.next is always created
-academic_year_start_month = cohort_2020.academic_year_start_date.month
+Importers::CreateCohort.new(path_to_csv: Rails.root.join("db/data/cohorts/cohorts.csv")).call
+
+# Ensure Cohort.next is always created
+academic_year_start_month = Cohort.find_by(start_year: 2020).academic_year_start_date.month
 next_cohort_start_year = Date.current.year + (Date.current.month < academic_year_start_month ? 0 : 1)
-(2021..next_cohort_start_year).to_a.each { |start_year| FactoryBot.create(:seed_cohort, start_year:) }
+FactoryBot.create(:seed_cohort, start_year: next_cohort_start_year) if Cohort.find_by(start_year: next_cohort_start_year).nil?

--- a/db/new_seeds/base/add_npq_courses.rb
+++ b/db/new_seeds/base/add_npq_courses.rb
@@ -53,8 +53,10 @@
     identifier: "npq-leading-literacy",
   },
   {
+    # this is the production uuid for npq-leading-primary-mathematics in case we want it to be the same like the others
+    # "id": "7866f853-064f-44b4-9287-20b9993452d6",
     id: "6f81f1ab-5c4e-445d-9363-0f91149c87db",
-    name: "NPQ for Leading Primary Mathematics (NPQLPM)",
+    name: "NPQ Leading Primary Mathematics (NPQLPM)",
     identifier: "npq-leading-primary-mathematics",
   },
 ].each do |hash|

--- a/db/new_seeds/base/add_schedules.rb
+++ b/db/new_seeds/base/add_schedules.rb
@@ -3,3 +3,138 @@
 Rails.logger.info("Importing schedules")
 
 Importers::CreateSchedule.new(path_to_csv: Rails.root.join("db/data/schedules/schedules.csv")).call
+
+# Ensure Cohort.next always has NPQ schedules that can be used
+if Finance::Schedule.find_by(cohort: Cohort.next, schedule_identifier: "npq-ehco-november").nil?
+  next_start_year = Cohort.next.start_year
+  csv = Tempfile.new("data.csv")
+
+  csv.write "type,schedule-identifier,schedule-name,schedule-cohort-year,milestone-name,milestone-declaration-type,milestone-start-date,milestone-date,milestone-payment-date"
+  csv.write "\n"
+
+  csv.write "npq_ehco,npq-ehco-november,NPQ EHCO November,#{next_start_year},Output 1 - Participant Start,started,01/11/#{next_start_year},,01/11/#{next_start_year}"
+  csv.write "npq_ehco,npq-ehco-november,NPQ EHCO November,#{next_start_year},Output 2 - Retention Point 1,retained-1,01/11/#{next_start_year},,01/11/#{next_start_year}"
+  csv.write "npq_ehco,npq-ehco-november,NPQ EHCO November,#{next_start_year},Output 3 - Retention Point 2,retained-2,01/11/#{next_start_year},,01/11/#{next_start_year}"
+  csv.write "npq_ehco,npq-ehco-november,NPQ EHCO November,#{next_start_year},Output 4 - Participant Completion,completed,01/11/#{next_start_year},,01/11/#{next_start_year}"
+
+  csv.close
+
+  Importers::CreateSchedule.new(path_to_csv: csv.path).call
+end
+
+if Finance::Schedule.find_by(cohort: Cohort.next, schedule_identifier: "npq-ehco-december").nil?
+  next_start_year = Cohort.next.start_year
+  csv = Tempfile.new("data.csv")
+
+  csv.write "type,schedule-identifier,schedule-name,schedule-cohort-year,milestone-name,milestone-declaration-type,milestone-start-date,milestone-date,milestone-payment-date"
+  csv.write "\n"
+
+  csv.write "npq_ehco,npq-ehco-december,NPQ EHCO December,#{next_start_year},Output 1 - Participant Start,started,01/12/#{next_start_year},,01/12/#{next_start_year}"
+  csv.write "npq_ehco,npq-ehco-december,NPQ EHCO December,#{next_start_year},Output 2 - Retention Point 1,retained-1,01/12/#{next_start_year},,01/12/#{next_start_year}"
+  csv.write "npq_ehco,npq-ehco-december,NPQ EHCO December,#{next_start_year},Output 3 - Retention Point 2,retained-2,01/12/#{next_start_year},,01/12/#{next_start_year}"
+  csv.write "npq_ehco,npq-ehco-december,NPQ EHCO December,#{next_start_year},Output 4 - Participant Completion,completed,01/12/#{next_start_year},,01/12/#{next_start_year}"
+
+  csv.close
+
+  Importers::CreateSchedule.new(path_to_csv: csv.path).call
+end
+
+if Finance::Schedule.find_by(cohort: Cohort.next, schedule_identifier: "npq-ehco-march").nil?
+  next_start_year = Cohort.next.start_year
+  csv = Tempfile.new("data.csv")
+
+  csv.write "type,schedule-identifier,schedule-name,schedule-cohort-year,milestone-name,milestone-declaration-type,milestone-start-date,milestone-date,milestone-payment-date"
+  csv.write "\n"
+
+  csv.write "npq_ehco,npq-ehco-march,NPQ EHCO March,#{next_start_year},Output 1 - Participant Start,started,01/03/#{next_start_year + 1},,01/03/#{next_start_year + 1}"
+  csv.write "npq_ehco,npq-ehco-march,NPQ EHCO March,#{next_start_year},Output 2 - Retention Point 1,retained-1,01/03/#{next_start_year + 1},,01/03/#{next_start_year + 1}"
+  csv.write "npq_ehco,npq-ehco-march,NPQ EHCO March,#{next_start_year},Output 3 - Retention Point 2,retained-2,01/03/#{next_start_year + 1},,01/03/#{next_start_year + 1}"
+  csv.write "npq_ehco,npq-ehco-march,NPQ EHCO March,#{next_start_year},Output 4 - Participant Completion,completed,01/03/#{next_start_year + 1},,01/03/#{next_start_year + 1}"
+
+  csv.close
+
+  Importers::CreateSchedule.new(path_to_csv: csv.path).call
+end
+
+if Finance::Schedule.find_by(cohort: Cohort.next, schedule_identifier: "npq-ehco-june").nil?
+  next_start_year = Cohort.next.start_year
+  csv = Tempfile.new("data.csv")
+
+  csv.write "type,schedule-identifier,schedule-name,schedule-cohort-year,milestone-name,milestone-declaration-type,milestone-start-date,milestone-date,milestone-payment-date"
+  csv.write "\n"
+
+  csv.write "npq_ehco,npq-ehco-june,NPQ EHCO June,#{next_start_year},Output 1 - Participant Start,started,01/06/#{next_start_year + 1},,01/06/#{next_start_year + 1}"
+  csv.write "npq_ehco,npq-ehco-june,NPQ EHCO June,#{next_start_year},Output 2 - Retention Point 1,retained-1,01/06/#{next_start_year + 1},,01/06/#{next_start_year + 1}"
+  csv.write "npq_ehco,npq-ehco-june,NPQ EHCO June,#{next_start_year},Output 3 - Retention Point 2,retained-2,01/06/#{next_start_year + 1},,01/06/#{next_start_year + 1}"
+  csv.write "npq_ehco,npq-ehco-june,NPQ EHCO June,#{next_start_year},Output 4 - Participant Completion,completed,01/06/#{next_start_year + 1},,01/06/#{next_start_year + 1}"
+
+  csv.close
+
+  Importers::CreateSchedule.new(path_to_csv: csv.path).call
+end
+
+if Finance::Schedule.find_by(cohort: Cohort.next, schedule_identifier: "npq-leadership-autumn").nil?
+  next_start_year = Cohort.next.start_year
+  csv = Tempfile.new("data.csv")
+
+  csv.write "type,schedule-identifier,schedule-name,schedule-cohort-year,milestone-name,milestone-declaration-type,milestone-start-date,milestone-date,milestone-payment-date"
+  csv.write "\n"
+
+  csv.write "npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,#{next_start_year},Output 1 - Participant Start,started,01/11/#{next_start_year},,01/11/#{next_start_year}"
+  csv.write "npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,#{next_start_year},Output 2 - Retention Point 1,retained-1,01/11/#{next_start_year},,01/11/#{next_start_year}"
+  csv.write "npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,#{next_start_year},Output 3 - Retention Point 2,retained-2,01/11/#{next_start_year},,01/11/#{next_start_year}"
+  csv.write "npq_leadership,npq-leadership-autumn,NPQ Leadership Autumn,#{next_start_year},Output 4 - Participant Completion,completed,01/11/#{next_start_year},,01/11/#{next_start_year}"
+
+  csv.close
+
+  Importers::CreateSchedule.new(path_to_csv: csv.path).call
+end
+
+if Finance::Schedule.find_by(cohort: Cohort.next, schedule_identifier: "npq-leadership-spring").nil?
+  next_start_year = Cohort.next.start_year
+  csv = Tempfile.new("data.csv")
+
+  csv.write "type,schedule-identifier,schedule-name,schedule-cohort-year,milestone-name,milestone-declaration-type,milestone-start-date,milestone-date,milestone-payment-date"
+  csv.write "\n"
+
+  csv.write "npq_leadership,npq-leadership-spring,NPQ Leadership Spring,#{next_start_year},Output 1 - Participant Start,started,01/01/#{next_start_year + 1},,01/01/#{next_start_year + 1}"
+  csv.write "npq_leadership,npq-leadership-spring,NPQ Leadership Spring,#{next_start_year},Output 2 - Retention Point 1,retained-1,01/01/#{next_start_year + 1},,01/01/#{next_start_year + 1}"
+  csv.write "npq_leadership,npq-leadership-spring,NPQ Leadership Spring,#{next_start_year},Output 3 - Retention Point 2,retained-2,01/01/#{next_start_year + 1},,01/01/#{next_start_year + 1}"
+  csv.write "npq_leadership,npq-leadership-spring,NPQ Leadership Spring,#{next_start_year},Output 4 - Participant Completion,completed,01/01/#{next_start_year + 1},,01/01/#{next_start_year + 1}"
+
+  csv.close
+
+  Importers::CreateSchedule.new(path_to_csv: csv.path).call
+end
+
+if Finance::Schedule.find_by(cohort: Cohort.next, schedule_identifier: "npq-specialist-autumn").nil?
+  next_start_year = Cohort.next.start_year
+  csv = Tempfile.new("data.csv")
+
+  csv.write "type,schedule-identifier,schedule-name,schedule-cohort-year,milestone-name,milestone-declaration-type,milestone-start-date,milestone-date,milestone-payment-date"
+  csv.write "\n"
+
+  csv.write "npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,#{next_start_year},Output 1 - Participant Start,started,01/11/#{next_start_year},,01/11/#{next_start_year}"
+  csv.write "npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,#{next_start_year},Output 2 - Retention Point 1,retained-1,01/11/#{next_start_year},,01/11/#{next_start_year}"
+  csv.write "npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,#{next_start_year},Output 3 - Participant Completion,completed,01/11/#{next_start_year},,01/11/#{next_start_year}"
+
+  csv.close
+
+  Importers::CreateSchedule.new(path_to_csv: csv.path).call
+end
+
+if Finance::Schedule.find_by(cohort: Cohort.next, schedule_identifier: "npq-specialist-spring").nil?
+  next_start_year = Cohort.next.start_year
+  csv = Tempfile.new("data.csv")
+
+  csv.write "type,schedule-identifier,schedule-name,schedule-cohort-year,milestone-name,milestone-declaration-type,milestone-start-date,milestone-date,milestone-payment-date"
+  csv.write "\n"
+
+  csv.write "npq_specialist,npq-specialist-spring,NPQ Specialist Spring,#{next_start_year},Output 1 - Participant Start,started,01/01/#{next_start_year + 1},,01/01/#{next_start_year + 1}"
+  csv.write "npq_specialist,npq-specialist-spring,NPQ Specialist Spring,#{next_start_year},Output 2 - Retention Point 1,retained-1,01/01/#{next_start_year + 1},,01/01/#{next_start_year + 1}"
+  csv.write "npq_specialist,npq-specialist-spring,NPQ Specialist Spring,#{next_start_year},Output 3 - Participant Completion,completed,01/01/#{next_start_year + 1},,01/01/#{next_start_year + 1}"
+
+  csv.close
+
+  Importers::CreateSchedule.new(path_to_csv: csv.path).call
+end

--- a/spec/components/admin/participants/audit_trail_component_spec.rb
+++ b/spec/components/admin/participants/audit_trail_component_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Admin::Participants::AuditTrailComponent, :with_support_for_ect_e
     it "has the correct lead provider induction programme when a FIP ECT is created" do
       travel_to(Time.zone.now - 1.minute) { fip_ect_only }
 
-      expect(subject).to include "Teach First TF Delivery Partner (2022/23)"
+      expect(subject).to include "Teach First TF Delivery Partner (#{Cohort.current.academic_year})"
     end
 
     it "shows a name change" do

--- a/spec/cypress/app_commands/scenarios/admin/schools.rb
+++ b/spec/cypress/app_commands/scenarios/admin/schools.rb
@@ -8,18 +8,18 @@ coordinator.induction_coordinator_profile.schools.first.destroy!
 coordinator.induction_coordinator_profile.schools = [school]
 
 school_with_cohorts = FactoryBot.create(:school, name: "Cohort School", urn: 900_123)
-cohort_2021 = Cohort.find_or_create_by!(start_year: 2021, registration_start_date: Date.new(2021, 5, 10), academic_year_start_date: Date.new(2021, 9, 1))
-cohort_2022 = Cohort.find_or_create_by!(start_year: 2022, registration_start_date: Date.new(2022, 5, 10), academic_year_start_date: Date.new(2022, 9, 1))
+cohort_previous = Cohort.previous || FactoryBot.create(:cohort, :previous)
+cohort_current = Cohort.current || FactoryBot.create(:cohort, :current)
 
 cip_1 = FactoryBot.create(:core_induction_programme, name: "CIP Programme 1")
 cip_2 = FactoryBot.create(:core_induction_programme, name: "CIP Programme 2")
-FactoryBot.create(:school_cohort, :cip, :with_induction_programme, cohort: cohort_2021, school: school_with_cohorts, core_induction_programme: cip_1)
-FactoryBot.create(:school_cohort, :cip, :with_induction_programme, cohort: cohort_2022, school: school_with_cohorts, core_induction_programme: cip_2)
+FactoryBot.create(:school_cohort, :cip, :with_induction_programme, cohort: cohort_previous, school: school_with_cohorts, core_induction_programme: cip_1)
+FactoryBot.create(:school_cohort, :cip, :with_induction_programme, cohort: cohort_current, school: school_with_cohorts, core_induction_programme: cip_2)
 
-FactoryBot.create(:seed_partnership, :with_lead_provider, :valid, cohort: cohort_2021, school:)
-FactoryBot.create(:seed_partnership, :with_lead_provider, :valid, cohort: cohort_2022, school:)
-FactoryBot.create(:seed_partnership, :with_lead_provider, :valid, cohort: cohort_2021, school: school_with_cohorts)
-FactoryBot.create(:seed_partnership, :with_lead_provider, :valid, cohort: cohort_2022, school: school_with_cohorts)
+FactoryBot.create(:seed_partnership, :with_lead_provider, :valid, cohort: cohort_previous, school:)
+FactoryBot.create(:seed_partnership, :with_lead_provider, :valid, cohort: cohort_current, school:)
+FactoryBot.create(:seed_partnership, :with_lead_provider, :valid, cohort: cohort_previous, school: school_with_cohorts)
+FactoryBot.create(:seed_partnership, :with_lead_provider, :valid, cohort: cohort_current, school: school_with_cohorts)
 
 Faker::UniqueGenerator.clear
 Faker::Config.random = Random.new(42)

--- a/spec/cypress/app_commands/scenarios/admin/schools.rb
+++ b/spec/cypress/app_commands/scenarios/admin/schools.rb
@@ -8,8 +8,8 @@ coordinator.induction_coordinator_profile.schools.first.destroy!
 coordinator.induction_coordinator_profile.schools = [school]
 
 school_with_cohorts = FactoryBot.create(:school, name: "Cohort School", urn: 900_123)
-cohort_2021 = Cohort.find_or_create_by!(start_year: 2021, registration_start_date: Date.new(2021, 5, 10), academic_year_start_date: Date.new(2021, 12, 1))
-cohort_2022 = Cohort.find_or_create_by!(start_year: 2022, registration_start_date: Date.new(2022, 5, 10), academic_year_start_date: Date.new(2022, 12, 1))
+cohort_2021 = Cohort.find_or_create_by!(start_year: 2021, registration_start_date: Date.new(2021, 5, 10), academic_year_start_date: Date.new(2021, 9, 1))
+cohort_2022 = Cohort.find_or_create_by!(start_year: 2022, registration_start_date: Date.new(2022, 5, 10), academic_year_start_date: Date.new(2022, 9, 1))
 
 cip_1 = FactoryBot.create(:core_induction_programme, name: "CIP Programme 1")
 cip_2 = FactoryBot.create(:core_induction_programme, name: "CIP Programme 2")

--- a/spec/factories/cohorts.rb
+++ b/spec/factories/cohorts.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
   factory :cohort do
     start_year { Faker::Number.unique.between(from: 2022, to: 2100) }
     registration_start_date { Date.new(start_year.to_i, 6, 5) }
-    academic_year_start_date { Date.new(start_year.to_i, 12, 1) }
+    academic_year_start_date { Date.new(start_year.to_i, 9, 1) }
     automatic_assignment_period_end_date { Date.new(start_year.to_i + 1, 3, 31) }
 
     initialize_with do
@@ -16,15 +16,15 @@ FactoryBot.define do
     end
 
     trait :previous do
-      start_year { Date.current.year - (Date.current.month < 12 ? 2 : 1) }
+      start_year { Date.current.year - (Date.current.month < 9 ? 2 : 1) }
     end
 
     trait :current do
-      start_year { Date.current.year - (Date.current.month < 12 ? 1 : 0) }
+      start_year { Date.current.year - (Date.current.month < 9 ? 1 : 0) }
     end
 
     trait :next do
-      start_year { Date.current.year + (Date.current.month < 12 ? 0 : 1) }
+      start_year { Date.current.year + (Date.current.month < 9 ? 0 : 1) }
     end
 
     trait :consecutive_years do

--- a/spec/factories/finance/schedules.rb
+++ b/spec/factories/finance/schedules.rb
@@ -95,11 +95,12 @@ FactoryBot.define do
 
     trait(:with_npq_milestones) do
       after(:create) do |schedule|
+        start_year = schedule.cohort.start_year
         [
-          { name: "Output 1 - Participant Start", start_date: Date.new(2021, 9, 1), payment_date: Date.new(2021, 11, 30), declaration_type: "started" },
-          { name: "Output 2 - Retention Point 1", start_date: Date.new(2021, 11, 1), payment_date: Date.new(2022, 2, 28), declaration_type: "retained-1" },
-          { name: "Output 3 - Retention Point 2", start_date: Date.new(2022, 2, 1), payment_date: Date.new(2022, 5, 31), declaration_type: "retained-2" },
-          { name: "Output 4 - Participant Completion", start_date: Date.new(2023, 2, 1), payment_date: Date.new(2023, 5, 31), declaration_type: "completed" },
+          { name: "Output 1 - Participant Start", start_date: Date.new(start_year, 9, 1), payment_date: Date.new(start_year, 11, 30), declaration_type: "started" },
+          { name: "Output 2 - Retention Point 1", start_date: Date.new(start_year, 11, 1), payment_date: Date.new(start_year + 1, 2, 28), declaration_type: "retained-1" },
+          { name: "Output 3 - Retention Point 2", start_date: Date.new(start_year + 1, 2, 1), payment_date: Date.new(start_year + 1, 5, 31), declaration_type: "retained-2" },
+          { name: "Output 4 - Participant Completion", start_date: Date.new(start_year + 2, 2, 1), payment_date: Date.new(start_year + 2, 5, 31), declaration_type: "completed" },
         ].each do |hash|
           Finance::Milestone.find_or_create_by!(
             schedule:,

--- a/spec/factories/finance/schedules.rb
+++ b/spec/factories/finance/schedules.rb
@@ -9,8 +9,8 @@ FactoryBot.define do
           {
             name: "Output 1 - Participant Start",
             start_date: Date.new(start_year, 9, 1),
-            milestone_date: Date.new(start_year, 12, 30),
-            payment_date: Date.new(start_year, 12, 30),
+            milestone_date: Date.new(start_year, 11, 30),
+            payment_date: Date.new(start_year, 11, 30),
             declaration_type: "started",
           },
           {

--- a/spec/factories/participant_declaration.rb
+++ b/spec/factories/participant_declaration.rb
@@ -33,9 +33,10 @@ FactoryBot.define do
       transient do
         npq_course { create(:npq_course) }
         school_urn {}
+        cohort     { Cohort.current || create(:cohort, :current) }
       end
       cpd_lead_provider   { create(:cpd_lead_provider, :with_npq_lead_provider) }
-      participant_profile { create(:npq_application, :accepted, *profile_traits, npq_lead_provider: cpd_lead_provider.npq_lead_provider, npq_course:, school_urn:).profile }
+      participant_profile { create(:npq_application, :accepted, *profile_traits, npq_lead_provider: cpd_lead_provider.npq_lead_provider, npq_course:, school_urn:, cohort:).profile }
       course_identifier   { participant_profile.npq_course.identifier }
     end
 

--- a/spec/factories/seeds/cohort_factory.rb
+++ b/spec/factories/seeds/cohort_factory.rb
@@ -4,9 +4,9 @@ FactoryBot.define do
   factory(:seed_cohort, class: "Cohort") do
     sequence(:start_year) { Faker::Number.unique.between(from: 2050, to: 3025) }
 
-    registration_start_date { Date.new(start_year, 6, 5) }
+    registration_start_date { Date.new(start_year, 5, 10) }
     academic_year_start_date { Date.new(start_year, 12, 1) }
-    automatic_assignment_period_end_date { Date.new(start_year + 1, 3, 31) }
+    automatic_assignment_period_end_date { Date.new(start_year + 1, 4, 3) }
 
     initialize_with do
       Cohort.find_by(start_year:) || new(**attributes)

--- a/spec/factories/seeds/cohort_factory.rb
+++ b/spec/factories/seeds/cohort_factory.rb
@@ -5,8 +5,8 @@ FactoryBot.define do
     sequence(:start_year) { Faker::Number.unique.between(from: 2050, to: 3025) }
 
     registration_start_date { Date.new(start_year, 5, 10) }
-    academic_year_start_date { Date.new(start_year, 12, 1) }
-    automatic_assignment_period_end_date { Date.new(start_year + 1, 4, 3) }
+    academic_year_start_date { Date.new(start_year, 9, 1) }
+    automatic_assignment_period_end_date { Date.new(start_year + 1, 3, 31) }
 
     initialize_with do
       Cohort.find_by(start_year:) || new(**attributes)

--- a/spec/features/finance/ecf/statement_spec.rb
+++ b/spec/features/finance/ecf/statement_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Show ECF statement", :js do
       end
     end
   end
-  let(:cohort) { Cohort.current || create(:cohort, :current) }
+  let!(:cohort) { Cohort.current || create(:cohort, :current) }
   let(:statement) { create(:ecf_payable_statement, cpd_lead_provider:, cohort:) }
   let(:lead_provider) { cpd_lead_provider.lead_provider }
   let(:schedule) { Finance::Schedule.find_by(schedule_identifier: "ecf-standard-september", cohort:) }
@@ -31,6 +31,8 @@ RSpec.describe "Show ECF statement", :js do
   end
 
   context "Statement authorise for payment" do
+    before { statement.deadline_date + 1.day }
+
     scenario "successfully authorising" do
       given_i_am_logged_in_as_a_finance_user
       and_multiple_declarations_exist

--- a/spec/features/finance/npq/course_payment_breakdown_spec.rb
+++ b/spec/features/finance/npq/course_payment_breakdown_spec.rb
@@ -5,7 +5,8 @@ require "rails_helper"
 RSpec.feature "NPQ Course payment breakdown", type: :feature, js: true do
   include FinanceHelper
 
-  let(:cohort) { Cohort.previous || create(:cohort, :previous) }
+  # This needs to be hardcoded to test targetted funding functionality
+  let(:cohort) { Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021) }
 
   let!(:npq_leadership_schedule) { create(:npq_leadership_schedule, cohort:) }
   let!(:npq_specialist_schedule) { create(:npq_specialist_schedule, cohort:) }

--- a/spec/features/finance/npq/course_payment_breakdown_spec.rb
+++ b/spec/features/finance/npq/course_payment_breakdown_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.feature "NPQ Course payment breakdown", type: :feature, js: true do
   include FinanceHelper
 
-  let(:cohort) { Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021) }
+  let(:cohort) { Cohort.previous || create(:cohort, :previous) }
 
   let!(:npq_leadership_schedule) { create(:npq_leadership_schedule, cohort:) }
   let!(:npq_specialist_schedule) { create(:npq_specialist_schedule, cohort:) }
@@ -22,18 +22,19 @@ RSpec.feature "NPQ Course payment breakdown", type: :feature, js: true do
   let(:npq_course_leading_teaching_development) { create(:npq_course, identifier: "npq-leading-teaching-development", name: "Leading Teaching Development") }
 
   let!(:statement) do
+    timestamp = npq_leadership_schedule.milestones.order(start_date: :asc).first.start_date + 1.day
     create(
       :npq_statement,
-      name: "January 2022",
-      deadline_date: Date.new(2022, 1, 31),
-      payment_date: Date.new(2022, 2, 16),
+      name: "January #{cohort_current.start_year}",
+      deadline_date: timestamp + 1.month,
+      payment_date: timestamp + 1.month,
       cpd_lead_provider:,
       contract_version: npq_leading_teaching_contract.version,
       cohort:,
     )
   end
 
-  let(:cohort_2022) { Cohort.find_by(start_year: 2022) }
+  let(:cohort_current) { Cohort.current }
 
   scenario "See a payment breakdown per NPQ course and a payment breakdown of each individual NPQ courses for each provider" do
     given_i_am_logged_in_as_a_finance_user
@@ -87,7 +88,7 @@ RSpec.feature "NPQ Course payment breakdown", type: :feature, js: true do
     and_the_page_should_be_accessible
   end
 
-  scenario "Duplicate NPQ contract with cohort 2022" do
+  scenario "Duplicate NPQ contract with current cohort" do
     given_i_am_logged_in_as_a_finance_user
     and_those_courses_have_submitted_declarations
     and_a_duplicate_npq_contract_exists
@@ -99,7 +100,7 @@ RSpec.feature "NPQ Course payment breakdown", type: :feature, js: true do
   end
 
   context "Targeted delivery funding" do
-    let(:cohort) { Cohort.find_by(start_year: 2022) || create(:cohort, start_year: 2022) }
+    let(:cohort) { Cohort.current || create(:cohort, :current) }
 
     scenario "See payment breakdown with targeted delivery funding" do
       given_i_am_logged_in_as_a_finance_user
@@ -129,7 +130,7 @@ RSpec.feature "NPQ Course payment breakdown", type: :feature, js: true do
   def and_a_duplicate_npq_contract_exists
     contract1 = statement.npq_lead_provider.npq_contracts.first
     statement.npq_lead_provider.npq_contracts.create!(
-      cohort: cohort_2022,
+      cohort: cohort_current,
       version: contract1.version,
       recruitment_target: contract1.recruitment_target,
       course_identifier: contract1.course_identifier,

--- a/spec/features/finance/npq/course_payment_breakdown_spec.rb
+++ b/spec/features/finance/npq/course_payment_breakdown_spec.rb
@@ -23,12 +23,12 @@ RSpec.feature "NPQ Course payment breakdown", type: :feature, js: true do
   let(:npq_course_leading_teaching_development) { create(:npq_course, identifier: "npq-leading-teaching-development", name: "Leading Teaching Development") }
 
   let!(:statement) do
-    timestamp = npq_leadership_schedule.milestones.order(start_date: :asc).first.start_date + 1.day
+    timestamp = npq_leadership_schedule.milestones.order(start_date: :asc).first.start_date + 1.month
     create(
       :npq_statement,
       name: "January #{cohort_current.start_year}",
-      deadline_date: timestamp + 1.month,
-      payment_date: timestamp + 1.month,
+      deadline_date: timestamp,
+      payment_date: timestamp,
       cpd_lead_provider:,
       contract_version: npq_leading_teaching_contract.version,
       cohort:,

--- a/spec/features/finance/payment_breakdown_spec.rb
+++ b/spec/features/finance/payment_breakdown_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Finance users payment breakdowns", type: :feature, js: true do
   let(:voided_declarations)    { create_list(:ect_participant_declaration, 2, :eligible, :voided, cpd_lead_provider:) }
 
   let!(:january_statement)  { create(:ecf_statement, name: "January #{next_start_year}", deadline_date: Date.new(next_start_year, 1, 31), cpd_lead_provider:, contract_version: contract.version) }
-  let!(:november_statement) { create(:ecf_statement, name: "November #{current_start_year}", deadline_date: Date.new(current_start_year, 12, 30), cpd_lead_provider:, contract_version: contract.version) }
+  let!(:november_statement) { create(:ecf_statement, name: "November #{current_start_year}", deadline_date: Date.new(current_start_year, 11, 30), cpd_lead_provider:, contract_version: contract.version) }
 
   let(:jan_statement_calculator) { Finance::ECF::StatementCalculator.new(statement: january_statement) }
 

--- a/spec/features/scenarios/participants/ect_doing_cip/after_cohort_transfer_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_cip/after_cohort_transfer_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "ECT doing CIP: after cohort transfer", type: :feature do
   let(:teacher_reference_number) { teacher_profile.trn }
   let(:training_record_id) { participant_profile.id }
   let(:participant_full_name) { "ECT doing CIP: after cohort transfer" }
-  let(:school_name) { "School chosen CIP in 2022 and 2023" }
+  let(:school_name) { "School chosen CIP in #{Cohort.current.start_year} and #{start_year}" }
   let(:sit_full_name) { "#{school_name} SIT" }
   let(:lead_provider_name) { "" }
   let(:delivery_partner_name) { "" }
@@ -27,7 +27,7 @@ RSpec.feature "ECT doing CIP: after cohort transfer", type: :feature do
   let(:schedule_identifier) { "ecf-standard-september" }
   let(:cip_material_provider) { "Education Development Trust" }
   let(:cip_materials) { "edt" }
-  let(:start_year) { 2023 }
+  let(:start_year) { Cohort.next.start_year }
   let(:previous_start_year) { start_year - 1 }
   let(:registration_completed) { true }
   let(:participant_status) { "active" }

--- a/spec/features/scenarios/participants/ect_doing_cip/in_training_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_cip/in_training_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "ECT doing CIP: in training", type: :feature do
   let(:teacher_reference_number) { teacher_profile.trn }
   let(:training_record_id) { participant_profile.id }
   let(:participant_full_name) { "ECT doing CIP: in training" }
-  let(:school_name) { "School chosen CIP in 2023" }
+  let(:school_name) { "School chosen CIP in #{start_year}" }
   let(:sit_full_name) { "#{school_name} SIT" }
   let(:lead_provider_name) { "" }
   let(:delivery_partner_name) { "" }
@@ -27,7 +27,7 @@ RSpec.feature "ECT doing CIP: in training", type: :feature do
   let(:schedule_identifier) { "ecf-standard-september" }
   let(:cip_material_provider) { "Education Development Trust" }
   let(:cip_materials) { "edt" }
-  let(:start_year) { 2023 }
+  let(:start_year) { Cohort.next.start_year }
   let(:registration_completed) { true }
   let(:participant_status) { "active" }
   let(:training_status) { "active" }

--- a/spec/features/scenarios/participants/ect_doing_fip/after_cohort_transfer_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_fip/after_cohort_transfer_spec.rb
@@ -13,10 +13,10 @@ RSpec.feature "ECT doing FIP: after cohort transfer", type: :feature do
   let(:teacher_reference_number) { teacher_profile.trn }
   let(:training_record_id) { participant_profile.id }
   let(:participant_full_name) { "ECT doing FIP: after cohort transfer" }
-  let(:school_name) { "School chosen FIP in 2022 and 2023" }
+  let(:school_name) { "School chosen FIP in #{Cohort.current.start_year} and #{start_year}" }
   let(:sit_full_name) { "#{school_name} SIT" }
-  let(:lead_provider_name) { "Lead Provider for FIP in 2022 and 2023" }
-  let(:delivery_partner_name) { "Delivery Partner for FIP in 2022 and 2023" }
+  let(:lead_provider_name) { "Lead Provider for FIP in #{Cohort.current.start_year} and #{start_year}" }
+  let(:delivery_partner_name) { "Delivery Partner for FIP in #{Cohort.current.start_year} and #{start_year}" }
   let(:appropriate_body_name) { "#{school_name} Appropriate Body" }
   let(:participant_type) { "early_career_teacher" }
   let(:long_participant_type) { "Early career teacher" }
@@ -26,7 +26,7 @@ RSpec.feature "ECT doing FIP: after cohort transfer", type: :feature do
   let(:programme_name) { "Full induction programme" }
   let(:schedule_identifier) { "ecf-standard-september" }
   let(:cip_materials) { "none" }
-  let(:start_year) { 2023 }
+  let(:start_year) { Cohort.next.start_year }
   let(:previous_start_year) { start_year - 1 }
   let(:registration_completed) { true }
   let(:participant_status) { "active" }

--- a/spec/features/scenarios/participants/ect_doing_fip/in_training_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_fip/in_training_spec.rb
@@ -13,10 +13,10 @@ RSpec.feature "ECT doing FIP: in training", type: :feature do
   let(:teacher_reference_number) { teacher_profile.trn }
   let(:training_record_id) { participant_profile.id }
   let(:participant_full_name) { "ECT doing FIP: in training" }
-  let(:school_name) { "School chosen FIP in 2023" }
+  let(:school_name) { "School chosen FIP in #{start_year}" }
   let(:sit_full_name) { "#{school_name} SIT" }
-  let(:lead_provider_name) { "Lead Provider for FIP in 2023" }
-  let(:delivery_partner_name) { "Delivery Partner for FIP in 2023" }
+  let(:lead_provider_name) { "Lead Provider for FIP in #{start_year}" }
+  let(:delivery_partner_name) { "Delivery Partner for FIP in #{start_year}" }
   let(:appropriate_body_name) { "#{school_name} Appropriate Body" }
   let(:participant_type) { "early_career_teacher" }
   let(:short_participant_type) { "ect" }
@@ -26,7 +26,7 @@ RSpec.feature "ECT doing FIP: in training", type: :feature do
   let(:programme_name) { "Full induction programme" }
   let(:schedule_identifier) { "ecf-standard-september" }
   let(:cip_materials) { "none" }
-  let(:start_year) { 2023 }
+  let(:start_year) { Cohort.next.start_year }
   let(:registration_completed) { true }
   let(:participant_status) { "active" }
   let(:training_status) { "active" }

--- a/spec/features/scenarios/participants/ect_doing_fip/no_validation_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_fip/no_validation_spec.rb
@@ -13,10 +13,10 @@ RSpec.feature "ECT doing FIP: no validation", type: :feature do
   let(:teacher_reference_number) { teacher_profile.trn }
   let(:training_record_id) { participant_profile.id }
   let(:participant_full_name) { "ECT doing FIP: no validation" }
-  let(:school_name) { "School chosen FIP in 2023" }
+  let(:school_name) { "School chosen FIP in #{start_year}" }
   let(:sit_full_name) { "#{school_name} SIT" }
-  let(:lead_provider_name) { "Lead Provider for FIP in 2023" }
-  let(:delivery_partner_name) { "Delivery Partner for FIP in 2023" }
+  let(:lead_provider_name) { "Lead Provider for FIP in #{start_year}" }
+  let(:delivery_partner_name) { "Delivery Partner for FIP in #{start_year}" }
   let(:appropriate_body_name) { "#{school_name} Appropriate Body" }
   let(:participant_type) { "early_career_teacher" }
   let(:short_participant_type) { "ect" }
@@ -26,7 +26,7 @@ RSpec.feature "ECT doing FIP: no validation", type: :feature do
   let(:programme_name) { "Full induction programme" }
   let(:schedule_identifier) { "ecf-standard-september" }
   let(:cip_materials) { "none" }
-  let(:start_year) { 2023 }
+  let(:start_year) { Cohort.next.start_year }
   let(:registration_completed) { true }
   let(:participant_status) { "active" }
   let(:training_status) { "active" }

--- a/spec/features/schools/participant_dashboard/manage_fip_partnered_participants_spec.rb
+++ b/spec/features/schools/participant_dashboard/manage_fip_partnered_participants_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "Manage FIP partnered participants with change of circumstances",
     end
   end
 
-  scenario "withdrawn partnership shouldn't cause an error", travel_to: Date.new(2021, 12, 1) do
+  scenario "withdrawn partnership shouldn't cause an error", travel_to: Date.new(2021, 11, 1) do
     expect {
       given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered_but_challenged
       and_i_have_added_an_ect

--- a/spec/features/schools/participant_dashboard/manage_fip_partnered_participants_spec.rb
+++ b/spec/features/schools/participant_dashboard/manage_fip_partnered_participants_spec.rb
@@ -69,15 +69,17 @@ RSpec.describe "Manage FIP partnered participants with change of circumstances",
     end
   end
 
-  scenario "withdrawn partnership shouldn't cause an error", travel_to: Date.new(2021, 11, 1) do
+  scenario "withdrawn partnership shouldn't cause an error" do
     expect {
       given_there_is_a_school_that_has_chosen_fip_for_previous_cohort_and_partnered_but_challenged
       and_i_have_added_an_ect
       and_an_ect_has_been_withdrawn_by_the_provider
-      and_i_am_signed_in_as_an_induction_coordinator
-      then_i_can_view_the_fip_induction_dashboard_without_partnership_details(displayed_value: "")
+      travel_to Date.new(Cohort.previous.start_year, 11, 1) do
+        and_i_am_signed_in_as_an_induction_coordinator
+        then_i_can_view_the_fip_induction_dashboard_without_partnership_details(displayed_value: "")
 
-      when_i_navigate_to_participants_dashboard
+        when_i_navigate_to_participants_dashboard
+      end
     }.not_to raise_error
   end
 end

--- a/spec/features/schools/participant_dashboard/manage_fip_partnered_participants_spec.rb
+++ b/spec/features/schools/participant_dashboard/manage_fip_partnered_participants_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Manage FIP partnered participants with change of circumstances",
 
   context "transferring participants" do
     before do
-      given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
+      given_there_is_a_school_that_has_chosen_fip_for_previous_cohort_and_partnered
       and_i_am_signed_in_as_an_induction_coordinator
     end
 
@@ -71,7 +71,7 @@ RSpec.describe "Manage FIP partnered participants with change of circumstances",
 
   scenario "withdrawn partnership shouldn't cause an error", travel_to: Date.new(2021, 11, 1) do
     expect {
-      given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered_but_challenged
+      given_there_is_a_school_that_has_chosen_fip_for_previous_cohort_and_partnered_but_challenged
       and_i_have_added_an_ect
       and_an_ect_has_been_withdrawn_by_the_provider
       and_i_am_signed_in_as_an_induction_coordinator

--- a/spec/features/schools/participants/add_participants/add_ect_as_mentor_spec.rb
+++ b/spec/features/schools/participants/add_participants/add_ect_as_mentor_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "Add ECT as mentor", js: true do
       when_i_click_on_continue
       then_i_am_taken_to_mentor_start_training_page
 
-      when_i_choose_summer_term_next_cohort
+      when_i_choose_summer_term_this_cohort
       when_i_click_on_continue
       then_i_am_taken_to_choose_mentor_partnership_page
 

--- a/spec/features/schools/participants/add_participants/add_ect_as_mentor_spec.rb
+++ b/spec/features/schools/participants/add_participants/add_ect_as_mentor_spec.rb
@@ -19,45 +19,47 @@ RSpec.describe "Add ECT as mentor", js: true do
   end
 
   scenario "Induction tutor tries to add an ECT that's a mentor in another school" do
-    when_i_navigate_to_participants_dashboard
-    when_i_click_to_add_a_new_ect_or_mentor
-    then_i_should_be_on_the_who_to_add_page
+    outside_auto_assignment_window do
+      when_i_navigate_to_participants_dashboard
+      when_i_click_to_add_a_new_ect_or_mentor
+      then_i_should_be_on_the_who_to_add_page
 
-    when_i_select_to_add_a "Mentor"
-    when_i_click_on_continue
-    then_i_am_taken_to_the_what_we_need_to_know_about_this_mentor_page
+      when_i_select_to_add_a "Mentor"
+      when_i_click_on_continue
+      then_i_am_taken_to_the_what_we_need_to_know_about_this_mentor_page
 
-    when_i_click_on_continue
-    then_i_am_taken_to_add_mentor_full_name_page
+      when_i_click_on_continue
+      then_i_am_taken_to_add_mentor_full_name_page
 
-    when_i_add_mentor_name
-    when_i_click_on_continue
-    then_i_am_taken_to_add_teachers_trn_page
+      when_i_add_mentor_name
+      when_i_click_on_continue
+      then_i_am_taken_to_add_teachers_trn_page
 
-    when_i_add_the_trn
-    when_i_click_on_continue
-    then_i_am_taken_to_add_date_of_birth_page
+      when_i_add_the_trn
+      when_i_click_on_continue
+      then_i_am_taken_to_add_date_of_birth_page
 
-    when_i_add_a_date_of_birth
-    when_i_click_on_continue
-    then_i_am_taken_to_add_ect_or_mentor_email_page
+      when_i_add_a_date_of_birth
+      when_i_click_on_continue
+      then_i_am_taken_to_add_ect_or_mentor_email_page
 
-    when_i_add_ect_or_mentor_email
-    when_i_click_on_continue
-    then_i_am_taken_to_mentor_start_training_page
+      when_i_add_ect_or_mentor_email
+      when_i_click_on_continue
+      then_i_am_taken_to_mentor_start_training_page
 
-    when_i_choose_summer_term_2023
-    when_i_click_on_continue
-    then_i_am_taken_to_choose_mentor_partnership_page
+      when_i_choose_summer_term_next_cohort
+      when_i_click_on_continue
+      then_i_am_taken_to_choose_mentor_partnership_page
 
-    when_i_choose_current_providers
-    and_i_click_on_continue
-    then_i_am_taken_to_check_answers_page
+      when_i_choose_current_providers
+      and_i_click_on_continue
+      then_i_am_taken_to_check_answers_page
 
-    when_i_click_confirm_and_add
-    then_i_am_taken_to_mentor_added_confirmation_page
+      when_i_click_confirm_and_add
+      then_i_am_taken_to_mentor_added_confirmation_page
 
-    click_on "View your ECTs and mentors"
-    then_i_see_the_mentor_name
+      click_on "View your ECTs and mentors"
+      then_i_see_the_mentor_name
+    end
   end
 end

--- a/spec/features/schools/participants/add_participants/add_previously_withdrawn_mentor_spec.rb
+++ b/spec/features/schools/participants/add_participants/add_previously_withdrawn_mentor_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe "Adding previously withdrawn Mentor", type: :feature, js: true do
         and_i_fill_in_all_info
         then_i_am_taken_to_mentor_start_training_page
 
-        when_i_choose_summer_term_next_cohort
+        when_i_choose_summer_term_this_cohort
         when_i_click_on_continue
         then_i_am_taken_to_choose_mentor_partnership_page
 
@@ -107,7 +107,7 @@ RSpec.describe "Adding previously withdrawn Mentor", type: :feature, js: true do
         and_i_fill_in_all_info
         then_i_am_taken_to_mentor_start_training_page
 
-        when_i_choose_summer_term_next_cohort
+        when_i_choose_summer_term_this_cohort
         when_i_click_on_continue
         then_i_am_taken_to_choose_mentor_partnership_page
 
@@ -141,7 +141,7 @@ RSpec.describe "Adding previously withdrawn Mentor", type: :feature, js: true do
         and_i_fill_in_all_info(email: new_email)
         then_i_am_taken_to_mentor_start_training_page
 
-        when_i_choose_summer_term_next_cohort
+        when_i_choose_summer_term_this_cohort
         when_i_click_on_continue
         then_i_am_taken_to_choose_mentor_partnership_page
 
@@ -173,7 +173,7 @@ RSpec.describe "Adding previously withdrawn Mentor", type: :feature, js: true do
         and_i_fill_in_all_info
         then_i_am_taken_to_mentor_start_training_page
 
-        when_i_choose_summer_term_next_cohort
+        when_i_choose_summer_term_this_cohort
         when_i_click_on_continue
         then_i_am_taken_to_choose_mentor_partnership_page
 
@@ -304,8 +304,8 @@ private
     expect(page).to have_selector("h1", text: "When will George Mentor start their mentor training?")
   end
 
-  def when_i_choose_summer_term_next_cohort
-    choose "Summer term #{Cohort.next.start_year}"
+  def when_i_choose_summer_term_this_cohort
+    choose "Summer term #{Cohort.current.start_year + 1}"
   end
 
   def then_i_am_taken_to_the_confirm_appropriate_body_page

--- a/spec/features/schools/participants/add_participants/add_previously_withdrawn_mentor_spec.rb
+++ b/spec/features/schools/participants/add_participants/add_previously_withdrawn_mentor_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 RSpec.describe "Adding previously withdrawn Mentor", type: :feature, js: true do
-  let(:previous_cohort) { create(:cohort, start_year: 2021) }
-  let!(:cohort) { Cohort.current || create(:cohort, start_year: 2022) }
+  let(:previous_cohort) { create(:cohort, :previous) }
+  let!(:cohort) { Cohort.current || create(:cohort, :current) }
   let!(:school) { create(:school, name: "Fip School") }
   let!(:appropriate_body) { create :appropriate_body_national_organisation }
   let!(:previous_school_cohort) do
@@ -59,30 +59,32 @@ RSpec.describe "Adding previously withdrawn Mentor", type: :feature, js: true do
     participant_profile = add_and_remove_participant_from_school_cohort(previous_school_cohort)
     the_participant_profile_is_set_up_as_withdrawn_correctly(participant_profile, previous_school_cohort)
 
-    expect {
-      sign_in
+    outside_auto_assignment_window do
+      expect {
+        sign_in
 
-      when_i_go_to_add_new_ect_or_mentor_page
-      and_i_go_through_the_who_do_you_want_to_add_page
-      and_i_go_through_the_what_we_need_from_you_page
+        when_i_go_to_add_new_ect_or_mentor_page
+        and_i_go_through_the_who_do_you_want_to_add_page
+        and_i_go_through_the_what_we_need_from_you_page
 
-      and_i_fill_in_all_info
-      then_i_am_taken_to_mentor_start_training_page
+        and_i_fill_in_all_info
+        then_i_am_taken_to_mentor_start_training_page
 
-      when_i_choose_summer_term_2023
-      when_i_click_on_continue
-      then_i_am_taken_to_choose_mentor_partnership_page
+        when_i_choose_summer_term_next_cohort
+        when_i_click_on_continue
+        then_i_am_taken_to_choose_mentor_partnership_page
 
-      when_i_choose_current_providers
-      when_i_click_on_continue
-      then_i_am_taken_to_the_confirmation_page
-      and_i_see_the_correct_details(joint_provider_details: true)
+        when_i_choose_current_providers
+        when_i_click_on_continue
+        then_i_am_taken_to_the_confirmation_page
+        and_i_see_the_correct_details(joint_provider_details: true)
 
-      when_i_check_the_mentor_details
-      and_i_see_the_correct_details
+        when_i_check_the_mentor_details
+        and_i_see_the_correct_details
 
-      and_the_participant_profile_is_set_up_correctly(participant_profile)
-    }.to_not change { ParticipantProfile.count }
+        and_the_participant_profile_is_set_up_correctly(participant_profile)
+      }.to_not change { ParticipantProfile.count }
+    end
   end
 
   scenario "Adding a Mentor without validation data back to the school it was withdrawn from" do
@@ -94,92 +96,98 @@ RSpec.describe "Adding previously withdrawn Mentor", type: :feature, js: true do
       expected_trn: nil,
     )
 
-    expect {
-      sign_in
+    outside_auto_assignment_window do
+      expect {
+        sign_in
 
-      when_i_go_to_add_new_ect_or_mentor_page
-      and_i_go_through_the_who_do_you_want_to_add_page
-      and_i_go_through_the_what_we_need_from_you_page
+        when_i_go_to_add_new_ect_or_mentor_page
+        and_i_go_through_the_who_do_you_want_to_add_page
+        and_i_go_through_the_what_we_need_from_you_page
 
-      and_i_fill_in_all_info
-      then_i_am_taken_to_mentor_start_training_page
+        and_i_fill_in_all_info
+        then_i_am_taken_to_mentor_start_training_page
 
-      when_i_choose_summer_term_2023
-      when_i_click_on_continue
-      then_i_am_taken_to_choose_mentor_partnership_page
+        when_i_choose_summer_term_next_cohort
+        when_i_click_on_continue
+        then_i_am_taken_to_choose_mentor_partnership_page
 
-      when_i_choose_current_providers
-      when_i_click_on_continue
-      then_i_am_taken_to_the_confirmation_page
-      and_i_see_the_correct_details(joint_provider_details: true)
+        when_i_choose_current_providers
+        when_i_click_on_continue
+        then_i_am_taken_to_the_confirmation_page
+        and_i_see_the_correct_details(joint_provider_details: true)
 
-      when_i_check_the_mentor_details
-      and_i_see_the_correct_details
+        when_i_check_the_mentor_details
+        and_i_see_the_correct_details
 
-      and_the_participant_profile_is_set_up_correctly(participant_profile)
-    }.to_not change { ParticipantProfile.count }
+        and_the_participant_profile_is_set_up_correctly(participant_profile)
+      }.to_not change { ParticipantProfile.count }
+    end
   end
 
   scenario "Adding a Mentor back to the school it was withdrawn from with a different email" do
     participant_profile = add_and_remove_participant_from_school_cohort(previous_school_cohort)
     the_participant_profile_is_set_up_as_withdrawn_correctly(participant_profile, previous_school_cohort)
 
-    expect {
-      new_email = "another_#{ect_email}"
+    outside_auto_assignment_window do
+      expect {
+        new_email = "another_#{ect_email}"
 
-      sign_in
+        sign_in
 
-      when_i_go_to_add_new_ect_or_mentor_page
-      and_i_go_through_the_who_do_you_want_to_add_page
-      and_i_go_through_the_what_we_need_from_you_page
+        when_i_go_to_add_new_ect_or_mentor_page
+        and_i_go_through_the_who_do_you_want_to_add_page
+        and_i_go_through_the_what_we_need_from_you_page
 
-      and_i_fill_in_all_info(email: new_email)
-      then_i_am_taken_to_mentor_start_training_page
+        and_i_fill_in_all_info(email: new_email)
+        then_i_am_taken_to_mentor_start_training_page
 
-      when_i_choose_summer_term_2023
-      when_i_click_on_continue
-      then_i_am_taken_to_choose_mentor_partnership_page
+        when_i_choose_summer_term_next_cohort
+        when_i_click_on_continue
+        then_i_am_taken_to_choose_mentor_partnership_page
 
-      when_i_choose_current_providers
-      when_i_click_on_continue
-      then_i_am_taken_to_the_confirmation_page
-      and_i_see_the_correct_details(joint_provider_details: true, expected_email: new_email)
+        when_i_choose_current_providers
+        when_i_click_on_continue
+        then_i_am_taken_to_the_confirmation_page
+        and_i_see_the_correct_details(joint_provider_details: true, expected_email: new_email)
 
-      when_i_check_the_mentor_details
-      and_i_see_the_correct_details(expected_email: new_email)
+        when_i_check_the_mentor_details
+        and_i_see_the_correct_details(expected_email: new_email)
 
-      and_the_participant_profile_is_set_up_correctly(participant_profile)
-    }.to_not change { ParticipantProfile.count }
+        and_the_participant_profile_is_set_up_correctly(participant_profile)
+      }.to_not change { ParticipantProfile.count }
+    end
   end
 
   scenario "Adding a Mentor to a school different to the one it was withdrawn from" do
     participant_profile = add_and_remove_participant_from_school_cohort(previous_school_cohort_different_school)
     the_participant_profile_is_set_up_as_withdrawn_correctly(participant_profile, previous_school_cohort_different_school)
 
-    expect {
-      sign_in
+    outside_auto_assignment_window do
+      expect {
+        sign_in
 
-      when_i_go_to_add_new_ect_or_mentor_page
-      and_i_go_through_the_who_do_you_want_to_add_page
-      and_i_go_through_the_what_we_need_from_you_page
+        when_i_go_to_add_new_ect_or_mentor_page
+        and_i_go_through_the_who_do_you_want_to_add_page
+        and_i_go_through_the_what_we_need_from_you_page
 
-      and_i_fill_in_all_info
-      then_i_am_taken_to_mentor_start_training_page
+        and_i_fill_in_all_info
+        then_i_am_taken_to_mentor_start_training_page
 
-      when_i_choose_summer_term_2023
-      when_i_click_on_continue
-      then_i_am_taken_to_choose_mentor_partnership_page
+        when_i_choose_summer_term_next_cohort
+        when_i_click_on_continue
+        then_i_am_taken_to_choose_mentor_partnership_page
 
-      when_i_choose_current_providers
-      when_i_click_on_continue
-      then_i_am_taken_to_the_confirmation_page
-      and_i_see_the_correct_details(joint_provider_details: true)
+        when_i_choose_current_providers
+        when_i_click_on_continue
+        then_i_am_taken_to_the_confirmation_page
+        and_i_see_the_correct_details(joint_provider_details: true)
 
-      when_i_check_the_mentor_details
-      and_i_see_the_correct_details
+        when_i_check_the_mentor_details
+        and_i_see_the_correct_details
 
-      and_the_participant_profile_is_set_up_correctly(participant_profile)
-    }.to_not change { ParticipantProfile.count }
+        and_the_participant_profile_is_set_up_correctly(participant_profile)
+      }.to_not change { ParticipantProfile.count }
+    end
   end
 
 private
@@ -296,8 +304,8 @@ private
     expect(page).to have_selector("h1", text: "When will George Mentor start their mentor training?")
   end
 
-  def when_i_choose_summer_term_2023
-    choose "Summer term 2023"
+  def when_i_choose_summer_term_next_cohort
+    choose "Summer term #{Cohort.next.start_year}"
   end
 
   def then_i_am_taken_to_the_confirm_appropriate_body_page

--- a/spec/features/schools/participants/add_participants/reporting_participants_with_trn_spec.rb
+++ b/spec/features/schools/participants/add_participants/reporting_participants_with_trn_spec.rb
@@ -13,8 +13,8 @@ end
 require "rails_helper"
 
 RSpec.describe "Reporting participants with a known TRN", type: :feature, js: true do
-  let!(:cohort) { Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021) }
-  let!(:next_cohort) { Cohort.find_by(start_year: 2022) || create(:cohort, start_year: 2022) }
+  let!(:cohort) { Cohort.previous || create(:cohort, :previous) }
+  let!(:next_cohort) { Cohort.current || create(:cohort, :current) }
   let!(:current_cohort) { Cohort.current || create(:cohort, :current) }
 
   let!(:privacy_policy) do
@@ -30,7 +30,7 @@ RSpec.describe "Reporting participants with a known TRN", type: :feature, js: tr
       date_of_birth: Date.new(1998, 3, 22),
       email: "sally@school.com",
       nino: "",
-      start_date: Date.new(2022, 9, 1),
+      start_date: Date.new(Cohort.current.start_year, 9, 1),
     }
   end
 

--- a/spec/features/schools/participants/add_participants/sit_add_ect_spec.rb
+++ b/spec/features/schools/participants/add_participants/sit_add_ect_spec.rb
@@ -52,53 +52,55 @@ RSpec.describe "SIT adding themself as ECT", js: true do
   end
 
   scenario "SIT chooses to add themself as Mentor instead" do
-    when_i_navigate_to_participants_dashboard
-    when_i_click_to_add_a_new_ect_or_mentor
-    then_i_should_be_on_the_who_to_add_page
+    outside_auto_assignment_window do
+      when_i_navigate_to_participants_dashboard
+      when_i_click_to_add_a_new_ect_or_mentor
+      then_i_should_be_on_the_who_to_add_page
 
-    when_i_select_to_add_a "ECT"
-    when_i_click_on_continue
+      when_i_select_to_add_a "ECT"
+      when_i_click_on_continue
 
-    then_i_am_taken_to_the_what_we_need_from_you_page
+      then_i_am_taken_to_the_what_we_need_from_you_page
 
-    when_i_click_on_continue
-    then_i_am_taken_to_add_ect_name_page
+      when_i_click_on_continue
+      then_i_am_taken_to_add_ect_name_page
 
-    when_i_add_ect_name
-    when_i_click_on_continue
-    then_i_am_taken_to_add_teachers_trn_page
+      when_i_add_ect_name
+      when_i_click_on_continue
+      then_i_am_taken_to_add_teachers_trn_page
 
-    when_i_add_the_trn
-    when_i_click_on_continue
-    then_i_am_taken_to_add_date_of_birth_page
+      when_i_add_the_trn
+      when_i_click_on_continue
+      then_i_am_taken_to_add_date_of_birth_page
 
-    when_i_add_a_date_of_birth
-    when_i_click_on_continue
-    then_i_am_taken_to_add_ect_or_mentor_email_page
+      when_i_add_a_date_of_birth
+      when_i_click_on_continue
+      then_i_am_taken_to_add_ect_or_mentor_email_page
 
-    when_i_add_sits_email
-    when_i_click_on_continue
-    then_i_am_taken_to_you_cant_add_yourself_as_ect_page
+      when_i_add_sits_email
+      when_i_click_on_continue
+      then_i_am_taken_to_you_cant_add_yourself_as_ect_page
 
-    when_i_choose_to_add_myself_as_mentor
-    and_i_click_on_continue
-    then_i_am_taken_to_add_yourself_as_mentor_confirmation_page
+      when_i_choose_to_add_myself_as_mentor
+      and_i_click_on_continue
+      then_i_am_taken_to_add_yourself_as_mentor_confirmation_page
 
-    when_i_click_on_confirm
-    then_i_am_taken_to_sit_mentor_start_training_page
+      when_i_click_on_confirm
+      then_i_am_taken_to_sit_mentor_start_training_page
 
-    when_i_choose_summer_term_2023
-    and_i_click_on_continue
-    then_i_am_taken_to_choose_sit_partnership_page
+      when_i_choose_summer_term_next_cohort
+      and_i_click_on_continue
+      then_i_am_taken_to_choose_sit_partnership_page
 
-    when_i_choose_current_providers
-    and_i_click_on_continue
-    then_i_am_taken_to_check_answers_page
+      when_i_choose_current_providers
+      and_i_click_on_continue
+      then_i_am_taken_to_check_answers_page
 
-    when_i_click_confirm_and_add
-    then_i_am_taken_to_yourself_as_mentor_confirmation_page
+      when_i_click_confirm_and_add
+      then_i_am_taken_to_yourself_as_mentor_confirmation_page
 
-    when_i_click_on_view_ects_and_mentors
-    then_i_see_the_sit_name
+      when_i_click_on_view_ects_and_mentors
+      then_i_see_the_sit_name
+    end
   end
 end

--- a/spec/features/schools/participants/add_participants/sit_add_ect_spec.rb
+++ b/spec/features/schools/participants/add_participants/sit_add_ect_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "SIT adding themself as ECT", js: true do
       when_i_click_on_confirm
       then_i_am_taken_to_sit_mentor_start_training_page
 
-      when_i_choose_summer_term_next_cohort
+      when_i_choose_summer_term_this_cohort
       and_i_click_on_continue
       then_i_am_taken_to_choose_sit_partnership_page
 

--- a/spec/features/schools/participants/add_participants/sit_add_mentor_spec.rb
+++ b/spec/features/schools/participants/add_participants/sit_add_mentor_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "SIT adding mentor", js: true do
       when_i_click_on_confirm
       then_i_am_taken_to_sit_mentor_start_training_page
 
-      when_i_choose_summer_term_next_cohort
+      when_i_choose_summer_term_this_cohort
       and_i_click_on_continue
       then_i_am_taken_to_choose_sit_partnership_page
 
@@ -155,7 +155,7 @@ RSpec.describe "SIT adding mentor", js: true do
       and_i_click_on_continue
       then_i_am_taken_to_mentor_start_training_page
 
-      when_i_choose_summer_term_next_cohort
+      when_i_choose_summer_term_this_cohort
       and_i_click_on_continue
       then_i_am_taken_to_choose_mentor_partnership_page
 

--- a/spec/features/schools/participants/add_participants/sit_add_mentor_spec.rb
+++ b/spec/features/schools/participants/add_participants/sit_add_mentor_spec.rb
@@ -7,60 +7,64 @@ RSpec.describe "SIT adding mentor", js: true do
   include ManageTrainingSteps
 
   before do
-    given_there_is_a_school_that_has_chosen_cip
-    given_there_is_a_school_that_has_chosen_fip_and_partnered
-    set_participant_data
-    set_dqt_validation_result
+    outside_auto_assignment_window do
+      given_there_is_a_school_that_has_chosen_cip
+      given_there_is_a_school_that_has_chosen_fip_and_partnered
+      set_participant_data
+      set_dqt_validation_result
+    end
   end
 
   scenario "Induction tutor adds themself as mentor using their own email address" do
-    when_i_am_signed_in_as_an_induction_coordinator
-    and_i_click_on(Cohort.current.description)
-    then_i_am_taken_to_fip_induction_dashboard
+    outside_auto_assignment_window do
+      when_i_am_signed_in_as_an_induction_coordinator
+      and_i_click_on(Cohort.current.description)
+      then_i_am_taken_to_fip_induction_dashboard
 
-    when_i_navigate_to_participants_dashboard
-    when_i_click_to_add_a_new_ect_or_mentor
-    then_i_should_be_on_the_who_to_add_page
+      when_i_navigate_to_participants_dashboard
+      when_i_click_to_add_a_new_ect_or_mentor
+      then_i_should_be_on_the_who_to_add_page
 
-    when_i_select_to_add_a "Mentor"
-    and_i_click_on_continue
-    then_i_am_taken_to_the_what_we_need_from_mentor_page
+      when_i_select_to_add_a "Mentor"
+      and_i_click_on_continue
+      then_i_am_taken_to_the_what_we_need_from_mentor_page
 
-    when_i_click_on_continue
-    then_i_am_taken_to_add_mentor_full_name_page
+      when_i_click_on_continue
+      then_i_am_taken_to_add_mentor_full_name_page
 
-    when_i_add_mentor_name
-    and_i_click_on_continue
-    then_i_am_taken_to_add_teachers_trn_page
+      when_i_add_mentor_name
+      and_i_click_on_continue
+      then_i_am_taken_to_add_teachers_trn_page
 
-    when_i_add_the_trn
-    and_i_click_on_continue
-    then_i_am_taken_to_add_date_of_birth_page
+      when_i_add_the_trn
+      and_i_click_on_continue
+      then_i_am_taken_to_add_date_of_birth_page
 
-    when_i_add_a_date_of_birth
-    and_i_click_on_continue
-    then_i_am_taken_to_add_ect_or_mentor_email_page
+      when_i_add_a_date_of_birth
+      and_i_click_on_continue
+      then_i_am_taken_to_add_ect_or_mentor_email_page
 
-    when_i_add_sits_email
-    and_i_click_on_continue
-    then_i_am_taken_to_are_you_sure_page
+      when_i_add_sits_email
+      and_i_click_on_continue
+      then_i_am_taken_to_are_you_sure_page
 
-    when_i_click_on_confirm
-    then_i_am_taken_to_sit_mentor_start_training_page
+      when_i_click_on_confirm
+      then_i_am_taken_to_sit_mentor_start_training_page
 
-    when_i_choose_summer_term_2023
-    and_i_click_on_continue
-    then_i_am_taken_to_choose_sit_partnership_page
+      when_i_choose_summer_term_next_cohort
+      and_i_click_on_continue
+      then_i_am_taken_to_choose_sit_partnership_page
 
-    when_i_choose_current_providers
-    and_i_click_on_continue
-    then_i_am_taken_to_check_answers_page
+      when_i_choose_current_providers
+      and_i_click_on_continue
+      then_i_am_taken_to_check_answers_page
 
-    when_i_click_confirm_and_add
-    then_i_am_taken_to_sit_mentor_added_confirmation_page
+      when_i_click_confirm_and_add
+      then_i_am_taken_to_sit_mentor_added_confirmation_page
 
-    when_i_click_on "View your ECTs and mentors"
-    then_i_see_the_sit_name
+      when_i_click_on "View your ECTs and mentors"
+      then_i_see_the_sit_name
+    end
   end
 
   scenario "Induction tutor adds themself as mentor using their own email address when email and TRN belongs to an existing mentor" do
@@ -117,51 +121,53 @@ RSpec.describe "SIT adding mentor", js: true do
   end
 
   scenario "Induction tutor adds a new mentor to current providers" do
-    given_there_is_a_sit
+    outside_auto_assignment_window do
+      given_there_is_a_sit
 
-    when_i_sign_in_as_sit
-    and_i_click_on(Cohort.current.description)
-    then_i_am_taken_to_fip_induction_dashboard
+      when_i_sign_in_as_sit
+      and_i_click_on(Cohort.current.description)
+      then_i_am_taken_to_fip_induction_dashboard
 
-    when_i_navigate_to_participants_dashboard
-    and_i_click_to_add_a_new_ect_or_mentor
-    then_i_should_be_on_the_who_to_add_page
+      when_i_navigate_to_participants_dashboard
+      and_i_click_to_add_a_new_ect_or_mentor
+      then_i_should_be_on_the_who_to_add_page
 
-    when_i_select_to_add_a "Mentor"
-    and_i_click_on_continue
-    then_i_am_taken_to_the_what_we_need_from_mentor_page
+      when_i_select_to_add_a "Mentor"
+      and_i_click_on_continue
+      then_i_am_taken_to_the_what_we_need_from_mentor_page
 
-    when_i_click_on_continue
-    then_i_am_taken_to_add_mentor_full_name_page
+      when_i_click_on_continue
+      then_i_am_taken_to_add_mentor_full_name_page
 
-    when_i_add_mentor_name
-    and_i_click_on_continue
-    then_i_am_taken_to_add_teachers_trn_page
+      when_i_add_mentor_name
+      and_i_click_on_continue
+      then_i_am_taken_to_add_teachers_trn_page
 
-    when_i_add_the_trn
-    and_i_click_on_continue
-    then_i_am_taken_to_add_date_of_birth_page
+      when_i_add_the_trn
+      and_i_click_on_continue
+      then_i_am_taken_to_add_date_of_birth_page
 
-    when_i_add_a_date_of_birth
-    and_i_click_on_continue
-    then_i_am_taken_to_add_ect_or_mentor_email_page
+      when_i_add_a_date_of_birth
+      and_i_click_on_continue
+      then_i_am_taken_to_add_ect_or_mentor_email_page
 
-    when_i_add_ect_or_mentor_email
-    and_i_click_on_continue
-    then_i_am_taken_to_mentor_start_training_page
+      when_i_add_ect_or_mentor_email
+      and_i_click_on_continue
+      then_i_am_taken_to_mentor_start_training_page
 
-    when_i_choose_summer_term_2023
-    and_i_click_on_continue
-    then_i_am_taken_to_choose_mentor_partnership_page
+      when_i_choose_summer_term_next_cohort
+      and_i_click_on_continue
+      then_i_am_taken_to_choose_mentor_partnership_page
 
-    when_i_choose_current_providers
-    and_i_click_on_continue
-    then_i_am_taken_to_check_answers_page
+      when_i_choose_current_providers
+      and_i_click_on_continue
+      then_i_am_taken_to_check_answers_page
 
-    when_i_click_confirm_and_add
-    then_i_am_taken_to_mentor_added_confirmation_page
+      when_i_click_confirm_and_add
+      then_i_am_taken_to_mentor_added_confirmation_page
 
-    when_i_click_on "View your ECTs and mentors"
-    then_i_see_the_mentor_name
+      when_i_click_on "View your ECTs and mentors"
+      then_i_see_the_mentor_name
+    end
   end
 end

--- a/spec/features/schools/participants/add_participants/sit_adding_self_as_mentor/unhappy_path_sit_adds_themselves_as_mentor.rb
+++ b/spec/features/schools/participants/add_participants/sit_adding_self_as_mentor/unhappy_path_sit_adds_themselves_as_mentor.rb
@@ -7,7 +7,7 @@ RSpec.describe "Add participants", js: true do
   include ManageTrainingSteps
 
   before do
-    given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
+    given_there_is_a_school_that_has_chosen_fip_for_previous_cohort_and_partnered
     set_sit_data
     and_i_am_signed_in_as_an_induction_coordinator
     and_i_have_added_an_ect

--- a/spec/features/schools/participants/transfer_out/ppt_transferred_in_and_transferred_out_spec.rb
+++ b/spec/features/schools/participants/transfer_out/ppt_transferred_in_and_transferred_out_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "old and new SIT transferring the same participant", type: :feature, js: true, rutabaga: false, travel_to: Time.zone.local(2021, 12, 21) do
+RSpec.describe "old and new SIT transferring the same participant", type: :feature, js: true, rutabaga: false, travel_to: Time.zone.local(2021, 10, 21) do
   context "Transfer out an ECT that has already been transferred in" do
     before do
       set_participant_data
@@ -83,7 +83,7 @@ RSpec.describe "old and new SIT transferring the same participant", type: :featu
     def when_i_add_a_valid_end_date
       legend = "When is #{@participant_data[:full_name]} leaving your school?"
 
-      fill_in_date(legend, with: "2022-12-24")
+      fill_in_date(legend, with: "2022-10-24")
     end
 
     def when_i_select(option)
@@ -179,7 +179,7 @@ RSpec.describe "old and new SIT transferring the same participant", type: :featu
         trn: "1001000",
         full_name: "Sally Teacher",
         start_date: Time.zone.today.prev_month,
-        end_date: Date.new(2022, 12, 24),
+        end_date: Date.new(2022, 10, 24),
         email: "sally-teacher@example.com",
       }
     end

--- a/spec/features/schools/participants/transfer_out/transfer_out_only_spec.rb
+++ b/spec/features/schools/participants/transfer_out/transfer_out_only_spec.rb
@@ -6,7 +6,7 @@ Dir.glob(Rails.root.join("db/new_seeds/scenarios/**/*.rb")).each do |scenario|
   require scenario
 end
 
-RSpec.describe "transfer out participants", type: :feature, js: true, rutabaga: false, travel_to: Time.zone.local(2022, 12, 21) do
+RSpec.describe "transfer out participants", type: :feature, js: true, rutabaga: false, travel_to: Time.zone.local(2022, 10, 21) do
   context "Transfer out an ECT" do
     before do
       allow_participant_transfer_mailers
@@ -74,13 +74,13 @@ RSpec.describe "transfer out participants", type: :feature, js: true, rutabaga: 
     def when_i_add_an_invalid_date
       legend = "When is #{@ect.full_name} leaving your school?"
 
-      fill_in_date(legend, with: "23-12-24")
+      fill_in_date(legend, with: "23-10-24")
     end
 
     def when_i_add_a_valid_end_date
       legend = "When is #{@ect.full_name} leaving your school?"
 
-      fill_in_date(legend, with: "2022-12-24")
+      fill_in_date(legend, with: "2022-10-24")
     end
 
     def when_i_select(option)
@@ -106,7 +106,7 @@ RSpec.describe "transfer out participants", type: :feature, js: true, rutabaga: 
     def then_i_should_be_on_the_check_your_answers_page
       expect(page).to have_selector("h1", text: "Check your answers")
       expect(page).to have_selector("dd", text: @ect.full_name)
-      expect(page).to have_selector("dd", text: Date.new(2022, 12, 24).to_fs(:govuk))
+      expect(page).to have_selector("dd", text: Date.new(2022, 10, 24).to_fs(:govuk))
     end
 
     def then_i_should_be_on_the_complete_page

--- a/spec/features/schools/participants/transferring_participants/already_enrolled_at_school_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/already_enrolled_at_school_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Transferring participants", type: :feature, js: true, rutabaga: 
     before do
       set_participant_data
       set_dqt_validation_result
-      given_a_school_has_chosen_fip_for_2021_and_partnered
+      given_a_school_has_chosen_fip_for_previous_cohort_and_partnered
       and_they_have_already_added_this_ect
       and_i_am_signed_in_as_an_induction_coordinator
       and_i_have_selected_my_cohort_tab
@@ -42,10 +42,10 @@ RSpec.describe "Transferring participants", type: :feature, js: true, rutabaga: 
 
   # given
 
-  def given_a_school_has_chosen_fip_for_2021_and_partnered
-    @cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
+  def given_a_school_has_chosen_fip_for_previous_cohort_and_partnered
+    @cohort = Cohort.previous || create(:cohort, :previous)
     @school_one = create(:school, name: "Fip School 1")
-    create(:school_cohort, school: @school_one, cohort: Cohort.find_by(start_year: 2022) || create(:cohort, start_year: 2022), induction_programme_choice: "full_induction_programme")
+    create(:school_cohort, school: @school_one, cohort: Cohort.current || create(:cohort, :current), induction_programme_choice: "full_induction_programme")
     @school_cohort_one = create(:school_cohort, school: @school_one, cohort: @cohort, induction_programme_choice: "full_induction_programme")
     @mentor = create(:mentor_participant_profile, user: create(:user, full_name: "Billy Mentor"), school_cohort: @school_cohort_one)
     @induction_programme_one = create(:induction_programme, :fip, school_cohort: @school_cohort_one, partnership: @partnership_one)

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_different_partner_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_different_partner_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Transferring ECT is with a different lead provider", type: :feat
     allow_participant_transfer_mailers
     set_participant_data
     set_dqt_validation_result
-    given_there_are_two_schools_that_have_chosen_fip_for_2021_and_partnered
+    given_there_are_two_schools_that_have_chosen_fip_for_previous_cohort_and_partnered
     and_there_is_an_ect_who_will_be_transferring
     and_i_am_signed_in_as_an_induction_coordinator
     and_i_have_selected_my_cohort_tab
@@ -136,11 +136,11 @@ RSpec.describe "Transferring ECT is with a different lead provider", type: :feat
 
   # given
 
-  def given_there_are_two_schools_that_have_chosen_fip_for_2021_and_partnered
-    @cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
+  def given_there_are_two_schools_that_have_chosen_fip_for_previous_cohort_and_partnered
+    @cohort = Cohort.previous || create(:cohort, :previous)
     @school_one = create(:school, name: "Fip School 1")
     @school_two = create(:school, name: "Fip School 2")
-    create(:school_cohort, school: @school_one, cohort: Cohort.find_by(start_year: 2022) || create(:cohort, start_year: 2022), induction_programme_choice: "full_induction_programme")
+    create(:school_cohort, school: @school_one, cohort: Cohort.current || create(:cohort, :current), induction_programme_choice: "full_induction_programme")
     @school_cohort_one = create(:school_cohort, school: @school_one, cohort: @cohort, induction_programme_choice: "full_induction_programme")
     @school_cohort_two = create(:school_cohort, school: @school_two, cohort: @cohort, induction_programme_choice: "full_induction_programme")
     @lead_provider = create(:lead_provider, name: "Big Provider Ltd")
@@ -156,7 +156,7 @@ RSpec.describe "Transferring ECT is with a different lead provider", type: :feat
     @induction_programme_two = create(:induction_programme, :fip, school_cohort: @school_cohort_two, partnership: @partnership_two)
     @school_cohort_one.update!(default_induction_programme: @induction_programme_one)
     @school_cohort_two.update!(default_induction_programme: @induction_programme_two)
-    Induction::Enrol.call(participant_profile: @mentor, start_date: Date.new(2021, 9, 1), induction_programme: @induction_programme_one)
+    Induction::Enrol.call(participant_profile: @mentor, start_date: Date.new(Cohort.previous.start_year, 9, 1), induction_programme: @induction_programme_one)
     Mentors::AddToSchool.call(school: @school_one, mentor_profile: @mentor)
   end
 
@@ -195,7 +195,7 @@ RSpec.describe "Transferring ECT is with a different lead provider", type: :feat
   def when_i_add_a_valid_start_date
     legend = "When is #{@participant_data[:full_name]} moving to your school?"
 
-    fill_in_date(legend, with: "2023-10-24")
+    fill_in_date(legend, with: "#{Cohort.next.start_year}-10-24")
   end
 
   def when_i_assign_a_mentor
@@ -315,7 +315,7 @@ RSpec.describe "Transferring ECT is with a different lead provider", type: :feat
 
   def and_there_is_an_ect_who_will_be_transferring
     @participant_profile_ect = create(:ect_participant_profile, schedule: create(:ecf_schedule, cohort: @cohort), user: create(:user, full_name: "Sally Teacher"), school_cohort: @school_cohort_two)
-    Induction::Enrol.call(participant_profile: @participant_profile_ect, induction_programme: @induction_programme_two, start_date: Date.new(2021, 9, 1))
+    Induction::Enrol.call(participant_profile: @participant_profile_ect, induction_programme: @induction_programme_two, start_date: Date.new(Cohort.previous.start_year, 9, 1))
     create(:ecf_participant_validation_data, participant_profile: @participant_profile_ect, full_name: "Sally Teacher", trn: "1001000", date_of_birth: Date.new(1990, 10, 24))
     @participant_profile_ect.teacher_profile.update!(trn: "1001000")
   end

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_no_change_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_no_change_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "ECT has matching lead provider and delivery partner", type: :fea
     allow_participant_transfer_mailers
     set_participant_data
     set_dqt_validation_result
-    given_there_are_two_schools_that_have_chosen_fip_for_2021_and_partnered
+    given_there_are_two_schools_that_have_chosen_fip_for_previous_cohort_and_partnered
     and_there_is_an_ect_who_will_be_transferring
     and_i_am_signed_in_as_an_induction_coordinator
     and_i_have_selected_my_cohort_tab
@@ -122,11 +122,11 @@ RSpec.describe "ECT has matching lead provider and delivery partner", type: :fea
   end
   # given
 
-  def given_there_are_two_schools_that_have_chosen_fip_for_2021_and_partnered
-    @cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
+  def given_there_are_two_schools_that_have_chosen_fip_for_previous_cohort_and_partnered
+    @cohort = Cohort.previous || create(:cohort, :previous)
     @school_one = create(:school, name: "Fip School 1")
     @school_two = create(:school, name: "Fip School 2")
-    create(:school_cohort, school: @school_one, cohort: Cohort.find_by(start_year: 2022) || create(:cohort, start_year: 2022), induction_programme_choice: "full_induction_programme")
+    create(:school_cohort, school: @school_one, cohort: Cohort.current || create(:cohort, :current), induction_programme_choice: "full_induction_programme")
     @school_cohort_one = create(:school_cohort, school: @school_one, cohort: @cohort, induction_programme_choice: "full_induction_programme")
     @school_cohort_two = create(:school_cohort, school: @school_two, cohort: @cohort, induction_programme_choice: "full_induction_programme")
     @lead_provider = create(:lead_provider, name: "Big Provider Ltd")
@@ -138,7 +138,7 @@ RSpec.describe "ECT has matching lead provider and delivery partner", type: :fea
     @induction_programme_one = create(:induction_programme, :fip, school_cohort: @school_cohort_one, partnership: @partnership_1)
     @induction_programme_two = create(:induction_programme, :fip, school_cohort: @school_cohort_two, partnership: @partnership_2)
     @school_cohort_one.update!(default_induction_programme: @induction_programme_one)
-    Induction::Enrol.call(participant_profile: @mentor, start_date: Date.new(2021, 9, 1), induction_programme: @induction_programme_one)
+    Induction::Enrol.call(participant_profile: @mentor, start_date: Date.new(Cohort.previous.start_year, 9, 1), induction_programme: @induction_programme_one)
     Mentors::AddToSchool.call(school: @school_one, mentor_profile: @mentor)
   end
 
@@ -199,7 +199,7 @@ RSpec.describe "ECT has matching lead provider and delivery partner", type: :fea
   def when_i_add_a_valid_start_date
     legend = "When is #{@participant_data[:full_name]} moving to your school?"
 
-    fill_in_date(legend, with: "2023-10-24")
+    fill_in_date(legend, with: "#{Cohort.next.start_year}-10-24")
   end
 
   def when_i_assign_a_mentor
@@ -341,7 +341,7 @@ RSpec.describe "ECT has matching lead provider and delivery partner", type: :fea
     @participant_profile_ect = create(:ect_participant_profile, schedule: create(:ecf_schedule, cohort: @cohort), user: create(:user, full_name: "Sally Teacher"), school_cohort: @school_cohort_two)
     create(:ecf_participant_validation_data, participant_profile: @participant_profile_ect, full_name: "Sally Teacher", trn: "1001000", date_of_birth: Date.new(1990, 10, 24))
     @participant_profile_ect.teacher_profile.update!(trn: "1001000")
-    Induction::Enrol.call(participant_profile: @participant_profile_ect, start_date: Date.new(2021, 9, 1), induction_programme: @induction_programme_two)
+    Induction::Enrol.call(participant_profile: @participant_profile_ect, start_date: Date.new(Cohort.previous.start_year, 9, 1), induction_programme: @induction_programme_two)
   end
 
   def and_it_should_list_the_schools_mentors

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_different_partner_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_different_partner_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Transferring a mentor with a different provider", type: :feature
     allow_participant_transfer_mailers
     set_participant_data
     set_dqt_validation_result
-    given_there_are_two_schools_that_have_chosen_fip_for_2021_and_partnered
+    given_there_are_two_schools_that_have_chosen_fip_for_previous_cohort_and_partnered
     and_there_is_a_mentor_who_will_be_transferring
     and_i_am_signed_in_as_an_induction_coordinator
     and_i_have_selected_my_cohort_tab
@@ -122,11 +122,11 @@ RSpec.describe "Transferring a mentor with a different provider", type: :feature
   end
 
   # given
-  def given_there_are_two_schools_that_have_chosen_fip_for_2021_and_partnered
-    @cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
+  def given_there_are_two_schools_that_have_chosen_fip_for_previous_cohort_and_partnered
+    @cohort = Cohort.previous || create(:cohort, :previous)
     @school_one = create(:school, name: "Fip School 1")
     @school_two = create(:school, name: "Fip School 2")
-    create(:school_cohort, school: @school_one, cohort: Cohort.find_by(start_year: 2022) || create(:cohort, start_year: 2022), induction_programme_choice: "full_induction_programme")
+    create(:school_cohort, school: @school_one, cohort: Cohort.current || create(:cohort, :current), induction_programme_choice: "full_induction_programme")
     @school_cohort_one = create(:school_cohort, school: @school_one, cohort: @cohort, induction_programme_choice: "full_induction_programme")
     @school_cohort_two = create(:school_cohort, school: @school_two, cohort: @cohort, induction_programme_choice: "full_induction_programme")
     @lead_provider = create(:lead_provider, name: "Lead Provider One Ltd")
@@ -142,7 +142,7 @@ RSpec.describe "Transferring a mentor with a different provider", type: :feature
     @induction_programme_two = create(:induction_programme, :fip, school_cohort: @school_cohort_two, partnership: @partnership_two)
     @school_cohort_one.update!(default_induction_programme: @induction_programme_one)
     @school_cohort_two.update!(default_induction_programme: @induction_programme_two)
-    Induction::Enrol.call(participant_profile: @mentor, start_date: Date.new(2021, 9, 1), induction_programme: @induction_programme_one)
+    Induction::Enrol.call(participant_profile: @mentor, start_date: Date.new(Cohort.previous.start_year, 9, 1), induction_programme: @induction_programme_one)
     Mentors::AddToSchool.call(school: @school_one, mentor_profile: @mentor)
   end
 
@@ -181,7 +181,7 @@ RSpec.describe "Transferring a mentor with a different provider", type: :feature
   def when_i_add_a_valid_start_date
     legend = "When is #{@participant_data[:full_name]} moving to your school?"
 
-    fill_in_date(legend, with: "2023-10-24")
+    fill_in_date(legend, with: "#{Cohort.next.start_year}-10-24")
   end
 
   def when_i_select(option)
@@ -295,7 +295,7 @@ RSpec.describe "Transferring a mentor with a different provider", type: :feature
 
   def and_there_is_a_mentor_who_will_be_transferring
     @participant_profile_mentor = create(:mentor_participant_profile, schedule: create(:ecf_schedule, cohort: @cohort), user: create(:user, full_name: "Sally Mentor"), school_cohort: @school_cohort_two)
-    Induction::Enrol.call(participant_profile: @participant_profile_mentor, start_date: Date.new(2021, 9, 1), induction_programme: @induction_programme_two)
+    Induction::Enrol.call(participant_profile: @participant_profile_mentor, start_date: Date.new(Cohort.previous.start_year, 9, 1), induction_programme: @induction_programme_two)
 
     create(:ecf_participant_validation_data, participant_profile: @participant_profile_mentor, full_name: "Sally Mentor", trn: "1001000", date_of_birth: Date.new(1990, 10, 24))
     @participant_profile_mentor.teacher_profile.update!(trn: "1001000")

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/unhappy_path_cannot_validate_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/unhappy_path_cannot_validate_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "transferring participants", type: :feature, js: true do
         set_participant_data
         set_dqt_validation_result
         set_nino_validation_result
-        given_there_are_two_schools_that_have_chosen_fip_for_2021_and_partnered
+        given_there_are_two_schools_that_have_chosen_fip_for_previous_cohort_and_partnered
         and_there_is_an_ect_who_will_be_transferring
         and_i_am_signed_in_as_an_induction_coordinator
         and_i_have_selected_my_cohort_tab
@@ -54,11 +54,11 @@ RSpec.describe "transferring participants", type: :feature, js: true do
 
       # given
 
-      def given_there_are_two_schools_that_have_chosen_fip_for_2021_and_partnered
-        @cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
+      def given_there_are_two_schools_that_have_chosen_fip_for_previous_cohort_and_partnered
+        @cohort = Cohort.previous || create(:cohort, :previous)
         @school_one = create(:school, name: "Fip School 1")
         @school_two = create(:school, name: "Fip School 2")
-        create(:school_cohort, school: @school_one, cohort: Cohort.find_by(start_year: 2022) || create(:cohort, start_year: 2022), induction_programme_choice: "full_induction_programme")
+        create(:school_cohort, school: @school_one, cohort: Cohort.current || create(:cohort, :current), induction_programme_choice: "full_induction_programme")
         @school_cohort_one = create(:school_cohort, school: @school_one, cohort: @cohort, induction_programme_choice: "full_induction_programme")
         @school_cohort_two = create(:school_cohort, school: @school_two, cohort: @cohort, induction_programme_choice: "full_induction_programme")
         @lead_provider = create(:lead_provider, name: "Big Provider Ltd")

--- a/spec/features/schools/training_dashboard/manage_cip_training_spec.rb
+++ b/spec/features/schools/training_dashboard/manage_cip_training_spec.rb
@@ -3,58 +3,70 @@
 require "rails_helper"
 require_relative "./manage_training_steps"
 
-RSpec.describe "Manage CIP training", js: true, travel_to: Date.new(2022, 3, 1) do
+RSpec.describe "Manage CIP training", js: true do
   include ManageTrainingSteps
 
   scenario "CIP Induction Mentor without materials chosen" do
     given_there_is_a_school_that_has_chosen_cip_for_previous_cohort
-    and_i_am_signed_in_as_an_induction_coordinator
-    then_i_am_taken_to_cip_induction_dashboard
-    then_the_page_should_be_accessible
 
-    when_i_click_on_change_programme
-    then_i_am_taken_to_cip_programme_choice_info_page
-    then_the_page_should_be_accessible
+    inside_auto_assignment_window(cohort: Cohort.previous) do
+      and_i_am_signed_in_as_an_induction_coordinator
+      then_i_am_taken_to_cip_induction_dashboard
+      then_the_page_should_be_accessible
+
+      when_i_click_on_change_programme
+      then_i_am_taken_to_cip_programme_choice_info_page
+      then_the_page_should_be_accessible
+    end
   end
 
   scenario "CIP Induction Mentor with materials chosen" do
     given_there_is_a_school_that_has_chosen_cip_for_previous_cohort
-    and_i_am_signed_in_as_an_induction_coordinator
-    then_i_am_taken_to_cip_induction_dashboard
 
-    when_i_click_on_choose_materials
-    then_i_am_taken_to_course_choice_page
-    then_the_page_should_be_accessible
+    inside_auto_assignment_window(cohort: Cohort.previous) do
+      and_i_am_signed_in_as_an_induction_coordinator
+      then_i_am_taken_to_cip_induction_dashboard
 
-    when_i_choose_materials
-    then_i_am_taken_to_training_materials_confirmed_page
-    when_i_visit_manage_training_dashboard
-    then_i_can_view_the_added_materials
-    then_the_page_should_be_accessible
+      when_i_click_on_choose_materials
+      then_i_am_taken_to_course_choice_page
+      then_the_page_should_be_accessible
+
+      when_i_choose_materials
+      then_i_am_taken_to_training_materials_confirmed_page
+      when_i_visit_manage_training_dashboard
+      then_i_can_view_the_added_materials
+      then_the_page_should_be_accessible
+    end
   end
 
   scenario "CIP Induction Mentor who has not added ECT or mentors" do
     given_there_is_a_school_that_has_chosen_cip_for_previous_cohort
-    and_i_am_signed_in_as_an_induction_coordinator
-    then_i_can_manage_ects_and_mentors
+    inside_auto_assignment_window(cohort: Cohort.previous) do
+      and_i_am_signed_in_as_an_induction_coordinator
+      then_i_can_manage_ects_and_mentors
+    end
   end
 
   scenario "CIP Induction Mentor who has added ECT or mentors" do
     given_there_is_a_school_that_has_chosen_cip_for_previous_cohort
-    and_i_have_added_an_ect
-    and_i_am_signed_in_as_an_induction_coordinator
-    then_i_can_manage_ects_and_mentors
+    inside_auto_assignment_window(cohort: Cohort.previous) do
+      and_i_have_added_an_ect
+      and_i_am_signed_in_as_an_induction_coordinator
+      then_i_can_manage_ects_and_mentors
+    end
   end
 
   scenario "Change induction programme to CIP" do
     given_there_is_a_school_that_has_chosen(induction_programme_choice: "design_our_own")
-    and_i_am_signed_in_as_an_induction_coordinator
-    then_i_should_see_the_program_and_click_to_change_it(program_label: "Design and deliver your own programme")
-    and_see_the_other_programs_before_choosing(labels: ["Use a training provider, funded by the DfE",
-                                                        "Deliver your own programme using DfE accredited materials",
-                                                        "We do not expect any early career teachers to join"],
-                                               choice: "Deliver your own programme using DfE accredited materials")
+    inside_auto_assignment_window(cohort: Cohort.previous) do
+      and_i_am_signed_in_as_an_induction_coordinator
+      then_i_should_see_the_program_and_click_to_change_it(program_label: "Design and deliver your own programme")
+      and_see_the_other_programs_before_choosing(labels: ["Use a training provider, funded by the DfE",
+                                                          "Deliver your own programme using DfE accredited materials",
+                                                          "We do not expect any early career teachers to join"],
+                                                 choice: "Deliver your own programme using DfE accredited materials")
 
-    expect(page).to have_text "You’ve submitted your training information"
+      expect(page).to have_text "You’ve submitted your training information"
+    end
   end
 end

--- a/spec/features/schools/training_dashboard/manage_cip_training_spec.rb
+++ b/spec/features/schools/training_dashboard/manage_cip_training_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Manage CIP training", js: true, travel_to: Date.new(2022, 3, 1) 
   include ManageTrainingSteps
 
   scenario "CIP Induction Mentor without materials chosen" do
-    given_there_is_a_school_that_has_chosen_cip_for_2021
+    given_there_is_a_school_that_has_chosen_cip_for_previous_cohort
     and_i_am_signed_in_as_an_induction_coordinator
     then_i_am_taken_to_cip_induction_dashboard
     then_the_page_should_be_accessible
@@ -18,7 +18,7 @@ RSpec.describe "Manage CIP training", js: true, travel_to: Date.new(2022, 3, 1) 
   end
 
   scenario "CIP Induction Mentor with materials chosen" do
-    given_there_is_a_school_that_has_chosen_cip_for_2021
+    given_there_is_a_school_that_has_chosen_cip_for_previous_cohort
     and_i_am_signed_in_as_an_induction_coordinator
     then_i_am_taken_to_cip_induction_dashboard
 
@@ -34,13 +34,13 @@ RSpec.describe "Manage CIP training", js: true, travel_to: Date.new(2022, 3, 1) 
   end
 
   scenario "CIP Induction Mentor who has not added ECT or mentors" do
-    given_there_is_a_school_that_has_chosen_cip_for_2021
+    given_there_is_a_school_that_has_chosen_cip_for_previous_cohort
     and_i_am_signed_in_as_an_induction_coordinator
     then_i_can_manage_ects_and_mentors
   end
 
   scenario "CIP Induction Mentor who has added ECT or mentors" do
-    given_there_is_a_school_that_has_chosen_cip_for_2021
+    given_there_is_a_school_that_has_chosen_cip_for_previous_cohort
     and_i_have_added_an_ect
     and_i_am_signed_in_as_an_induction_coordinator
     then_i_can_manage_ects_and_mentors

--- a/spec/features/schools/training_dashboard/manage_fip_training_spec.rb
+++ b/spec/features/schools/training_dashboard/manage_fip_training_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "./manage_training_steps"
 
-RSpec.describe "Manage FIP training", js: true, travel_to: Time.zone.local(2021, 12, 17, 16, 15, 0) do
+RSpec.describe "Manage FIP training", js: true, travel_to: Time.zone.local(2021, 9, 17, 16, 15, 0) do
   include ManageTrainingSteps
 
   scenario "FIP Induction Coordinator with training provider" do

--- a/spec/features/schools/training_dashboard/manage_fip_training_spec.rb
+++ b/spec/features/schools/training_dashboard/manage_fip_training_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe "Manage FIP training", js: true, travel_to: Time.zone.local(2021,
   include ManageTrainingSteps
 
   scenario "FIP Induction Coordinator with training provider" do
-    given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
+    given_there_is_a_school_that_has_chosen_fip_for_previous_cohort_and_partnered
     and_i_am_signed_in_as_an_induction_coordinator
     then_i_am_taken_to_fip_induction_dashboard
     then_the_page_should_be_accessible
   end
 
   scenario "FIP Induction Coordinator without training provider" do
-    given_there_is_a_school_that_has_chosen_fip_for_2021
+    given_there_is_a_school_that_has_chosen_fip_for_previous_cohort
     and_i_am_signed_in_as_an_induction_coordinator
     then_i_can_view_the_fip_induction_dashboard_without_partnership_details
     then_the_page_should_be_accessible

--- a/spec/features/schools/training_dashboard/manage_fip_training_spec.rb
+++ b/spec/features/schools/training_dashboard/manage_fip_training_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Manage FIP training", js: true do
 
   scenario "FIP Induction Coordinator with training provider" do
     given_there_is_a_school_that_has_chosen_fip_for_previous_cohort_and_partnered
-    travel_to Time.zone.local(Cohort.previous.start_year, 9, 17, 16, 15, 0) do
+    travel_to Cohort.previous.academic_year_start_date + 10.days do
       and_i_am_signed_in_as_an_induction_coordinator
       then_i_am_taken_to_fip_induction_dashboard
       then_the_page_should_be_accessible
@@ -17,7 +17,7 @@ RSpec.describe "Manage FIP training", js: true do
 
   scenario "FIP Induction Coordinator without training provider" do
     given_there_is_a_school_that_has_chosen_fip_for_previous_cohort
-    travel_to Time.zone.local(Cohort.previous.start_year, 9, 17, 16, 15, 0) do
+    travel_to Cohort.previous.academic_year_start_date + 10.days do
       and_i_am_signed_in_as_an_induction_coordinator
       then_i_can_view_the_fip_induction_dashboard_without_partnership_details
       then_the_page_should_be_accessible
@@ -26,7 +26,7 @@ RSpec.describe "Manage FIP training", js: true do
 
   scenario "Change induction programme to FIP" do
     given_there_is_a_school_that_has_chosen(induction_programme_choice: "design_our_own")
-    travel_to Time.zone.local(Cohort.previous.start_year, 9, 17, 16, 15, 0) do
+    travel_to Cohort.previous.academic_year_start_date + 10.days do
       and_i_am_signed_in_as_an_induction_coordinator
       then_i_should_see_the_program_and_click_to_change_it(program_label: "Design and deliver your own programme")
       and_see_the_other_programs_before_choosing(labels: ["Use a training provider, funded by the DfE",

--- a/spec/features/schools/training_dashboard/manage_fip_training_spec.rb
+++ b/spec/features/schools/training_dashboard/manage_fip_training_spec.rb
@@ -3,31 +3,37 @@
 require "rails_helper"
 require_relative "./manage_training_steps"
 
-RSpec.describe "Manage FIP training", js: true, travel_to: Time.zone.local(2021, 9, 17, 16, 15, 0) do
+RSpec.describe "Manage FIP training", js: true do
   include ManageTrainingSteps
 
   scenario "FIP Induction Coordinator with training provider" do
     given_there_is_a_school_that_has_chosen_fip_for_previous_cohort_and_partnered
-    and_i_am_signed_in_as_an_induction_coordinator
-    then_i_am_taken_to_fip_induction_dashboard
-    then_the_page_should_be_accessible
+    travel_to Time.zone.local(Cohort.previous.start_year, 9, 17, 16, 15, 0) do
+      and_i_am_signed_in_as_an_induction_coordinator
+      then_i_am_taken_to_fip_induction_dashboard
+      then_the_page_should_be_accessible
+    end
   end
 
   scenario "FIP Induction Coordinator without training provider" do
     given_there_is_a_school_that_has_chosen_fip_for_previous_cohort
-    and_i_am_signed_in_as_an_induction_coordinator
-    then_i_can_view_the_fip_induction_dashboard_without_partnership_details
-    then_the_page_should_be_accessible
+    travel_to Time.zone.local(Cohort.previous.start_year, 9, 17, 16, 15, 0) do
+      and_i_am_signed_in_as_an_induction_coordinator
+      then_i_can_view_the_fip_induction_dashboard_without_partnership_details
+      then_the_page_should_be_accessible
+    end
   end
 
   scenario "Change induction programme to FIP" do
     given_there_is_a_school_that_has_chosen(induction_programme_choice: "design_our_own")
-    and_i_am_signed_in_as_an_induction_coordinator
-    then_i_should_see_the_program_and_click_to_change_it(program_label: "Design and deliver your own programme")
-    and_see_the_other_programs_before_choosing(labels: ["Use a training provider, funded by the DfE",
-                                                        "Deliver your own programme using DfE accredited materials"],
-                                               choice: "Use a training provider, funded by the DfE")
+    travel_to Time.zone.local(Cohort.previous.start_year, 9, 17, 16, 15, 0) do
+      and_i_am_signed_in_as_an_induction_coordinator
+      then_i_should_see_the_program_and_click_to_change_it(program_label: "Design and deliver your own programme")
+      and_see_the_other_programs_before_choosing(labels: ["Use a training provider, funded by the DfE",
+                                                          "Deliver your own programme using DfE accredited materials"],
+                                                 choice: "Use a training provider, funded by the DfE")
 
-    expect(page).to have_text "You’ve submitted your training information"
+      expect(page).to have_text "You’ve submitted your training information"
+    end
   end
 end

--- a/spec/features/schools/training_dashboard/manage_no_ect_training_spec.rb
+++ b/spec/features/schools/training_dashboard/manage_no_ect_training_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Manage No ECT training", js: true, travel_to: Date.new(2022, 3, 
   include ManageTrainingSteps
 
   scenario "Manage No ECT Induction Coordinator" do
-    given_there_is_a_school_that_has_chosen_no_ect_for_2021
+    given_there_is_a_school_that_has_chosen_no_ect_for_previous_cohort
     and_i_am_signed_in_as_an_induction_coordinator
     then_i_can_view_the_no_ect_induction_dashboard
     then_the_page_should_be_accessible

--- a/spec/features/schools/training_dashboard/manage_no_ect_training_spec.rb
+++ b/spec/features/schools/training_dashboard/manage_no_ect_training_spec.rb
@@ -3,18 +3,20 @@
 require "rails_helper"
 require_relative "./manage_training_steps"
 
-RSpec.describe "Manage No ECT training", js: true, travel_to: Date.new(2022, 3, 1) do
+RSpec.describe "Manage No ECT training", js: true do
   include ManageTrainingSteps
 
   scenario "Manage No ECT Induction Coordinator" do
     given_there_is_a_school_that_has_chosen_no_ect_for_previous_cohort
-    and_i_am_signed_in_as_an_induction_coordinator
-    then_i_can_view_the_no_ect_induction_dashboard
-    then_the_page_should_be_accessible
+    inside_auto_assignment_window(cohort: Cohort.previous) do
+      and_i_am_signed_in_as_an_induction_coordinator
+      then_i_can_view_the_no_ect_induction_dashboard
+      then_the_page_should_be_accessible
 
-    when_i_click_on_tell_us_if_this_has_changed
-    then_i_am_taken_to_setup_my_programme
-    then_the_page_should_be_accessible
+      when_i_click_on_tell_us_if_this_has_changed
+      then_i_am_taken_to_setup_my_programme
+      then_the_page_should_be_accessible
+    end
   end
 
   scenario "Change induction programme to No ECTs" do

--- a/spec/features/schools/training_dashboard/manage_schools_spec.rb
+++ b/spec/features/schools/training_dashboard/manage_schools_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature "School Tutors should be able to manage schools", type: :feature, 
   context "Multiple cohorts when the new cohort is open for registrations" do
     scenario "Start setting up the new cohort" do
       given_there_is_a_school_that_has_chosen_cip_for_previous_cohort(pilot: true)
-      travel_to Time.zone.local(Cohort.current.start_year, 6, 5, 16, 15, 0) do
+      travel_to Cohort.current.registration_start_date + 1.day do
         and_cohort_current_is_created
         and_i_am_signed_in_as_an_induction_coordinator
         then_i_am_on_the_what_we_need_to_know_page(previous_year: Cohort.next.start_year, current_year: Cohort.next.start_year + 1)

--- a/spec/features/schools/training_dashboard/manage_schools_spec.rb
+++ b/spec/features/schools/training_dashboard/manage_schools_spec.rb
@@ -28,12 +28,14 @@ RSpec.feature "School Tutors should be able to manage schools", type: :feature, 
     and_the_page_should_be_accessible
   end
 
-  context "Multiple cohorts when the new cohort is open for registrations", travel_to: Time.zone.local(2022, 6, 5, 16, 15, 0) do
+  context "Multiple cohorts when the new cohort is open for registrations" do
     scenario "Start setting up the new cohort" do
       given_there_is_a_school_that_has_chosen_cip_for_previous_cohort(pilot: true)
-      and_cohort_current_is_created
-      and_i_am_signed_in_as_an_induction_coordinator
-      then_i_am_on_the_what_we_need_to_know_page
+      travel_to Time.zone.local(Cohort.current.start_year, 6, 5, 16, 15, 0) do
+        and_cohort_current_is_created
+        and_i_am_signed_in_as_an_induction_coordinator
+        then_i_am_on_the_what_we_need_to_know_page(previous_year: Cohort.next.start_year, current_year: Cohort.next.start_year + 1)
+      end
     end
   end
 end

--- a/spec/features/schools/training_dashboard/manage_schools_spec.rb
+++ b/spec/features/schools/training_dashboard/manage_schools_spec.rb
@@ -30,8 +30,8 @@ RSpec.feature "School Tutors should be able to manage schools", type: :feature, 
 
   context "Multiple cohorts when the new cohort is open for registrations", travel_to: Time.zone.local(2022, 6, 5, 16, 15, 0) do
     scenario "Start setting up the new cohort" do
-      given_there_is_a_school_that_has_chosen_cip_for_2021(pilot: true)
-      and_cohort_2022_is_created
+      given_there_is_a_school_that_has_chosen_cip_for_previous_cohort(pilot: true)
+      and_cohort_current_is_created
       and_i_am_signed_in_as_an_induction_coordinator
       then_i_am_on_the_what_we_need_to_know_page
     end

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -56,8 +56,8 @@ module ManageTrainingSteps
     @school_cohort.update!(default_induction_programme: @induction_programme)
   end
 
-  def given_there_is_a_school_that_has_chosen_fip_for_2021
-    @cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
+  def given_there_is_a_school_that_has_chosen_fip_for_previous_cohort
+    @cohort = Cohort.previous || create(:cohort, :previous)
     @school = create(:school, name: "Fip School")
     @school_cohort = create(:school_cohort, school: @school, cohort: @cohort, induction_programme_choice: "full_induction_programme")
     @induction_programme = create(:induction_programme, :fip, school_cohort: @school_cohort, partnership: nil)
@@ -75,27 +75,27 @@ module ManageTrainingSteps
     @school_cohort2.update!(default_induction_programme: @induction_programme2)
   end
 
-  def given_there_is_a_school_that_has_chosen_fip_for_2021_and_2022_and_partnered
-    given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
-    @cohort22 = Cohort.find_or_create_by!(start_year: 2022)
-    @partnership22 = @partnership.dup
-    @partnership22.cohort = @cohort22
-    @partnership22.save!
-    @school_cohort22 = create(:school_cohort, :fip, school: @school, cohort: @cohort22)
-    @induction_programme22 = create(:induction_programme, :fip, school_cohort: @school_cohort22, partnership: @partnership22)
-    @school_cohort22.update!(default_induction_programme: @induction_programme22)
+  def given_there_is_a_school_that_has_chosen_fip_for_previous_and_current_cohort_and_partnered
+    given_there_is_a_school_that_has_chosen_fip_for_previous_cohort_and_partnered
+    @cohort_current = Cohort.current || create(:cohort, :current)
+    @partnership_current = @partnership.dup
+    @partnership_current.cohort = @cohort_current
+    @partnership_current.save!
+    @school_cohort_current = create(:school_cohort, :fip, school: @school, cohort: @cohort_current)
+    @induction_programme_current = create(:induction_programme, :fip, school_cohort: @school_cohort_current, partnership: @partnership_current)
+    @school_cohort_current.update!(default_induction_programme: @induction_programme_current)
   end
 
-  def given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
-    given_there_is_a_school_that_has_chosen_fip_for_2021
+  def given_there_is_a_school_that_has_chosen_fip_for_previous_cohort_and_partnered
+    given_there_is_a_school_that_has_chosen_fip_for_previous_cohort
     @lead_provider = create(:lead_provider, name: "Big Provider Ltd")
     @delivery_partner = create(:delivery_partner, name: "Amazing Delivery Team")
     @partnership = create(:partnership, school: @school, lead_provider: @lead_provider, delivery_partner: @delivery_partner, cohort: @cohort, challenge_deadline: 2.weeks.ago)
     @induction_programme.update!(partnership: @partnership)
   end
 
-  def given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered_but_challenged
-    given_there_is_a_school_that_has_chosen_fip_for_2021
+  def given_there_is_a_school_that_has_chosen_fip_for_previous_cohort_and_partnered_but_challenged
+    given_there_is_a_school_that_has_chosen_fip_for_previous_cohort
     @lead_provider = create(:lead_provider, name: "Big Provider Ltd")
     @delivery_partner = create(:delivery_partner, name: "Amazing Delivery Team")
     @partnership = create(:partnership, school: @school, lead_provider: @lead_provider, delivery_partner: @delivery_partner, cohort: @cohort, challenge_deadline: 1.week.from_now, challenged_at: 1.day.ago, challenge_reason: "mistake")
@@ -111,9 +111,9 @@ module ManageTrainingSteps
     @school_cohort.update!(default_induction_programme: @induction_programme)
   end
 
-  def given_there_is_a_school_that_has_chosen_cip_for_2021(pilot: false)
+  def given_there_is_a_school_that_has_chosen_cip_for_previous_cohort(pilot: false)
     @cip = create(:core_induction_programme, name: "CIP Programme 1")
-    @cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
+    @cohort = Cohort.previous || create(:cohort, :previous)
     @school = create(:school, name: "CIP School")
     @school_cohort = create(:school_cohort, school: @school, cohort: @cohort, induction_programme_choice: "core_induction_programme")
     @induction_programme = create(:induction_programme, :cip, school_cohort: @school_cohort, core_induction_programme: nil)
@@ -160,14 +160,14 @@ module ManageTrainingSteps
     @school_cohort = create(:school_cohort, school: @school, cohort: @cohort, induction_programme_choice: "design_our_own")
   end
 
-  def given_there_is_a_school_that_has_chosen_design_our_own_for_2021
-    @cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
+  def given_there_is_a_school_that_has_chosen_design_our_own_for_previous_cohort
+    @cohort = Cohort.previous || create(:cohort, :previous)
     @school = create(:school, name: "Design Our Own Programme School")
     @school_cohort = create(:school_cohort, school: @school, cohort: @cohort, induction_programme_choice: "design_our_own")
   end
 
-  def given_there_is_a_school_that_has_chosen_no_ect_for_2021
-    @cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
+  def given_there_is_a_school_that_has_chosen_no_ect_for_previous_cohort
+    @cohort = Cohort.previous || create(:cohort, previous)
     @school = create(:school, name: "No ECT Programme School")
     @school_cohort = create(:school_cohort, school: @school, cohort: @cohort, induction_programme_choice: "no_early_career_teachers")
     create(:school_cohort, school: @school, cohort: Cohort.find_by(start_year: 2020) || create(:cohort, start_year: 2020))
@@ -646,12 +646,12 @@ module ManageTrainingSteps
     expect(page).to have_text("Remove")
   end
 
-  def and_cohort_2022_is_created
-    Cohort.find_by(start_year: 2022) || create(:cohort, start_year: 2022)
+  def and_cohort_current_is_created
+    Cohort.current || create(:cohort, :current)
   end
 
-  def and_the_cohort_2022_tab_is_selected
-    expect(page).to have_text("Tell us if any new ECTs or mentors will start training at your school in the 2022 to 2023 academic year")
+  def and_the_current_cohort_tab_is_selected
+    expect(page).to have_text("Tell us if any new ECTs or mentors will start training at your school in the #{Cohort.previous.start_year} to Cohort.current.start_year} academic year")
   end
 
   # When_steps
@@ -668,8 +668,8 @@ module ManageTrainingSteps
     choose option: "other_providers"
   end
 
-  def when_i_choose_summer_term_2023
-    choose "Summer term 2023"
+  def when_i_choose_summer_term_next_cohort
+    choose "Summer term #{Cohort.next.start_year}"
   end
 
   def when_i_choose_yes
@@ -1354,12 +1354,12 @@ module ManageTrainingSteps
   end
 
   def then_i_see_the_cohort_tabs
-    then_i_see_the_tab_for_the_cohort(2021)
-    then_i_see_the_tab_for_the_cohort(2022)
+    then_i_see_the_tab_for_the_cohort(Cohort.previous.start_year)
+    then_i_see_the_tab_for_the_cohort(Cohort.current.start_year)
   end
 
   def then_i_am_on_the_what_we_need_to_know_page
-    expect(page).to have_text("Tell us if any new ECTs or mentors will start training at your school in the 2022 to 2023 academic year")
+    expect(page).to have_text("Tell us if any new ECTs or mentors will start training at your school in the #{Cohort.previous.start_year} to #{Cohort.current.start_year} academic year")
   end
 
   def then_i_am_taken_to_the_what_we_need_to_know_about_this_mentor_page
@@ -1403,7 +1403,7 @@ module ManageTrainingSteps
       date_of_birth: Date.new(1998, 3, 22),
       email: "sally@school.com",
       nino: "AB123456A",
-      start_date: Date.new(2022, 9, 1),
+      start_date: Date.new(Cohort.current.start_year, 9, 1),
       start_term: "summer",
     }
   end

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -668,8 +668,8 @@ module ManageTrainingSteps
     choose option: "other_providers"
   end
 
-  def when_i_choose_summer_term_next_cohort
-    choose "Summer term #{Cohort.next.start_year}"
+  def when_i_choose_summer_term_this_cohort
+    choose "Summer term #{Cohort.current.start_year + 1}"
   end
 
   def when_i_choose_yes

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -1358,8 +1358,8 @@ module ManageTrainingSteps
     then_i_see_the_tab_for_the_cohort(Cohort.current.start_year)
   end
 
-  def then_i_am_on_the_what_we_need_to_know_page
-    expect(page).to have_text("Tell us if any new ECTs or mentors will start training at your school in the #{Cohort.previous.start_year} to #{Cohort.current.start_year} academic year")
+  def then_i_am_on_the_what_we_need_to_know_page(previous_year: Cohort.previous.start_year, current_year: Cohort.current.start_year)
+    expect(page).to have_text("Tell us if any new ECTs or mentors will start training at your school in the #{previous_year} to #{current_year} academic year")
   end
 
   def then_i_am_taken_to_the_what_we_need_to_know_about_this_mentor_page

--- a/spec/fixtures/files/importers/cohort_csv_data.csv
+++ b/spec/fixtures/files/importers/cohort_csv_data.csv
@@ -1,2 +1,2 @@
 start-year,registration-start-date,academic-year-start-date,npq-registration-start-date
-2024,2024/05/10,2024/09/01
+2025,2025/05/10,2025/09/01

--- a/spec/fixtures/files/importers/cohort_lead_provider_csv_data.csv
+++ b/spec/fixtures/files/importers/cohort_lead_provider_csv_data.csv
@@ -1,2 +1,2 @@
 lead-provider-name,cohort-start-year
-Ambition Institute,2024
+Ambition Institute,2025

--- a/spec/fixtures/files/importers/contract_csv_data.csv
+++ b/spec/fixtures/files/importers/contract_csv_data.csv
@@ -1,2 +1,2 @@
 lead-provider-name,cohort-start-year,uplift-target,uplift-amount,recruitment-target,revised-target,set-up-fee,monthly-service-fee,band-a-min,band-a-max,band-a-per-participant,band-b-min,band-b-max,band-b-per-participant,band-c-min,band-c-max,band-c-per-participant,band-d-min,band-d-max,band-d-per-participant
-Ambition Institute,2024,0.44,200,4600,4790,0,0,90,895,91,199,700,200,299,600,300,400,500
+Ambition Institute,2025,0.44,200,4600,4790,0,0,90,895,91,199,700,200,299,600,300,400,500

--- a/spec/fixtures/files/importers/schedule_csv_data.csv
+++ b/spec/fixtures/files/importers/schedule_csv_data.csv
@@ -1,2 +1,2 @@
 type,schedule-identifier,schedule-name,schedule-cohort-year,milestone-name,milestone-declaration-type,milestone-start-date,milestone-date,milestone-payment-date
-ecf_standard,ecf-standard-september,ECF Standard September,2024,Output 1 - Participant Start,started,2024/09/01,2024/11/30,2024/11/30
+ecf_standard,ecf-standard-september,ECF Standard September,2025,Output 1 - Participant Start,started,2024/09/01,2024/11/30,2024/11/30

--- a/spec/fixtures/files/importers/statement_csv_data.csv
+++ b/spec/fixtures/files/importers/statement_csv_data.csv
@@ -1,2 +1,2 @@
 type,name,cohort,deadline_date,payment_date,output_fee
-ecf,September 2024,2024,2024-09-01,2024-11-25,true
+ecf,September 2025,2025,2025-09-01,2025-11-25,true

--- a/spec/forms/schools/add_participants/transfer_wizard_spec.rb
+++ b/spec/forms/schools/add_participants/transfer_wizard_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Schools::AddParticipants::TransferWizard, type: :model do
-  let(:cohort) { Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021) }
-  let(:next_cohort) { Cohort.find_by(start_year: 2022) || create(:cohort, start_year: 2022) }
+  let(:cohort) { Cohort.previous || create(:cohort, :previous) }
+  let(:next_cohort) { Cohort.current || create(:cohort, :current) }
   let(:data_store) do
     FormData::AddParticipantStore.new(session: { any_key: { trn:,
                                                             confirmed_trn: trn,

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       context "when a new registration cohort is active", travel_to: Time.current + 3.years do
         let(:future_cohort) do
           create(:cohort,
-                 start_year: Time.current.year,
+                 start_year: Time.current.year + 1,
                  registration_start_date: Time.current - 1.day)
         end
 

--- a/spec/lib/participant_profile_deduplicator_spec.rb
+++ b/spec/lib/participant_profile_deduplicator_spec.rb
@@ -45,11 +45,13 @@ describe ParticipantProfileDeduplicator do
 
       context "when there are declarations on the duplicate" do
         let!(:duplicate_declaration) do
-          create(:ect_participant_declaration,
-                 :submitted,
-                 declaration_type: "retained-1",
-                 participant_profile: duplicate_profile,
-                 cpd_lead_provider: duplicate_profile.lead_provider.cpd_lead_provider)
+          travel_to duplicate_profile.schedule.milestones.find_by(declaration_type: "retained-1").start_date + 2.days do
+            create(:ect_participant_declaration,
+                   :submitted,
+                   declaration_type: "retained-1",
+                   participant_profile: duplicate_profile,
+                   cpd_lead_provider: duplicate_profile.lead_provider.cpd_lead_provider)
+          end
         end
 
         it { expect { dedup! }.to raise_error(described_class::DeduplicationError, "Lead provider change retaining the same school is not supported when there are declarations on the duplicate") }
@@ -261,19 +263,23 @@ describe ParticipantProfileDeduplicator do
       let(:primary_profile) { create(:ect, :eligible_for_funding) }
 
       let!(:duplicate_declaration) do
-        create(:ect_participant_declaration,
-               :submitted,
-               declaration_type: "retained-1",
-               participant_profile: duplicate_profile,
-               cpd_lead_provider: duplicate_profile.lead_provider.cpd_lead_provider)
+        travel_to duplicate_profile.schedule.milestones.find_by(declaration_type: "retained-1").start_date + 2.days do
+          create(:ect_participant_declaration,
+                 :submitted,
+                 declaration_type: "retained-1",
+                 participant_profile: duplicate_profile,
+                 cpd_lead_provider: duplicate_profile.lead_provider.cpd_lead_provider)
+        end
       end
       let!(:conflicting_declaration) do
-        create(:ect_participant_declaration,
-               :submitted,
-               declaration_type: "retained-1",
-               declaration_date: duplicate_declaration.declaration_date + 1.day,
-               participant_profile: primary_profile,
-               cpd_lead_provider: primary_profile.lead_provider.cpd_lead_provider)
+        travel_to primary_profile.schedule.milestones.find_by(declaration_type: "retained-1").start_date + 2.days do
+          create(:ect_participant_declaration,
+                 :submitted,
+                 declaration_type: "retained-1",
+                 declaration_date: duplicate_declaration.declaration_date + 1.day,
+                 participant_profile: primary_profile,
+                 cpd_lead_provider: primary_profile.lead_provider.cpd_lead_provider)
+        end
       end
 
       context "when primary profile only has voided declarations and duplicate does not" do
@@ -331,18 +337,22 @@ describe ParticipantProfileDeduplicator do
 
     context "when the schedules and cohorts are different" do
       let!(:primary_profile_declaration) do
-        create(:ect_participant_declaration,
-               :submitted,
-               declaration_type: "retained-1",
-               participant_profile: primary_profile,
-               cpd_lead_provider: primary_profile.lead_provider.cpd_lead_provider)
+        travel_to primary_profile.schedule.milestones.find_by(declaration_type: "retained-1").start_date + 2.days do
+          create(:ect_participant_declaration,
+                 :submitted,
+                 declaration_type: "retained-1",
+                 participant_profile: primary_profile,
+                 cpd_lead_provider: primary_profile.lead_provider.cpd_lead_provider)
+        end
       end
       let!(:duplicate_profile_declaration) do
-        create(:ect_participant_declaration,
-               :submitted,
-               declaration_type: "retained-2",
-               participant_profile: duplicate_profile,
-               cpd_lead_provider: duplicate_profile.lead_provider.cpd_lead_provider)
+        travel_to duplicate_profile.schedule.milestones.find_by(declaration_type: "retained-2").start_date + 2.days do
+          create(:ect_participant_declaration,
+                 :submitted,
+                 declaration_type: "retained-2",
+                 participant_profile: duplicate_profile,
+                 cpd_lead_provider: duplicate_profile.lead_provider.cpd_lead_provider)
+        end
       end
       let!(:primary_profile_schedule) { primary_profile.latest_induction_record.schedule }
       let(:duplicate_profile_cohort) { create(:cohort, start_year: primary_profile.cohort.start_year + 1) }

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Cohort, type: :model do
   describe ".current" do
     describe "when the current date matches the academic year start date" do
       it "returns the cohort with start_year the current year" do
-        Timecop.freeze(Date.new(2021, 12, 1)) do
+        Timecop.freeze(Date.new(2021, 9, 1)) do
           expect(Cohort.current.start_year).to eq 2021
         end
       end
@@ -49,7 +49,7 @@ RSpec.describe Cohort, type: :model do
   describe ".next" do
     describe "when the current date matches the academic year start date" do
       it "returns the cohort with start_year the next year" do
-        Timecop.freeze(Date.new(2021, 12, 1)) do
+        Timecop.freeze(Date.new(2021, 9, 1)) do
           expect(Cohort.next.start_year).to eq 2022
         end
       end
@@ -67,7 +67,7 @@ RSpec.describe Cohort, type: :model do
   describe ".previous" do
     describe "when exactly 1 year ago matches the academic year start date" do
       it "returns the cohort with start_year the previous year" do
-        Timecop.freeze(Date.new(2021, 12, 10)) do
+        Timecop.freeze(Date.new(2021, 9, 10)) do
           expect(Cohort.previous.start_year).to eq 2020
         end
       end
@@ -84,14 +84,14 @@ RSpec.describe Cohort, type: :model do
 
   describe ".containing_date" do
     it "returns the cohort which contains the given date" do
-      expect(Cohort.containing_date(Date.new(2021, 12, 1)).start_year).to eq 2021
-      expect(Cohort.containing_date(Date.new(2022, 12, 10)).start_year).to eq 2022
+      expect(Cohort.containing_date(Date.new(2021, 9, 1)).start_year).to eq 2021
+      expect(Cohort.containing_date(Date.new(2022, 9, 10)).start_year).to eq 2022
       expect(Cohort.containing_date(Date.new(2023, 1, 10)).start_year).to eq 2022
       expect(Cohort.containing_date(Date.new(2024, 3, 22)).start_year).to eq 2023
     end
 
     context "when outside the currently added cohorts" do
-      let(:oob_date) { Date.new(Cohort.maximum(:start_year) + 1, 12, 1) }
+      let(:oob_date) { Date.new(Cohort.maximum(:start_year) + 1, 9, 1) }
 
       it "returns nil" do
         expect(Cohort.containing_date(oob_date)).to be_nil
@@ -101,7 +101,7 @@ RSpec.describe Cohort, type: :model do
 
   describe ".within_next_registration_period?" do
     before do
-      Cohort.find_by(start_year: 2023).update!(registration_start_date: Date.new(2023, 6, 1), academic_year_start_date: Date.new(2023, 12, 1))
+      Cohort.find_by(start_year: 2023).update!(registration_start_date: Date.new(2023, 6, 1), academic_year_start_date: Date.new(2023, 9, 1))
     end
 
     context "when the current time is after the registration start date for then next cohort" do
@@ -114,7 +114,7 @@ RSpec.describe Cohort, type: :model do
 
     context "when the active_registration_cohort and the current cohort are the same" do
       it "returns false" do
-        Timecop.freeze(Date.new(2023, 12, 1)) do
+        Timecop.freeze(Date.new(2023, 9, 1)) do
           expect(Cohort).not_to be_within_next_registration_period
         end
       end
@@ -160,7 +160,7 @@ RSpec.describe Cohort, type: :model do
 
     describe "when the current date is before the registration start date of the next cohort" do
       it "returns the cohort with start_year the previous year" do
-        Timecop.freeze(Date.new(2022, 5, 12)) do
+        Timecop.freeze(Date.new(2022, 5, 9)) do
           expect(Cohort.active_npq_registration_cohort.start_year).to eq 2021
         end
       end

--- a/spec/models/participant_outcome/npq_spec.rb
+++ b/spec/models/participant_outcome/npq_spec.rb
@@ -4,7 +4,8 @@ require "rails_helper"
 
 RSpec.describe ParticipantOutcome::NPQ, type: :model do
   let(:provider) { create :cpd_lead_provider, :with_npq_lead_provider }
-  let(:npq_application) { create :npq_application, :accepted, cohort: Cohort.previous, npq_lead_provider: provider.npq_lead_provider }
+  let!(:cohort) { Cohort.find_by(start_year: Cohort.previous.start_year - 1) }
+  let(:npq_application) { create :npq_application, :accepted, cohort:, npq_lead_provider: provider.npq_lead_provider }
   let(:declaration_date) { npq_application.profile.schedule.milestones.find_by(declaration_type: "completed").start_date + 1.day }
   let(:declaration) do
     travel_to declaration_date do
@@ -172,9 +173,9 @@ RSpec.describe ParticipantOutcome::NPQ, type: :model do
     end
 
     describe ".declarations_where_outcome_passed_and_sent" do
-      let(:npq_application_1) { create :npq_application, :accepted, cohort: Cohort.previous, npq_lead_provider: provider.npq_lead_provider }
+      let(:npq_application_1) { create :npq_application, :accepted, cohort:, npq_lead_provider: provider.npq_lead_provider }
       let(:declaration_date_1) { npq_application.profile.schedule.milestones.find_by(declaration_type: "completed").start_date + 1.day }
-      let(:npq_application_2) { create :npq_application, :accepted, cohort: Cohort.previous, npq_lead_provider: provider.npq_lead_provider }
+      let(:npq_application_2) { create :npq_application, :accepted, cohort:, npq_lead_provider: provider.npq_lead_provider }
       let(:declaration_date_2) { npq_application.profile.schedule.milestones.find_by(declaration_type: "completed").start_date + 1.day }
       let!(:declaration_1) do
         travel_to declaration_date_1 do
@@ -198,9 +199,9 @@ RSpec.describe ParticipantOutcome::NPQ, type: :model do
     end
 
     describe ".latest_per_declaration" do
-      let(:npq_application_1) { create :npq_application, :accepted, cohort: Cohort.previous, npq_lead_provider: provider.npq_lead_provider }
+      let(:npq_application_1) { create :npq_application, :accepted, cohort:, npq_lead_provider: provider.npq_lead_provider }
       let(:declaration_date_1) { npq_application.profile.schedule.milestones.find_by(declaration_type: "completed").start_date + 1.day }
-      let(:npq_application_2) { create :npq_application, :accepted, cohort: Cohort.previous, npq_lead_provider: provider.npq_lead_provider }
+      let(:npq_application_2) { create :npq_application, :accepted, cohort:, npq_lead_provider: provider.npq_lead_provider }
       let(:declaration_date_2) { npq_application.profile.schedule.milestones.find_by(declaration_type: "completed").start_date + 1.day }
       let!(:declaration_1) do
         travel_to declaration_date_1 do

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -574,8 +574,7 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
 
       context "when NPQ participant has completed declaration" do
         let(:cpd_lead_provider)     { create(:cpd_lead_provider, :with_lead_provider, :with_npq_lead_provider) }
-        let(:schedule)              { NPQCourse.schedule_for(npq_course:) }
-        let(:declaration_date)      { schedule.milestones.find_by(declaration_type:).start_date + 1.day }
+        let(:declaration_date)      { participant_profile.schedule.milestones.find_by(declaration_type:).start_date + 1.day }
         let(:npq_course) { create(:npq_leadership_course) }
         let(:participant_profile) do
           create(:npq_participant_profile, npq_lead_provider: cpd_lead_provider.npq_lead_provider, npq_course:)

--- a/spec/requests/api/v2/participant_declarations_spec.rb
+++ b/spec/requests/api/v2/participant_declarations_spec.rb
@@ -269,8 +269,7 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
 
       context "when NPQ participant has completed declaration" do
         let(:cpd_lead_provider)     { create(:cpd_lead_provider, :with_lead_provider, :with_npq_lead_provider) }
-        let(:schedule)              { NPQCourse.schedule_for(npq_course:) }
-        let(:declaration_date)      { schedule.milestones.find_by(declaration_type:).start_date + 1.day }
+        let(:declaration_date)      { participant_profile.schedule.milestones.find_by(declaration_type:).start_date + 1.day }
         let(:npq_course) { create(:npq_leadership_course) }
         let(:participant_profile) do
           create(:npq_participant_profile, npq_lead_provider: cpd_lead_provider.npq_lead_provider, npq_course:)

--- a/spec/requests/api/v3/participant_declarations_spec.rb
+++ b/spec/requests/api/v3/participant_declarations_spec.rb
@@ -581,8 +581,7 @@ RSpec.describe "API Participant Declarations", type: :request do
 
       context "when NPQ participant has completed declaration" do
         let(:cpd_lead_provider)     { create(:cpd_lead_provider, :with_npq_lead_provider) }
-        let(:schedule)              { NPQCourse.schedule_for(npq_course:) }
-        let(:declaration_date)      { schedule.milestones.find_by(declaration_type:).start_date + 1.day }
+        let(:declaration_date)      { participant_profile.schedule.milestones.find_by(declaration_type:).start_date + 1.day }
         let(:npq_course) { create(:npq_leadership_course) }
         let(:participant_profile) do
           create(:npq_participant_profile, npq_lead_provider: cpd_lead_provider.npq_lead_provider, npq_course:)

--- a/spec/requests/integration/participant_outcomes/creation_spec.rb
+++ b/spec/requests/integration/participant_outcomes/creation_spec.rb
@@ -3,12 +3,17 @@
 require "rails_helper"
 
 RSpec.describe "Participant outcomes", type: :request, end_to_end_scenario: true, perform_jobs: true do
-  let!(:declaration) { create :npq_participant_declaration, :eligible, declaration_type: "completed", participant_profile: npq_application.profile, cpd_lead_provider: provider }
+  let(:declaration_date) { npq_application.profile.schedule.milestones.find_by(declaration_type: "completed").start_date }
+  let!(:declaration) do
+    travel_to declaration_date + 2.days do
+      create(:npq_participant_declaration, :eligible, declaration_type: "completed", participant_profile: npq_application.profile, cpd_lead_provider: provider, declaration_date:)
+    end
+  end
   let(:provider) { create :cpd_lead_provider, :with_npq_lead_provider }
   let(:npq_application) { create :npq_application, :accepted, npq_lead_provider: provider.npq_lead_provider }
 
   let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: provider) }
-  let(:date) { Time.zone.today.to_fs("Y-m-d") }
+  let(:date) { (declaration_date + 2.days).to_fs("Y-m-d") }
   let(:response_headers) { { "test" => "test" } }
   let(:queue_name) { :participant_outcomes }
 
@@ -22,21 +27,23 @@ RSpec.describe "Participant outcomes", type: :request, end_to_end_scenario: true
   # Happy path
   scenario "provider creates a passed outcome for a participant with no previous recorded outcomes" do
     # Provider supplies the outcome via the API
-    post create_outcome_api_v2_npq_participants_path(participant_id: npq_application.participant_identity.external_identifier),
-         headers: {
-           Authorization: "Bearer #{token}",
-           CONTENT_TYPE: "application/json",
-         },
-         params: {
-           data: {
-             type: "npq-outcome-confirmation",
-             attributes: {
-               course_identifier: declaration.course_identifier,
-               state: "passed",
-               completion_date: date,
-             },
+    travel_to declaration_date + 3.days do
+      post create_outcome_api_v2_npq_participants_path(participant_id: npq_application.participant_identity.external_identifier),
+           headers: {
+             Authorization: "Bearer #{token}",
+             CONTENT_TYPE: "application/json",
            },
-         }.to_json
+           params: {
+             data: {
+               type: "npq-outcome-confirmation",
+               attributes: {
+                 course_identifier: declaration.course_identifier,
+                 state: "passed",
+                 completion_date: date,
+               },
+             },
+           }.to_json
+    end
 
     expect(response).to be_ok
     parsed_response = JSON.parse(response.body)
@@ -48,7 +55,7 @@ RSpec.describe "Participant outcomes", type: :request, end_to_end_scenario: true
     expect(outcome.sent_to_qualified_teachers_api_at).to be_nil
 
     # Outcome is sent to the qualified teachers API and the response is recorded correctly
-    freeze_time do
+    travel_to(date) do
       # TODO: This will either be triggered on demand or scheduled in future - remove if possible
       ParticipantOutcomes::BatchSendLatestOutcomesJob.perform_now
 

--- a/spec/requests/schools/dashboard_spec.rb
+++ b/spec/requests/schools/dashboard_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Schools::Dashboard", type: :request do
   let(:school) { user.schools.first }
 
   before do
-    travel_to Date.new(2022, 12, 1)
+    travel_to Date.new(2022, 9, 1)
     sign_in user
   end
 

--- a/spec/requests/schools/programme_choice_spec.rb
+++ b/spec/requests/schools/programme_choice_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Schools::ProgrammeChoice", type: :request, travel_to: Date.new(2021, 12, 1) do
+RSpec.describe "Schools::ProgrammeChoice", type: :request, travel_to: Date.new(2021, 10, 1) do
   let(:user) { create(:user, :induction_coordinator) }
   let(:school) { user.induction_coordinator_profile.schools.first }
   let(:cohort) { create(:cohort, start_year: 2021) }

--- a/spec/serializers/api/v1/participant_declaration_serializer_spec.rb
+++ b/spec/serializers/api/v1/participant_declaration_serializer_spec.rb
@@ -17,11 +17,12 @@ RSpec.describe Api::V1::ParticipantDeclarationSerializer do
   describe "#has_passed" do
     let(:declaration_type) { "completed" }
     let(:npq_course) { create(:npq_leadership_course) }
-    let(:schedule) { NPQCourse.schedule_for(npq_course:) }
-    let(:declaration_date) { schedule.milestones.find_by(declaration_type:).start_date + 1.day }
+    let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_npq_lead_provider) }
+    let(:npq_application) { create(:npq_application, :accepted, npq_course:, npq_lead_provider: cpd_lead_provider.npq_lead_provider) }
+    let(:declaration_date) { npq_application.profile.schedule.milestones.find_by(declaration_type:).start_date + 1.day }
     let(:participant_declaration) do
       travel_to declaration_date do
-        create(:npq_participant_declaration, :eligible, declaration_type:, declaration_date:, has_passed:)
+        create(:npq_participant_declaration, :eligible, declaration_type:, declaration_date:, has_passed:, participant_profile: npq_application.profile, cpd_lead_provider:)
       end
     end
 

--- a/spec/serializers/api/v2/participant_declaration_serializer_spec.rb
+++ b/spec/serializers/api/v2/participant_declaration_serializer_spec.rb
@@ -6,11 +6,12 @@ RSpec.describe Api::V2::ParticipantDeclarationSerializer do
   describe "#has_passed" do
     let(:declaration_type) { "completed" }
     let(:npq_course) { create(:npq_leadership_course) }
-    let(:schedule) { NPQCourse.schedule_for(npq_course:) }
-    let(:declaration_date) { schedule.milestones.find_by(declaration_type:).start_date + 1.day }
+    let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_npq_lead_provider) }
+    let(:npq_application) { create(:npq_application, :accepted, npq_course:, npq_lead_provider: cpd_lead_provider.npq_lead_provider) }
+    let(:declaration_date) { npq_application.profile.schedule.milestones.find_by(declaration_type:).start_date + 1.day }
     let(:participant_declaration) do
       travel_to declaration_date do
-        create(:npq_participant_declaration, :eligible, declaration_type:, declaration_date:, has_passed:)
+        create(:npq_participant_declaration, :eligible, declaration_type:, declaration_date:, has_passed:, participant_profile: npq_application.profile, cpd_lead_provider:)
       end
     end
 

--- a/spec/serializers/api/v3/participant_declaration_serializer_spec.rb
+++ b/spec/serializers/api/v3/participant_declaration_serializer_spec.rb
@@ -124,19 +124,19 @@ RSpec.describe Api::V3::ParticipantDeclarationSerializer do
   end
 
   describe "#has_passed" do
+    let(:cpd_lead_provider) { create :cpd_lead_provider, :with_npq_lead_provider }
+    let(:npq_application) { create(:npq_application, :accepted, npq_lead_provider: cpd_lead_provider.npq_lead_provider) }
     let(:declaration_type) { "completed" }
-    let(:npq_course) { create(:npq_leadership_course) }
-    let(:schedule) { NPQCourse.schedule_for(npq_course:) }
-    let(:declaration_date) { schedule.milestones.find_by(declaration_type:).start_date + 1.day }
+    let(:declaration_date) { npq_application.profile.schedule.milestones.find_by(declaration_type:).start_date + 1.day }
     let(:participant_declaration) do
       travel_to declaration_date do
-        create(:npq_participant_declaration, :eligible, declaration_type:, declaration_date:, has_passed:)
+        create(:npq_participant_declaration, :eligible, declaration_type:, declaration_date:, participant_profile: npq_application.profile, has_passed:, cpd_lead_provider:)
       end
     end
 
     describe "when participant declaration does not have outcome" do
       let(:participant_declaration) do
-        create(:npq_participant_declaration, :eligible, declaration_type: "started")
+        create(:npq_participant_declaration, :eligible, participant_profile: npq_application.profile, declaration_type: "started", cpd_lead_provider:)
       end
 
       it "returns nil" do

--- a/spec/serializers/finance/ecf/duplicate_serializer_spec.rb
+++ b/spec/serializers/finance/ecf/duplicate_serializer_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Finance::ECF::DuplicateSerializer do
         cohort: Cohort.current.display_name,
         training_status: "active",
         induction_status: "active",
-        start_date: Time.zone.local(Cohort.current.start_year, 9, 1), # FIXME: when fixing cohort academic start year
+        start_date: Cohort.current.academic_year_start_date.rfc3339,
         end_date: nil,
         school_transfer: false,
       )
@@ -53,7 +53,7 @@ RSpec.describe Finance::ECF::DuplicateSerializer do
       result = subject.serializable_hash
       expect(result[:data][:attributes][:participant_declarations][0]).to include(
         declaration_type: "started",
-        declaration_date: Time.zone.local(Cohort.current.start_year, 9, 1), # FIXME: when fixing cohort academic start year
+        declaration_date: Cohort.current.academic_year_start_date.rfc3339,
         course_identifier: "ecf-induction",
       )
     end

--- a/spec/services/change_milestone_date_spec.rb
+++ b/spec/services/change_milestone_date_spec.rb
@@ -61,7 +61,12 @@ describe ChangeMilestoneDate, type: :model do
       it { is_expected.to validate_presence_of(:new_start_date).with_message(/must be specified/) }
 
       context "when the declarations fall within the new milestone dates" do
-        before { create(:ect_participant_declaration, participant_profile:, cpd_lead_provider:, declaration_date: new_milestone_date - 1.day) }
+        let(:declaration_date) { new_milestone_date - 1.day }
+        before do
+          travel_to declaration_date do
+            create(:ect_participant_declaration, participant_profile:, cpd_lead_provider:, declaration_date:)
+          end
+        end
 
         it { expect(errors).not_to have_key(:new_milestone_date) }
       end

--- a/spec/services/importers/create_new_ecf_cohort_spec.rb
+++ b/spec/services/importers/create_new_ecf_cohort_spec.rb
@@ -4,7 +4,8 @@ require "tempfile"
 
 RSpec.describe Importers::CreateNewECFCohort do
   describe "#call" do
-    let(:start_year) { "2024" }
+    # TODO: hard coding year for now here and in csvs due to flaky tests but those need to be dynamic
+    let(:start_year) { "2025" }
 
     let(:cohort_csv) { "spec/fixtures/files/importers/cohort_csv_data.csv" }
     let(:cohort_lead_provider_csv) { "spec/fixtures/files/importers/cohort_lead_provider_csv_data.csv" }

--- a/spec/services/induction/amend_participant_cohort_spec.rb
+++ b/spec/services/induction/amend_participant_cohort_spec.rb
@@ -3,8 +3,8 @@
 RSpec.describe Induction::AmendParticipantCohort do
   describe "#save" do
     let(:participant_profile) {}
-    let(:source_cohort_start_year) { 2021 }
-    let(:target_cohort_start_year) { 2022 }
+    let(:source_cohort_start_year) { Cohort.previous.start_year }
+    let(:target_cohort_start_year) { Cohort.current.start_year }
 
     subject(:form) do
       described_class.new(participant_profile:, source_cohort_start_year:, target_cohort_start_year:)
@@ -71,8 +71,8 @@ RSpec.describe Induction::AmendParticipantCohort do
     end
 
     context "when the target cohort has not been setup in the service" do
-      let(:source_cohort_start_year) { 2023 }
-      let(:target_cohort_start_year) { 2024 }
+      let!(:source_cohort_start_year) { Cohort.next.start_year }
+      let!(:target_cohort_start_year) { Cohort.next.start_year + 1 }
 
       it "returns false and set errors" do
         travel_to Date.new(Cohort.ordered_by_start_year.last.start_year + 2, 9, 1)
@@ -222,7 +222,7 @@ RSpec.describe Induction::AmendParticipantCohort do
         %i[voided ineligible awaiting_clawback clawed_back].each do |declaration_state|
           context "when the participant has #{declaration_state} declarations and no billable or changeable declarations" do
             before do
-              participant_profile.participant_declarations.create!(declaration_date: Date.new(2021, 10, 10),
+              participant_profile.participant_declarations.create!(declaration_date: Date.new(Cohort.previous.start_year, 10, 10),
                                                                    declaration_type: :started,
                                                                    state: declaration_state,
                                                                    course_identifier: "ecf-induction",

--- a/spec/services/induction/amend_participant_cohort_spec.rb
+++ b/spec/services/induction/amend_participant_cohort_spec.rb
@@ -75,8 +75,7 @@ RSpec.describe Induction::AmendParticipantCohort do
       let(:target_cohort_start_year) { 2024 }
 
       it "returns false and set errors" do
-        # FIXME: this is temp until cohort specs are reverted back to 1/9
-        travel_to Date.new(Cohort.ordered_by_start_year.last.start_year + 2, 12, 1)
+        travel_to Date.new(Cohort.ordered_by_start_year.last.start_year + 2, 9, 1)
 
         expect(form.save).to be_falsey
         expect(form.errors[:target_cohort]).to_not be_nil

--- a/spec/services/npq/amend_participant_cohort_spec.rb
+++ b/spec/services/npq/amend_participant_cohort_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe NPQ::AmendParticipantCohort, type: :model do
   let!(:cohort_current) { Cohort.current }
   let(:cohort_previous) { Cohort.previous }
 
-  let(:target_cohort_start_year) { 2021 }
+  let(:target_cohort_start_year) { cohort_previous.start_year }
 
   subject { described_class.new(npq_application_id:, target_cohort_start_year:) }
 
@@ -55,7 +55,7 @@ RSpec.describe NPQ::AmendParticipantCohort, type: :model do
     context "when the target cohort is already set on the NPQ application" do
       it "returns an error message" do
         expect(subject).to be_invalid
-        expect(subject.errors.messages_for(:target_cohort_start_year)).to include("Invalid value. Must be different to 2021")
+        expect(subject.errors.messages_for(:target_cohort_start_year)).to include("Invalid value. Must be different to #{cohort_previous.start_year}")
       end
     end
 

--- a/spec/services/participants/history_builder_spec.rb
+++ b/spec/services/participants/history_builder_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Participants::HistoryBuilder, :with_support_for_ect_examples do
       event_list = described_class.from_participant_profile(fip_ect_only).events
 
       induction_programme_entries = event_list.filter { |ev| ev.type.to_s == "InductionRecord" and ev.predicate == "induction_programme_id" }
-      expect(induction_programme_entries.first.value).to include "Teach First TF Delivery Partner (2022/23)"
+      expect(induction_programme_entries.first.value).to include "Teach First TF Delivery Partner (#{Cohort.current.academic_year})"
     end
 
     it "records a name change at the end" do

--- a/spec/services/participants/sync_dqt_induction_start_date_spec.rb
+++ b/spec/services/participants/sync_dqt_induction_start_date_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Participants::SyncDQTInductionStartDate, with_feature_flags: { co
 
   context "when the participant was added to the service before 1st Jun 2023" do
     let(:participant_created_at) { Date.new(2023, 5, 31) }
-    let(:dqt_induction_start_date) { Date.new(2022, 12, 1) }
+    let(:dqt_induction_start_date) { Date.new(2022, 10, 1) }
 
     context "when participant's induction start date is present" do
       let(:participant_induction_start_date) { Date.new(2022, 9, 1) }
@@ -121,7 +121,7 @@ RSpec.describe Participants::SyncDQTInductionStartDate, with_feature_flags: { co
     end
 
     context "when the DQT induction start date's related cohort and the participant's cohort are the same" do
-      let(:dqt_induction_start_date) { Date.new(2022, 12, 2) }
+      let(:dqt_induction_start_date) { Date.new(2022, 10, 2) }
       let(:participant_cohort_start_year) { 2022 }
 
       it "changes the participant's induction start date only" do
@@ -133,7 +133,7 @@ RSpec.describe Participants::SyncDQTInductionStartDate, with_feature_flags: { co
     end
 
     context "when the DQT induction start date's related cohort and the participant's cohort are different" do
-      let(:dqt_induction_start_date) { Date.new(Cohort.current.start_year, 12, 2) }
+      let(:dqt_induction_start_date) { Date.new(Cohort.current.start_year, 10, 2) }
       let(:participant_cohort_start_year) { Cohort.previous.start_year }
       let(:target_school_cohort) do
         create(:seed_school_cohort, :fip, cohort: Cohort.current, school: participant_profile.school)
@@ -153,7 +153,7 @@ RSpec.describe Participants::SyncDQTInductionStartDate, with_feature_flags: { co
     end
 
     context "when the cohort can't be amended" do
-      let(:dqt_induction_start_date) { Date.new(Cohort.current.start_year, 12, 2) }
+      let(:dqt_induction_start_date) { Date.new(Cohort.current.start_year, 10, 2) }
       let(:participant_cohort_start_year) { Cohort.previous.start_year }
 
       it "does not change the participant and save the errors" do
@@ -166,7 +166,7 @@ RSpec.describe Participants::SyncDQTInductionStartDate, with_feature_flags: { co
     end
 
     context "when an error is already present from a previous job" do
-      let(:dqt_induction_start_date) { Date.new(Cohort.current.start_year, 12, 2) }
+      let(:dqt_induction_start_date) { Date.new(Cohort.current.start_year, 10, 2) }
       let!(:error) { SyncDQTInductionStartDateError.create!(participant_profile:, message: "test message") }
 
       context "when the participant is successfully processed" do

--- a/spec/services/partnerships/report_spec.rb
+++ b/spec/services/partnerships/report_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe Partnerships::Report do
   end
 
   context "challenge deadline to 31st October from 2023" do
-    let(:cohort) { create(:cohort, start_year: 2023, academic_year_start_date: Date.new(2023, 9, 1)) }
+    let(:cohort) { create(:cohort, start_year: 2023) }
 
     it "sets the challenge deadline to 31st October when the partnership is created before the 17th October", travel_to: Date.new(2023, 5, 1) do
       expect(result.challenge_deadline).to eq(Date.new(2023, 10, 31))
@@ -164,7 +164,7 @@ RSpec.describe Partnerships::Report do
   end
 
   context "challenge deadline to 31st October until 2022" do
-    let(:cohort) { create(:cohort, start_year: 2022, academic_year_start_date: Date.new(2022, 9, 1)) }
+    let(:cohort) { create(:cohort, start_year: 2022) }
 
     it "sets the challenge deadline to two weeks when the partnership is created from the 17th October", travel_to: Date.new(2023, 5, 1) do
       expect(result.challenge_deadline).to eq(Date.new(2023, 5, 15))

--- a/spec/services/record_declaration_spec.rb
+++ b/spec/services/record_declaration_spec.rb
@@ -403,19 +403,21 @@ RSpec.describe RecordDeclaration do
 
     context "for next cohort" do
       let!(:schedule) { create(:npq_specialist_schedule, cohort:) }
-      let!(:statement) { create(:npq_statement, :output_fee, deadline_date: 6.weeks.from_now, cpd_lead_provider:, cohort:) }
+      let!(:statement) { create(:npq_statement, :output_fee, deadline_date: declaration_date + 6.weeks, cpd_lead_provider:, cohort:) }
       let(:cohort) { Cohort.next || create(:cohort, :next) }
       let(:npq_lead_provider) { cpd_lead_provider.npq_lead_provider }
       let(:participant_profile) { create(:npq_participant_profile, :eligible_for_funding, npq_lead_provider:, npq_course:, schedule:) }
       let(:declaration_date) { participant_profile.schedule.milestones.find_by(declaration_type: "started").start_date }
 
       it "creates declaration to next cohort statement" do
-        expect { service.call }.to change { ParticipantDeclaration.count }.by(1)
+        travel_to declaration_date + 1.day do
+          expect { service.call }.to change { ParticipantDeclaration.count }.by(1)
 
-        declaration = ParticipantDeclaration.last
+          declaration = ParticipantDeclaration.last
 
-        expect(declaration).to be_eligible
-        expect(declaration.statements).to include(statement)
+          expect(declaration).to be_eligible
+          expect(declaration.statements).to include(statement)
+        end
       end
     end
 

--- a/spec/services/record_declaration_spec.rb
+++ b/spec/services/record_declaration_spec.rb
@@ -297,7 +297,7 @@ RSpec.describe RecordDeclaration do
 
   context "when the participant is an ECF" do
     let(:schedule)              { Finance::Schedule::ECF.find_by(schedule_identifier: "ecf-standard-september", cohort: current_cohort) }
-    let(:declaration_date)      { Date.new(current_cohort.start_year, 12, 2) } # FIXME: schedule.milestones.find_by(declaration_type: "started").start_date
+    let(:declaration_date)      { schedule.milestones.find_by(declaration_type: "started").start_date }
     let(:traits)                { [] }
     let(:opts)                  { {} }
     let(:participant_profile) do

--- a/spec/services/record_declarations/actions/make_declarations_payable_spec.rb
+++ b/spec/services/record_declarations/actions/make_declarations_payable_spec.rb
@@ -4,14 +4,14 @@ require "rails_helper"
 
 RSpec.describe RecordDeclarations::Actions::MakeDeclarationsPayable do
   let(:cpd_lead_provider)                { create(:cpd_lead_provider, :with_lead_provider, :with_npq_lead_provider) }
-  let(:cutoff_date)                      { Time.zone.local(2022, 1, 29) }
+  let(:cutoff_date)                      { Time.zone.local(2021, 11, 1) }
   let(:before_cutoff_date)               { cutoff_date - 1.day }
   let(:after_cutoff_date)                { cutoff_date + 1.day }
   let(:eligible_before_start_date_count) { 3 }
   let(:submitted_after_end_date_count)   { 2 }
   let(:ecf_declaration) do
     travel_to before_cutoff_date do
-      create(:ect_participant_declaration, :eligible, declaration_date: before_cutoff_date, cpd_lead_provider:, declaration_type: "retained-1")
+      create(:ect_participant_declaration, :eligible, declaration_date: before_cutoff_date, cpd_lead_provider:)
     end
   end
   let(:npq_declaration) do
@@ -34,8 +34,8 @@ RSpec.describe RecordDeclarations::Actions::MakeDeclarationsPayable do
     npq_declaration
 
     travel_to after_cutoff_date do
-      create_list(:ect_participant_declaration, submitted_after_end_date_count, :submitted, declaration_date: after_cutoff_date, cpd_lead_provider:, declaration_type: "retained-1")
-      create_list(:npq_participant_declaration, submitted_after_end_date_count, :submitted, declaration_date: after_cutoff_date, cpd_lead_provider:, declaration_type: "retained-1")
+      create_list(:ect_participant_declaration, submitted_after_end_date_count, :submitted, declaration_date: after_cutoff_date, cpd_lead_provider:)
+      create_list(:npq_participant_declaration, submitted_after_end_date_count, :submitted, declaration_date: after_cutoff_date, cpd_lead_provider:)
     end
   end
 

--- a/spec/services/statements/mark_as_paid_spec.rb
+++ b/spec/services/statements/mark_as_paid_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Statements::MarkAsPaid do
   let(:cpd_lead_provider)             { create(:cpd_lead_provider, :with_npq_lead_provider) }
   let(:cohort)                        { Cohort.current }
-  let(:eligible_statement)            { create(:npq_statement, cpd_lead_provider:, cohort:, deadline_date: 3.months.ago) }
-  let(:statement)                     { create(:npq_statement, cpd_lead_provider:, cohort:, deadline_date: 2.months.ago) }
+  let(:eligible_statement)            { create(:npq_statement, cpd_lead_provider:, cohort:, deadline_date: Cohort.next.registration_start_date - 3.months) }
+  let(:statement)                     { create(:npq_statement, cpd_lead_provider:, cohort:, deadline_date: Cohort.next.registration_start_date - 2.months) }
   let(:awaiting_clawback_declaration) { create(:npq_participant_declaration, :eligible, cpd_lead_provider:) }
 
   subject { described_class.new(statement) }

--- a/spec/services/void_participant_declaration_spec.rb
+++ b/spec/services/void_participant_declaration_spec.rb
@@ -113,8 +113,7 @@ RSpec.describe VoidParticipantDeclaration do
     end
 
     context "when NPQ completed declaration thats paid" do
-      let(:schedule) { NPQCourse.schedule_for(npq_course:) }
-      let(:declaration_date) { schedule.milestones.find_by(declaration_type:).start_date }
+      let(:declaration_date) { participant_profile.schedule.milestones.find_by(declaration_type:).start_date }
       let(:npq_course) { create(:npq_leadership_course) }
       let(:declaration_type) { "completed" }
       let(:participant_profile) do
@@ -127,7 +126,7 @@ RSpec.describe VoidParticipantDeclaration do
       end
 
       before do
-        create(:npq_statement, :output_fee, deadline_date: 6.weeks.from_now, cpd_lead_provider:)
+        create(:npq_statement, :output_fee, deadline_date: declaration_date + 1.month, cpd_lead_provider:)
       end
 
       it "can be voided" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -110,7 +110,7 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     # create cohorts since 2020 with default schedule
-    end_year = Date.current.month < 12 ? Date.current.year : Date.current.year + 1
+    end_year = Date.current.month < 9 ? Date.current.year : Date.current.year + 1
     (2020..end_year).each do |start_year|
       cohort = Cohort.find_by(start_year:) || FactoryBot.create(:cohort, start_year:)
       Finance::Schedule::ECF.default_for(cohort:) || FactoryBot.create(:ecf_schedule, cohort:)


### PR DESCRIPTION
### Context

When the new cohort rolled over on 1/9 many tests broke. To allow time to fix the tests, we pushed the date in cohort factories and specs a month (and then another and another) to buy ourselves time. 
The following prs are where we've pushed things forward, sometimes adding some hacks to get tests green:
https://github.com/DFE-Digital/early-careers-framework/pull/4216
https://github.com/DFE-Digital/early-careers-framework/pull/4071
https://github.com/DFE-Digital/early-careers-framework/pull/3919

Those prs have now been reverted, and the specs fixed to allow for dynamic cohorts going forward.

- Ticket: https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-2568

### Changes proposed in this pull request
- Revert all 3 pr changes to dates to original dates
- Add schedule tidy up from the following pr: https://github.com/DFE-Digital/early-careers-framework/pull/4169 to ensure we have accurate seeds
- Change factory schedule setup to be dynamic
- Amend as much as possible specs/features to be dynamic.

There are a few edgecases which needed to be hardcoded. Also please note further cleanup is needed on the specs, as this is just to get it green. We also need to get this merged before further schools team work on cleaning up cohortless dashboard which touches many of those features

### Guidance to review
Commit by commit, as although looks big its mostly similar logic
