### PR TITLE
[CST-2166] Add additional support forms

### DIFF
--- a/app/components/support_form_component.html.erb
+++ b/app/components/support_form_component.html.erb
@@ -7,7 +7,7 @@
       <%= f.govuk_error_summary %>
 
       <p class="govuk-body">
-        <%= t("support_form.introduction.#{subject}", participant_name: participant_profile_full_name, cohort_year: cohort_year) %>
+        <%= t("support_form.introduction.#{subject}", **i18n_params) %>
       </p>
 
       <p class="govuk-body">We’ll automatically include these details for you: </p>
@@ -68,7 +68,7 @@
       </dl>
 
       <p class="govuk-body">
-        <%= t("support_form.instructions.#{subject}_html", participant_name: participant_profile_full_name, cohort_year: cohort_year) %>
+        <%= t("support_form.instructions.#{subject}_html", **i18n_params) %>
       </p>
 
       <%= f.hidden_field :subject %>

--- a/app/components/support_form_component.html.erb
+++ b/app/components/support_form_component.html.erb
@@ -3,12 +3,11 @@
     <span class="govuk-caption-l"><%= school.name if school.present? %></span>
     <h1 class="govuk-heading-l">Contact support</h1>
 
-
     <%= form_for @form, url: support_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
       <p class="govuk-body">
-        <%= t("support_form.introduction.#{subject}", participant_name: participant_profile_full_name) %>
+        <%= t("support_form.introduction.#{subject}", participant_name: participant_profile_full_name, cohort_year: cohort_year) %>
       </p>
 
       <p class="govuk-body">We’ll automatically include these details for you: </p>
@@ -55,15 +54,27 @@
             </dd>
           </div>
         <% end %>
+
+        <% if cohort_year.present? %>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Cohort
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <%= cohort_year %>
+            </dd>
+          </div>
+        <% end %>
       </dl>
 
       <p class="govuk-body">
-        <%= t("support_form.instructions.#{subject}_html", participant_name: participant_profile_full_name) %>
+        <%= t("support_form.instructions.#{subject}_html", participant_name: participant_profile_full_name, cohort_year: cohort_year) %>
       </p>
 
       <%= f.hidden_field :subject %>
       <%= f.hidden_field :participant_profile_id %>
       <%= f.hidden_field :school_id %>
