### PR TITLE
Rename admin school overview page to details

### DIFF
--- a/app/views/admin/schools/shared/_navigation.html.erb
+++ b/app/views/admin/schools/shared/_navigation.html.erb
@@ -1,6 +1,6 @@
 <%= render SubnavComponent.new do |component| %>
   <%= component.with_nav_item(path: admin_school_path(@school)) do %>
-    Overview
+    Details
   <% end %>
   <%= component.with_nav_item(path: admin_school_participants_path(@school)) do %>
     Participants

--- a/app/views/admin/schools/show.html.erb
+++ b/app/views/admin/schools/show.html.erb
@@ -2,7 +2,7 @@
 
 <h1 class="govuk-heading-l"><%= @school.name %></h1>
 <%= render partial: "admin/schools/shared/navigation" %>
-<h2 class="govuk-heading-m">Overview</h2>
+<h2 class="govuk-heading-m">Details</h2>
 
 <% if @induction_coordinator && ImpersonationPolicy.new(current_user, @induction_coordinator).create? %>
   <%= govuk_button_to("Impersonate induction tutor", admin_impersonate_path,


### PR DESCRIPTION
This improves consistency with the Participant details page, and avoids having 2 "Overview" pages – as there's also an Overview page for the whole admin interface.