### PR TITLE
Fix syntax error in cron job for backup

### DIFF
--- a/.github/workflows/backup_nightly_database.yml
+++ b/.github/workflows/backup_nightly_database.yml
@@ -1,8 +1,8 @@
 name: Production DB nightly backup
 on:
   workflow_dispatch:
-    schedule:
-      - cron: "0 3 * * *" # 03:00 UTC
+  schedule:
+    - cron: "0 3 * * *" # 03:00 UTC
 
 jobs:
   backup-production:


### PR DESCRIPTION
### Context
The schedule should not be part of the workflow dispatch as they are separate. This prevents the cron job from running

- Ticket: n/a

### Changes proposed in this pull request
Fix syntax to allow job to run nightly

### Guidance to review
meh
