### PR TITLE
Make teacher profile selection consistent

### DIFF
--- a/app/models/teacher_profile.rb
+++ b/app/models/teacher_profile.rb
@@ -20,6 +20,8 @@ class TeacherProfile < ApplicationRecord
 
   self.filter_attributes += [:trn]
 
+  scope :oldest_first, -> { order(created_at: "asc") }
+
   def self.trn_matches(search_term)
     return none if search_term.blank?
 

--- a/app/services/npq/application/accept.rb
+++ b/app/services/npq/application/accept.rb
@@ -118,6 +118,7 @@ module NPQ
         return if teacher_profile&.trn.blank?
 
         @same_trn_user ||= TeacherProfile
+                           .oldest_first
                            .where(trn: teacher_profile.trn)
                            .where.not(id: teacher_profile.id)
                            .first

--- a/spec/models/teacher_profile_spec.rb
+++ b/spec/models/teacher_profile_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe(TeacherProfile, type: :model) do
+  describe(:oldest_first) do
+    specify "constructs the right order by clause" do
+      expect(TeacherProfile.oldest_first.to_sql).to match(/ORDER BY "teacher_profiles"."created_at" ASC/)
+    end
+  end
+end


### PR DESCRIPTION
Inside the `#same_trn_user` we are selecting all teacher profiles that match a TRN but aren't specifying any explicit order, so there's no guarantee which `TeacherProfile` record is found and used.

This appears to have caused some problems where providers expect a user to have one ID but they have another, because the `#deduplicate_by_trn!` method picked the 'wrong' teacher profile, so the wrong user to attach the `ParticipantIdentity` to.

This change orders the TeacherProfile records by created_at, so it will consistently link to the oldest record.
