### PR TITLE
Update DP status tag localisations

### DIFF
--- a/app/components/delivery_partners/participants/table_row.html.erb
+++ b/app/components/delivery_partners/participants/table_row.html.erb
@@ -24,9 +24,6 @@
     <%= cohort&.start_year %>
   </td>
   <td class="govuk-table__cell">
-    <%= training_status %>
-  </td>
-  <td class="govuk-table__cell">
     <%= render StatusTags::DeliveryPartnerParticipantStatusTag.new(training_record_states[participant_profile.id]) %>
   </td>
 </tr>

--- a/app/components/delivery_partners/participants/table_row.rb
+++ b/app/components/delivery_partners/participants/table_row.rb
@@ -16,8 +16,7 @@ module DeliveryPartners
                :user,
                to: :induction_record
 
-      delegate :training_status,
-               :school,
+      delegate :school,
                :participant_profile,
                to: :induction_record,
                allow_nil: true

--- a/app/components/status_tags/delivery_partner_participant_status_tag.rb
+++ b/app/components/status_tags/delivery_partner_participant_status_tag.rb
@@ -17,7 +17,7 @@ module StatusTags
     end
 
     def description
-      Array.wrap(t(:description, scope: translation_scope, contact_us: render(MailToSupportComponent.new("contact us")))).map(&:html_safe)
+      Array.wrap(I18n.t(:description, scope: translation_scope, induction_completion_date:))
     rescue I18n::MissingTranslationData
       []
     end
@@ -27,6 +27,10 @@ module StatusTags
     end
 
   private
+
+    def induction_completion_date
+      training_record_state.participant_profile.induction_completion_date&.strftime("%-e %B %Y")
+    end
 
     def translation_scope
       @translation_scope ||= "status_tags.delivery_partner_participant_status.#{record_state}"

--- a/app/views/delivery_partners/participants/index.html.erb
+++ b/app/views/delivery_partners/participants/index.html.erb
@@ -41,7 +41,6 @@
       <th scope="col" class="govuk-table__header">School</th>
       <th scope="col" class="govuk-table__header">School unique reference number</th>
       <th scope="col" class="govuk-table__header">Academic year</th>
-      <th scope="col" class="govuk-table__header">Training status</th>
       <th scope="col" class="govuk-table__header">Status</th>
     </tr>
   </thead>

--- a/config/locales/status_tags/delivery_partner_participant_status.yml
+++ b/config/locales/status_tags/delivery_partner_participant_status.yml
@@ -152,9 +152,9 @@ en:
         description: "We’ve confirmed these people are eligible for this programme. Your training provider will contact them directly."
 
       deferred_training:
-        id: "training_or_eligible_for_training"
-        label: "Training or eligible for training"
-        description: "We’ve confirmed these people are eligible for this programme. Your training provider will contact them directly."
+        id: "participant_deferred"
+        label: "Participant deferred"
+        description: "Your provider has reported that this particpant has deferred. Contact the provider if you think this is wrong."
 
       withdrawn_training:
         id: "no_longer_being_trained"
@@ -189,6 +189,6 @@ en:
         description: "We’ve checked these people’s details and found they’re not eligible for this programme."
 
       completed_training:
-        id: "training_or_eligible_for_training"
-        label: "Training or eligible for training"
-        description: "We’ve confirmed these people are eligible for this programme. Your training provider will contact them directly."
+        id: "induction_completed"
+        label: "Induction completed"
+        description: "The Teaching Regulation Agency has recorded that this ECT completed their induction on %{induction_completion_date}."

--- a/config/locales/status_tags/delivery_partner_participant_status.yml
+++ b/config/locales/status_tags/delivery_partner_participant_status.yml
@@ -7,149 +7,149 @@ en:
       validation_not_started:
         id: "contacted_for_information"
         label: "Contacted for information"
-        description: "We need this to check their eligibility with the Teaching Regulation Agency."
+        description: "We're checking this participant's details with the Teaching Regulation Agency to make sure they're eligible for funding."
 
       request_for_details_submitted:
         id: "contacted_for_information"
         label: "Contacted for information"
-        description: "We need this to check their eligibility with the Teaching Regulation Agency."
+        description: "We're checking this participant's details with the Teaching Regulation Agency to make sure they're eligible for funding."
 
       request_for_details_delivered:
         id: "contacted_for_information"
         label: "Contacted for information"