+      <%= f.hidden_field :cohort_year %>
 
       <%= f.govuk_text_area(
             :message,

--- a/app/components/support_form_component.rb
+++ b/app/components/support_form_component.rb
@@ -9,6 +9,7 @@ class SupportFormComponent < BaseComponent
            :school,
            :participant_profile,
            :current_user,
+           :cohort_year,
            to: :form
   delegate :full_name,
            to: :participant_profile,

--- a/app/components/support_form_component.rb
+++ b/app/components/support_form_component.rb
@@ -16,7 +16,18 @@ class SupportFormComponent < BaseComponent
            prefix: true,
            allow_nil: true
 
+  def i18n_params
+    @i18n_params ||= {
+      participant_name: participant_profile_full_name,
+      cohort_year_range:,
+    }
+  end
+
 private
 
   attr_reader :form
+
+  def cohort_year_range
+    Cohort.new(start_year: cohort_year)&.description if cohort_year.present?
+  end
 end

--- a/app/controllers/support_controller.rb
+++ b/app/controllers/support_controller.rb
@@ -35,12 +35,13 @@ private
     {
       participant_profile_id:,
       school_id: params[:school_id],
+      cohort_year: params[:cohort_year],
       current_user:,
       subject:,
     }
   end
 
   def create_params
-    params.require(:support_form).permit(:subject, :participant_profile_id, :school_id, :message).merge(current_user:)
+    params.require(:support_form).permit(:subject, :participant_profile_id, :school_id, :cohort_year, :message).merge(current_user:)
   end
 end

--- a/app/forms/support_form.rb
+++ b/app/forms/support_form.rb
@@ -3,7 +3,7 @@
 class SupportForm
   include ActiveModel::Model
 
-  attr_accessor :message, :participant_profile_id, :school_id, :current_user
+  attr_accessor :message, :participant_profile_id, :school_id, :current_user, :cohort_year
   attr_reader :subject
 
   validates :message, presence: { message: "Enter your message" }
@@ -42,6 +42,7 @@ class SupportForm
     {
       school_id: school&.id,
       participant_profile_id: participant_profile&.id,
+      cohort_year:,
     }.reject { |_k, v| v.blank? }
   end
 

--- a/app/models/support_query.rb
+++ b/app/models/support_query.rb
@@ -4,6 +4,7 @@ class SupportQuery < ApplicationRecord
   VALID_SUBJECTS = %w[
     unspecified
     change-participant-lead-provider
+    change-cohort-lead-provider
   ].freeze
 
   belongs_to :user
@@ -59,6 +60,8 @@ class SupportQuery < ApplicationRecord
       #{school_additional_information&.strip}
 
       #{participant_profile_additional_information&.strip}
+
+      #{cohort_additional_information&.strip}
     BODY
 
     additional_information_string.strip
@@ -145,6 +148,15 @@ private
       User ID: #{participant_profile.user.id}
       Participant Profile ID: #{participant_profile.id}
       #{current_information.map { |key, value| "Current #{key.to_s.titleize}: #{value}" }.join("\n")}
+    BODY
+  end
+
+  def cohort_additional_information
+    return if cohort_year.blank?
+
+    <<~BODY
+      Cohort:
+      Start Year: #{cohort_year}
     BODY
   end
 end

--- a/app/models/support_query.rb
+++ b/app/models/support_query.rb
@@ -53,16 +53,15 @@ class SupportQuery < ApplicationRecord
   end
 
   def expanded_additional_information
-    <<~BODY
-      Ticket Created By:
+    additional_information_string = <<~BODY
       #{user_additional_information.strip}
 
-      School:
-      #{school_additional_information.strip}
+      #{school_additional_information&.strip}
 
-      Participant Profile:
-      #{participant_profile_additional_information.strip}
+      #{participant_profile_additional_information&.strip}
     BODY
+
+    additional_information_string.strip
   end
 
 private
@@ -94,6 +93,10 @@ private
     additional_information["participant_profile_id"]
   end
 
+  def cohort_year
+    additional_information["cohort_year"]
+  end
+
   def participant_profile
     @participant_profile ||= ParticipantProfile.find_by(id: participant_profile_id) if participant_profile_id.present?
   end
@@ -104,6 +107,7 @@ private
 
   def user_additional_information
     <<~BODY
+      Ticket Created By:
       User ID: #{user.id}
       Name: #{user.full_name}
       Email: #{user.email}
@@ -111,21 +115,36 @@ private
   end
 
   def school_additional_information
-    return "No school provided" if school.blank?
+    return if school.blank?
 
     <<~BODY
+      School:
       URN: #{school.urn}
       Name: #{school.name}
     BODY
   end
 
   def participant_profile_additional_information
-    return "No participant profile provided" if participant_profile.blank?
+    return if participant_profile.blank?
+
+    latest_induction_record = participant_profile.latest_induction_record
+
+    current_information = {
+      name: participant_profile.full_name,
+      email: participant_profile.user.email,
+      lead_provider: participant_profile.lead_provider&.name,
+      delivery_partner: participant_profile.delivery_partner&.name,
+      cohort: participant_profile.cohort_start_year,
+      induction_status: latest_induction_record&.induction_status,
+      training_status: latest_induction_record&.training_status,
+      type: participant_profile.participant_type,
+    }
 
     <<~BODY
-      ID: #{participant_profile.id}
-      Current Name: #{participant_profile.full_name}
-      Current Email: #{participant_profile.user.email}
+      Participant Profile:
+      User ID: #{participant_profile.user.id}
+      Participant Profile ID: #{participant_profile.id}
+      #{current_information.map { |key, value| "Current #{key.to_s.titleize}: #{value}" }.join("\n")}
     BODY
   end
 end

--- a/app/models/support_query.rb
+++ b/app/models/support_query.rb
@@ -5,6 +5,7 @@ class SupportQuery < ApplicationRecord
     unspecified
     change-participant-lead-provider
     change-cohort-lead-provider
+    change-cohort-delivery-partner
   ].freeze
 
   belongs_to :user

--- a/app/views/schools/dashboard/_school_cohort_details.html.erb
+++ b/app/views/schools/dashboard/_school_cohort_details.html.erb
@@ -48,7 +48,7 @@
       <% else %>
         <% row.with_value(text: school_cohort_lead_provider_name(school_cohort)) %>
       <% end %>
