### PR TITLE
Update appropriate body status translations

### DIFF
--- a/app/components/status_tags/appropriate_body_participant_status_tag.rb
+++ b/app/components/status_tags/appropriate_body_participant_status_tag.rb
@@ -17,7 +17,7 @@ module StatusTags
     end
 
     def description
-      Array.wrap(t(:description, scope: translation_scope, contact_us: render(MailToSupportComponent.new("contact us")))).map(&:html_safe)
+      Array.wrap(I18n.t(:description, scope: translation_scope, induction_completion_date:))
     rescue I18n::MissingTranslationData
       []
     end
@@ -27,6 +27,10 @@ module StatusTags
     end
 
   private
+
+    def induction_completion_date
+      training_record_state.participant_profile.induction_completion_date&.strftime("%-e %B %Y")
+    end
 
     def translation_scope
       @translation_scope ||= "status_tags.appropriate_body_participant_status.#{record_state}"

--- a/config/locales/status_tags/appropriate_body_participant_status.yml
+++ b/config/locales/status_tags/appropriate_body_participant_status.yml
@@ -152,9 +152,9 @@ en:
         description: "An induction period has been registered with the Teaching Regulation Agency (TRA) for this ECT."
 
       deferred_training:
-        id: "training_or_eligible_for_training"
-        label: "Induction confirmed"
-        description: "An induction period has been registered with the Teaching Regulation Agency (TRA) for this ECT."
+        id: "participant_deferred"
+        label: "Participant deferred"
+        description: "This participant's provider has reported that they've deferred. Contact the provider if you think this is wrong."
 
       withdrawn_training:
         id: "ect_no_longer_linked"
@@ -189,6 +189,6 @@ en:
         description: "This means the ECT has either completed, failed, or is exempt from serving their induction."
 
       completed_training:
-        id: "training_or_eligible_for_training"
-        label: "Induction confirmed"
-        description: "An induction period has been registered with the Teaching Regulation Agency (TRA) for this ECT."
+        id: "induction_completed"
+        label: "Induction completed"
+        description: "The Teaching Regulation Agency has recorded that this ECT completed their induction on %{induction_completion_date}."

--- a/spec/components/status_tags/appropriate_body_participant_status_tag_spec.rb
+++ b/spec/components/status_tags/appropriate_body_participant_status_tag_spec.rb
@@ -1,28 +1,26 @@
 # frozen_string_literal: true
 
 RSpec.describe StatusTags::AppropriateBodyParticipantStatusTag, type: :component do
-  let(:training_record_state) { instance_double(TrainingRecordState) }
+  let(:participant_profile) { create(:ect_participant_profile, induction_completion_date: Time.zone.now) }
+  let(:training_record_state) { instance_double(TrainingRecordState, participant_profile:) }
   let(:component) { described_class.new(training_record_state) }
 
-  subject(:label) { render_inline component }
+  subject { render_inline(component) }
 
-  context "The language file" do
-    TrainingRecordState::RECORD_STATES.each_key do |key|
-      it "includes the record_state :#{key} as a language entry" do
-        expect(I18n.t("status_tags.appropriate_body_participant_status").keys).to include key.to_sym
+  TrainingRecordState::RECORD_STATES.each_key do |record_state|
+    it "includes the record_state :#{record_state} as a language entry" do
+      allow(training_record_state).to receive(:record_state) { record_state }
+
+      expect(component.label).to be_present
+
+      expect(component.description).not_to be_empty
+      expect(component.description).to all(be_present)
+
+      is_expected.to have_css("p", text: component.label)
+
+      component.description.each do |description|
+        is_expected.to have_css("p", text: description)
       end
-    end
-  end
-
-  I18n.t("status_tags.appropriate_body_participant_status").each do |key, value|
-    context "when :#{key} is the determined state" do
-      before { allow(component).to receive(:record_state).and_return(key) }
-      it { is_expected.to have_text value[:label] }
-      it { is_expected.to have_text Array.wrap(value[:description]).join(" ") }
-    end
-
-    it "includes :#{key} as a recognised record_state" do
-      expect(TrainingRecordState::RECORD_STATES.keys).to include key.to_s
     end
   end
 end

--- a/spec/features/appropriate_bodies/participants_spec.rb
+++ b/spec/features/appropriate_bodies/participants_spec.rb
@@ -145,6 +145,6 @@ private
   end
 
   def and_i_do_not_see_newer_induction_record_details
-    expect(page).not_to have_content(latest_induction_record.training_status)
+    expect(page).not_to have_content("particpant has deferred")
   end
 end

--- a/spec/services/appropriate_bodies/participants_filter_spec.rb
+++ b/spec/services/appropriate_bodies/participants_filter_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe AppropriateBodies::ParticipantsFilter do
   end
 
   context "Status filter" do
-    context "Filter by training_or_eligible_for_training" do
-      let(:params) { { status: "training_or_eligible_for_training" } }
+    context "Filter by participant_deferred" do
+      let(:params) { { status: "participant_deferred" } }
 
       it { is_expected.to match_array([induction_record2]) }
     end


### PR DESCRIPTION
[Jira-2613](https://dfedigital.atlassian.net/browse/CPDLP-2613)

### Context

We have a new set of copy for some of the record states in the appropriate body status tag.

### Changes proposed in this pull request

- Update AB status tag localisations

Also removes unused code from view component and clean up the specs.

### Guidance to review

A side-effect of this is that the status filter labels will have changed.

I've updated the review app so the example AB has participants for testing.