### PR TITLE
[CPDLP-2609] Ensure that updated_at value of unfunded mentor is touched when an unfunded mentor gets linked to an ECT

### DIFF
--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -146,7 +146,10 @@ private
   def sync_status_with_induction_record
     induction_record = induction_records.latest
     induction_record&.update!(induction_status: status) if saved_change_to_status?
-    induction_record&.update!(mentor_profile:) if saved_change_to_mentor_profile_id?
+    if saved_change_to_mentor_profile_id?
+      induction_record&.update!(mentor_profile:)
+      mentor_profile&.user&.touch
+    end
   end
 end
 

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -146,10 +146,7 @@ private
   def sync_status_with_induction_record
     induction_record = induction_records.latest
     induction_record&.update!(induction_status: status) if saved_change_to_status?
-    if saved_change_to_mentor_profile_id?
-      induction_record&.update!(mentor_profile:)
-      mentor_profile&.user&.touch
-    end
+    induction_record&.update!(mentor_profile:) if saved_change_to_mentor_profile_id?
   end
 end
 

--- a/app/services/induction/change_mentor.rb
+++ b/app/services/induction/change_mentor.rb
@@ -7,6 +7,7 @@ class Induction::ChangeMentor < BaseService
                                             changes: { mentor_profile: })
 
       induction_record.participant_profile.update!(mentor_profile:)
+      mentor_profile&.user&.touch
     end
   end
 

--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -7,6 +7,14 @@ weight: 8
 
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
 
+## 20 November 2023
+
+We've fixed a bug that meant some providers were having issues finding unfunded mentor IDs in GET participants.
+
+The `updated_at` value of an unfunded mentor now gets touched when the mentor is linked to an ECT.
+
+An API call to the unfunded mentors endpoint filtered for any updates once the link has been made will return the unfunded mentor in the response.
+
 ## 9 November 2023
 
 We're trialing new functionality in the API v3 sandbox which allows lead providers to add a participant's schedule when accepting NPQ applications.

--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -7,7 +7,7 @@ weight: 8
 
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
 
-## 20 November 2023
+## 28 November 2023
 
 We've fixed a bug that meant some providers were having issues finding unfunded mentor IDs in GET participants.
 

--- a/spec/models/participant_profile/ecf_spec.rb
+++ b/spec/models/participant_profile/ecf_spec.rb
@@ -49,6 +49,21 @@ RSpec.describe ParticipantProfile::ECF, type: :model do
         expect(induction_record.reload).to be_training_status_deferred
       end
     end
+
+    context "when the mentor profile changes" do
+      let(:mentor_profile) { create(:mentor_participant_profile) }
+
+      it "updates the mentor profile on the active induction record" do
+        profile.update!(mentor_profile:)
+        expect(induction_record.reload.mentor_profile).to eq(mentor_profile)
+      end
+
+      it "touches the mentor user" do
+        expect {
+          profile.update!(mentor_profile:)
+        }.to change(mentor_profile.user, :updated_at)
+      end
+    end
   end
 
   describe "contacted_for_info?" do

--- a/spec/models/participant_profile/ecf_spec.rb
+++ b/spec/models/participant_profile/ecf_spec.rb
@@ -57,12 +57,6 @@ RSpec.describe ParticipantProfile::ECF, type: :model do
         profile.update!(mentor_profile:)
         expect(induction_record.reload.mentor_profile).to eq(mentor_profile)
       end
-
-      it "touches the mentor user" do
-        expect {
-          profile.update!(mentor_profile:)
-        }.to change(mentor_profile.user, :updated_at)
-      end
     end
   end
 

--- a/spec/models/participant_profile/ect_spec.rb
+++ b/spec/models/participant_profile/ect_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe ParticipantProfile::ECT, type: :model do
+  let(:instance) { described_class.new }
+
+  describe "associations" do
+    it { is_expected.to belong_to(:mentor_profile).class_name("ParticipantProfile::Mentor").optional }
+    it { is_expected.to have_one(:mentor).through(:mentor_profile).source(:user) }
+  end
+
+  describe "callbacks" do
+    it "updates the updated_at on associated mentor profile user when meaningfully updated" do
+      freeze_time
+      profile = create(:ect_participant_profile, updated_at: 2.weeks.ago)
+      user = profile.user
+      user.update!(updated_at: 2.weeks.ago)
+
+      profile.update!(updated_at: Time.zone.now - 1.day)
+
+      expect(user.reload.updated_at).to be_within(1.second).of Time.zone.now
+    end
+
+    it "does not update the updated_at on associated mentor profile user when not changed" do
+      freeze_time
+      profile = create(:ect_participant_profile, updated_at: 2.weeks.ago)
+      user = profile.user
+      user.update!(updated_at: 2.weeks.ago)
+
+      profile.save!
+
+      expect(user.reload.updated_at).to be_within(1.second).of 2.weeks.ago
+    end
+  end
+
+  describe "#ect?" do
+    it { expect(instance).to be_ect }
+  end
+
+  describe "#participant_type" do
+    it { expect(instance.participant_type).to eq(:ect) }
+  end
+
+  describe "#role" do
+    it { expect(instance.role).to eq("Early career teacher") }
+  end
+end

--- a/spec/services/induction/change_mentor_spec.rb
+++ b/spec/services/induction/change_mentor_spec.rb
@@ -22,5 +22,11 @@ RSpec.describe Induction::ChangeMentor do
       service.call(induction_record:, mentor_profile: mentor_profile_2)
       expect(ect_profile.current_induction_record.mentor_profile).to eq mentor_profile_2
     end
+
+    it "touches the mentor user" do
+      expect {
+        service.call(induction_record:, mentor_profile: mentor_profile_2)
+      }.to change(mentor_profile_2.user, :updated_at)
+    end
   end
 end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-2609

### Changes proposed in this pull request

Ensure that updated_at value of unfunded mentor is touched when an unfunded mentor gets linked to an ECT.