-        description: "We need this to check their eligibility with the Teaching Regulation Agency."
+        description: "We're checking this participant's details with the Teaching Regulation Agency to make sure they're eligible for funding."
 
       request_for_details_failed:
         id: "contacted_for_information"
         label: "Contacted for information"
-        description: "We need this to check their eligibility with the Teaching Regulation Agency."
+        description: "We're checking this participant's details with the Teaching Regulation Agency to make sure they're eligible for funding."
 
       internal_error:
         id: "dfe_checking_eligibility"
         label: "DfE checking eligibility"
-        description: "We’re checking these people’s details with the Teaching Regulation Agency to make sure they’re eligible for funding. We’ll confirm this soon."
+        description: "We're checking this participant's details with the Teaching Regulation Agency to make sure they're eligible for funding."
 
       checks_not_complete:
         id: "dfe_checking_eligibility"
         label: "DfE checking eligibility"
-        description: "We’re checking these people’s details with the Teaching Regulation Agency to make sure they’re eligible for funding. We’ll confirm this soon."
+        description: "We're checking this participant's details with the Teaching Regulation Agency to make sure they're eligible for funding."
 
       different_trn:
         id: "dfe_checking_eligibility"
         label: "DfE checking eligibility"
-        description: "We’re checking these people’s details with the Teaching Regulation Agency to make sure they’re eligible for funding. We’ll confirm this soon."
+        description: "We're checking this participant's details with the Teaching Regulation Agency to make sure they're eligible for funding."
 
       tra_record_not_found:
         id: "dfe_checking_eligibility"
         label: "DfE checking eligibility"
-        description: "We’re checking these people’s details with the Teaching Regulation Agency to make sure they’re eligible for funding. We’ll confirm this soon."
+        description: "We're checking this participant's details with the Teaching Regulation Agency to make sure they're eligible for funding."
 
       duplicate_profile:
         id: "not_eligible_for_funded_training"
         label: "Not eligible for funded training"
-        description: "We’ve checked these people’s details and found they’re not eligible for this programme."
+        description: "We’ve checked this participant’s details and found they’re not eligible for this programme."
 
       # TRA Record checks
 
       active_flags:
         id: "dfe_checking_eligibility"
         label: "DfE checking eligibility"
-        description: "We’re checking these people’s details with the Teaching Regulation Agency to make sure they’re eligible for funding. We’ll confirm this soon."
+        description: "We're checking this participant's details with the Teaching Regulation Agency to make sure they're eligible for funding."
 
       not_allowed:
         id: "not_eligible_for_funded_training"
         label: "Not eligible for funded training"
-        description: "We’ve checked these people’s details and found they’re not eligible for this programme."
+        description: "We’ve checked this participant’s details and found they’re not eligible for this programme."
 
       exempt_from_induction:
         id: "not_eligible_for_funded_training"
         label: "Not eligible for funded training"
-        description: "We’ve checked these people’s details and found they’re not eligible for this programme."
+        description: "We’ve checked this participant’s details and found they’re not eligible for this programme."
 
       not_qualified:
         id: "checking_qts"
         label: "Checking QTS"
-        description: "These ECTs do not have qualified teacher status (QTS) yet. They need this to be eligible for funded training. We’ll keep checking their status and notify you if something changes."
+        description: "This ECT does not have qualified teacher status (QTS) yet. They need this to be eligible for funded training. We’ll keep checking their status and notify you if something changes."
 
       no_induction_start:
         id: "dfe_checking_eligibility"
         label: "DfE checking eligibility"
-        description: "We’re checking these people’s details with the Teaching Regulation Agency to make sure they’re eligible for funding. We’ll confirm this soon."
+        description: "We're checking this participant's details with the Teaching Regulation Agency to make sure they're eligible for funding."
 
       # FIP ECTs
 
       registered_for_fip_no_partner:
         id: "training_or_eligible_for_training"
         label: "Training or eligible for training"
-        description: "We’ve confirmed these people are eligible for this programme. Your training provider will contact them directly."
+        description: "We’ve confirmed this participant is eligible for this programme. Your training provider will contact them directly."
 
       registered_for_fip_training:
         id: "training_or_eligible_for_training"
         label: "Training or eligible for training"
-        description: "We’ve confirmed these people are eligible for this programme. Your training provider will contact them directly."
+        description: "We’ve confirmed this participant is eligible for this programme. Your training provider will contact them directly."
 
       active_fip_training:
         id: "training_or_eligible_for_training"
         label: "Training or eligible for training"
