### PR TITLE
[CPDLP-2589] Spike: What are options for solving/managing ECF participants with induction records in multiple cohorts (stop flip flopping)

### DIFF
--- a/app/services/api/v3/ecf/participants_query.rb
+++ b/app/services/api/v3/ecf/participants_query.rb
@@ -62,14 +62,9 @@ module Api
         end
 
         def latest_induction_records_join
-          # InductionRecord
-          #   .select("induction_records.id AS latest_id")
-          #   .joins("JOIN (#{super.to_sql}) AS latest_induction_records_join ON latest_induction_records_join.latest_id = induction_records.id")
-          #   .joins(:schedule)
-          #   .where(
-          #     schedule: { cohort_id: cohorts.map(&:id) },
-          #   )
-          super
+          InductionRecord
+            .select("induction_records.id AS latest_id")
+            .joins("JOIN (#{super.to_sql}) AS latest_induction_records_join ON latest_induction_records_join.latest_id = induction_records.id")
             .joins(:schedule)
             .where(
               schedule: { cohort_id: cohorts.map(&:id) },

--- a/app/services/api/v3/ecf/participants_query.rb
+++ b/app/services/api/v3/ecf/participants_query.rb
@@ -62,9 +62,14 @@ module Api
         end
 
         def latest_induction_records_join
-          InductionRecord
-            .select("induction_records.id AS latest_id")
-            .joins("JOIN (#{super.to_sql}) AS latest_induction_records_join ON latest_induction_records_join.latest_id = induction_records.id")
+          # InductionRecord
+          #   .select("induction_records.id AS latest_id")
+          #   .joins("JOIN (#{super.to_sql}) AS latest_induction_records_join ON latest_induction_records_join.latest_id = induction_records.id")
+          #   .joins(:schedule)
+          #   .where(
+          #     schedule: { cohort_id: cohorts.map(&:id) },
+          #   )
+          super
             .joins(:schedule)
             .where(
               schedule: { cohort_id: cohorts.map(&:id) },

--- a/app/services/api/v3/ecf/participants_query.rb
+++ b/app/services/api/v3/ecf/participants_query.rb
@@ -62,7 +62,9 @@ module Api
         end
 
         def latest_induction_records_join
-          super
+          InductionRecord
+            .select("induction_records.id AS latest_id")
+            .joins("JOIN (#{super.to_sql}) AS latest_induction_records_join ON latest_induction_records_join.latest_id = induction_records.id")
             .joins(:schedule)
             .where(
               schedule: { cohort_id: cohorts.map(&:id) },

--- a/spec/services/api/v3/ecf/participants_query_spec.rb
+++ b/spec/services/api/v3/ecf/participants_query_spec.rb
@@ -48,8 +48,8 @@ RSpec.describe Api::V3::ECF::ParticipantsQuery do
       context "when changing schedule on different cohort" do
         let(:participant_identity) { create(:participant_identity) }
         let!(:user) { participant_identity.user }
-        let!(:another_user) { }
-        let(:lead_provider) { cpd_lead_provider.lead_provider  }
+        let!(:another_user) {}
+        let(:lead_provider) { cpd_lead_provider.lead_provider }
         let(:participant_profile) { create(:ect, lead_provider:, user:) }
         let(:participant_id) { participant_profile.participant_identity.external_identifier }
         let(:schedule_identifier) { "ecf-standard-september" }
@@ -77,7 +77,7 @@ RSpec.describe Api::V3::ECF::ParticipantsQuery do
           service = ChangeSchedule.new(change_schedule_params)
           expect(service).to be_valid
           service.call
-          expect(participant_profile.induction_records.map{|ir| ir.schedule.cohort.start_year }.sort).to match_array([cohort.start_year, new_cohort.start_year])
+          expect(participant_profile.induction_records.map { |ir| ir.schedule.cohort.start_year }.sort).to match_array([cohort.start_year, new_cohort.start_year])
           # binding.pry
 
           # Current cohort

--- a/spec/services/api/v3/ecf/participants_query_spec.rb
+++ b/spec/services/api/v3/ecf/participants_query_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Api::V3::ECF::ParticipantsQuery do
           # Current cohort
           current_params = { filter: { cohort: cohort.start_year.to_s } }
           query = described_class.new(lead_provider:, params: current_params)
-          expect(query.participants_for_pagination).to match_array([user])
+          expect(query.participants_for_pagination).to match_array([]) # without the fix this returns user
 
           # New cohort
           new_params = { filter: { cohort: new_cohort.start_year.to_s } }


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-2589

### Changes proposed in this pull request

* Solution returns full list of latest InductionRecord and then we filter out cohorts (as before we'd filter cohort while getting latest induction records). This should correctly return participants for the filter cohort.

### Guidance to review

