### PR TITLE
Add make cmd for konduit to snapshot DB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,3 +198,23 @@ aks-copy-tmp-file: get-cluster-credentials
 	$(if $(PULL_REQUEST_NUMBER), $(eval export APP_ID=review-$(PULL_REQUEST_NUMBER)) , $(eval export APP_ID=$(CONFIG_LONG)))
 	$(if $(FILENAME), , $(error Usage: FILENAME=restart.txt make staging aks-copy-tmp-file))
 	kubectl -n ${NAMESPACE} exec -ti --tty deployment/cpd-ecf-${APP_ID}-web -- cat /app/tmp/${FILENAME} > ${FILENAME}
+
+# Removes explicit postgres database URLs from database.yml
+konduit-cleanup:
+	sed -i '' -e '/url\: "postgres/d' config/database.yml; \
+	exit 0
+
+# Creates a konduit to the snapshot DB and points development to
+# it. The konduit URL is removed when the konduit is closed.
+konduit-snapshot: get-cluster-credentials
+	trap 'make konduit-cleanup' INT; \
+	tmp_file=$$(mktemp); \
+	$(MAKE) konduit-cleanup; \
+	{ \
+			(tail -f -n0 "$$tmp_file" & ) | grep -q "postgres://"; \
+			postgres_url=$$(grep -o 'postgres://[^ ]*' "$$tmp_file"); \
+			echo "$$postgres_url"; \
+			sed -i '' -e "s|database: \"early_careers_framework_development\"|&\\n    url: \"$$postgres_url\"|g" config/database.yml; \
+	} & \
+	bin/konduit.sh -d s189p01-cpdecf-pd-pg-snapshot -k s189p01-cpdecf-pd-app-kv cpd-ecf-production-web -- psql > "$$tmp_file"
+	exit 0


### PR DESCRIPTION
[Jira-2644](https://dfedigital.atlassian.net/browse/CPDLP-2644)

### Context

At the moment we have to run the `konduit` command and then manually update the `database.yml`, which can be a bit of a faff. Instead, we want to automate as much of this as possible.

### Changes proposed in this pull request

- Add a `make` command to more easily create a konduit to the snapshot database.

The command will remove any existing `url` in the development section of the `database.yml` and then create a `konduit` to the snapshot DB. When its created the `url` in the development section of the `database.yml` will be updated.

When the make command exits the `url` is removed form the `database.yml` file.

### Guidance to review

Run `make ci production konduit-snapshot` to test.