### PR TITLE
Add oneoff service to migrate declarations between statements

### DIFF
--- a/app/services/oneoffs/npq/migrate_declarations_between_statements.rb
+++ b/app/services/oneoffs/npq/migrate_declarations_between_statements.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "has_recordable_information"
+
+module Oneoffs::NPQ
+  class MigrateDeclarationsBetweenStatements
+    class StatementMismatchError < StandardError; end
+
+    include HasRecordableInformation
+
+    def initialize(cohort:, from_statement_name:, to_statement_name:)
+      @cohort = cohort
+      @from_statement_name = from_statement_name
+      @to_statement_name = to_statement_name
+    end
+
+    def migrate(dry_run: true)
+      reset_recorded_info
+      ensure_statements_align!
+      record_summary_info(dry_run)
+
+      ActiveRecord::Base.transaction do
+        migrate_declarations_between_statements!
+
+        raise ActiveRecord::Rollback if dry_run
+      end
+
+      recorded_info
+    end
+
+  private
+
+    attr_reader :cohort, :from_statement_name, :to_statement_name
+
+    def migrate_declarations_between_statements!
+      each_statements_by_provider do |provider, from_statement, to_statement|
+        record_declarations_info(provider, from_statement.participant_declarations)
+        migrate_line_items!(from_statement, to_statement)
+        from_statement.update!(output_fee: false)
+      end
+    end
+
+    def migrate_line_items!(from_statement, to_statement)
+      from_statement.statement_line_items.update!(statement_id: to_statement.id)
+    end
+
+    def each_statements_by_provider
+      from_statements_by_provider.each do |provider, from_statement|
+        to_statement = to_statements_by_provider[provider]
+        yield(provider, from_statement, to_statement)
+      end
+    end
+
+    def record_summary_info(dry_run)
+      record_info("~~~ DRY RUN ~~~") if dry_run
+      record_info("Migrating declarations from #{from_statement_name} to #{to_statement_name} for #{provider_count} providers")
+    end
+
+    def record_declarations_info(provider, declarations)
+      record_info("Migrating #{declarations.size} declarations for #{provider.name}")
+    end
+
+    def ensure_statements_align!
+      statements_mismatch = from_statements_by_provider.keys.sort != to_statements_by_provider.keys.sort
+      statements_empty = from_statements_by_provider.empty? && to_statements_by_provider.empty?
+
+      raise StatementMismatchError, "There is a mismatch between to/from statements" if statements_mismatch
+      raise StatementMismatchError, "No statements were found" if statements_empty
+    end
+
+    def provider_count
+      from_statements_by_provider.count
+    end
+
+    def from_statements_by_provider
+      @from_statements_by_provider ||= statements_by_provider(from_statement_name)
+    end
+
+    def to_statements_by_provider
+      @to_statements_by_provider ||= statements_by_provider(to_statement_name)
+    end
+
+    def statements_by_provider(statement_name)
+      Finance::Statement::NPQ
+        .includes(:cohort)
+        .where(cohort:, name: statement_name)
+        .output
+        .group_by(&:npq_lead_provider)
+        .transform_values(&:first)
+    end
+  end
+end