-      <% row.with_action(text: :none) %>
+      <% row.with_action(text: 'Change', href: support_path(cohort_year: school_cohort.start_year, school_id: @school.id, subject: :"change-cohort-lead-provider")) %>
     <% end %>
 
     <% list.with_row do |row| %>

--- a/app/views/schools/dashboard/_school_cohort_details.html.erb
+++ b/app/views/schools/dashboard/_school_cohort_details.html.erb
@@ -48,7 +48,7 @@
       <% else %>
         <% row.with_value(text: school_cohort_lead_provider_name(school_cohort)) %>
       <% end %>
-      <% row.with_action(text: 'Change', href: support_path(cohort_year: school_cohort.start_year, school_id: @school.id, subject: :"change-cohort-lead-provider")) %>
+      <% row.with_action(text: 'Change', visually_hidden_text: "lead provider", href: support_path(cohort_year: school_cohort.start_year, school_id: @school.id, subject: :"change-cohort-lead-provider")) %>
     <% end %>
 
     <% list.with_row do |row| %>
@@ -58,7 +58,7 @@
       <% else %>
         <% row.with_value(text: school_cohort_delivery_partner_name(school_cohort)) %>
       <% end %>
-      <% row.with_action(text: 'Change', href: support_path(cohort_year: school_cohort.start_year, school_id: @school.id, subject: :"change-cohort-delivery-partner")) %>
+      <% row.with_action(text: 'Change', visually_hidden_text: "delivery partner", href: support_path(cohort_year: school_cohort.start_year, school_id: @school.id, subject: :"change-cohort-delivery-partner")) %>
     <% end %>
   <% end %>
 <% end %>
@@ -68,10 +68,6 @@
     <p class="govuk-body">
       If your school is not working with this lead provider or delivery
       partner, <%= govuk_link_to("tell us before #{latest_partnership.challenge_deadline&.to_date&.to_fs(:govuk)}", challenge_partnership_path(partnership: latest_partnership), id: "challenge-partnership-link") %>.
-    </p>
-  <% else %>
-    <p class="govuk-body">
-      If this does not look right, contact: <%= render MailToSupportComponent.new %>
     </p>
   <% end %>
 <% end %>

--- a/app/views/schools/dashboard/_school_cohort_details.html.erb
+++ b/app/views/schools/dashboard/_school_cohort_details.html.erb
@@ -58,7 +58,7 @@
       <% else %>
         <% row.with_value(text: school_cohort_delivery_partner_name(school_cohort)) %>
       <% end %>
-      <% row.with_action(text: :none) %>
+      <% row.with_action(text: 'Change', href: support_path(cohort_year: school_cohort.start_year, school_id: @school.id, subject: :"change-cohort-delivery-partner")) %>
     <% end %>
   <% end %>
 <% end %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -361,3 +361,10 @@
   - user_description
   - created_at
   - updated_at
+  :support_queries:
+  - id
+  - user_id
+  - zendesk_ticket_id
+  - subject
+  - created_at
+  - updated_at

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -166,14 +166,8 @@
   - created_at
   - updated_at
   :support_queries:
-  - id
-  - user_id
-  - zendesk_ticket_id
-  - subject
   - message
   - additional_information
-  - created_at
-  - updated_at
   :school_links:
   - id
   - school_id

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -857,8 +857,8 @@ en:
     introduction:
       unspecified: "If you have a question about the Manage training for early career teachers service, you can contact the DfE using this form."
       change-participant-lead-provider: "Complete this form to request a change to %{participant_name}’s registered training provider."
-      change-cohort-lead-provider: "Complete this form to request a change to %{cohort_year} cohort’s registered training provider."
-      change-cohort-delivery-partner: "Complete this form to request a change to %{cohort_year} cohort’s delivery partner."
+      change-cohort-lead-provider: "Complete this form to tell us about a change of provider for ECTs and mentors who started their training in the %{cohort_year_range} academic year."
+      change-cohort-delivery-partner: "Complete this form to tell us about a change of partner for ECTs and mentors who started their training in the %{cohort_year_range} academic year."
     instructions:
       unspecified_html: ""
       change-participant-lead-provider_html: |