-        description: "We’ve confirmed these people are eligible for this programme. Your training provider will contact them directly."
+        description: "We’ve confirmed this participant is eligible for this programme. Your training provider will contact them directly."
 
       # CIP ECTs
 
       registered_for_cip_training:
         id: "training_or_eligible_for_training"
         label: "Training or eligible for training"
-        description: "We’ve confirmed these people are eligible for this programme. Your training provider will contact them directly."
+        description: "We’ve confirmed this participant is eligible for this programme. Your training provider will contact them directly."
 
       active_cip_training:
         id: "training_or_eligible_for_training"
         label: "Training or eligible for training"
-        description: "We’ve confirmed these people are eligible for this programme. Your training provider will contact them directly."
+        description: "We’ve confirmed this participant is eligible for this programme. Your training provider will contact them directly."
 
       # DIY ECTs
 
       registered_for_diy_training:
         id: "training_or_eligible_for_training"
         label: "Training or eligible for training"
-        description: "We’ve confirmed these people are eligible for this programme. Your training provider will contact them directly."
+        description: "We’ve confirmed this participant is eligible for this programme. Your training provider will contact them directly."
 
       active_diy_training:
         id: "training_or_eligible_for_training"
         label: "Training or eligible for training"
-        description: "We’ve confirmed these people are eligible for this programme. Your training provider will contact them directly."
+        description: "We’ve confirmed this participant is eligible for this programme. Your training provider will contact them directly."
 
       # mentoring
 
       active_mentoring:
         id: "training_or_eligible_for_training"
         label: "Training or eligible for training"
-        description: "We’ve confirmed these people are eligible for this programme. Your training provider will contact them directly."
+        description: "We’ve confirmed this participant is eligible for this programme. Your training provider will contact them directly."
 
       not_yet_mentoring:
         id: "training_or_eligible_for_training"
         label: "Training or eligible for training"
-        description: "We’ve confirmed these people are eligible for this programme. Your training provider will contact them directly."
+        description: "We’ve confirmed this participant is eligible for this programme. Your training provider will contact them directly."
 
       active_mentoring_ero:
         id: "training_or_eligible_for_training"
         label: "Training or eligible for training"
-        description: "We’ve confirmed these people are eligible for this programme. Your training provider will contact them directly."
+        description: "We’ve confirmed this participant is eligible for this programme. Your training provider will contact them directly."
 
       not_yet_mentoring_ero:
         id: "training_or_eligible_for_training"
         label: "Training or eligible for training"
-        description: "We’ve confirmed these people are eligible for this programme. Your training provider will contact them directly."
+        description: "We’ve confirmed this participant is eligible for this programme. Your training provider will contact them directly."
 
       # changes of circumstance
 
       leaving:
         id: "training_or_eligible_for_training"
         label: "Training or eligible for training"
-        description: "We’ve confirmed these people are eligible for this programme. Your training provider will contact them directly."
+        description: "We’ve confirmed this participant is eligible for this programme. Your training provider will contact them directly."
 
       joining:
         id: "training_or_eligible_for_training"
         label: "Training or eligible for training"
-        description: "We’ve confirmed these people are eligible for this programme. Your training provider will contact them directly."
+        description: "We’ve confirmed this participant is eligible for this programme. Your training provider will contact them directly."
 
       deferred_training:
         id: "participant_deferred"
@@ -159,34 +159,34 @@ en:
       withdrawn_training:
         id: "no_longer_being_trained"
         label: "No longer being trained"
-        description: "Your provider reported that they’re not training the people listed below. If this is wrong, contact the relevant provider."
+        description: "Your provider reported they’re not training this participant. Ask them to update us if you think this is wrong."
 
       left:
         id: "no_longer_being_trained"
         label: "No longer being trained"
-        description: "Your provider reported that they’re not training the people listed below. If this is wrong, contact the relevant provider."
+        description: "Your provider reported they’re not training this participant. Ask them to update us if you think this is wrong."
 
       withdrawn_programme:
         id: "no_longer_being_trained"
         label: "No longer being trained"
-        description: "You are not responsible for the people listed below. If this is wrong, contact the relevant provider."
+        description: "Your provider reported they’re not training this participant. Ask them to update us if you think this is wrong."
 
       no_longer_involved:
         id: "no_longer_being_trained"
         label: "No longer being trained"
