### PR TITLE
CST-2131: only migrate active induction records to a new programme

### DIFF
--- a/app/services/induction/migrate_participants_to_new_programme.rb
+++ b/app/services/induction/migrate_participants_to_new_programme.rb
@@ -3,7 +3,7 @@
 class Induction::MigrateParticipantsToNewProgramme < BaseService
   def call
     ActiveRecord::Base.transaction do
-      from_programme.induction_records.each do |induction_record|
+      from_programme.active_induction_records.each do |induction_record|
         # this will duplicate the induction record and set the new programme
         Induction::ChangeInductionRecord.call(induction_record:,
                                               changes: { induction_programme_id: to_programme.id })

--- a/spec/services/induction/migrate_participants_to_new_programme_spec.rb
+++ b/spec/services/induction/migrate_participants_to_new_programme_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Induction::MigrateParticipantsToNewProgramme do
     let(:induction_programme_2) { create(:induction_programme, :cip, school_cohort:) }
     let(:ect_profile) { create(:ect_participant_profile, school_cohort:) }
     let(:mentor_profile) { create(:mentor_participant_profile, school_cohort:) }
+    let(:appropriate_body) { create(:appropriate_body_teaching_school_hub) }
 
     subject(:service) { described_class }
 
@@ -14,6 +15,8 @@ RSpec.describe Induction::MigrateParticipantsToNewProgramme do
       Induction::Enrol.call(induction_programme:,
                             participant_profile: mentor_profile,
                             start_date: 6.months.ago)
+      Induction::ChangeInductionRecord.call(induction_record: mentor_profile.latest_induction_record,
+                                            changes: { appropriate_body_id: appropriate_body.id })
 
       Induction::Enrol.call(induction_programme:,
                             participant_profile: ect_profile,
@@ -29,10 +32,12 @@ RSpec.describe Induction::MigrateParticipantsToNewProgramme do
     end
 
     it "updates the old programmes induction records to changing status" do
+      expect(induction_programme.induction_records.changed_induction_status.count).to eq 1
+
       service.call(from_programme: induction_programme,
                    to_programme: induction_programme_2)
 
-      expect(induction_programme.induction_records.changed_induction_status.count).to eq 2
+      expect(induction_programme.induction_records.changed_induction_status.count).to eq 3
     end
 
     it "migrates the participants to the new programme" do

--- a/spec/services/induction/migrate_participants_to_new_programme_spec.rb
+++ b/spec/services/induction/migrate_participants_to_new_programme_spec.rb
@@ -47,5 +47,12 @@ RSpec.describe Induction::MigrateParticipantsToNewProgramme do
       expect(ect_profile.current_induction_record.induction_programme).to eq induction_programme_2
       expect(mentor_profile.current_induction_record.induction_programme).to eq induction_programme_2
     end
+
+    it "does not migrate historical induction records" do
+      service.call(from_programme: induction_programme,
+                   to_programme: induction_programme_2)
+
+      expect(mentor_profile.induction_records.where(induction_programme: induction_programme_2).count).to eq 1
+    end
   end
 end


### PR DESCRIPTION
### Context

- [Ticket](https://dfedigital.atlassian.net/browse/CST-2131)

### Changes proposed in this pull request
From the latest induction record of each participant, add a new induction record to the chain instead of from each induction record

### Guidance to review

