### PR TITLE
[CST-2094] Enable SITs to access profiles of all their school mentors

### DIFF
--- a/app/controllers/schools/participants_controller.rb
+++ b/app/controllers/schools/participants_controller.rb
@@ -26,7 +26,7 @@ class Schools::ParticipantsController < Schools::BaseController
   end
 
   def show
-    @induction_record = @profile.induction_records.for_school(@school).latest
+    @induction_record = (@profile.induction_records.for_school(@school).latest || @profile.latest_induction_record)
     @first_induction_record = @profile.induction_records.oldest
     @mentor_profile = @induction_record.mentor_profile
     @ects = Dashboard::Participants.new(school: @school, user: current_user)

--- a/spec/policies/participant_profile/ecf_policy_spec.rb
+++ b/spec/policies/participant_profile/ecf_policy_spec.rb
@@ -170,6 +170,22 @@ RSpec.describe ParticipantProfile::ECFPolicy, type: :policy do
       it { is_expected.to forbid_action(:edit_email) }
       it { is_expected.to forbid_action(:update_email) }
     end
+
+    context "with a mentor who is mentoring, but not training at the school" do
+      let(:user) { create(:user, :induction_coordinator) }
+      let(:participant_profile) { create(:mentor_participant_profile) }
+
+      before do
+        Mentors::AddToSchool.call(mentor_profile: participant_profile, school: user.school)
+      end
+
+      it { is_expected.to permit_action(:show) }
+      it { is_expected.to forbid_action(:edit_name) }
+      it { is_expected.to forbid_action(:update_name) }
+      it { is_expected.to forbid_action(:edit_email) }
+      it { is_expected.to forbid_action(:update_email) }
+      it { is_expected.to forbid_action(:withdraw_record) }
+    end
   end
 
   context "induction tutor at a different school" do


### PR DESCRIPTION
### Context

- Ticket: CST-2094

Currently, SITs can't see profiles of mentors who are only mentoring at the school (a.k.a mentors in the school's mentor pool).

We want to enable SITs to see such profiles, but without altering them.

### Changes proposed in this pull request
- Update the ECFPolicy to enable SITs to see mentor profiles that are mentoring in their schools
- Update the ParticipantsController to get the mentor's induction record

### Guidance to review
1. Find to a school with mentors in their school mentor pool
2. Impersonate the SIT of the school
3. Visit the school's "Manage mentors and ECTs" page
4. Click on the name of the mentor
5. You should be able to see their profile, but not change any info
