### PR TITLE
Remove codeowners entry for `db/schema.rb`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-db/schema.rb @peteryates @cwrw @tonyheadford


### PR DESCRIPTION
This is no longer needed now we've stopped flip flopping on the index syntax in db/schema.rb
