### PR TITLE
Update to govuk-frontend v5 (node) and govuk-components v5 (ruby)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem "mail-notify", "~> 1.2"
 # do not rely on host's timezone data, which can be inconsistent
 gem "tzinfo-data"
 
-gem "govuk-components", "~> 4.1.2"
+gem "govuk-components", "~> 5.0.0"
 gem "govuk_design_system_formbuilder", "~> 4.1.1"
 gem "view_component", require: "view_component/engine"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -241,10 +241,10 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
-    govuk-components (4.1.2)
+    govuk-components (5.0.0)
       html-attributes-utils (~> 1.0.0, >= 1.0.0)
       pagy (~> 6.0)
-      view_component (>= 3.3, < 3.7)
+      view_component (>= 3.3, < 3.8)
     govuk_design_system_formbuilder (4.1.1)
       actionview (>= 6.1)
       activemodel (>= 6.1)
@@ -665,7 +665,7 @@ DEPENDENCIES
   google-apis-drive_v3
   google-cloud-bigquery
   googleauth
-  govuk-components (~> 4.1.2)
+  govuk-components (~> 5.0.0)
   govuk_design_system_formbuilder (~> 4.1.1)
   httpclient (~> 2.8, >= 2.8.3)
   jsbundling-rails

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,6 +1,6 @@
 //= link_tree ../images
-//= link_directory ../../../node_modules/govuk-frontend/govuk/assets/images
-//= link_directory ../../../node_modules/govuk-frontend/govuk/assets/fonts
+//= link_directory ../../../node_modules/govuk-frontend/dist/govuk/assets/images
+//= link_directory ../../../node_modules/govuk-frontend/dist/govuk/assets/fonts
 //= link application.css
 //= link application.js
 //= link sentry.js

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,9 +1,5 @@
 /* eslint-disable import/first */
-require.context("govuk-frontend/govuk/assets");
-
-document.body.className = document.body.className
-  ? `${document.body.className} js-enabled`
-  : "js-enabled";
+require.context("govuk-frontend/dist/govuk/assets");
 
 // External dependencies
 import "es6-promise/auto";

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -2,7 +2,7 @@ $govuk-images-path: "";
 $govuk-fonts-path: "";
 $govuk-new-link-styles: true;
 
-@import "govuk-frontend/govuk/all";
+@import "govuk-frontend/dist/govuk/all";
 @import "accessible-autocomplete/src/autocomplete";
 
 @import "notification_banner";

--- a/app/helpers/phase_banner_helper.rb
+++ b/app/helpers/phase_banner_helper.rb
@@ -4,7 +4,7 @@ module PhaseBannerHelper
   def phase_banner_tag_text(env = Rails.env)
     return "Beta" if env == "production"
 
-    env
+    env.capitalize
   end
 
   def phase_banner_tag_colour(env = Rails.env)

--- a/app/views/admin/participants/statuses/show.html.erb
+++ b/app/views/admin/participants/statuses/show.html.erb
@@ -44,7 +44,7 @@
 
       sl.with_row do |row|
         row.with_key(text: "Training record state")
-        row.with_value(text: govuk_tag(text: @participant_presenter.relevant_induction_record&.training_status || "No Induction Record Found", colour: "grey"))
+        row.with_value(text: govuk_tag(text: @participant_presenter.relevant_induction_record&.training_status&.capitalize || "No Induction Record Found", colour: "grey"))
       end
     end %>
   <% end %>
@@ -128,7 +128,7 @@ end %>
 <%= govuk_summary_list(actions: true) do |sl|
   sl.with_row do |row|
     row.with_key(text: "induction status")
