### PR TITLE
[CST-2093] Add unvalidated profile archive service

### DIFF
--- a/app/serializers/archive/participant_profile_serializer.rb
+++ b/app/serializers/archive/participant_profile_serializer.rb
@@ -28,12 +28,16 @@ module Archive
     attribute :notes
     attribute :created_at
 
-    attribute :induction_record_ids do |participant_profile|
-      participant_profile.induction_records.map do |induction_record|
-        {
-          id: induction_record.id,
-        }
-      end
+    attribute :induction_records do |participant_profile|
+      InductionRecordSerializer.new(participant_profile.induction_records).serializable_hash[:data]
+    end
+
+    attribute :participant_declarations do |participant_profile|
+      ParticipantDeclarationSerializer.new(participant_profile.participant_declarations).serializable_hash[:data]
+    end
+
+    attribute :participant_profile_states do |participant_profile|
+      ParticipantProfileStateSerializer.new(participant_profile.participant_profile_states).serializable_hash[:data]
     end
   end
 end

--- a/app/serializers/archive/user_serializer.rb
+++ b/app/serializers/archive/user_serializer.rb
@@ -28,24 +28,6 @@ module Archive
       ParticipantProfileSerializer.new(user.participant_profiles).serializable_hash[:data]
     end
 
-    attribute :induction_records do |user|
-      user.participant_profiles.map { |participant_profile|
-        InductionRecordSerializer.new(participant_profile.induction_records).serializable_hash[:data]
-      }.flatten
-    end
-
-    attribute :participant_declarations do |user|
-      user.participant_profiles.map { |participant_profile|
-        ParticipantDeclarationSerializer.new(participant_profile.participant_declarations).serializable_hash[:data]
-      }.flatten
-    end
-
-    attribute :participant_profile_states do |user|
-      user.participant_profiles.map { |participant_profile|
-        ParticipantProfileStateSerializer.new(participant_profile.participant_profile_states).serializable_hash[:data]
-      }.flatten
-    end
-
     attribute :npq_applications do |user|
       NPQApplicationSerializer.new(user.npq_applications).serializable_hash[:data]
     end

--- a/app/services/archive/unvalidated_profile.rb
+++ b/app/services/archive/unvalidated_profile.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Archive
+  class UnvalidatedProfile < ::BaseService
+    def call
+      check_profile_can_be_archived!
+
+      data = Archive::ParticipantProfileSerializer.new(participant_profile).serializable_hash[:data]
+
+      ActiveRecord::Base.transaction do
+        relic = Archive::Relic.create!(object_type: participant_profile.class.name,
+                                       object_id: participant_profile.id,
+                                       display_name: user.full_name,
+                                       reason:,
+                                       data:)
+        destroy_profile! unless keep_original
+        relic
+      end
+    end
+
+  private
+
+    attr_accessor :participant_profile, :user, :reason, :keep_original
+
+    def initialize(participant_profile, reason: "unvalidated/undeclared ECTs 2021 or 2022", keep_original: false)
+      @participant_profile = participant_profile
+      @user = participant_profile.user
+      @reason = reason
+      @keep_original = keep_original
+    end
+
+    def check_profile_can_be_archived!
+      if profile_has_declarations?
+        raise ArchiveError, "Profile #{participant_profile.id} has non-voided declarations"
+      elsif profile_has_eligibility?
+        raise ArchiveError, "Profile #{participant_profile.id} has an eligibility record"
+      elsif profile_has_mentees?
+        raise ArchiveError, "Profile #{participant_profile.id} has mentees"
+      end
+    end
+
+    def profile_has_declarations?
+      participant_profile.participant_declarations.not_voided.any?
+    end
+
+    def profile_has_eligibility?
+      participant_profile.ecf_participant_eligibility.present?
+    end
+
+    def profile_has_mentees?
+      participant_profile.mentor? && InductionRecord.where(mentor_profile: participant_profile).any?
+    end
+
+    def destroy_profile!
+      participant_profile.ecf_participant_validation_data&.destroy!
+      participant_profile.ecf_participant_eligibility&.destroy!
+      participant_profile.participant_profile_states.destroy_all
+      participant_profile.participant_profile_schedules.destroy_all
+      participant_profile.participant_declarations.destroy_all
+      participant_profile.induction_records.destroy_all
+      participant_profile.validation_decisions.destroy_all
+
+      participant_profile.school_mentors.destroy_all if participant_profile.mentor?
+      participant_profile.destroy!
+    end
+  end
+end

