### PR TITLE
[Bug-fix] Archive declaration presenter missing from list of presenters

### DIFF
--- a/app/presenters/archive/relic_presenter.rb
+++ b/app/presenters/archive/relic_presenter.rb
@@ -25,6 +25,8 @@ module Archive
         when "ParticipantProfile::Mentor"
           ::Archive::ParticipantProfilePresenter.new(relic_data)
         end
+      when "participant_declaration"
+        ::Archive::ParticipantDeclarationPresenter.new(relic_data)
       when "induction_record"
         ::Archive::InductionRecordPresenter.new(relic_data)
       else


### PR DESCRIPTION
### Context

The code to choose the correct presenter was missing the option to handle a declaration from the list of choices.

### Changes proposed in this pull request
Add the condition to choose the correct presenter for a declaration

### Guidance to review

