### PR TITLE
[CPDLP-2646] Stream ApiRequest with request body to big query events

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,3 +55,7 @@ Lint/MissingSuper:
 Rails/SaveBang:
   Exclude:
     - "app/services/migrators/*"
+
+Style/RedundantFetchBlock:
+  Exclude:
+    - 'app/middlewares/api_request_middleware.rb'

--- a/app/jobs/api_request_job.rb
+++ b/app/jobs/api_request_job.rb
@@ -4,7 +4,9 @@ class ApiRequestJob
   include Sidekiq::Worker
   include ActionController::HttpAuthentication::Token
 
-  def perform(request_data, response_data, status_code, created_at)
+  def perform(request_data, response_data, status_code, created_at, uuid)
+    RequestLocals.store[:dfe_analytics_request_id] = uuid
+
     request_data = request_data.with_indifferent_access
     response_data = response_data.with_indifferent_access
     request_headers = request_data.fetch(:headers, {})

--- a/app/middlewares/api_request_middleware.rb
+++ b/app/middlewares/api_request_middleware.rb
@@ -29,7 +29,7 @@ class ApiRequestMiddleware
 
     begin
       if trace_request?
-        ApiRequestJob.perform_async(request_data.stringify_keys, response_data.stringify_keys, status, Time.zone.now.to_s)
+        ApiRequestJob.perform_async(request_data.stringify_keys, response_data.stringify_keys, status, Time.zone.now.to_s, RequestLocals.fetch(:dfe_analytics_request_id) { nil })
       end
     rescue StandardError => e
       Rails.logger.warn e.message

--- a/app/middlewares/api_request_middleware.rb
+++ b/app/middlewares/api_request_middleware.rb
@@ -29,6 +29,8 @@ class ApiRequestMiddleware
 
     begin
       if trace_request?
+        # dfe_analytics_request_id is explicitly being sent to ApiRequestJob as sidekiq does not share the same locals of the main app
+        # and dfe_analytics_request_id is used to set request_uuid value for analytics events
         ApiRequestJob.perform_async(request_data.stringify_keys, response_data.stringify_keys, status, Time.zone.now.to_s, RequestLocals.fetch(:dfe_analytics_request_id) { nil })
       end
     rescue StandardError => e

--- a/app/models/api_request.rb
+++ b/app/models/api_request.rb
@@ -5,4 +5,10 @@ class ApiRequest < ApplicationRecord
   scope :unprocessable_entities, -> { where(status_code: 422) }
   scope :errors, -> { where.not(status_code: [200, 302, 301]) }
   scope :successful, -> { where(status_code: [200]) }
+
+  def send_event(type, data)
+    return if cpd_lead_provider.blank?
+
+    super
+  end
 end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -348,3 +348,16 @@
   - type
   - cohort_id
   - identifier_alias
+  :api_requests:
+  - id
+  - request_path
+  - status_code
+  - request_headers
+  - request_body
+  - response_body
+  - request_method
+  - response_headers
+  - cpd_lead_provider_id
+  - user_description
+  - created_at
+  - updated_at

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -420,19 +420,6 @@
   - body
   - created_at
   - updated_at
-  :api_requests:
-  - id
-  - request_path
-  - status_code
-  - request_headers
-  - request_body
-  - response_body
-  - request_method
-  - response_headers
-  - cpd_lead_provider_id
-  - user_description
-  - created_at
-  - updated_at
   :admin_profiles:
   - id
   - user_id

