### PR TITLE
run database sanitisation script and upload to database backups

### DIFF
--- a/.github/actions/backup-and-upload-database/action.yml
+++ b/.github/actions/backup-and-upload-database/action.yml
@@ -32,7 +32,8 @@ runs:
     - name: Backup database
       shell: bash
       run: |
-        bin/konduit.sh cpd-ecf-production-web -- pg_dump -E utf8 --compress=1 --clean --if-exists --no-privileges --no-owner --verbose -f backup-production.sql.gz
+        bin/konduit.sh cpd-ecf-production-web -- pg_dump -E utf8 --clean --if-exists --no-privileges --no-owner --verbose --no-password -f backup-production.sql
+        tar -cvzf backup-production.sql.gz backup-production.sql
 
     - name: Set connection string
       shell: bash
@@ -50,6 +51,36 @@ runs:
           --container database-backup \
           --source backup-production.sql.gz \
           --destination $(date +"%F-%H").sql.gz
+
+    - name: Sanitise the Database backup
+      run: |
+        echo "::group::Restore backup to intermediate database"
+        createdb ${DATABASE_NAME} && psql -d ${DATABASE_NAME} -f backup-production.sql
+        echo "::endgroup::"
+        echo "::group::Sanitise data"
+        psql -d ${DATABASE_NAME} -f db/scripts/sanitise.sql
+        echo "::endgroup::"
+
+        echo "::group::Backup Sanitised Database"
+        pg_dump -E utf8 --clean --if-exists --no-privileges --no-owner --verbose --no-password -d ${DATABASE_NAME} -f sanitised-production.sql
+        tar -cvzf sanitised-production.sql.gz sanitised-production.sql
+        echo "::endgroup::"
+      env:
+        DATABASE_NAME: early-careers-framework
+        PGUSER:  postgres
+        PGPASSWORD: postgres
+        PGHOST: localhost
+        PGPORT: 5432
+
+    - name: Upload sanitised version
+      shell: bash
+      run: |
+        az config set extension.use_dynamic_install=yes_without_prompt
+        az config set core.only_show_errors=true
+        az storage azcopy blob upload \
+          --container database-backup \
+          --source sanitised-production.sql.gz \
+          --destination $(date +"%F-%H")-sanitised.sql.gz
 
     - uses: Azure/get-keyvault-secrets@v1
       if: failure()

--- a/.github/workflows/backup_nightly_database.yml
+++ b/.github/workflows/backup_nightly_database.yml
@@ -6,8 +6,21 @@ on:
 
 jobs:
   backup-production:
+    name: Backup production database
     runs-on: ubuntu-20.04
     environment: production