--- a/spec/serializers/archive/participant_profile_serializer_spec.rb
+++ b/spec/serializers/archive/participant_profile_serializer_spec.rb
@@ -42,7 +42,9 @@ RSpec.describe Archive::ParticipantProfileSerializer do
       expect(attrs[:profile_duplicity]).to eq profile.profile_duplicity
       expect(attrs[:notes]).to eq profile.notes
       expect(attrs[:created_at]).to eq profile.created_at
-      expect(attrs[:induction_record_ids]).to match_array profile.induction_records.map { |ir| { id: ir.id } }
+      expect(attrs[:induction_records]).to match_array Archive::InductionRecordSerializer.new(profile.induction_records).serializable_hash[:data]
+      expect(attrs[:participant_declarations]).to match_array Archive::ParticipantDeclarationSerializer.new(profile.participant_declarations).serializable_hash[:data]
+      expect(attrs[:participant_profile_states]).to match_array Archive::ParticipantProfileStateSerializer.new(profile.participant_profile_states).serializable_hash[:data]
     end
   end
 end

--- a/spec/serializers/archive/user_serializer_spec.rb
+++ b/spec/serializers/archive/user_serializer_spec.rb
@@ -32,10 +32,6 @@ RSpec.describe Archive::UserSerializer do
       expect(attrs[:teacher_profile]).to eq Archive::TeacherProfileSerializer.new(user.teacher_profile).serializable_hash[:data]
       expect(attrs[:participant_identities]).to match_array Archive::ParticipantIdentitySerializer.new(user.participant_identities).serializable_hash[:data]
       expect(attrs[:participant_profiles]).to match_array Archive::ParticipantProfileSerializer.new(user.participant_profiles).serializable_hash[:data]
-      expect(attrs[:induction_records]).to match_array Archive::InductionRecordSerializer.new(ect_profile.induction_records).serializable_hash[:data]
-      # TODO: not needed as yet
-      expect(attrs[:participant_declarations]).to match_array Archive::ParticipantDeclarationSerializer.new(ect_profile.participant_declarations).serializable_hash[:data]
-      expect(attrs[:participant_profile_states]).to match_array Archive::ParticipantProfileStateSerializer.new(ect_profile.participant_profile_states).serializable_hash[:data]
       expect(attrs[:npq_applications]).to match_array Archive::NPQApplicationSerializer.new(user.npq_applications).serializable_hash[:data]
     end
   end