@@ -866,21 +866,18 @@ en:
         <ul>
           <li>which training provider they’ll work with instead</li>
           <li>the date they’ll start training with the new provider</li>
-          <li>the reason for this change</li>
         </ul>
       change-cohort-delivery-partner_html: |
         Tell us:
         <ul>
           <li>which delivery partner this cohort will work with instead</li>
           <li>the date they’ll start training with the new delivery partner</li>
-          <li>the reason for this change</li>
         </ul>
       change-cohort-lead-provider_html: |
         Tell us:
         <ul>
         <li>which training provider this cohort will work with instead</li>
         <li>the date they’ll start training with the new provider</li>
-        <li>the reason for this change</li>
         </ul>
 
   support_query:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -883,6 +883,6 @@ en:
   support_query:
     subjects:
       unspecified: Support request
-      change-participant-lead-provider: Request to change lead provider on a participant profile
+      change-participant-lead-provider: Request to change lead provider for a participant profile
       change-cohort-lead-provider: Request to change lead provider for a cohort
       change-cohort-delivery-partner: Request to change delivery partner for a cohort

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -857,6 +857,7 @@ en:
     introduction:
       unspecified: "If you have a question about the Manage training for early career teachers service, you can contact the DfE using this form."
       change-participant-lead-provider: "Complete this form to request a change to %{participant_name}’s registered training provider."
+      change-cohort-lead-provider: "Complete this form to request a change to %{cohort_year} cohort’s registered training provider."
     instructions:
       unspecified_html: ""
       change-participant-lead-provider_html: |
@@ -866,8 +867,16 @@ en:
           <li>the date they’ll start training with the new provider</li>
           <li>the reason for this change</li>
         </ul>
+      change-cohort-lead-provider_html: |
+        Tell us:
+        <ul>
+        <li>which training provider this cohort will work with instead</li>
+        <li>the date they’ll start training with the new provider</li>
+        <li>the reason for this change</li>
+        </ul>
 
   support_query:
     subjects:
       unspecified: Support request
       change-participant-lead-provider: Request to change lead provider on a participant profile
+      change-cohort-lead-provider: Request to change lead provider on a cohort

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -858,6 +858,7 @@ en:
       unspecified: "If you have a question about the Manage training for early career teachers service, you can contact the DfE using this form."
       change-participant-lead-provider: "Complete this form to request a change to %{participant_name}’s registered training provider."
       change-cohort-lead-provider: "Complete this form to request a change to %{cohort_year} cohort’s registered training provider."
+      change-cohort-delivery-partner: "Complete this form to request a change to %{cohort_year} cohort’s delivery partner."
     instructions:
       unspecified_html: ""
       change-participant-lead-provider_html: |
@@ -865,6 +866,13 @@ en:
         <ul>
           <li>which training provider they’ll work with instead</li>
           <li>the date they’ll start training with the new provider</li>
+          <li>the reason for this change</li>
+        </ul>
+      change-cohort-delivery-partner_html: |
+        Tell us:
+        <ul>
+          <li>which delivery partner this cohort will work with instead</li>
+          <li>the date they’ll start training with the new delivery partner</li>
           <li>the reason for this change</li>
         </ul>
       change-cohort-lead-provider_html: |
@@ -880,3 +888,4 @@ en:
       unspecified: Support request
       change-participant-lead-provider: Request to change lead provider on a participant profile
       change-cohort-lead-provider: Request to change lead provider on a cohort
+      change-cohort-delivery-partner: Request to change delivery partner on a cohort

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -885,4 +885,4 @@ en:
       unspecified: Support request
       change-participant-lead-provider: Request to change lead provider on a participant profile
       change-cohort-lead-provider: Request to change lead provider on a cohort
-      change-cohort-delivery-partner: Request to change delivery partner on a cohort
+      change-cohort-delivery-partner: Request to change delivery partner for a cohort

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -884,5 +884,5 @@ en:
     subjects:
       unspecified: Support request
       change-participant-lead-provider: Request to change lead provider on a participant profile
-      change-cohort-lead-provider: Request to change lead provider on a cohort
+      change-cohort-lead-provider: Request to change lead provider for a cohort
       change-cohort-delivery-partner: Request to change delivery partner for a cohort