+
+    services:
+      postgres:
+        image: postgres:14.9-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/db/scripts/sanitise.sql
+++ b/db/scripts/sanitise.sql
@@ -1,0 +1,256 @@
+/* create temporary look up tables for foreign key identifiers (TRNs, URNs, UK PRNs) */
+
+SELECT
+    schools.urn as original_urn,
+    RIGHT(CONCAT('000000', CAST(rows.index AS VARCHAR(6))), 6) as urn,
+    RIGHT(CONCAT('00000000', CAST(rows.index AS VARCHAR(8))), 8) as uk_prn
+INTO schools_ref
+FROM schools
+    LEFT OUTER JOIN (
+        SELECT entry.id as id, row_number() over () as index
+        FROM schools as entry
+        ORDER BY entry.created_at
+    ) AS rows ON schools.id = rows.id;
+
+SELECT
+    teacher_profiles.trn as original_trn,
+    RIGHT(CONCAT('0000000', CAST(rows.index AS VARCHAR(7))), 7) as trn
+INTO teacher_profiles_ref
+FROM teacher_profiles
+    LEFT OUTER JOIN (
+        SELECT entry.id as id, row_number() over () as index
+        FROM teacher_profiles as entry
+        ORDER BY entry.created_at
+    ) AS rows ON teacher_profiles.id = rows.id;
+
+SELECT
+    local_authority_districts.code as original_code,
+    RIGHT(CONCAT('E09000000', CAST(rows.index AS VARCHAR(9))), 9) as code,
+    CONCAT('Local Authority District ', local_authority_districts.id) as name
+    INTO local_authority_districts_ref
+FROM local_authority_districts
+    LEFT OUTER JOIN (
+        SELECT entry.id as id, row_number() over () as index
+        FROM local_authority_districts as entry
+        ORDER BY entry.created_at
+    ) AS rows ON local_authority_districts.id = rows.id;
+
+/* truncate or alter tables to remove PII */
+
+TRUNCATE TABLE additional_school_emails;
+
+/* KEEP admin_profiles INTACT */
+
+TRUNCATE TABLE api_request_audits;
+TRUNCATE TABLE api_requests;
+TRUNCATE TABLE api_tokens;
+
+UPDATE appropriate_bodies as item
+    SET name=CONCAT('Appropriate Body ', id);
+
+/* KEEP appropriate_body_profiles INTACT */
+
+/* reset all call off contracts to default values */
+UPDATE call_off_contracts
+    SET raw='{"version":"1.0.0"}',
+        uplift_target=1000,
+        uplift_amount=1000,
+        recruitment_target=1000,
+        set_up_fee=100,
+        revised_target=1111,
+        monthly_service_fee=150;
+
+/* KEEP cohorts INTACT */
+/* KEEP cohorts_lead_providers INTACT */
+/* KEEP completion_candidates INTACT */
+/* KEEP core_induction_programmes INTACT */
+
+/* sequentially rename CPD lead providers */
+UPDATE cpd_lead_providers
+    SET name=CONCAT('Lead Provider ', id);
+
+/* cascades to data_stage_school_changes, data_stage_school_links */
+TRUNCATE TABLE data_stage_schools CASCADE;
+
+/* KEEP declaration_states INTACT */
+
+TRUNCATE TABLE deleted_duplicates;
+
+/* KEEP delivery_partner_profiles INTACT */
+
+/* sequentially rename delivery partners */
+UPDATE delivery_partners
+    SET name=CONCAT('Delivery Partner ', id);
+
+/* KEEP district_sparsities INTACT */
+/* KEEP ecf_ineligible_participants INTACT */
+/* KEEP ecf_participant_eligibilities INTACT */
+
+TRUNCATE TABLE ecf_participant_validation_data;
+
+/* cascades to email_associations */
+TRUNCATE TABLE emails CASCADE;
+
+/* KEEP event_logs INTACT */
+/* KEEP feature_selected_objects INTACT */
+/* KEEP features INTACT */
+
+/* reset all payment adjustments to default values */
+UPDATE finance_adjustments
+    SET amount=1000;
+
+TRUNCATE TABLE finance_profiles;
+
+/* KEEP friendly_id_slugs INTACT */
+
+/* KEEP induction_coordinator_profiles INTACT */
+/* KEEP induction_coordinator_profiles_schools INTACT */
+/* KEEP induction_programmes INTACT */
+/* KEEP induction_records INTACT */
+/* KEEP lead_provider_cips INTACT */
+/* KEEP lead_provider_profiles INTACT */
+
+/* rename ECF lead providers to match their CPD name */
+UPDATE lead_providers AS lp
+    SET name=clp.name
+    FROM cpd_lead_providers AS clp
+    WHERE lp.cpd_lead_provider_id = clp.id;
+
+/* sequentially rename local authorities */
+UPDATE local_authorities
+    SET name=CONCAT('Local Authority ', id);
+
+UPDATE local_authority_districts
+    SET code=local_authority_districts_ref.code,
+        name=local_authority_districts_ref.name
+    FROM local_authority_districts_ref
+    WHERE local_authority_districts.code = local_authority_districts_ref.original_code;
+
+/* KEEP milestones INTACT */
+/* KEEP networks INTACT */
+
+TRUNCATE TABLE npq_application_eligibility_imports;
+TRUNCATE TABLE npq_application_exports;
+
+/* need to rewrite these IDs */
+UPDATE npq_applications
+    SET school_ukprn=schools_ref.uk_prn,
+        school_urn=schools_ref.urn,
+        teacher_reference_number=teacher_profiles_ref.trn,
+        date_of_birth=NULL
+    FROM schools_ref, teacher_profiles_ref
+    WHERE npq_applications.school_urn = schools_ref.original_urn
+        AND npq_applications.teacher_reference_number = teacher_profiles_ref.original_trn;
+
+/* reset all NPQ contracts to default values */
+UPDATE npq_contracts
+    SET per_participant=800,
+        monthly_service_fee=NULL,
+        targeted_delivery_funding_per_participant=100;
+
+/* KEEP npq_courses INTACT */
+
+/* rename NPQ lead providers to match their CPD name */
+UPDATE npq_lead_providers AS lp
+    SET name=clp.name
+    FROM cpd_lead_providers AS clp
+    WHERE lp.cpd_lead_provider_id = clp.id;
+
+UPDATE participant_bands
+    SET per_participant=800;
+
+TRUNCATE TABLE participant_declaration_attempts;
+
+/* KEEP participant_declarations INTACT */
+/* KEEP participant_id_changes INTACT */
+
+/* rename NPQ lead providers to match their CPD name */
+UPDATE participant_identities as item
+    SET email=CONCAT('participant-identity-', id, '@example.com');
+
+TRUNCATE TABLE participant_outcome_api_requests;
+
+/* KEEP participant_outcomes INTACT */
+/* KEEP participant_profile_schedules INTACT */
+/* KEEP participant_profile_states INTACT */
+
+/* need to rewrite these IDs */
+UPDATE participant_profiles
+    SET school_ukprn=schools_ref.uk_prn,
+        school_urn=schools_ref.urn,
+        notes=''
+    FROM schools_ref
+    WHERE schools_ref.original_urn = participant_profiles.school_urn;
+
+TRUNCATE TABLE partnership_csv_uploads;
+
+/* cascades to nomination_emails */
+TRUNCATE TABLE partnership_notification_emails CASCADE;
+
+/* KEEP partnerships INTACT */
+/* KEEP privacy_policies INTACT */
+/* KEEP privacy_policy_acceptances INTACT */
+
+TRUNCATE TABLE profile_validation_decisions;
+
+/* KEEP provider_relationships INTACT */
+/* KEEP pupil_premiums INTACT */
+/* KEEP schedule_milestones INTACT */
+/* KEEP schedules INTACT */
+/* KEEP schema_migrations INTACT */
+/* KEEP school_cohorts INTACT */
+
+UPDATE school_links
+    SET link_urn=schools_ref.urn
+    FROM schools_ref
+    WHERE schools_ref.original_urn = school_links.link_urn;
+
+/* KEEP school_local_authorities INTACT */
+/* KEEP school_local_authority_districts INTACT */
+/* KEEP school_mentors INTACT */
+
+UPDATE schools
+    SET name=CONCAT('School ', id),
+        urn=schools_ref.urn,
+        address_line1=CONCAT(id, ' School Lane'),
+        address_line2=CONCAT('School Town ', id),
+        address_line3=CONCAT('School County ', id),
+        postcode='AA01 AAA',
+        domains=array[]::varchar[],
+        ukprn=schools_ref.uk_prn,
+        school_website=CONCAT('school-', id, '.school'),
+        secondary_contact_email=CONCAT('school-', id, '-primary@example.com'),
+        primary_contact_email=CONCAT('school-', id, '-secondary@example.com'),
+        administrative_district_name=local_authority_districts_ref.name,
+        administrative_district_code=local_authority_districts_ref.code,
+        slug=CONCAT(schools_ref.urn, '-', CONCAT('school-', id))
+    FROM schools_ref, local_authority_districts_ref
+    WHERE schools_ref.original_urn = schools.urn
+        AND local_authority_districts_ref.original_code = schools.administrative_district_code;
+
+TRUNCATE TABLE sessions;
+
+/* KEEP statement_line_items INTACT */
+
+UPDATE statements
+    SET original_value=0,
+        reconcile_amount=0;
+
+TRUNCATE TABLE sync_dqt_induction_start_date_errors;
+
+UPDATE teacher_profiles
+    SET trn=teacher_profiles_ref.trn
+    FROM teacher_profiles_ref
+    WHERE teacher_profiles_ref.original_trn = teacher_profiles.trn;
+
+UPDATE users as item
+    SET full_name=CONCAT('User ', id),
+        email=CONCAT('user-', id, '@example.com'),
+        current_sign_in_ip='127.0.0.1',
+        last_sign_in_ip='127.0.0.1',
+        get_an_identity_id=gen_random_uuid();
+
+TRUNCATE TABLE versions;
+
+DROP TABLE schools_ref;
+DROP TABLE teacher_profiles_ref;

