### PR TITLE
Comment out ignored columns for testing

### DIFF
--- a/app/models/participant_profile.rb
+++ b/app/models/participant_profile.rb
@@ -3,7 +3,7 @@
 class ParticipantProfile < ApplicationRecord
   has_paper_trail
 
-  self.ignored_columns = %w[user_id]
+  # self.ignored_columns = %w[user_id]
 
   attr_reader :participant_type
 

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ParticipantProfile::ECF < ParticipantProfile
-  self.ignored_columns = %i[school_id]
+  # self.ignored_columns = %i[school_id]
 
   POST_TRANSITIONAL_INDUCTION_START_DATE_DEADLINE = ActiveSupport::TimeZone["London"].local(2021, 9, 1).freeze
   VALID_EVIDENCE_HELD = %w[training-event-attended self-study-material-completed other].freeze

--- a/app/models/participant_profile/mentor.rb
+++ b/app/models/participant_profile/mentor.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ParticipantProfile::Mentor < ParticipantProfile::ECF
-  self.ignored_columns = %i[mentor_profile_id school_id]
+  # self.ignored_columns = %i[mentor_profile_id school_id]
 
   COURSE_IDENTIFIERS = %w[ecf-mentor].freeze
 

--- a/app/models/participant_profile/npq.rb
+++ b/app/models/participant_profile/npq.rb
@@ -37,7 +37,7 @@ class ParticipantProfile::NPQ < ParticipantProfile
     other
   ].freeze
 
-  self.ignored_columns = %i[mentor_profile_id school_cohort_id]
+  # self.ignored_columns = %i[mentor_profile_id school_cohort_id]
   belongs_to :cohort, optional: true
   belongs_to :school, optional: true
   belongs_to :npq_course, optional: true


### PR DESCRIPTION
Ignored columns in a single table inheritance hierarchy cause DataForm problems. We don't think the `ignored_columns` are actually any use, other than hinting to the developer that this model doesn't need these columns.