--- a/spec/features/support_forms/change_cohort_delivery_partner_spec.rb
+++ b/spec/features/support_forms/change_cohort_delivery_partner_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Support Forms: change-cohort-delivery-partner", type: :feature do
+  let(:school) { create(:school) }
+  let(:participant_profile) { create(:ect_participant_profile) }
+  let(:cohort_year) { rand(2020..2030) }
+
+  scenario "User submits a support request" do
+    given_a_user_exists
+    and_i_am_logged_in_as_user
+
+    visit "/support?subject=change-cohort-delivery-partner&cohort_year=#{cohort_year}&school_id=#{school.id}"
+
+    expect(page).to have_text("Support")
+
+    fill_in "support-form-message-field", with: "Test message"
+
+    expect {
+      click_button "Send message to support"
+    }.to change(SupportQuery, :count).by(1)
+
+    expect(SupportQuery.last.as_json).to include(
+      "user_id" => @user.id,
+      "subject" => "change-cohort-delivery-partner",
+      "message" => "Test message",
+      "additional_information" => { "cohort_year" => cohort_year.to_s, "school_id" => school.id },
+    )
+
+    expect(SupportQuerySyncJob).to have_been_enqueued
+
+    expect(page).to have_text("Your support request has been submitted")
+  end
+
+private
+
+  def given_a_user_exists
+    @user = create(:user)
+  end
+
+  def and_i_am_logged_in_as_user
+    sign_in_as(@user)
+  end
+end

--- a/spec/features/support_forms/change_cohort_lead_provider_spec.rb
+++ b/spec/features/support_forms/change_cohort_lead_provider_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Support Forms: change-cohort-lead-provider", type: :feature do
+  let(:school) { create(:school) }
+  let(:participant_profile) { create(:ect_participant_profile) }
+  let(:cohort_year) { rand(2020..2030) }
+
+  scenario "User submits a support request" do
+    given_a_user_exists
+    and_i_am_logged_in_as_user
+
+    visit "/support?subject=change-cohort-lead-provider&cohort_year=#{cohort_year}&school_id=#{school.id}"
+
+    expect(page).to have_text("Support")
+
+    fill_in "support-form-message-field", with: "Test message"
+
+    expect {
+      click_button "Send message to support"
+    }.to change(SupportQuery, :count).by(1)
+
+    expect(SupportQuery.last.as_json).to include(
+      "user_id" => @user.id,
+      "subject" => "change-cohort-lead-provider",
+      "message" => "Test message",
+      "additional_information" => { "cohort_year" => cohort_year.to_s, "school_id" => school.id },
+    )
+
+    expect(page).to have_text("Your support request has been submitted")
+  end
+
+private
+
+  def given_a_user_exists
+    @user = create(:user)
+  end
+
+  def and_i_am_logged_in_as_user
+    sign_in_as(@user)
+  end
+end

--- a/spec/models/support_query_spec.rb
+++ b/spec/models/support_query_spec.rb
@@ -108,6 +108,9 @@ RSpec.describe SupportQuery, type: :model do
           Current Induction Status: #{participant_profile.latest_induction_record.induction_status}
           Current Training Status: #{participant_profile.latest_induction_record.training_status}
           Current Type: #{participant_profile.participant_type}
+
+          Cohort:
+          Start Year: #{cohort_year}
         BODY
       )
     end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CST-2166

### Changes proposed in this pull request

- Adds support forms data back to analytics upload
- Add Support Form: change-cohort-lead-provider
- Add Support Form: change-cohort-delivery-partner
- Add additional information to support queries detailing current participant profile state (see below for seed data example)

```
Test Message

---

Ticket Created By:
User ID: b4251de1-e8b2-4060-9e3f-08ee56ad18eb
Name: John Doe 5
Email: carlton@prosacco.io

School:
URN: 0019392
Name: Ruecker College

Participant Profile:
User ID: bf67f111-6c0d-483f-b6f2-37def8d7e377
Participant Profile ID: 37367df3-fad3-4e41-be0e-2212b77a9dc7
Current Name: Aldo Padberg
Current Email: aldo-padberg.splir@example.com
Current Lead Provider: Lead Provider
Current Delivery Partner: Delivery Partner 1
Current Cohort: 2026
Current Induction Status: active
Current Training Status: active
Current Type: ect
```

