### PR TITLE
Account for minimum band A being set to 0

### DIFF
--- a/app/services/finance/ecf/output_calculator.rb
+++ b/app/services/finance/ecf/output_calculator.rb
@@ -147,7 +147,11 @@ module Finance
         pot_size = previous_fill_level_for_declaration_type(declaration_type)
 
         bands.zip(:a..:z).map do |band, letter|
-          band_capacity = band.max - (band.min || 1) + 1
+          # minimum band should always be 1 or more, otherwise band a will go over
+          # its max limit
+          band_min = band.min.to_i.zero? ? 1 : band.min
+
+          band_capacity = band.max - band_min + 1
 
           fill_level = [pot_size, band_capacity].min
 
@@ -157,7 +161,7 @@ module Finance
 
           {
             band: letter,
-            min: band.min || 1,
+            min: band_min,
             max: band.max,
             key_name => fill_level,
           }

--- a/spec/services/finance/ecf/output_calculator_spec.rb
+++ b/spec/services/finance/ecf/output_calculator_spec.rb
@@ -228,6 +228,54 @@ RSpec.describe Finance::ECF::OutputCalculator do
         ]
         expect(first_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(expected)
       end
+
+      context "when band a min is set to zero" do
+        before do
+          contract.participant_bands.find_by!(min: nil).update(min: 0)
+        end
+
+        it "returns correct bands" do
+          expected = [
+            {
+              band: :a,
+              min: 1,
+              max: 2,
+              previous_started_count: 0,
+              started_count: 2,
+              started_additions: 2,
+              started_subtractions: 0,
+            },
+            {
+              band: :b,
+              min: 3,
+              max: 4,
+              previous_started_count: 0,
+              started_count: 0,
+              started_additions: 0,
+              started_subtractions: 0,
+            },
+            {
+              band: :c,
+              min: 5,
+              max: 6,
+              previous_started_count: 0,
+              started_count: 0,
+              started_additions: 0,
+              started_subtractions: 0,
+            },
+            {
+              band: :d,
+              min: 7,
+              max: 8,
+              previous_started_count: 0,
+              started_count: 0,
+              started_additions: 0,
+              started_subtractions: 0,
+            },
+          ]
+          expect(first_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(expected)
+        end
+      end
     end
 
     context "when multiple bands" do


### PR DESCRIPTION
### Context
In cohort 2023 all band A declarations are appearing one over the max value, see https://manage-training-for-early-career-teachers.education.gov.uk/finance/ecf/payment_breakdowns/c3bc3cee-a636-42d6-8324-c033a6c38d31/statements/084aa7ad-2545-48a9-9388-a2c963855755 as an example where it should be 2000 rather than 2001 in band A

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-2654

### Changes proposed in this pull request
In legacy bandings, the minimum value for band A was set to `nil`, which meant in the output calculator it defaulted to 1. Since we introduced services to accept csvs and create contracts/bandings we set the band A min to 0. This pushed started declarations in band A above the max value, for instance band A max is set to 2000, it would appear in the dashboard as 2001.

Ensure that we account for both `nil` and 0 values in calculations to avoid wrong banding for declarations by setting both 1 otherwise the band min value

### Guidance to review
Tested on snapshot
