### PR TITLE
Enable and schedule entity table check job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -116,7 +116,7 @@ gem "rouge"
 
 gem "auto_strip_attributes", "~> 2.6"
 
-gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.11.5"
+gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.11.6"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/DFE-Digital/dfe-analytics.git
-  revision: fdfd7f0bdbe5c6b6677d7502afb8691ae08bedeb
-  tag: v1.11.5
+  revision: 33251ca61e4806fc7eb86538c24de578bfea0007
+  tag: v1.11.6
   specs:
-    dfe-analytics (1.11.5)
+    dfe-analytics (1.11.6)
       google-cloud-bigquery (~> 1.38)
       request_store_rails (~> 2)
 

--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -38,6 +38,9 @@ DfE::Analytics.configure do |config|
   #
   # config.bigquery_timeout = 120
 
+  # enable EntityTableCheckJob
+  config.entity_table_checks_enabled = true
+
   # A proc which returns true or false depending on whether you want to
   # enable analytics. You might want to hook this up to a feature flag or
   # environment variable.

--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -49,3 +49,7 @@ detect_sidekiq_metrics_issues_job:
   cron: "0 * * * *"
   class: "DetectSidekiqMetricsIssuesJob"
   queue: slack_alerts
+send_entity_table_checks_to_bigquery:
+  cron: "30 0 * * *"
+  class: "DfE::Analytics::EntityTableCheckJob"
+  queue: dfe_analytics


### PR DESCRIPTION
### Context

EntityTableCheckJob sends a row_count, a checksum and a timestamp for each entity table sent to Big Query so that we can identify where database tables match Big Query tables and then help to debug where they don’t

- Ticket: n/a

### Changes proposed in this pull request

The EntityTableCheckJob is enabled and scheduled to run every day at 00:30

### Guidance to review

Check scheduling is a reasonable time for job to run
N.B. Worth testing in staging/ review app prior to deploying - I can help!
