### PR TITLE
Fix the indentation when injecting the snapshot postgres url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ konduit-snapshot: get-cluster-credentials
 			(tail -f -n0 "$$tmp_file" & ) | grep -q "postgres://"; \
 			postgres_url=$$(grep -o 'postgres://[^ ]*' "$$tmp_file"); \
 			echo "$$postgres_url"; \
-			sed -i '' -e "s|database: \"early_careers_framework_development\"|&\\n    url: \"$$postgres_url\"|g" config/database.yml; \
+			sed -i '' -e "s|database: \"early_careers_framework_development\"|&\\n  url: \"$$postgres_url\"|g" config/database.yml; \
 	} & \
 	bin/konduit.sh -d s189p01-cpdecf-pd-pg-snapshot -k s189p01-cpdecf-pd-app-kv cpd-ecf-production-web -- psql > "$$tmp_file"
 	exit 0


### PR DESCRIPTION
### Context

- Ticket: N/A

The `konduit-snapshot` rule in the makefile injects the postgres url of the snapshot db in the database.yml with four spaces which nests it incorrectly.

### Changes proposed in this pull request
Use two spaces indentation

### Guidance to review

