### PR TITLE
Exclude mentors from AB participants

### DIFF
--- a/app/services/appropriate_bodies/induction_records_query.rb
+++ b/app/services/appropriate_bodies/induction_records_query.rb
@@ -14,7 +14,7 @@ module AppropriateBodies
       join = InductionRecord
         .select(Arel.sql("DISTINCT FIRST_VALUE(induction_records.id) OVER (#{latest_induction_record_order}) AS latest_id"))
         .joins(:participant_profile)
-        .where(appropriate_body:)
+        .where(appropriate_body:, participant_profile: { type: ParticipantProfile::ECT })
 
       InductionRecord.distinct
         .joins("JOIN (#{join.to_sql}) AS latest_induction_records ON latest_induction_records.latest_id = induction_records.id")
@@ -29,8 +29,6 @@ module AppropriateBodies
         .select(
           "induction_records.*",
           latest_email_status_per_participant,
-          mentees_count,
-          current_mentees_count,
         )
     end
 

--- a/spec/features/appropriate_bodies/participants_spec.rb
+++ b/spec/features/appropriate_bodies/participants_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature "Appropriate body users participants", type: :feature do
   let(:appropriate_body) { appropriate_body_user.appropriate_bodies.first }
 
   let(:participant_profile) { create :ect_participant_profile, training_status: "withdrawn" }
+  let(:mentor_profile) { create :mentor_participant_profile, training_status: "withdrawn" }
   let(:lead_provider) { create(:lead_provider) }
   let(:delivery_partner) { create(:delivery_partner) }
   let(:school) { create(:school) }
@@ -23,6 +24,7 @@ RSpec.feature "Appropriate body users participants", type: :feature do
   end
   let(:induction_programme) { create(:induction_programme, :fip, partnership:, school_cohort:) }
   let!(:induction_record) { create(:induction_record, participant_profile:, appropriate_body:, induction_programme:, training_status: "withdrawn") }
+  let!(:mentor_induction_record) { create(:induction_record, participant_profile: mentor_profile, appropriate_body:, induction_programme:, training_status: "withdrawn") }
 
   let!(:prev_cohort_year) { create(:cohort, start_year: 2020) }
 
@@ -35,12 +37,14 @@ RSpec.feature "Appropriate body users participants", type: :feature do
   scenario "Visit participants page" do
     then_i_see("Participants")
     and_i_see_participant_details
+    and_i_do_not_see_mentor_details
   end
 
   scenario "Download participants CSV" do
     then_i_see("Participants")
     when_i_click_on("Download (csv)")
     and_i_see_participant_details_csv_export
+    and_i_do_not_see_mentor_details_csv_export
   end
 
   context "Search query" do
@@ -118,6 +122,10 @@ private
     expect(page).not_to have_content(participant_profile.user.full_name)
   end
 
+  def and_i_do_not_see_mentor_details
+    expect(page).not_to have_content(mentor_profile.user.full_name)
+  end
+
   def when_i_fill_in(selector, with:)
     page.fill_in selector, with:
   end
@@ -142,6 +150,10 @@ private
     expect(data[3]).to eq(["status", "ECT not currently linked to you"])
     expect(data[4]).to eq(%w[induction_type FIP])
     expect(data[5]).to eq(["induction_tutor", induction_record.school.contact_email])
+  end
+
+  def and_i_do_not_see_mentor_details_csv_export
+    expect(page.body).not_to include(mentor_profile.user.full_name)
   end
 
   def and_i_do_not_see_newer_induction_record_details

--- a/spec/services/appropriate_bodies/induction_records_query_spec.rb
+++ b/spec/services/appropriate_bodies/induction_records_query_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe AppropriateBodies::InductionRecordsQuery do
   let(:appropriate_body_user) { create(:user, :appropriate_body) }
   let(:appropriate_body) { appropriate_body_user.appropriate_bodies.first }
   let(:participant_profile) { create(:ect_participant_profile) }