-        description: "You are not responsible for the people listed below. If this is wrong, contact the relevant provider."
+        description: "Your provider reported they’re not training this participant. Ask them to update us if you think this is wrong."
 
       not_registered_for_training:
         id: "no_longer_being_trained"
         label: "No longer being trained"
-        description: "You are not responsible for the people listed below. If this is wrong, contact the relevant provider."
+        description: "Your provider reported they’re not training this participant. Ask them to update us if you think this is wrong."
 
       # completion
 
       previous_induction:
         id: "not_eligible_for_funded_training"
         label: "Not eligible for funded training"
-        description: "We’ve checked these people’s details and found they’re not eligible for this programme."
+        description: "We’ve checked this participant’s details and found they’re not eligible for this programme."
 
       completed_training:
         id: "induction_completed"

--- a/spec/features/scenarios/participants/ect_doing_fip/after_cohort_transfer_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_fip/after_cohort_transfer_spec.rb
@@ -30,11 +30,10 @@ RSpec.feature "ECT doing FIP: after cohort transfer", type: :feature do
   let(:previous_start_year) { start_year - 1 }
   let(:registration_completed) { true }
   let(:participant_status) { "active" }
-  let(:training_status) { "active" }
   let(:training_record_state) { "Eligible to start" }
   let(:school_record_state) { "ELIGIBLE FOR TRAINING" }
   let(:delivery_partner_record_state) { "Training or eligible for training" }
-  let(:appropriate_body_Record_state) { "Training or eligible for training" }
+  let(:appropriate_body_record_state) { "Training or eligible for training" }
 
   let(:previous_cohort) do
     Cohort.find_by(start_year: previous_start_year)
@@ -127,7 +126,7 @@ RSpec.feature "ECT doing FIP: after cohort transfer", type: :feature do
     expect(appropriate_body_portal).to have_school_urn school.urn
     expect(appropriate_body_portal).to have_academic_year start_year
     expect(appropriate_body_portal).to have_training_status training_status
-    expect(appropriate_body_portal).to have_training_record_status appropriate_body_Record_state
+    expect(appropriate_body_portal).to have_training_record_status appropriate_body_record_state
   end
 
   scenario "The current lead provider can locate a record for the ECT" do
@@ -148,7 +147,6 @@ RSpec.feature "ECT doing FIP: after cohort transfer", type: :feature do
     expect(ecf_participant_endpoint).to have_pupil_premium_uplift
     expect(ecf_participant_endpoint).to have_sparsity_uplift
     expect(ecf_participant_endpoint).to have_status participant_status
-    expect(ecf_participant_endpoint).to have_training_status training_status
     expect(ecf_participant_endpoint).to have_training_record_id training_record_id
     expect(ecf_participant_endpoint).to have_schedule_identifier schedule_identifier
 
@@ -167,7 +165,6 @@ RSpec.feature "ECT doing FIP: after cohort transfer", type: :feature do
     expect(participant_endpoint).to have_pupil_premium_uplift
     expect(participant_endpoint).to have_sparsity_uplift
     expect(participant_endpoint).to have_status participant_status
-    expect(participant_endpoint).to have_training_status training_status
     expect(participant_endpoint).to have_training_record_id training_record_id
     expect(participant_endpoint).to have_schedule_identifier schedule_identifier
   end
@@ -186,7 +183,6 @@ RSpec.feature "ECT doing FIP: after cohort transfer", type: :feature do
     expect(delivery_partner_portal).to have_school_name school_name
     expect(delivery_partner_portal).to have_school_urn school.urn
     expect(delivery_partner_portal).to have_academic_year new_school_cohort.start_year
-    expect(delivery_partner_portal).to have_training_status training_status
     expect(delivery_partner_portal).to have_training_record_status delivery_partner_record_state
   end
 
@@ -240,7 +236,6 @@ RSpec.feature "ECT doing FIP: after cohort transfer", type: :feature do
     expect(drilldown).to have_school_urn school.urn
     expect(drilldown).to have_status participant_status
     expect(drilldown).to have_induction_status participant_status
-    expect(drilldown).to have_training_status training_status
     expect(drilldown).to be_eligible_for_funding
     expect(drilldown).to have_schedule schedule_identifier
     expect(drilldown).to have_schedule_identifier schedule_identifier

