### PR TITLE
Increase sandbox webapp memory to 2GB

### DIFF
--- a/terraform/aks/workspace_variables/sandbox_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/sandbox_aks.tfvars.json
@@ -6,5 +6,6 @@
   "enable_monitoring": false,
   "namespace": "cpd-production",
   "domain": "sb.manage-training-for-early-career-teachers.education.gov.uk",
-  "external_hostname": "sb.manage-training-for-early-career-teachers.education.gov.uk/"
+  "external_hostname": "sb.manage-training-for-early-career-teachers.education.gov.uk/",
+  "webapp_memory_max": "2Gi"
 }


### PR DESCRIPTION
### Context

- Ticket: https://trello.com/c/Fy5fgxAG/813-increase-sandbox-webapp-memory

Sandbox webapp keeps restarting due to OOM 

### Changes proposed in this pull request

Update sandbox tfvars.json with "webapp_memory_max": "2Gi"
Currently set to 1Gi

### Guidance to review

make sandbox terraform-plan