--- a/spec/services/archive/unvalidated_profile_spec.rb
+++ b/spec/services/archive/unvalidated_profile_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+RSpec.describe Archive::UnvalidatedProfile do
+  let(:participant_profile) { create(:ect_participant_profile) }
+  let!(:user) { participant_profile.user }
+
+  subject(:service_call) { described_class.call(participant_profile) }
+
+  it "creates a Relic record" do
+    expect { service_call }.to change { Archive::Relic.count }.by(1)
+  end
+
+  it "removes the ParticipantProfile record" do
+    participant_profile
+    expect { service_call }.to change { ParticipantProfile.count }.by(-1)
+  end
+
+  it "does not remove the any ParticipantIdentity records" do
+    participant_profile
+    expect { service_call }.not_to change { ParticipantIdentity.count }
+  end
+
+  it "does not remove the User" do
+    user
+    expect { service_call }.not_to change { User.count }
+  end
+
+  describe "relic details" do
+    let(:relic) { service_call }
+
+    it "sets the reason on the Relic" do
+      expect(relic.reason).to eq "unvalidated/undeclared ECTs 2021 or 2022"
+    end
+
+    it "sets the object_type" do
+      expect(relic.object_type).to eq participant_profile.class.name
+    end
+
+    it "sets the object_id" do
+      expect(relic.object_id).to eq participant_profile.id
+    end
+
+    it "sets the display_name" do
+      expect(relic.display_name).to eq user.full_name
+    end
+
+    it "sets the relic data to the serialized participant_profile record" do
+      expect(relic.data.to_json).to eq Archive::ParticipantProfileSerializer.new(participant_profile).serializable_hash[:data].to_json
+    end
+
+    context "when a reason is specified" do
+      let(:relic) { described_class.call(participant_profile, reason: "a different reason") }
+
+      it "sets the reason correctly" do
+        expect(relic.reason).to eq "a different reason"
+      end
+    end
+  end
+
+  context "when the profile has a declaration" do
+    let(:state) { "submitted" }
+    let!(:declaration) { create(:seed_ecf_participant_declaration, :with_cpd_lead_provider, state:, user:, participant_profile:) }
+
+    it "raises an ArchiveError" do
+      expect {
+        service_call
+      }.to raise_error Archive::ArchiveError
+    end
+
+    context "when the declaration is void" do
+      let(:state) { "voided" }
+
+      it "creates a Relic" do
+        expect {
+          service_call
+        }.to change { Archive::Relic.count }.by(1)
+      end
+
+      it "does not raise an error" do
+        expect {
+          service_call
+        }.not_to raise_error
+      end
+    end
+  end
+
+  context "when the keep original flag is set" do
+    let(:relic) { described_class.call(participant_profile, keep_original: true) }
+
+    it "creates a Relic" do
+      expect {
+        relic
+      }.to change { Archive::Relic.count }.by(1)
+    end
+
+    it "does not remove any of the source records" do
+      participant_profile
+      expect {
+        relic
+      }.not_to change { ParticipantProfile.count }
+    end
+  end
+
+  context "when the profile has an eligibility record" do
+    let!(:eligibility) { create(:ecf_participant_eligibility, participant_profile:) }
+
+    it "raises an ArchiveError" do
+      expect {
+        service_call
+      }.to raise_error Archive::ArchiveError
+    end
+  end
+
+  context "when the profile is a mentor" do
+    let(:participant_profile) { create(:mentor_participant_profile) }
+    let!(:school_mentor) { create(:seed_school_mentor, :with_school, preferred_identity: participant_profile.participant_identity, participant_profile:) }
+
+    it "removes their school mentor relations" do
+      expect {
+        service_call
+      }.to change { SchoolMentor.count }.by(-1)
+    end
+
+    context "when the profile has mentees" do
+      let!(:mentee) { create(:seed_induction_record, :valid, mentor_profile: participant_profile) }
+
+      it "raises an ArchiveError" do
+        expect {
+          service_call
+        }.to raise_error Archive::ArchiveError
+      end
+    end
+  end
+
+  context "when the profile has states" do
+    let!(:states) { create_list(:seed_ect_participant_profile_state, 3, participant_profile:) }
+
+    it "removes the participant profile states" do
+      expect {
+        service_call
+      }.to change { ParticipantProfileState.count }.by(-3)
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: [Jira ticket](https://dfedigital.atlassian.net/browse/CST-2093)
Add service to archive an individual unvalidated participant profile without removing/archiving the entire User record.
e.g. For a NPQ participant that has a withdrawn unvalidated ECT profile from yesteryear, we can archive the ECT profile and leave the User and all the  NPQ information intact.

### Changes proposed in this pull request

### Guidance to review