--- a/spec/factories/api_request.rb
+++ b/spec/factories/api_request.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :api_request do
+    association :cpd_lead_provider
+
+    request_path { "/api/v3/npq-applications" }
+    request_headers do
+      {
+        "host"=>"example.com",
+        "accept"=>"*/*",
+        "user-agent"=>"Ruby",
+        "content-type"=>"application/json",
+        "content-length"=>"59",
+        "accept-encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+      }
+    end
+    request_body { { "page" => { "page" => "61", "per_page" => "100" }, "filter" => { "updated_since"=>"1970-01-01T00:00:00+01:00" } } }
+    response_body { nil }
+    request_method { "GET" }
+    response_headers { { "Content-Type"=>"application/vnd.api+json" } }
+    user_description { "CPD lead provider: Test" }
+
+    trait :unprocessable_entity do
+      status_code { 422 }
+    end
+
+    trait :success do
+      status_code { 200 }
+    end
+
+    trait :errors do
+      status_code { 400 }
+      response_body do
+        { "errors"=>
+      [{ "title"=>"test_id",
+        "detail"=>
+         "Test error message" }] }
+      end
+    end
+  end
+end

--- a/spec/jobs/api_request_job_spec.rb
+++ b/spec/jobs/api_request_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ApiRequestJob do
     it "creates a ApiRequest record" do
       Sidekiq::Testing.inline! do
         expect {
-          described_class.new.perform({}, {}, 401, Time.zone.now)
+          described_class.new.perform({}, {}, 401, Time.zone.now, nil)
         }.to change(ApiRequest, :count).by(1)
       end
     end
@@ -18,7 +18,7 @@ RSpec.describe ApiRequestJob do
       token = LeadProviderApiToken.create_with_random_token!(cpd_lead_provider:)
 
       headers = { "HTTP_AUTHORIZATION" => "Bearer #{token}" }
-      described_class.new.perform({ headers: }, {}, 500, Time.zone.now)
+      described_class.new.perform({ headers: }, {}, 500, Time.zone.now, nil)
 
       expect(ApiRequest.find_by(cpd_lead_provider:)).not_to be_nil
       expect(ApiRequest.find_by(cpd_lead_provider:).user_description).to eq "CPD lead provider: Ambition"
@@ -28,7 +28,7 @@ RSpec.describe ApiRequestJob do
       token = EngageAndLearnApiToken.create_with_random_token!
 
       headers = { "HTTP_AUTHORIZATION" => "Bearer #{token}" }
-      described_class.new.perform({ headers: }, {}, 500, Time.zone.now)
+      described_class.new.perform({ headers: }, {}, 500, Time.zone.now, nil)
 
       expect(ApiRequest.find_by(user_description: "Engage and learn application")).not_to be_nil
     end
@@ -40,6 +40,7 @@ RSpec.describe ApiRequestJob do
       { headers: { "this" => "that" }, body: { "that" => "this" }.to_json },
       500,
       Time.zone.now,
+      nil,
     )
 
     api_request = ApiRequest.find_by(request_path: "/api/v1/foo")
@@ -49,7 +50,7 @@ RSpec.describe ApiRequestJob do
   end
 
   it "saves the request method on the api request" do
-    described_class.new.perform({ headers: {}, path: "/api/v1/bar", method: "GET" }, {}, 500, Time.zone.now)
+    described_class.new.perform({ headers: {}, path: "/api/v1/bar", method: "GET" }, {}, 500, Time.zone.now, nil)
 
     expect(ApiRequest.find_by(request_path: "/api/v1/bar").request_method).to eq("GET")
   end
@@ -59,7 +60,7 @@ RSpec.describe ApiRequestJob do
       params: { "foo" => "meh" },
       path: "/api/v1/bar",
       method: "GET",
-    }, {}, 500, Time.zone.now)
+    }, {}, 500, Time.zone.now, nil)
 
     expect(ApiRequest.find_by(request_path: "/api/v1/bar").request_body).to eq("foo" => "meh")
   end
@@ -69,7 +70,7 @@ RSpec.describe ApiRequestJob do
       body: { "foo" => "meh" }.to_json,
       path: "/api/v1/bar",
       method: "POST",
-    }, {}, 500, Time.zone.now)
+    }, {}, 500, Time.zone.now, nil)
 
     expect(ApiRequest.find_by(request_path: "/api/v1/bar").request_body).to eq("foo" => "meh")
   end
@@ -79,7 +80,7 @@ RSpec.describe ApiRequestJob do
       body: { "foo" => "meh" }.to_json,
       path: "/api/v1/bar",
       method: "PUT",
-    }, {}, 500, Time.zone.now)
+    }, {}, 500, Time.zone.now, nil)
 
     expect(ApiRequest.find_by(request_path: "/api/v1/bar").request_body).to eq("foo" => "meh")
   end
@@ -89,7 +90,7 @@ RSpec.describe ApiRequestJob do
       body: "This is not JSON",
       path: "/api/v1/bar",
       method: "POST",
-    }, {}, 500, Time.zone.now)
+    }, {}, 500, Time.zone.now, nil)
 
     expect(ApiRequest.find_by(request_path: "/api/v1/bar").request_body).to eq("error" => "request data did not contain valid JSON")
   end
@@ -99,8 +100,29 @@ RSpec.describe ApiRequestJob do
       body: "",
       path: "/api/v1/bar",
       method: "POST",
-    }, {}, 500, Time.zone.now)
+    }, {}, 500, Time.zone.now, nil)
 
     expect(ApiRequest.find_by(request_path: "/api/v1/bar").request_body).to be_nil
+  end
+
+  context "when the dfe_analytics feature is enabled" do
+    before { FeatureFlag.activate(:dfe_analytics) }
+
+    let(:request_uuid) { SecureRandom.uuid }
+
+    it "saves the request_uuid on the big query event" do
+      cpd_lead_provider = create(:cpd_lead_provider, name: "Ambition")
+      token = LeadProviderApiToken.create_with_random_token!(cpd_lead_provider:)
+      headers = { "HTTP_AUTHORIZATION" => "Bearer #{token}" }
+
+      expect {
+        described_class.new.perform({
+          headers:,
+          body: { "foo" => "meh" }.to_json,
+          path: "/api/v1/bar",
+          method: "POST",
+        }, {}, 500, Time.zone.now, request_uuid)
+      }.to have_enqueued_job(DfE::Analytics::SendEvents).with(array_including(hash_including("request_uuid" => request_uuid))).on_queue("dfe_analytics")
+    end
   end
 end