--- a/spec/features/scenarios/participants/ect_doing_fip/in_training_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_fip/in_training_spec.rb
@@ -29,11 +29,10 @@ RSpec.feature "ECT doing FIP: in training", type: :feature do
   let(:start_year) { Cohort.next.start_year }
   let(:registration_completed) { true }
   let(:participant_status) { "active" }
-  let(:training_status) { "active" }
   let(:training_record_state) { "Eligible to start" }
   let(:school_record_state) { "ELIGIBLE FOR TRAINING" }
   let(:delivery_partner_record_state) { "Training or eligible for training" }
-  let(:appropriate_body_Record_state) { "Training or eligible for training" }
+  let(:appropriate_body_record_state) { "Training or eligible for training" }
 
   let(:cohort) do
     Cohort.find_by(start_year:)
@@ -110,8 +109,7 @@ RSpec.feature "ECT doing FIP: in training", type: :feature do
     expect(appropriate_body_portal).to have_school_name school_name
     expect(appropriate_body_portal).to have_school_urn school.urn
     expect(appropriate_body_portal).to have_academic_year start_year
-    expect(appropriate_body_portal).to have_training_status training_status
-    expect(appropriate_body_portal).to have_training_record_status appropriate_body_Record_state
+    expect(appropriate_body_portal).to have_training_record_status appropriate_body_record_state
   end
 
   scenario "The current lead provider can locate a record for the ECT" do
@@ -132,7 +130,6 @@ RSpec.feature "ECT doing FIP: in training", type: :feature do
     expect(ecf_participant_endpoint).to have_pupil_premium_uplift
     expect(ecf_participant_endpoint).to have_sparsity_uplift
     expect(ecf_participant_endpoint).to have_status participant_status
-    expect(ecf_participant_endpoint).to have_training_status training_status
     expect(ecf_participant_endpoint).to have_training_record_id training_record_id
     expect(ecf_participant_endpoint).to have_schedule_identifier schedule_identifier
 
@@ -151,7 +148,6 @@ RSpec.feature "ECT doing FIP: in training", type: :feature do
     expect(participant_endpoint).to have_pupil_premium_uplift
     expect(participant_endpoint).to have_sparsity_uplift
     expect(participant_endpoint).to have_status participant_status
-    expect(participant_endpoint).to have_training_status training_status
     expect(participant_endpoint).to have_training_record_id training_record_id
     expect(participant_endpoint).to have_schedule_identifier schedule_identifier
   end
@@ -170,7 +166,6 @@ RSpec.feature "ECT doing FIP: in training", type: :feature do
     expect(delivery_partner_portal).to have_school_name school_name
     expect(delivery_partner_portal).to have_school_urn school.urn
     expect(delivery_partner_portal).to have_academic_year start_year
-    expect(delivery_partner_portal).to have_training_status training_status
     expect(delivery_partner_portal).to have_training_record_status delivery_partner_record_state
   end
 
@@ -224,7 +219,6 @@ RSpec.feature "ECT doing FIP: in training", type: :feature do
     expect(drilldown).to have_school_urn school.urn
     expect(drilldown).to have_status participant_status
     expect(drilldown).to have_induction_status participant_status
-    expect(drilldown).to have_training_status training_status
     expect(drilldown).to be_eligible_for_funding
     expect(drilldown).to have_schedule schedule_identifier
     expect(drilldown).to have_schedule_identifier schedule_identifier

--- a/spec/features/scenarios/participants/ect_doing_fip/no_validation_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_fip/no_validation_spec.rb
@@ -29,11 +29,10 @@ RSpec.feature "ECT doing FIP: no validation", type: :feature do
   let(:start_year) { Cohort.next.start_year }
   let(:registration_completed) { true }
   let(:participant_status) { "active" }
-  let(:training_status) { "active" }
   let(:training_record_state) { "Eligible to start" }
   let(:school_record_state) { "ELIGIBLE FOR TRAINING" }
   let(:delivery_partner_record_state) { "Training or eligible for training" }
-  let(:appropriate_body_Record_state) { "Training or eligible for training" }
+  let(:appropriate_body_record_state) { "Training or eligible for training" }
 
   let(:cohort) do
     Cohort.find_by(start_year:)
@@ -111,8 +110,7 @@ RSpec.feature "ECT doing FIP: no validation", type: :feature do
     expect(appropriate_body_portal).to have_school_name school_name
     expect(appropriate_body_portal).to have_school_urn school.urn
     expect(appropriate_body_portal).to have_academic_year start_year