--- a/performance/db/create_performance_database.sql
+++ b/performance/db/create_performance_database.sql
@@ -1,0 +1,1 @@
+CREATE DATABASE early_careers_framework_performance;

--- a/performance/docker-compose.yml
+++ b/performance/docker-compose.yml
@@ -45,6 +45,8 @@ services:
     image: postgres:11-alpine
     volumes:
       - db_data:/var/lib/postgresql/data
+      # copy the sql script to create the performance database
+      - ./db/create_performance_database.sql:/docker-entrypoint-initdb.d/create_database.sql
     environment:
       POSTGRES_PASSWORD: performancepassword
     healthcheck:
@@ -81,18 +83,6 @@ services:
     networks:
       - performance
     command: /bin/sh -c "rm -f tmp/pids/server.pid && bundle exec rails server -b 0.0.0.0"
-
-  seed:
-    image: ${IMAGE:-ghcr.io/dfe-digital/early-careers-framework:main}
-    <<: *env
-    depends_on:
-      db:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-    networks:
-      - performance
-    command: bundle exec rails db:setup
 
   k6:
     image: grafana/k6:latest

--- a/performance/run_performance_tests_locally.sh
+++ b/performance/run_performance_tests_locally.sh
@@ -1,7 +1,12 @@
-export IMAGE=ghcr.io/dfe-digital/early-careers-framework:1980b11829bde48805fa53c568a6f994ae33246b
+#!/bin/bash
+
+export SERVICE_NAME=early-careers-framework
+export DATABASE_NAME=early_careers_framework_performance
+
+export IMAGE=ghcr.io/dfe-digital/early-careers-framework:main
 
 export PERF_NUM_AUTHORITIES=10