+  let(:mentor_profile) { create(:mentor_participant_profile) }
   let(:partnership) do
     create(
       :partnership,
@@ -17,11 +18,12 @@ RSpec.describe AppropriateBodies::InductionRecordsQuery do
   let(:induction_programme) { create(:induction_programme, partnership:) }
   let!(:induction_record) { create(:induction_record, participant_profile:, appropriate_body:, induction_programme:) }
   let!(:another_induction_record) { create(:induction_record, participant_profile:, induction_programme:) }
+  let!(:mentor_induction_record) { create(:induction_record, participant_profile: mentor_profile, appropriate_body:, induction_programme:) }
 
   subject { described_class.new(appropriate_body:) }
 
   describe "#induction_records" do
-    it_behaves_like "a query optimised for calculating training record states"
+    it_behaves_like "a query optimised for calculating training record states", mentor_optimization: false
 
     it "returns latest induction record for appropriate body" do
       expect(subject.induction_records).to match_array([induction_record])

--- a/spec/support/shared_examples/optimised_training_record_state_query_support.rb
+++ b/spec/support/shared_examples/optimised_training_record_state_query_support.rb
@@ -1,34 +1,38 @@
 # frozen_string_literal: true
 
-shared_examples "a query optimised for calculating training record states" do
+shared_examples "a query optimised for calculating training record states" do |email_optimization: true, mentor_optimization: true|
   describe "#induction_records" do
-    context "when there is an email associated with the participant that has a request_for_details tag" do
-      before { create(:email, associated_with: [participant_profile], tags: %w[request_for_details]) }
+    if email_optimization
+      context "when there is an email associated with the participant that has a request_for_details tag" do
+        before { create(:email, associated_with: [participant_profile], tags: %w[request_for_details]) }
 
-      it "populates transient_latest_request_for_details_status with the email status" do
-        expect(subject.induction_records.last).to have_attributes(transient_latest_request_for_details_status: "submitted")
+        it "populates transient_latest_request_for_details_status with the email status" do
+          expect(subject.induction_records.last).to have_attributes(transient_latest_request_for_details_status: "submitted")
+        end
       end
     end
 
-    context "when there are historical mentees associated with the participant" do
-      let(:participant_profile) { create(:mentor) }
-      let!(:mentee) { create(:ect, mentor_profile: participant_profile) }
+    if mentor_optimization
+      context "when there are historical mentees associated with the participant" do
+        let(:participant_profile) { create(:mentor) }
+        let!(:mentee) { create(:ect, mentor_profile: participant_profile) }
 
-      before { mentee.latest_induction_record.update!(induction_status: "completed") }
+        before { mentee.latest_induction_record.update!(induction_status: "completed") }
 
-      it "populates transient_mentees with true" do
-        expect(subject.induction_records.last).to have_attributes(transient_mentees: true)
-        expect(subject.induction_records.last).to have_attributes(transient_current_mentees: false)
+        it "populates transient_mentees with true" do
+          expect(subject.induction_records.last).to have_attributes(transient_mentees: true)
+          expect(subject.induction_records.last).to have_attributes(transient_current_mentees: false)
+        end
       end
-    end
 
-    context "when there are current mentees associated with the participant" do
-      let(:participant_profile) { create(:mentor) }
-      let!(:mentee) { create(:ect, mentor_profile: participant_profile) }
+      context "when there are current mentees associated with the participant" do
+        let(:participant_profile) { create(:mentor) }
+        let!(:mentee) { create(:ect, mentor_profile: participant_profile) }
 
-      it "populates transient_current_mentees with true" do
-        expect(subject.induction_records.last).to have_attributes(transient_current_mentees: true)
-        expect(subject.induction_records.last).to have_attributes(transient_mentees: true)
+        it "populates transient_current_mentees with true" do
+          expect(subject.induction_records.last).to have_attributes(transient_current_mentees: true)
+          expect(subject.induction_records.last).to have_attributes(transient_mentees: true)
+        end
       end
     end
   end


### PR DESCRIPTION
[Jira-2653](https://dfedigital.atlassian.net/browse/CPDLP-2653)

### Context

Currently, we show all participants associated with an appropriate body in the participants view and CSV export. Going forward, we only want to show ECTs here.

### Changes proposed in this pull request

- Exclude mentors from AB participants

### Guidance to review

I assigned all mentors/ects to [this appropriate body](https://cpd-ecf-review-4285-web.test.teacherservices.cloud/appropriate-bodies/35391f57-a881-479d-9e7e-9ce8380f77dc/participants). Only the ECTs display now.