### PR TITLE
[CST-2152] Fix mentor mentoring status

### DIFF
--- a/app/services/api/concerns/training_record_state_optimizable.rb
+++ b/app/services/api/concerns/training_record_state_optimizable.rb
@@ -19,7 +19,7 @@ protected
       EXISTS (
         SELECT 1 FROM induction_records as cmir
           WHERE cmir.mentor_profile_id = induction_records.participant_profile_id
-            AND (cmir.induction_status = 'active' OR cmir.induction_status = 'leaving')
+            AND (cmir.induction_status = 'active' OR (cmir.induction_status = 'leaving' AND cmir.end_date > CURRENT_TIMESTAMP))
         ) AS transient_current_mentees
     SQL
   end

--- a/app/services/determine_training_record_state_legacy.rb
+++ b/app/services/determine_training_record_state_legacy.rb
@@ -243,7 +243,7 @@ private
       FROM "induction_records"
       WHERE
           "induction_records"."mentor_profile_id" = '#{participant_profile_id}'
-          AND ("induction_records"."induction_status" = 'active' OR "induction_records"."induction_status" = 'leaving')
+          AND ("induction_records"."induction_status" = 'active' OR ("induction_records"."induction_status" = 'leaving' AND "induction_records"."end_date" > CURRENT_TIMESTAMP))
       GROUP BY
           "induction_records"."mentor_profile_id",
           "induction_records"."participant_profile_id"

--- a/db/new_seeds/scenarios/participants/training_record_states.rb
+++ b/db/new_seeds/scenarios/participants/training_record_states.rb
@@ -1144,6 +1144,52 @@ module NewSeeds
           end
         end
 
+        def mentor_on_fip_leaving_mentee
+          school_cohort = fip_school.school_cohort
+          induction_programme = school_cohort.default_induction_programme
+
+          @mentor_on_fip_leaving_mentee ||= travel_to(2.days.ago) do
+            builder = NewSeeds::Scenarios::Participants::Mentors::MentorWithNoEcts
+                        .new(school_cohort:)
+                        .build
+                        .with_validation_data
+                        .with_eligibility
+                        .with_induction_record(induction_programme: school_cohort.default_induction_programme)
+
+            NewSeeds::Scenarios::Participants::Ects::Ect
+              .new(school_cohort:, full_name: "ECT on FIP: after mentor change")
+              .build
+              .with_validation_data
+              .with_eligibility
+              .with_induction_record(induction_programme:, mentor_profile: builder.participant_profile, induction_status: "leaving", start_date: 1.day.ago, end_date: 1.week.from_now)
+
+            builder
+          end
+        end
+
+        def mentor_on_fip_mentee_has_left
+          school_cohort = fip_school.school_cohort
+          induction_programme = school_cohort.default_induction_programme
+
+          @mentor_on_fip_mentee_has_left ||= travel_to(2.days.ago) do
+            builder = NewSeeds::Scenarios::Participants::Mentors::MentorWithNoEcts
+                        .new(school_cohort:)
+                        .build
+                        .with_validation_data
+                        .with_eligibility
+                        .with_induction_record(induction_programme: school_cohort.default_induction_programme)
+
+            NewSeeds::Scenarios::Participants::Ects::Ect
+              .new(school_cohort:, full_name: "ECT on FIP: after mentor change")
+              .build
+              .with_validation_data
+              .with_eligibility
+              .with_induction_record(induction_programme:, mentor_profile: builder.participant_profile, induction_status: "leaving", start_date: 1.day.ago, end_date: Time.zone.now)
+
+            builder
+          end
+        end
+
         def mentor_on_fip_withdrawn
           school_cohort = fip_school.school_cohort
 

--- a/db/new_seeds/scenarios/participants/training_record_states.rb
+++ b/db/new_seeds/scenarios/participants/training_record_states.rb
@@ -1184,7 +1184,7 @@ module NewSeeds
               .build
               .with_validation_data
               .with_eligibility
-              .with_induction_record(induction_programme:, mentor_profile: builder.participant_profile, induction_status: "leaving", start_date: 1.day.ago, end_date: Time.zone.now)
+              .with_induction_record(induction_programme:, mentor_profile: builder.participant_profile, induction_status: "leaving", start_date: 1.week.ago, end_date: 1.day.ago)
 
             builder
           end

--- a/spec/services/determine_training_record_state_legacy_spec.rb
+++ b/spec/services/determine_training_record_state_legacy_spec.rb
@@ -1137,6 +1137,30 @@ RSpec.describe DetermineTrainingRecordStateLegacy do
                          "not_yet_mentoring"
       end
 
+      context "and their mentee is leaving" do
+        let!(:participant_profile) { scenarios.mentor_on_fip_leaving_mentee.participant_profile }
+
+        include_examples "determines states as",
+                         "valid",
+                         "eligible_for_mentor_training",
+                         "eligible_for_mentor_funding",
+                         "active_mentoring",
+                         "registered_for_fip_training",
+                         "active_mentoring"
+      end
+
+      context "and their mentee has left" do
+        let!(:participant_profile) { scenarios.mentor_on_fip_mentee_has_left.participant_profile }
+
+        include_examples "determines states as",
+                         "valid",
+                         "eligible_for_mentor_training",
+                         "eligible_for_mentor_funding",
+                         "not_yet_mentoring",
+                         "registered_for_fip_training",
+                         "not_yet_mentoring"
+      end
+
       context "and they have been withdrawn by a training provider through the API" do
         let!(:participant_profile) { scenarios.mentor_on_fip_withdrawn.participant_profile }
 

--- a/spec/support/shared_examples/optimised_training_record_state_query_support.rb
+++ b/spec/support/shared_examples/optimised_training_record_state_query_support.rb
@@ -25,6 +25,30 @@ shared_examples "a query optimised for calculating training record states" do |e
         end
       end
 
+      context "when there are mentees associated with the participant that are leaving" do
+        let(:participant_profile) { create(:mentor) }
+        let!(:mentee) { create(:ect, mentor_profile: participant_profile) }
+
+        before { mentee.latest_induction_record.update!(induction_status: "leaving", end_date: 1.week.from_now) }
+
+        it "populates transient_current_mentees with true" do
+          expect(subject.induction_records.last).to have_attributes(transient_mentees: true)
+          expect(subject.induction_records.last).to have_attributes(transient_current_mentees: true)
+        end
+      end
+
+      context "when there are mentees associated with the participant that have left" do
+        let(:participant_profile) { create(:mentor) }
+        let!(:mentee) { create(:ect, mentor_profile: participant_profile) }
+
+        before { mentee.latest_induction_record.update!(induction_status: "leaving", end_date: 1.week.ago) }
+
+        it "populates transient_mentees with true" do
+          expect(subject.induction_records.last).to have_attributes(transient_mentees: true)
+          expect(subject.induction_records.last).to have_attributes(transient_current_mentees: false)
+        end
+      end
+
       context "when there are current mentees associated with the participant" do
         let(:participant_profile) { create(:mentor) }
         let!(:mentee) { create(:ect, mentor_profile: participant_profile) }


### PR DESCRIPTION
### Context

When a mentor has a mentee that has left (`induction_status = leaving` and `end_date=a_date_in_the_past`) they should not have the "mentoring" status tag and should appear as not mentoring to the school.

### Changes proposed in this pull request
Add a check for the `end_date` when the mentee induction_status is `leaving` in the SQL query

### Guidance to review