--- a/spec/middlewares/api_request_middleware_spec.rb
+++ b/spec/middlewares/api_request_middleware_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ApiRequestMiddleware do
       request.get "/api/v1/participants/ecf", params: { foo: "bar" }
 
       expect(ApiRequestJob).to have_received(:perform_async).with(
-        hash_including("path" => "/api/v1/participants/ecf", "params" => { "foo" => "bar" }, "method" => "GET"), anything, 200, anything
+        hash_including("path" => "/api/v1/participants/ecf", "params" => { "foo" => "bar" }, "method" => "GET"), anything, 200, anything, anything
       )
     end
   end
@@ -45,7 +45,7 @@ RSpec.describe ApiRequestMiddleware do
       request.get "/api/v3/participants/ecf", params: { foo: "bar" }
 
       expect(ApiRequestJob).to have_received(:perform_async).with(
-        hash_including("path" => "/api/v3/participants/ecf", "params" => { "foo" => "bar" }, "method" => "GET"), anything, 200, anything
+        hash_including("path" => "/api/v3/participants/ecf", "params" => { "foo" => "bar" }, "method" => "GET"), anything, 200, anything, anything
       )
     end
   end
@@ -55,7 +55,7 @@ RSpec.describe ApiRequestMiddleware do
       request.post "/api/v1/participant-declarations", as: :json, params: { foo: "bar" }.to_json
 
       expect(ApiRequestJob).to have_received(:perform_async).with(
-        hash_including("path" => "/api/v1/participant-declarations", "body" => '{"foo":"bar"}', "method" => "POST"), anything, 200, anything
+        hash_including("path" => "/api/v1/participant-declarations", "body" => '{"foo":"bar"}', "method" => "POST"), anything, 200, anything, anything
       )
     end
   end

--- a/spec/models/api_request_spec.rb
+++ b/spec/models/api_request_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ApiRequest, type: :model do
+  subject { build(:api_request) }
+
+  describe "associations" do
+    it { is_expected.to belong_to(:cpd_lead_provider).optional }
+  end
+
+  describe "scopes" do
+    describe "unprocessable_entities" do
+      let!(:api_request_one) { create(:api_request, :success) }
+      let!(:api_request_two) { create(:api_request, :unprocessable_entity) }
+
+      it "returns unprocessable entities records only" do
+        expect(described_class.unprocessable_entities).to eq([api_request_two])
+      end
+    end
+
+    describe "errors" do
+      let!(:api_request_one) { create(:api_request, :errors) }
+      let!(:api_request_two) { create(:api_request, :success) }
+
+      it "returns unprocessable entities records only" do
+        expect(described_class.errors).to eq([api_request_one])
+      end
+    end
+
+    describe "successful" do
+      let!(:api_request_one) { create(:api_request, :success) }
+      let!(:api_request_two) { create(:api_request, :unprocessable_entity) }
+
+      it "returns unprocessable entities records only" do
+        expect(described_class.successful).to eq([api_request_one])
+      end
+    end
+  end
+
+  describe "#send_event" do
+    before do
+      FeatureFlag.activate(:dfe_analytics)
+      allow(DfE::Analytics::SendEvents).to receive(:perform_later)
+    end
+
+    it "sends analytics events with the request uuid" do
+      RequestLocals.store[:dfe_analytics_request_id] = "example-request-id"
+
+      subject.send_event("create_entity", {})
+
+      expect(DfE::Analytics::SendEvents).to have_received(:perform_later)
+        .with([a_hash_including({
+          "request_uuid" => "example-request-id",
+        })])
+    end
+
+    context "when api request is not from a lead provider" do
+      subject { create(:api_request, cpd_lead_provider: nil) }
+
+      it "does not send analytics events" do
+        subject.send_event("create_entity", {})
+
+        expect(DfE::Analytics::SendEvents).not_to have_received(:perform_later)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-2646](https://dfedigital.atlassian.net/browse/CPDLP-2646)

### Changes proposed in this pull request

Stream request body to events production table.

### Guidance to review

After calling any api endpoint on the review app.. analytics events should appear on [BQ](https://console.cloud.google.com/bigquery?authuser=4&project=ecf-bq&supportedpurview=project&ws=!1m5!1m4!4m3!1secf-bq!2secf_events_review!3sevents).

```SELECT * FROM `ecf-bq.ecf_events_review.events` WHERE TIMESTAMP_TRUNC(occurred_at, DAY) >= TIMESTAMP("2023-11-20") AND entity_table_name = 'api_requests' LIMIT 1000```



[CPDLP-2646]: https://dfedigital.atlassian.net/browse/CPDLP-2646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