--- a/spec/services/oneoffs/npq/migrate_declarations_between_statements_spec.rb
+++ b/spec/services/oneoffs/npq/migrate_declarations_between_statements_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+describe Oneoffs::NPQ::MigrateDeclarationsBetweenStatements do
+  let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_npq_lead_provider) }
+  let(:npq_lead_provider) { cpd_lead_provider.npq_lead_provider }
+  let(:from_statement) { create(:npq_statement, name: "April 2023", cpd_lead_provider:, cohort:, output_fee: true) }
+  let(:to_statement) { create(:npq_statement, name: "May 2023", cpd_lead_provider:, cohort:, output_fee: true) }
+  let(:from_statement_name) { from_statement.name }
+  let(:to_statement_name) { to_statement.name }
+  let(:cohort) { Cohort.current }
+
+  let(:instance) { described_class.new(cohort:, from_statement_name:, to_statement_name:) }
+
+  before { allow(Rails.logger).to receive(:info) }
+
+  describe "#migrate" do
+    let(:dry_run) { false }
+
+    subject(:migrate) { instance.migrate(dry_run:) }
+
+    it { is_expected.to eq(instance.recorded_info) }
+
+    it "sets output_fee to false on the from statements" do
+      expect { migrate }.to change { from_statement.reload.output_fee }.to(false)
+    end
+
+    context "when there are declarations" do
+      let(:declaration) { create(:npq_participant_declaration, :payable, cohort:, cpd_lead_provider:) }
+      let(:from_statement) { declaration.statements.first }
+
+      let(:cpd_lead_provider2) { declaration2.cpd_lead_provider }
+      let(:npq_lead_provider2) { cpd_lead_provider2.npq_lead_provider }
+      let(:declaration2) { create(:npq_participant_declaration, :payable, cohort:) }
+      let!(:from_statement2) { declaration2.statements.first.tap { |s| s.update!(name: from_statement.name) } }
+      let!(:to_statement2) { create(:npq_statement, name: to_statement.name, cpd_lead_provider: cpd_lead_provider2, cohort:, output_fee: true) }
+
+      let(:declarations) { [declaration1, declaration2] }
+
+      it "migrates them to the new statement" do
+        migrate
+
+        expect(declaration.statement_line_items.map(&:statement)).to all(eq(to_statement))
+        expect(declaration2.statement_line_items.map(&:statement)).to all(eq(to_statement2))
+      end
+
+      it "records information" do
+        migrate
+
+        expect(instance).to have_recorded_info([
+          "Migrating declarations from #{from_statement_name} to #{to_statement_name} for 2 providers",
+          "Migrating 1 declarations for #{npq_lead_provider.name}",
+          "Migrating 1 declarations for #{npq_lead_provider2.name}",
+        ])
+      end
+    end
+
+    context "when dry_run is true" do
+      let(:dry_run) { true }
+
+      it "does not make any changes, but logs out as if it does" do
+        expect { migrate }.not_to change { from_statement.reload.output_fee }
+
+        expect(instance).to have_recorded_info([
+          "~~~ DRY RUN ~~~",
+          "Migrating declarations from #{from_statement_name} to #{to_statement_name} for 1 providers",
+          "Migrating 0 declarations for #{npq_lead_provider.name}",
+        ])
+      end
+    end
+
+    describe "integrity checks" do
+      context "when there is a mismatch between the number of statements" do
+        let!(:mismatched_statement) { create(:npq_statement, cohort:, name: from_statement.name, output_fee: true) }
+
+        it { expect { migrate }.to raise_error(described_class::StatementMismatchError, "There is a mismatch between to/from statements") }
+      end
+
+      context "when attempting to migrate between statements on different cohorts" do
+        let(:other_cohort) { Cohort.previous }
+
+        before { from_statement.update!(cohort: other_cohort) }
+
+        it { expect { migrate }.to raise_error(described_class::StatementMismatchError, "There is a mismatch between to/from statements") }
+      end
+
+      context "when attempting to migrate statements that are output_fee false" do
+        before { from_statement.update!(output_fee: false) }
+
+        it { expect { migrate }.to raise_error(described_class::StatementMismatchError, "There is a mismatch between to/from statements") }
+      end
+
+      context "when attempting to migrate ECF statements" do
+        let(:from_statement) { create(:ecf_statement, name: "April 2023", cpd_lead_provider:, output_fee: true) }
+
+        it { expect { migrate }.to raise_error(described_class::StatementMismatchError, "There is a mismatch between to/from statements") }
+      end
+
+      context "when there are no statements found" do
+        let(:from_statement_name) { "Not found" }
+        let(:to_statement_name) { "Not found" }
+
+        it { expect { migrate }.to raise_error(described_class::StatementMismatchError, "No statements were found") }
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Jira-2592](https://dfedigital.atlassian.net/browse/CPDLP-2592)

### Context

We occasionally need to migrate declarations between different finance statements.

When doing this, we expect both statements to be output statements and after migrating the from statement should be updated to `output_fee: false`.

We only want to allow migration of NPQ declarations between NPQ statements and only when they are of the same cohort. We need to ensure there is a to/from statement for each provider.

### Changes proposed in this pull request

- Add oneoff service to migrate declarations between statements

### Guidance to review

It may be that in the future we want to allow an output fee of `false` for the to/from statements. I've hard-coded an output-fee of `true` for now and I figure we can expand the interface if we meet that use case in the future.

Dry run output of the declaration migration in the ticket of Dec 23 -> Feb 24 is in the Jira ticket.