-export PERF_NUM_SCHOOLS=100
+export PERF_NUM_SCHOOLS=10
 export PERF_NUM_PARTICIPANTS=10
 
 export PERF_SCENARIO=api-load-test
@@ -10,13 +15,26 @@ export PERF_REPORT_FILE=k6-output.json
 mkdir ../reports
 rm -fr ../reports/${PERF_SCENARIO}*
 
-docker-compose up -d web
-docker-compose up seed
-docker-compose up k6
-docker-compose cp k6:/home/k6/${PERF_REPORT_FILE} ../reports/${PERF_SCENARIO}-report.json
-docker-compose cp k6:/home/k6/k6.log ../reports/${PERF_SCENARIO}.log
+# docker compose build
+docker compose up -d web
+
+if [ -f ./db/${SERVICE_NAME}-full.sql ]; then
+  echo "restoring performance database from dump"
+  docker compose exec -T db psql --username postgres ${DATABASE_NAME} < ./db/${SERVICE_NAME}-full.sql
+
+  echo "Migrating db schema"
+  docker compose exec web bundle exec rails db:migrate:primary
+else
+  echo "Running db seed"
+  docker compose exec web bundle exec rails db:create db:schema:load
+  docker compose exec web bundle exec rails db:seed
+fi
+
+docker compose up k6
+docker compose cp k6:/home/k6/${PERF_REPORT_FILE} ../reports/${PERF_SCENARIO}-report.json
+docker compose cp k6:/home/k6/k6.log ../reports/${PERF_SCENARIO}.log
 
 node dfe-k6-log-to-json.js ../reports/${PERF_SCENARIO}.log ../reports/${PERF_SCENARIO}-log.json
 node dfe-k6-reporter.js ../reports/${PERF_SCENARIO}-report.json ../reports/${PERF_SCENARIO}-report.html ../reports/${PERF_SCENARIO}-summary.md
 
-docker-compose down
+docker compose down -v

--- a/performance/run_sanitise_data_dump.sh
+++ b/performance/run_sanitise_data_dump.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+export SERVICE_NAME=early-careers-framework
+export DATABASE_NAME=early_careers_framework_performance
+
+export IMAGE=ghcr.io/dfe-digital/early-careers-framework:main
+
+# docker compose build
+docker compose up -d web
+
+if [ -f ./db/${SERVICE_NAME}-full.sql ]; then
+  echo "::group::Restore backup to intermediate database"
+  docker compose exec -T db psql --username postgres ${DATABASE_NAME} < ./db/${SERVICE_NAME}-full.sql
+  echo "::endgroup::"
+
+  echo "::group::Sanitise data"
+  docker compose exec -T db psql --username postgres ${DATABASE_NAME} < ../db/scripts/sanitise.sql
+  echo "::endgroup::"
+
+  echo "::group::Backup Sanitised Database"
+  docker compose exec db pg_dump --username postgres ${DATABASE_NAME} > ./db/${SERVICE_NAME}-sanitised.sql
+  tar -cvzf ./db/${SERVICE_NAME}-sanitised.tar.gz ./db/${SERVICE_NAME}-sanitised.sql
+  echo "::endgroup::"
+fi
+
+docker compose down -v


### PR DESCRIPTION
### Context

Seeding a performance database takes too long to get anywhere near production levels. if we sanitise the production data then we can restore the sanitised database to the performance environment for use in our performance tests as a base line data set.

### Changes proposed in this pull request

after dumping the product database, restore it locally and run a sanitise.sql script, dump the new data to a santisised dump and upload alongside the actual data.