-    expect(appropriate_body_portal).to have_training_status training_status
-    expect(appropriate_body_portal).to have_training_record_status appropriate_body_Record_state
+    expect(appropriate_body_portal).to have_training_record_status appropriate_body_record_state
   end
 
   scenario "The current lead provider can locate a record for the ECT" do
@@ -133,7 +131,6 @@ RSpec.feature "ECT doing FIP: no validation", type: :feature do
     expect(ecf_participant_endpoint).to have_pupil_premium_uplift
     expect(ecf_participant_endpoint).to have_sparsity_uplift
     expect(ecf_participant_endpoint).to have_status participant_status
-    expect(ecf_participant_endpoint).to have_training_status training_status
     expect(ecf_participant_endpoint).to have_training_record_id training_record_id
     expect(ecf_participant_endpoint).to have_schedule_identifier schedule_identifier
 
@@ -152,7 +149,6 @@ RSpec.feature "ECT doing FIP: no validation", type: :feature do
     expect(participant_endpoint).to have_pupil_premium_uplift
     expect(participant_endpoint).to have_sparsity_uplift
     expect(participant_endpoint).to have_status participant_status
-    expect(participant_endpoint).to have_training_status training_status
     expect(participant_endpoint).to have_training_record_id training_record_id
     expect(participant_endpoint).to have_schedule_identifier schedule_identifier
   end
@@ -171,7 +167,6 @@ RSpec.feature "ECT doing FIP: no validation", type: :feature do
     expect(delivery_partner_portal).to have_school_name school_name
     expect(delivery_partner_portal).to have_school_urn school.urn
     expect(delivery_partner_portal).to have_academic_year start_year
-    expect(delivery_partner_portal).to have_training_status training_status
     expect(delivery_partner_portal).to have_training_record_status delivery_partner_record_state
   end
 
@@ -225,7 +220,6 @@ RSpec.feature "ECT doing FIP: no validation", type: :feature do
     expect(drilldown).to have_school_urn school.urn
     expect(drilldown).to have_status participant_status
     expect(drilldown).to have_induction_status participant_status
-    expect(drilldown).to have_training_status training_status
     # TODO: is this correct?
     expect(drilldown).to be_eligible_for_funding
     expect(drilldown).to have_schedule schedule_identifier

--- a/spec/services/delivery_partners/participants_filter_spec.rb
+++ b/spec/services/delivery_partners/participants_filter_spec.rb
@@ -112,8 +112,8 @@ RSpec.describe DeliveryPartners::ParticipantsFilter do
       it { is_expected.to be_empty }
     end
 
-    context "when status is training_or_eligible_for_training" do
-      let(:params) { { status: "training_or_eligible_for_training" } }
+    context "when status is participant_deferred" do
+      let(:params) { { status: "participant_deferred" } }
 
       it { is_expected.to contain_exactly(induction_record2) }
     end

--- a/spec/support/features/pages/delivery_partner/delivery_partner_portal.rb
+++ b/spec/support/features/pages/delivery_partner/delivery_partner_portal.rb
@@ -16,7 +16,6 @@ module Pages
       column :school_name
       column :school_urn
       column :academic_year, format: ->(s) { s.to_i }
-      column :training_status
       column :training_record_status, format: ->(s) { s.split("\n")[0] }
     end
 
@@ -59,10 +58,6 @@ module Pages
 
     def has_academic_year?(expected_value)
       has_attribute_value? "academic_year", expected_value.to_i
-    end
-
-    def has_training_status?(expected_value)
-      has_attribute_value? "training_status", expected_value
     end
 
     def has_training_record_status?(expected_value)


### PR DESCRIPTION
[Jira-2564](https://dfedigital.atlassian.net/browse/CPDLP-2564)

### Context

We have a new set of copy for some of the record states in the delivery partner status tag. We also want to remove the training status column (to leave only the status column).

### Changes proposed in this pull request

- Update DP status tag localisations

We have a new set of copy for some of the record states in the delivery partner status tag.

- Remove training status column from DP participants

We no longer want to display the training status in the DP participants view.

### Guidance to review

I've added a bunch of participants to [this delivery partner](https://cpd-ecf-review-4270-web.test.teacherservices.cloud/delivery-partners/6cdcdf5c-3ab0-4759-b67c-f216490d9405/participants) for testing.