-    row.with_value(text: govuk_tag(text: @participant_presenter.relevant_induction_record&.induction_status || "No Induction Record Found", colour: "grey"))
+    row.with_value(text: govuk_tag(text: @participant_presenter.relevant_induction_record&.induction_status&.capitalize || "No Induction Record Found", colour: "grey"))
     if allowed_to_change_induction_status?(@participant_presenter)
       row.with_action(
         href: edit_admin_participant_change_induction_status_path(@participant_presenter.participant_profile),
@@ -139,7 +139,7 @@ end %>
 
   sl.with_row do |row|
     row.with_key(text: "training status")
-    row.with_value(text: govuk_tag(text: @participant_presenter.relevant_induction_record&.training_status || "No Induction Record Found", colour: "grey"))
+    row.with_value(text: govuk_tag(text: @participant_presenter.relevant_induction_record&.training_status&.capitalize || "No Induction Record Found", colour: "grey"))
   end
 end %>
 
@@ -147,13 +147,13 @@ end %>
 <%= govuk_summary_list(actions: true) do |sl|
   sl.with_row do |row|
     row.with_key(text: "status")
-    row.with_value(text: govuk_tag(text: @participant_presenter.participant_profile.status, colour: "grey") +
+    row.with_value(text: govuk_tag(text: @participant_presenter.participant_profile.status&.capitalize, colour: "grey") +
       "<p class=\"govuk-body-s\">A historical status used if the induction_records induction_status is not set. Note: a status of Withdrawn indicates a 'soft delete' of this record.</p>".html_safe)
   end
 
   sl.with_row do |row|
     row.with_key(text: "training status")
-    row.with_value(text: govuk_tag(text: @participant_presenter.participant_profile.training_status, colour: "grey") +
+    row.with_value(text: govuk_tag(text: @participant_presenter.participant_profile.training_status&.capitalize, colour: "grey") +
       "<p class=\"govuk-body-s\">A historical status used if the induction_records training_status is not set.</p>".html_safe)
   end
 end %>

--- a/app/views/finance/ecf/duplicates/index.html.erb
+++ b/app/views/finance/ecf/duplicates/index.html.erb
@@ -39,7 +39,7 @@
             row.with_cell(text: participant_profile.duplicate_profile_count - 1)
             row.with_cell(text: participant_profile.declaration_count)
             row.with_cell do
-              govuk_link_to "View duplicates", finance_ecf_duplicate_path(participant_profile), { class: govuk_link_classes }
+              govuk_link_to "View duplicates", finance_ecf_duplicate_path(participant_profile), class: govuk_link_classes
             end
           end
         end

--- a/app/views/layouts/_application.html.erb
+++ b/app/views/layouts/_application.html.erb
@@ -18,20 +18,11 @@
     <%= tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1' %>
     <%= tag :meta, property: 'og:image', content: image_path('govuk-opengraph-image.png') %>
     <%= tag :meta, name: 'theme-color', content: '#0b0c0c' %>
-    <%= favicon_link_tag image_path('favicon.ico') %>
-    <%= favicon_link_tag image_path('govuk-mask-icon.svg'), rel: 'mask-icon', type: 'image/svg', color: "#0b0c0c" %>
-    <%= favicon_link_tag image_path('govuk-apple-touch-icon.png'), rel: 'apple-touch-icon', type: 'image/png' %>
-    <%= favicon_link_tag image_path('govuk-apple-touch-icon-152x152.png'), rel: 'apple-touch-icon', type: 'image/png', size: '152x152' %>
-    <%= favicon_link_tag image_path('govuk-apple-touch-icon-167x167.png'), rel: 'apple-touch-icon', type: 'image/png', size: '167x167' %>
-    <%= favicon_link_tag image_path('govuk-apple-touch-icon-180x180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
+    <%= favicon_link_tag image_path('favicon.ico'), type: nil, sizes: "48x48" %>
+    <%= favicon_link_tag image_path('favicon.svg'), type: 'image/svg+xml', sizes: "any" %>
+    <%= favicon_link_tag image_path('govuk-icon-mask.svg'), rel: 'mask-icon', color: "#0b0c0c", type: nil %>
+    <%= favicon_link_tag image_path('govuk-icon-180.png'), rel: 'apple-touch-icon', type: nil %>
     <%= stylesheet_link_tag 'application', media: 'all' %>
-
-    <% if content_for?(:stylesheets) %>
-      <%= yield :stylesheets %>
-    <% end %>
-
-    <%= javascript_include_tag *javascript_tag_args, defer: true unless params[:nojs] == "nojs" %>
-
     <script>
       dataLayer = <%= data_layer.to_json.html_safe %>;
     </script>
@@ -64,6 +55,7 @@
   </head>
 
   <body class="govuk-template__body">
+    <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
     <!-- Google Tag Manager (noscript) -->
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-N58Z5PG"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -105,5 +97,6 @@
     <%= yield %>
 
     <%= render "layouts/footer" %>
+    <%= javascript_include_tag *javascript_tag_args, defer: true unless params[:nojs] == "nojs" %>
   </body>
 </html>

--- a/app/views/lead_providers/report_schools/base/success.html.erb
+++ b/app/views/lead_providers/report_schools/base/success.html.erb
@@ -11,4 +11,4 @@
   <li>each school needs to add their early career teachers and mentors</li>
 </ul>
 
-<%= govuk_button_link_to("Confirm more schools", { action: :start })  %>
+<%= govuk_button_link_to("Confirm more schools", lead_providers_report_schools_start_path)  %>

--- a/app/views/nominations/nominate_induction_coordinator/check.html.erb
+++ b/app/views/nominations/nominate_induction_coordinator/check.html.erb
@@ -18,7 +18,7 @@
                     <%= @nominate_induction_tutor_form.full_name %>
                 </dd>
                 <dd class="govuk-summary-list__actions">
-                    <%= govuk_link_to({ action: :full_name }) do %>
+                    <%= govuk_link_to(full_name_nominate_induction_coordinator_path) do %>
                     Change <span class="govuk-visually-hidden">name</span>
                     <% end %>
                 </dd>
@@ -29,7 +29,7 @@
                     <%= @nominate_induction_tutor_form.email %>
                 </dd>
                 <dd class="govuk-summary-list__actions">
-                    <%= govuk_link_to({ action: :email }) do %>
+                    <%= govuk_link_to(email_nominate_induction_coordinator_path) do %>
                     Change <span class="govuk-visually-hidden">email address</span>
                     <% end %>
                 </dd>

--- a/app/views/nominations/nominate_induction_coordinator/start_nomination.html.erb
+++ b/app/views/nominations/nominate_induction_coordinator/start_nomination.html.erb
@@ -25,7 +25,7 @@
         </p>
         <p class="govuk-body govuk-!-margin-bottom-7">If you’re supported by a MAT (multi-academy trust) or federation, you can choose someone who manages training for a number of schools.</p>
 
-        <%= govuk_button_link_to "Continue", { action: :full_name  } %>
+        <%= govuk_button_link_to "Continue", full_name_nominate_induction_coordinator_path %>
 
     </div>
 </div>

--- a/app/views/participants/validations/no_match.html.erb
+++ b/app/views/participants/validations/no_match.html.erb
@@ -26,7 +26,7 @@
           <dt class="govuk-summary-list__key">National Insurance Number</dt>
           <dd class="govuk-summary-list__value"><%= validation_form.nino %></dd>
           <dd class="govuk-summary-list__actions">
-            <%= govuk_link_to "Change", { action: :show, step: :nino } %>
+            <%= govuk_link_to "Change", participants_validation_step_path(step: :nino) %>
             <span class="govuk-visually-hidden">your National Insurance number</span>
           </dd>
         </div>
@@ -36,7 +36,7 @@
         <dt class="govuk-summary-list__key">Date of birth</dt>
         <dd class="govuk-summary-list__value"><%= validation_form.dob.to_fs(:govuk) %></dd>
         <dd class="govuk-summary-list__actions">
-          <%= govuk_link_to "Change", { action: :show, step: :dob } %>
+          <%= govuk_link_to "Change", participants_validation_step_path(step: :dob) %>
           <span class="govuk-visually-hidden">your date of birth</span>
         </dd>
       </div>
@@ -46,7 +46,7 @@
           <dt class="govuk-summary-list__key">Name</dt>
           <dd class="govuk-summary-list__value"><%= validation_form.full_name %></dd>
           <dd class="govuk-summary-list__actions">
-            <%= govuk_link_to "Change", { action: :show, step: :name } %>
+            <%= govuk_link_to "Change", participants_validation_step_path(step: :name) %>
             <span class="govuk-visually-hidden">your name</span>
           </dd>
         </div>

--- a/app/views/participants/validations/trn.html.erb
+++ b/app/views/participants/validations/trn.html.erb
@@ -21,7 +21,7 @@
         <p class="govuk-body">You can usually find your TRN on your payslip, teachers’ pension documents or teacher training records.</p>
       <% end %>
 
-      <p class="govuk-body"><%= govuk_link_to "I cannot find my TRN", { action: :no_trn }, class: 'govuk-link--no-visit-state'  %></p>
+      <p class="govuk-body"><%= govuk_link_to "I cannot find my TRN", participants_validation_no_trn_path, no_visited_state: true  %></p>
 
       <%= f.govuk_submit "Continue" %>
     <% end %>

--- a/app/views/schools/add_participants/confirm_appropriate_body.html.erb
+++ b/app/views/schools/add_participants/confirm_appropriate_body.html.erb
@@ -12,7 +12,7 @@
 
       <%= govuk_inset_text(text: @wizard.school_cohort.appropriate_body.name) %>
 
-      <%= govuk_link_to "They have a different appropriate body", url_for({ action: :change_appropriate_body }) %>
+      <%= govuk_link_to "They have a different appropriate body", schools_add_change_appropriate_body_path(@school) %>
 
       <%= form_with model: @wizard.form, url: url_for(action: :update), scope: @wizard.form_scope, method: :put do |f| %>
         <%= f.govuk_error_summary %>

--- a/app/views/schools/change_sit/check_details.html.erb
+++ b/app/views/schools/change_sit/check_details.html.erb
@@ -34,6 +34,6 @@
       </div>
     </dl>
 
-    <%= govuk_button_link_to "Accept and continue", {action: :confirm} %>
+    <%= govuk_button_link_to "Accept and continue", confirm_schools_change_sit_path(@induction_tutor_form.school) %>
   </div>
 </div>

--- a/app/views/schools/change_sit/check_details.html.erb
+++ b/app/views/schools/change_sit/check_details.html.erb
@@ -14,7 +14,7 @@
           <div><%= @induction_tutor_form.full_name %></div>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <%= govuk_link_to({ action: :name }) do %>
+          <%= govuk_link_to(name_schools_change_sit_path(@induction_tutor_form.school)) do %>
             Change <span class="govuk-visually-hidden">name</span>
           <% end %>
         </dd>
@@ -27,7 +27,7 @@
           <div><%= @induction_tutor_form.email %></div>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <%= govuk_link_to({ action: :email }) do %>
+          <%= govuk_link_to(email_schools_change_sit_path(@induction_tutor_form.school)) do %>
             Change <span class="govuk-visually-hidden">email</span>
           <% end %>
         </dd>

--- a/app/views/schools/core_programme/materials/info.html.erb
+++ b/app/views/schools/core_programme/materials/info.html.erb
@@ -4,13 +4,13 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    
+
     <span class="govuk-caption-l"><%= @school.name %></span>
     <h1 class="govuk-heading-l">Do you know which accredited materials you want to use?</h1>
 
     <p class="govuk-body">You’ll be choosing materials for any new ECTs.</p>
     <p class="govuk-body govuk-!-margin-bottom-7">They’ll access these materials on our service, and usually complete their training programme over 2 years.</p>
-        
-    <%= govuk_link_to "Continue", { action: :edit }, class: "govuk-button" %>
+
+    <%= govuk_button_link_to "Continue", edit_schools_core_programme_materials_path(@school, @school_cohort.cohort) %>
   </div>
 </div>

--- a/app/views/schools/participants/show.html.erb
+++ b/app/views/schools/participants/show.html.erb
@@ -169,7 +169,7 @@
                   @profile.policy_class.new(current_user, @profile).add_appropriate_body? &&
                   policy(@induction_record).edit_appropriate_body? %>
 
-              <%= govuk_link_to({ action: :add_appropriate_body, participant_id: @profile }) do %>
+              <%= govuk_link_to(school_participant_add_appropriate_body_path(@school, @profile)) do %>
                 <%= participant_has_appropriate_body? ? 'Change' : 'Add' %> <span class="govuk-visually-hidden"> Appropriate body</span>
               <% end %>
             <% end %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -4,10 +4,10 @@
 
 # Because these paths are searched in order, we want the assets to come first
 # Add the GOVUK Frontend images path
-Rails.application.config.assets.paths << Rails.root.join("node_modules/govuk-frontend/govuk/assets/images")
+Rails.application.config.assets.paths << Rails.root.join("node_modules/govuk-frontend/dist/govuk/assets/images")
 
 # Add the GOVUK Frontend fonts path
-Rails.application.config.assets.paths << Rails.root.join("node_modules/govuk-frontend/govuk/assets/fonts")
+Rails.application.config.assets.paths << Rails.root.join("node_modules/govuk-frontend/dist/govuk/assets/fonts")
 
 # Add Yarn node_modules folder to the asset load path.
 Rails.application.config.assets.paths << Rails.root.join("node_modules")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -617,7 +617,7 @@ Rails.application.routes.draw do
     end
 
     multistep_form :validation, Participants::ParticipantValidationForm, controller: :validations do
-      get :no_trn, as: nil
+      get :no_trn, as: "no_trn"
       get :already_completed, as: nil
     end
   end

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "compression-webpack-plugin": "^9.2.0",
     "es6-promise": "^4.2.8",
     "file-loader": "^6.2.0",
-    "govuk-frontend": "^4.7.0",
+    "govuk-frontend": "^5.0.0",
     "nunjucks": "^3.2.4",
     "sass": "^1.69.4",
     "terser-webpack-plugin": "^5.3.9",

--- a/spec/features/admin/participants/participant_steps.rb
+++ b/spec/features/admin/participants/participant_steps.rb
@@ -224,11 +224,11 @@ module ParticipantSteps
 
   def and_i_should_see_the_induction_statuses_are_active
     within(page.find("dt", text: /^induction status$/).ancestor(".govuk-summary-list__row").find("dd")) do
-      expect(page).to have_text("ACTIVE")
+      expect(page).to have_text("Active")
     end
 
     within(page.find("dt", text: /^status$/).ancestor(".govuk-summary-list__row").find("dd")) do
-      expect(page).to have_text("ACTIVE")
+      expect(page).to have_text("Active")
     end
   end
 

--- a/spec/features/finance/ecf/statement_spec.rb
+++ b/spec/features/finance/ecf/statement_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "Show ECF statement", :js do
 
       when_i_visit_the_ecf_financial_statements_page
 
-      then_i_do_not_see("Authorised for payment at #{statement.marked_as_paid_at.in_time_zone('London').strftime('%-I:%M%P on %-e %b %Y')}".upcase)
+      then_i_do_not_see("Authorised for payment at #{statement.marked_as_paid_at.in_time_zone('London').strftime('%-I:%M%P on %-e %b %Y')}")
     end
 
     scenario "successfully authorised", perform_jobs: true do
@@ -83,7 +83,7 @@ RSpec.describe "Show ECF statement", :js do
 
       when_i_visit_the_ecf_financial_statements_page
 
-      then_i_see("Authorised for payment at #{Finance::Statement.find(statement.id).marked_as_paid_at.in_time_zone('London').strftime('%-I:%M%P on %-e %b %Y')}".upcase)
+      then_i_see("Authorised for payment at #{Finance::Statement.find(statement.id).marked_as_paid_at.in_time_zone('London').strftime('%-I:%M%P on %-e %b %Y')}")
     end
 
     scenario "missing doing assurance checks" do

--- a/spec/features/finance/npq/statement_spec.rb
+++ b/spec/features/finance/npq/statement_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "Show NPQ statement", :js do
 
       when_i_visit_the_npq_financial_statements_page
 
-      then_i_do_not_see("Authorised for payment at #{statement.marked_as_paid_at.strftime('%-I:%M%P on %-e %b %Y')}".upcase)
+      then_i_do_not_see("Authorised for payment at #{statement.marked_as_paid_at.strftime('%-I:%M%P on %-e %b %Y')}")
     end
 
     scenario "successfully authorised", perform_jobs: true do
@@ -63,7 +63,7 @@ RSpec.describe "Show NPQ statement", :js do
 
       when_i_visit_the_npq_financial_statements_page
 
-      then_i_see("Authorised for payment at #{Finance::Statement.find(statement.id).marked_as_paid_at.strftime('%-I:%M%P on %-e %b %Y')}".upcase)
+      then_i_see("Authorised for payment at #{Finance::Statement.find(statement.id).marked_as_paid_at.strftime('%-I:%M%P on %-e %b %Y')}")
     end
 
     scenario "missing doing assurance checks" do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe ApplicationHelper, type: :helper do
   include Devise::Test::ControllerHelpers
   include GovukLinkHelper
+  include GovukVisuallyHiddenHelper
 
   let(:admin_user) { create(:user, :admin) }
   let(:induction_coordinator) { create(:user, :induction_coordinator) }
@@ -134,7 +135,7 @@ RSpec.describe ApplicationHelper, type: :helper do
     it "renders a HTML link to print/save via the built-in browser functionality" do
       is_expected.to eq(
         <<~HTML.chomp,
-          <a onclick="window.formattedPrint(this)" data-filename="My Document" class="govuk-link" href="javascript:void(0)">Save as PDF</a>
+          <a class="govuk-link" onclick="window.formattedPrint(this)" data-filename="My Document" href="javascript:void(0)">Save as PDF</a>
         HTML
       )
     end

--- a/spec/helpers/phase_banner_helper_spec.rb
+++ b/spec/helpers/phase_banner_helper_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe PhaseBannerHelper, type: :helper do
         let(:other_env) { other_env }
 
         it "for #{other_env} it returns #{other_env}" do
-          expect(phase_banner_tag_text(other_env)).to eql(other_env)
+          expect(phase_banner_tag_text(other_env)).to eql(other_env.capitalize)
         end
       end
     end

--- a/yarn.lock
+++ b/yarn.lock
@@ -5363,7 +5363,7 @@ __metadata:
     eslint-plugin-import: "npm:^2.29.0"
     eslint-plugin-no-only-tests: "npm:^2.6.0"
     file-loader: "npm:^6.2.0"
-    govuk-frontend: "npm:^4.7.0"
+    govuk-frontend: "npm:^5.0.0"
     nunjucks: "npm:^3.2.4"
     prettier: "npm:^2.8.8"
     sass: "npm:^1.69.4"
@@ -6639,10 +6639,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"govuk-frontend@npm:^4.7.0":
-  version: 4.7.0
-  resolution: "govuk-frontend@npm:4.7.0"
-  checksum: 02038b797e157dfa2c959464ecb5b9998ec5b1e126a97f14315b504e0b5a9d1d962c7490dca38b53b6f6bbc2fa13944d9974244ab2f819328e94782ac66bf505
+"govuk-frontend@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "govuk-frontend@npm:5.0.0"
+  checksum: c2053221f46ed9823da6e069d4d5c1a804f65c265fac49760e59b6c9f61dbe9145f98144f9fd16cf37c299b668aba58be8c1b41d713b227b96a26debfdbd048e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This updates both `govuk-frontend` (node package) and `govuk-components` (Ruby gem) to version5.

Both have to be updated at the same time, as they are co-dependent on each other.

The main changes affecting this service are:

* the paths for the frontend assets have changed, now within a `dist/` folder in `govuk-frontend`
* the tag component no longer uses uppercase via CSS - so instead the tag text is capitalised within code
* the locations and sizes of the govuk icons has changed
* the javascript snippet adding class names to the `<body>` tag has changed
* the `govuk_link_to` ruby helper syntax has changed slightly

Thanks to @peteryates for helping with this.