### PR TITLE
Add NPQ registration DBs to ECF

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,9 @@ inherit_gem:
 
 AllCops:
   Exclude:
+    - app/models/migration/**/*
+    - db/npq_registration_schema.rb
+    - db/npq_registration_migrate/**/*
     - 'node_modules/**/*'
     - 'bin/**/*'
     - 'db/schema.rb'

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -2,4 +2,6 @@
 
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  connects_to database: { writing: :primary, reading: :primary }
 end

--- a/app/models/migration/npq_registration/application.rb
+++ b/app/models/migration/npq_registration/application.rb
@@ -1,0 +1,55 @@
+class Migration::NPQRegistration::Application < Migration::NPQRegistration::BaseRecord
+  # These columns are no longer populated with data for future applications
+  # but are still in place because they contain historical data.
+  # This constant is set so that despite still existing they won't be hooked up
+  # within the rails model
+  self.ignored_columns = %w[DEPRECATED_cohort]
+
+  has_paper_trail only: %i[lead_provider_approval_status participant_outcome_state]
+
+  belongs_to :user
+  belongs_to :course
+  belongs_to :lead_provider
+  belongs_to :school, optional: true
+  belongs_to :private_childcare_provider, optional: true
+  belongs_to :itt_provider, optional: true
+
+  has_many :ecf_sync_request_logs, as: :syncable, dependent: :destroy
+
+  scope :unsynced, -> { where(ecf_id: nil) }
+
+  enum kind_of_nursery: {
+    local_authority_maintained_nursery: "local_authority_maintained_nursery",
+    preschool_class_as_part_of_school: "preschool_class_as_part_of_school",
+    private_nursery: "private_nursery",
+    another_early_years_setting: "another_early_years_setting",
+  }
+
+  def synced_to_ecf?
+    ecf_id.present?
+  end
+
+  def inside_catchment?
+    %w[england].include?(teacher_catchment)
+  end
+
+  def new_headteacher?
+    %w[yes_when_course_starts yes_in_first_five_years yes_in_first_two_years].include?(headteacher_status)
+  end
+
+  def employer_name_to_display
+    employer_name || private_childcare_provider&.provider_name || school&.name || ""
+  end
+
+  def employer_urn
+    private_childcare_provider&.urn || school_urn || ""
+  end
+
+  def school_urn
+    school&.urn
+  end
+
+  def school_urn=(urn)
+    school.urn = urn
+  end
+end

--- a/app/models/migration/npq_registration/base_record.rb
+++ b/app/models/migration/npq_registration/base_record.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Migration::NPQRegistration
+  class BaseRecord < ApplicationRecord
+    self.abstract_class = true
+
+    connects_to database: { reading: :npq_registration, writing: :npq_registration }
+
+    def send_event(type, data)
+      # We don't want to send any events for migration models!
+    end
+  end
+end

--- a/app/models/migration/npq_registration/base_record.rb
+++ b/app/models/migration/npq_registration/base_record.rb
@@ -6,6 +6,10 @@ module Migration::NPQRegistration
 
     connects_to database: { reading: :npq_registration, writing: :npq_registration }
 
+    def readonly?
+      !Rails.env.development?
+    end
+
     def send_event(type, data)
       # We don't want to send any events for migration models!
     end

--- a/app/models/migration/npq_registration/course.rb
+++ b/app/models/migration/npq_registration/course.rb
@@ -1,0 +1,50 @@
+class Migration::NPQRegistration::Course < Migration::NPQRegistration::BaseRecord
+  class << self
+    def npqeyl
+      find_by(identifier: NPQ_EARLY_YEARS_LEADERSHIP)
+    end
+
+    def npqltd
+      find_by(identifier: NPQ_LEADING_TEACHING_DEVELOPMENT)
+    end
+
+    def ehco
+      find_by(identifier: NPQ_EARLY_HEADSHIP_COACHING_OFFER)
+    end
+  end
+
+  def supports_targeted_delivery_funding?
+    !ehco?
+  end
+
+  def npqh?
+    identifier == NPQ_HEADSHIP
+  end
+
+  def npqsl?
+    identifier == NPQ_SENIOR_LEADERSHIP
+  end
+
+  def ehco?
+    identifier == NPQ_EARLY_HEADSHIP_COACHING_OFFER
+  end
+
+  def eyl?
+    identifier == NPQ_EARLY_YEARS_LEADERSHIP
+  end
+
+  def npqltd?
+    identifier == NPQ_LEADING_TEACHING_DEVELOPMENT
+  end
+
+  def npqlpm?
+    identifier == NPQ_LEADING_PRIMARY_MATHEMATICS
+  end
+
+  NPQ_HEADSHIP = "npq-headship".freeze
+  NPQ_SENIOR_LEADERSHIP = "npq-senior-leadership".freeze
+  NPQ_EARLY_HEADSHIP_COACHING_OFFER = "npq-early-headship-coaching-offer".freeze
+  NPQ_EARLY_YEARS_LEADERSHIP = "npq-early-years-leadership".freeze
+  NPQ_LEADING_TEACHING_DEVELOPMENT = "npq-leading-teaching-development".freeze
+  NPQ_LEADING_PRIMARY_MATHEMATICS = "npq-leading-primary-mathematics".freeze
+end

--- a/app/models/migration/npq_registration/lead_provider.rb
+++ b/app/models/migration/npq_registration/lead_provider.rb
@@ -1,0 +1,91 @@
+class Migration::NPQRegistration::LeadProvider < Migration::NPQRegistration::BaseRecord
+  ALL_PROVIDERS = {
+    "Ambition Institute" => "9e35e998-c63b-4136-89c4-e9e18ddde0ea",
+    "Best Practice Network (home of Outstanding Leaders Partnership)" => "57ba9e86-559f-4ff4-a6d2-4610c7259b67",
+    "Church of England" => "79cb41ca-cb6d-405c-b52c-b6f7c752388d",
+    "Education Development Trust" => "21e61f53-9b34-4384-a8f5-d8224dbf946d",
+    "LLSE" => "230e67c0-071a-4a48-9673-9d043d456281",
+    "National Institute of Teaching" => "3ec607f2-7a3a-421f-9f1a-9aca8a634aeb",
+    "School-Led Network" => "bc5e4e37-1d64-4149-a06b-ad10d3c55fd0",
+    "Teacher Development Trust" => "30fd937e-b93c-4f81-8fff-3c27544193f1",
+    "Teach First" => "a02ae582-f939-462f-90bc-cebf20fa8473",
+    "UCL Institute of Education" => "ef687b3d-c1c0-4566-a295-16d6fa5d0fa7",
+  }.freeze
+
+  NPQH_SL_LT_LTD_LBC_EHCO_PROVIDERS = [
+    "Ambition Institute",
+    "Best Practice Network (home of Outstanding Leaders Partnership)",
+    "Church of England",
+    "Education Development Trust",
+    "LLSE",
+    "National Institute of Teaching",
+    "Teacher Development Trust",
+    "Teach First",
+    "UCL Institute of Education",
+  ].freeze
+
+  EYL_LL_PROVIDERS = [
+    "Ambition Institute",
+    "Education Development Trust",
+    "National Institute of Teaching",
+    "Teacher Development Trust",
+    "Teach First",
+    "UCL Institute of Education",
+  ].freeze
+
+  EL_PROVIDERS = [
+    "Ambition Institute",
+    "Best Practice Network (home of Outstanding Leaders Partnership)",
+    "Church of England",
+    "Education Development Trust",
+    "LLSE",
+    "National Institute of Teaching",
+    "Teacher Development Trust",
+    "Teach First",
+    "UCL Institute of Education",
+  ].freeze
+
+  LPM_PROVIDERS = [
+    "Ambition Institute",
+    "Church of England",
+    "Education Development Trust",
+    "LLSE",
+    "Teach First",
+    "UCL Institute of Education",
+    "National Institute of Teaching",
+  ].freeze
+
+  # TODO: Move all of this mapping into the database
+  #       Hardcoding this has been done for expediency but
+  #       longterm having this handled in the DB so none of
+  #       this data has to be hardcoded would be preferable.
+  COURSE_TO_PROVIDER_MAPPING = {
+    "npq-headship" => NPQH_SL_LT_LTD_LBC_EHCO_PROVIDERS,
+    "npq-senior-leadership" => NPQH_SL_LT_LTD_LBC_EHCO_PROVIDERS,
+    "npq-leading-teaching" => NPQH_SL_LT_LTD_LBC_EHCO_PROVIDERS,
+    "npq-leading-teaching-development" => NPQH_SL_LT_LTD_LBC_EHCO_PROVIDERS,
+    "npq-leading-behaviour-culture" => NPQH_SL_LT_LTD_LBC_EHCO_PROVIDERS,
+    "npq-early-headship-coaching-offer" => NPQH_SL_LT_LTD_LBC_EHCO_PROVIDERS,
+    "npq-additional-support-offer" => NPQH_SL_LT_LTD_LBC_EHCO_PROVIDERS,
+
+    "npq-early-years-leadership" => EYL_LL_PROVIDERS,
+    "npq-leading-literacy" => EYL_LL_PROVIDERS,
+
+    "npq-executive-leadership" => EL_PROVIDERS,
+
+    "npq-leading-primary-mathematics" => LPM_PROVIDERS,
+  }.freeze
+
+  scope :alphabetical, -> { order(name: :asc) }
+
+  def self.for(course:)
+    course_specific_list = COURSE_TO_PROVIDER_MAPPING[course.identifier]
+
+    return all if course_specific_list.blank?
+
+    ecf_ids = ALL_PROVIDERS.slice(*course_specific_list).values.compact_blank
+    raise "Missing provider ECF_ID for available providers list" if ecf_ids.count != course_specific_list.count
+
+    where(ecf_id: ecf_ids)
+  end
+end

--- a/app/models/migration/npq_registration/school.rb
+++ b/app/models/migration/npq_registration/school.rb
@@ -1,0 +1,88 @@
+class Migration::NPQRegistration::School < Migration::NPQRegistration::BaseRecord
+  PRIMARY_PHASE = "Primary".freeze
+  MIDDLE_DEEMED_PRIMARY_PHASE = "Middle deemed primary".freeze
+
+  # 1 => establishment_status_name: "Open"
+  # 2 => establishment_status_name: "Closed"
+  # 3 => establishment_status_name: "Open, but proposed to close"
+  # 4 => establishment_status_name: "Proposed to open"
+
+  scope :open, -> { where(establishment_status_code: %w[1 3 4]) }
+
+  def display_name
+    name
+  end
+
+  def primary_education_phase?
+    phase_name == MIDDLE_DEEMED_PRIMARY_PHASE ||
+      phase_name == PRIMARY_PHASE
+  end
+
+  def address
+    [address_1, address_2, address_3, town, county, postcode].reject(&:blank?)
+  end
+
+  def address_string
+    address.join(", ")
+  end
+
+  def name_with_address
+    [display_name, address_string].join(" – ")
+  end
+
+  def in_england?
+    return if establishment_type_code == "30" # Welsh establishment
+    return if la_code == "673" # "Vale of Glamorgan"
+    return if la_code == "702" # "BFPO Overseas Establishments"
+    return if la_code == "000" # "Does not apply"
+    return if la_code == "704" # "Fieldwork Overseas Establishments"
+    return if la_code == "708" # "Gibraltar Overseas Establishments"
+
+    true
+  end
+
+  def identifier
+    "School-#{urn}"
+  end
+
+  def eligible_establishment?
+    eligible_establishment_type_codes.include?(establishment_type_code)
+  end
+
+private
+
+  def eligible_establishment_type_codes
+    [
+      1, # Community school
+      2, # Voluntary aided school
+      3, # Voluntary controlled school
+      5, # Foundation school
+      6, # City technology college
+      7, # Community special school
+      8, # Non-maintained special school
+      10, # Other independent special school
+      12, # Foundation special school
+      14, # Pupil referral unit
+      15, # Local authority nursery school
+      18, # Further education
+      24, # Secure units
+      26, # Service children's education
+      28, # Academy sponsor led
+      31, # Sixth form centres
+      32, # Special post 16 institution
+      33, # Academy special sponsor led
+      34, # Academy converter
+      35, # Free schools
+      36, # Free schools special
+      38, # Free schools alternative provision
+      39, # Free schools 16 to 19
+      40, # University technical college
+      41, # Studio schools
+      42, # Academy alternative provision converter
+      43, # Academy alternative provision sponsor led
+      44, # Academy special converter
+      45, # Academy 16-19 converter
+      46, # Academy 16 to 19 sponsor led
+    ].map(&:to_s)
+  end
+end

--- a/app/models/migration/npq_registration/user.rb
+++ b/app/models/migration/npq_registration/user.rb
@@ -1,0 +1,145 @@
+class Migration::NPQRegistration::User < Migration::NPQRegistration::BaseRecord
+  has_many :applications, dependent: :destroy
+  has_many :ecf_sync_request_logs, as: :syncable, dependent: :destroy
+
+  scope :admins, -> { where(admin: true) }
+  scope :unsynced, -> { where(ecf_id: nil) }
+  scope :synced_to_ecf, -> { where.not(ecf_id: nil) }
+
+  scope :with_get_an_identity_id, lambda {
+    where.not(uid: nil)
+         .where(provider: "tra_openid_connect")
+  }
+
+  # TODO: for investigation of the GAI error, we currently have very small number of duplicated emails
+  # rubocop:disable Rails/UniqueValidationWithoutIndex
+  validates :email, uniqueness: true
+  # rubocop:enable Rails/UniqueValidationWithoutIndex
+
+  def self.find_by_get_an_identity_id(get_an_identity_id)
+    with_get_an_identity_id.find_by(uid: get_an_identity_id)
+  end
+
+  def self.find_or_create_from_provider_data(provider_data, feature_flag_id:)
+    user = find_or_create_from_tra_data_on_uid(provider_data, feature_flag_id:)
+
+    if user.persisted?
+      unless user.valid?
+        Rails.logger.info("[GAI] User persisted BUT not valid, #{user.errors.full_messages.join(';')}, ID=#{user.id}, UID=#{provider_data.uid}, trying to join account")
+      end
+
+      return user
+    end
+
+    Rails.logger.info("[GAI] User not persisted, #{user.errors.full_messages.join(';')}, ID=#{user.id}, UID=#{provider_data.uid}, trying to join account")
+
+    find_or_create_from_tra_data_on_unclaimed_email(provider_data, feature_flag_id:)
+  end
+
+  def self.find_or_create_from_tra_data_on_uid(provider_data, feature_flag_id:)
+    user_from_provider_data = find_or_initialize_by(provider: provider_data.provider, uid: provider_data.uid)
+    user_from_provider_data.feature_flag_id = feature_flag_id
+
+    trn = provider_data.info.trn
+
+    user_from_provider_data.assign_attributes(
+      email: provider_data.info.email,
+      date_of_birth: provider_data.info.date_of_birth,
+      trn:,
+      trn_lookup_status: provider_data.info.trn_lookup_status,
+      trn_verified: trn.present?,
+      full_name: provider_data.info.preferred_name || provider_data.info.name,
+      raw_tra_provider_data: provider_data,
+      updated_from_tra_at: Time.zone.now,
+    )
+
+    user_from_provider_data.tap(&:save)
+  end
+
+  def self.find_or_create_from_tra_data_on_unclaimed_email(provider_data, feature_flag_id:)
+    user_from_provider_data = find_or_initialize_by(provider: nil, uid: nil, email: provider_data.info.email)
+
+    user_from_provider_data.feature_flag_id = feature_flag_id
+
+    trn = provider_data.info.trn
+
+    user_from_provider_data.assign_attributes(
+      provider: provider_data.provider,
+      uid: provider_data.uid,
+      date_of_birth: provider_data.info.date_of_birth,
+      trn:,
+      trn_lookup_status: provider_data.info.trn_lookup_status,
+      trn_verified: trn.present?,
+      full_name: provider_data.info.preferred_name || provider_data.info.name,
+      raw_tra_provider_data: provider_data,
+      updated_from_tra_at: Time.zone.now,
+    )
+
+    unless user_from_provider_data.save
+      Rails.logger.info("[GAI] User not persisted, #{user_from_provider_data.errors.full_messages.join(';')}, ID=#{user_from_provider_data.id}, UID=#{provider_data.uid}, trying to reclaim email failed")
+    end
+
+    user_from_provider_data
+  end
+
+  def get_an_identity_user
+    return if get_an_identity_id.blank?
+
+    External::GetAnIdentity::User.find(get_an_identity_id)
+  end
+
+  def ecf_user
+    return if ecf_id.blank?
+
+    External::EcfApi::Npq::User.find(ecf_id).first
+  end
+
+  def get_an_identity_provider?
+    provider == "tra_openid_connect"
+  end
+
+  def get_an_identity_id
+    uid if get_an_identity_provider?
+  end
+
+  def get_an_identity_id=(new_get_an_identity_id)
+    self.uid = new_get_an_identity_id
+    self.provider = :tra_openid_connect
+  end
+
+  def null_user?
+    false
+  end
+
+  def synced_to_ecf?
+    ecf_id.present?
+  end
+
+  def applications_synced_to_ecf?
+    applications.map(&:synced_to_ecf?).all?
+  end
+
+  def ecf_sync_jobs
+    arel_table = Delayed::Job.arel_table
+    job_name_query = arel_table[:handler].matches("%ApplicationSubmissionJob%")
+    user_id_query = arel_table[:handler].matches("%_aj_globalid: gid://npq-registration/User/#{id}%")
+    Delayed::Job.where(job_name_query)
+                .where(user_id_query)
+                .order(run_at: :asc)
+  end
+
+  # Whether this user has admin access to the feature flagging interface
+  def flipper_access?
+    admin? && super_admin?
+  end
+
+  def flipper_id
+    "User;#{retrieve_or_persist_feature_flag_id}"
+  end
+
+  def retrieve_or_persist_feature_flag_id
+    self.feature_flag_id ||= SecureRandom.uuid
+    save!(validate: false) if feature_flag_id_changed?
+    self.feature_flag_id
+  end
+end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -176,6 +176,31 @@
   - link_reason
   - created_at
   - updated_at
+  :schools:
+  - la_code
+  - la_name
+  - establishment_number
+  - establishment_status_code
+  - establishment_status_name
+  - close_date
+  - last_changed_date
+  - address_1
+  - address_2
+  - address_3
+  - town
+  - county
+  - easting
+  - northing
+  - region
+  - country
+  - establishment_type_code
+  - establishment_type_name
+  - high_pupil_premium
+  - postcode_without_spaces
+  - number_of_pupils
+  - eyl_funding_eligible
+  - phase_type
+  - phase_name
   :profile_validation_decisions:
   - id
   - participant_profile_id
@@ -298,6 +323,9 @@
   - core_induction_programme_id
   - created_at
   - updated_at
+  :lead_providers:
+  - ecf_id
+  - hint
   :finance_profiles:
   - id
   - user_id
@@ -463,3 +491,70 @@
   - get_an_identity_id
   - archived_email
   - archived_at
+  - ecf_id
+  - trn
+  - otp_hash
+  - otp_expires_at
+  - date_of_birth
+  - trn_verified
+  - active_alert
+  - national_insurance_number
+  - trn_auto_verified
+  - admin
+  - feature_flag_id
+  - provider
+  - uid
+  - raw_tra_provider_data
+  - get_an_identity_id_synced_to_ecf
+  - super_admin
+  - updated_from_tra_at
+  - trn_lookup_status
+  :courses:
+  - id
+  - name
+  - created_at
+  - updated_at
+  - ecf_id
+  - description
+  - position
+  - display
+  - identifier
+  :applications:
+  - id
+  - user_id
+  - course_id
+  - lead_provider_id
+  - DEPRECATED_school_urn
+  - created_at
+  - updated_at
+  - ecf_id
+  - headteacher_status
+  - eligible_for_funding
+  - funding_choice
+  - ukprn
+  - teacher_catchment
+  - teacher_catchment_country
+  - works_in_school
+  - employer_name
+  - employment_role
+  - DEPRECATED_private_childcare_provider_urn
+  - works_in_nursery
+  - works_in_childcare
+  - kind_of_nursery
+  - targeted_delivery_funding_eligibility
+  - funding_eligiblity_status_code
+  - raw_application_data
+  - work_setting
+  - teacher_catchment_synced_to_ecf
+  - employment_type
+  - DEPRECATED_itt_provider
+  - lead_mentor
+  - primary_establishment
+  - number_of_pupils
+  - tsf_primary_eligibility
+  - tsf_primary_plus_eligibility
+  - lead_provider_approval_status
+  - participant_outcome_state
+  - private_childcare_provider_id
+  - itt_provider_id
+  - school_id

--- a/config/database.yml
+++ b/config/database.yml
@@ -61,18 +61,18 @@ staging:
     <<: *default_primary
   npq_registration:
     <<: *default_npq_registration
-    url: "<%= ENV['NPQ_DATABASE_URL'] %>"
+    # url: "<%= ENV['NPQ_DATABASE_URL'] %>"
 
 sandbox:
   primary:
     <<: *default_primary
   npq_registration:
     <<: *default_npq_registration
-    url: "<%= ENV['NPQ_DATABASE_URL'] %>"
+    # url: "<%= ENV['NPQ_DATABASE_URL'] %>"
 
 production:
   primary:
     <<: *default_primary
   npq_registration:
     <<: *default_npq_registration
-    url: "<%= ENV['NPQ_DATABASE_URL'] %>"
+    # url: "<%= ENV['NPQ_DATABASE_URL'] %>"

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,43 +1,78 @@
-default: &default
+shared_db_settings: &shared_db_settings
   adapter: postgresql
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  variables:
-    statement_timeout: 20000
-    idle_in_transaction_session_timeout: 10000
+  database: "<%= ENV['DB_DATABASE'] %>"
   username: "<%= ENV['DB_USERNAME'] %>"
   password: "<%= ENV['DB_PASSWORD'] %>"
   host: "<%= ENV['DB_HOSTNAME'] %>"
   port: "<%= ENV['DB_PORT'] %>"
-  database: "<%= ENV['DB_DATABASE'] %>"
+  variables:
+    statement_timeout: 20000
+    idle_in_transaction_session_timeout: 10000
+
+default_primary: &default_primary
+  <<: *shared_db_settings
+default_npq_registration: &default_npq_registration
+  <<: *shared_db_settings
+  migrations_paths: db/npq_registration_migrate
+  database_tasks: false
 
 development:
-  <<: *default
-  database: "early_careers_framework_development"
+  primary:
+    <<: *default_primary
+    database: early_careers_framework_development
+  npq_registration:
+    <<: *default_npq_registration
+    database_tasks: true
+    database: npq_registration_development
 
 test:
-  <<: *default
-  database: early_careers_framework_test<%= ENV['TEST_ENV_NUMBER'] %>
-  variables:
-    idle_in_transaction_session_timeout: 0
+  primary:
+    <<: *default_primary
+    database: early_careers_framework_test<%= ENV['TEST_ENV_NUMBER'] %>
+    variables:
+      idle_in_transaction_session_timeout: 0
+  npq_registration:
+    <<: *default_npq_registration
+    <<: *default_primary # As the test database is shared
+    database: npq_registration_test<%= ENV['TEST_ENV_NUMBER'] %>
+    database_tasks: true
+    variables:
+      idle_in_transaction_session_timeout: 0
 
 review:
-  <<: *default
-  sslmode: <%= ENV.fetch("DB_SSLMODE") { "require" } %>
+  primary:
+    <<: *default_primary
+    sslmode: <%= ENV.fetch("DB_SSLMODE") { "require" } %>
+  npq_registration:
+    <<: *default_npq_registration
+    sslmode: <%= ENV.fetch("DB_SSLMODE") { "require" } %>
 
 performance:
-  <<: *default
-  database: 'early_careers_framework_performance'
+  primary:
+    <<: *default_primary
+    database: early_careers_framework_performance
+  npq_registration:
+    <<: *default_npq_registration
+    database: npq_registration_performance
 
 staging:
-  <<: *default
-  url: <%= ENV["DATABASE_URL"] %>
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  primary:
+    <<: *default_primary
+  npq_registration:
+    <<: *default_npq_registration
+    url: "<%= ENV['NPQ_DATABASE_URL'] %>"
 
 sandbox:
-  <<: *default
-  url: <%= ENV["DATABASE_URL"] %>
+  primary:
+    <<: *default_primary
+  npq_registration:
+    <<: *default_npq_registration
+    url: "<%= ENV['NPQ_DATABASE_URL'] %>"
 
 production:
-  <<: *default
-  url: <%= ENV["DATABASE_URL"] %>
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  primary:
+    <<: *default_primary
+  npq_registration:
+    <<: *default_npq_registration
+    url: "<%= ENV['NPQ_DATABASE_URL'] %>"

--- a/db/npq_registration_migrate/20210517135314_devise_create_users.rb
+++ b/db/npq_registration_migrate/20210517135314_devise_create_users.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class DeviseCreateUsers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :users do |t|
+      ## Database authenticatable
+      t.string :email,              null: false, default: ""
+      t.string :encrypted_password, null: false, default: ""
+
+      ## Recoverable
+      # t.string   :reset_password_token
+      # t.datetime :reset_password_sent_at
+
+      ## Rememberable
+      # t.datetime :remember_created_at
+
+      ## Trackable
+      # t.integer  :sign_in_count, default: 0, null: false
+      # t.datetime :current_sign_in_at
+      # t.datetime :last_sign_in_at
+      # t.string   :current_sign_in_ip
+      # t.string   :last_sign_in_ip
+
+      ## Confirmable
+      # t.string   :confirmation_token
+      # t.datetime :confirmed_at
+      # t.datetime :confirmation_sent_at
+      # t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+      t.timestamps null: false
+    end
+
+    add_index :users, :email, unique: true
+    # add_index :users, :reset_password_token, unique: true
+    # add_index :users, :confirmation_token,   unique: true
+    # add_index :users, :unlock_token,         unique: true
+  end
+end

--- a/db/npq_registration_migrate/20210524095724_create_schools.rb
+++ b/db/npq_registration_migrate/20210524095724_create_schools.rb
@@ -1,0 +1,36 @@
+class CreateSchools < ActiveRecord::Migration[6.1]
+  def change
+    create_table :schools do |t|
+      t.text :urn, null: false
+      t.text :la_code
+      t.text :la_name
+      t.text :establishment_number
+      t.text :name
+
+      t.text :establishment_status_code
+      t.text :establishment_status_name
+      t.date :close_date
+
+      t.text :ukprn
+
+      t.date :last_changed_date
+
+      t.text :address_1 # street
+      t.text :address_2 # locality
+      t.text :address_3
+      t.text :town
+      t.text :county
+      t.text :postcode
+
+      t.integer :easting
+      t.integer :northing
+
+      t.text :region # RSCRegion
+      t.text :country
+
+      t.timestamps
+    end
+
+    add_index :schools, :urn
+  end
+end

--- a/db/npq_registration_migrate/20210525085327_create_delayed_jobs.rb
+++ b/db/npq_registration_migrate/20210525085327_create_delayed_jobs.rb
@@ -1,0 +1,22 @@
+class CreateDelayedJobs < ActiveRecord::Migration[6.1]
+  def self.up
+    create_table :delayed_jobs do |table|
+      table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
+      table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
+      table.text :handler,                 null: false # YAML-encoded string of the object that will do work
+      table.text :last_error                           # reason for last failure (See Note below)
+      table.datetime :run_at                           # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      table.datetime :locked_at                        # Set when a client is working on this object
+      table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
+      table.string :locked_by                          # Who is working on this object (if locked)
+      table.string :queue                              # The name of the queue this job is in
+      table.timestamps null: true
+    end
+
+    add_index :delayed_jobs, %i[priority run_at], name: "delayed_jobs_priority"
+  end
+
+  def self.down
+    drop_table :delayed_jobs
+  end
+end

--- a/db/npq_registration_migrate/20210526113917_update_users.rb
+++ b/db/npq_registration_migrate/20210526113917_update_users.rb
@@ -1,0 +1,16 @@
+class UpdateUsers < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :users, :encrypted_password, :text, null: false, default: ""
+
+    add_column :users, :ecf_id, :text
+    add_column :users, :trn, :text
+
+    add_column :users, :first_name, :text
+    add_column :users, :last_name, :text
+
+    add_column :users, :otp_hash, :text
+    add_column :users, :otp_expires_at, :datetime
+
+    add_index :users, :ecf_id, unique: true
+  end
+end

--- a/db/npq_registration_migrate/20210603153706_add_establishment_types_to_schools.rb
+++ b/db/npq_registration_migrate/20210603153706_add_establishment_types_to_schools.rb
@@ -1,0 +1,6 @@
+class AddEstablishmentTypesToSchools < ActiveRecord::Migration[6.1]
+  def change
+    add_column :schools, :establishment_type_code, :text
+    add_column :schools, :establishment_type_name, :text
+  end
+end

--- a/db/npq_registration_migrate/20210604122940_convert_users_to_full_name.rb
+++ b/db/npq_registration_migrate/20210604122940_convert_users_to_full_name.rb
@@ -1,0 +1,6 @@
+class ConvertUsersToFullName < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :users, :first_name, :full_name
+    remove_column :users, :last_name, :text
+  end
+end

--- a/db/npq_registration_migrate/20210604150738_create_courses.rb
+++ b/db/npq_registration_migrate/20210604150738_create_courses.rb
@@ -1,0 +1,9 @@
+class CreateCourses < ActiveRecord::Migration[6.1]
+  def change
+    create_table :courses do |t|
+      t.text :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/npq_registration_migrate/20210607090516_create_lead_providers.rb
+++ b/db/npq_registration_migrate/20210607090516_create_lead_providers.rb
@@ -1,0 +1,9 @@
+class CreateLeadProviders < ActiveRecord::Migration[6.1]
+  def change
+    create_table :lead_providers do |t|
+      t.text :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/npq_registration_migrate/20210607102935_create_applications.rb
+++ b/db/npq_registration_migrate/20210607102935_create_applications.rb
@@ -1,0 +1,13 @@
+class CreateApplications < ActiveRecord::Migration[6.1]
+  def change
+    create_table :applications do |t|
+      t.references :user, index: true, null: false
+      t.references :course, null: false
+      t.references :lead_provider, null: false
+      t.text :school_urn, null: false
+      t.boolean :headerteacher_over_two_years
+
+      t.timestamps
+    end
+  end
+end

--- a/db/npq_registration_migrate/20210617150140_add_ecf_ids.rb
+++ b/db/npq_registration_migrate/20210617150140_add_ecf_ids.rb
@@ -1,0 +1,7 @@
+class AddEcfIds < ActiveRecord::Migration[6.1]
+  def change
+    add_column :applications, :ecf_id, :text, null: true
+    add_column :courses, :ecf_id, :text, null: true
+    add_column :lead_providers, :ecf_id, :text, null: true
+  end
+end

--- a/db/npq_registration_migrate/20210617164111_add_dob_to_users.rb
+++ b/db/npq_registration_migrate/20210617164111_add_dob_to_users.rb
@@ -1,0 +1,5 @@
+class AddDobToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :date_of_birth, :date
+  end
+end

--- a/db/npq_registration_migrate/20210617172955_fix_typo_headteacher_status.rb
+++ b/db/npq_registration_migrate/20210617172955_fix_typo_headteacher_status.rb
@@ -1,0 +1,6 @@
+class FixTypoHeadteacherStatus < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :applications, :headerteacher_over_two_years, :boolean
+    add_column :applications, :headteacher_status, :text
+  end
+end

--- a/db/npq_registration_migrate/20210621162804_add_trn_verified_to_users.rb
+++ b/db/npq_registration_migrate/20210621162804_add_trn_verified_to_users.rb
@@ -1,0 +1,5 @@
+class AddTrnVerifiedToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :trn_verified, :boolean, null: false, default: false
+  end
+end

--- a/db/npq_registration_migrate/20210623090146_add_active_alert_to_user.rb
+++ b/db/npq_registration_migrate/20210623090146_add_active_alert_to_user.rb
@@ -1,0 +1,5 @@
+class AddActiveAlertToUser < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :active_alert, :boolean, default: false
+  end
+end

--- a/db/npq_registration_migrate/20210624102737_update_lead_provider_names.rb
+++ b/db/npq_registration_migrate/20210624102737_update_lead_provider_names.rb
@@ -1,0 +1,6 @@
+class UpdateLeadProviderNames < ActiveRecord::Migration[6.1]
+  def change
+    LeadProvider.where(name: "Best Practice Network").update_all(name: "Best Practice Network (home of Outstanding Leaders Partnership)")
+    LeadProvider.where(name: "Leadership Learning South East").update_all(name: "Leadership Learning South East (LLSE)")
+  end
+end

--- a/db/npq_registration_migrate/20210624161922_add_high_pupil_premium_to_schools.rb
+++ b/db/npq_registration_migrate/20210624161922_add_high_pupil_premium_to_schools.rb
@@ -1,0 +1,5 @@
+class AddHighPupilPremiumToSchools < ActiveRecord::Migration[6.1]
+  def change
+    add_column :schools, :high_pupil_premium, :boolean, null: false, default: false
+  end
+end

--- a/db/npq_registration_migrate/20210625153342_add_funding_fields_to_applications.rb
+++ b/db/npq_registration_migrate/20210625153342_add_funding_fields_to_applications.rb
@@ -1,0 +1,6 @@
+class AddFundingFieldsToApplications < ActiveRecord::Migration[6.1]
+  def change
+    add_column :applications, :eligible_for_funding, :boolean, null: false, default: false
+    add_column :applications, :funding_choice, :text
+  end
+end

--- a/db/npq_registration_migrate/20210701145259_add_school_search_indexes.rb
+++ b/db/npq_registration_migrate/20210701145259_add_school_search_indexes.rb
@@ -1,0 +1,9 @@
+class AddSchoolSearchIndexes < ActiveRecord::Migration[6.1]
+  def up
+    add_index :schools, 'to_tsvector(\'english\', coalesce("schools"."name"::text, \'\'))', using: :gin, name: "school_name_search_idx"
+  end
+
+  def down
+    remove_index :schools, name: "school_name_search_idx"
+  end
+end

--- a/db/npq_registration_migrate/20210715092732_add_ni_number_to_users.rb
+++ b/db/npq_registration_migrate/20210715092732_add_ni_number_to_users.rb
@@ -1,0 +1,5 @@
+class AddNiNumberToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :national_insurance_number, :text, null: true
+  end
+end

--- a/db/npq_registration_migrate/20210719104504_create_reports.rb
+++ b/db/npq_registration_migrate/20210719104504_create_reports.rb
@@ -1,0 +1,10 @@
+class CreateReports < ActiveRecord::Migration[6.1]
+  def change
+    create_table :reports do |t|
+      t.text :identifier, null: false
+      t.text :data, null: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/npq_registration_migrate/20210730094220_add_postcode_without_spaces.rb
+++ b/db/npq_registration_migrate/20210730094220_add_postcode_without_spaces.rb
@@ -1,0 +1,5 @@
+class AddPostcodeWithoutSpaces < ActiveRecord::Migration[6.1]
+  def change
+    add_column :schools, :postcode_without_spaces, :text
+  end
+end

--- a/db/npq_registration_migrate/20210802094543_add_trn_auto_verified_to_users.rb
+++ b/db/npq_registration_migrate/20210802094543_add_trn_auto_verified_to_users.rb
@@ -1,0 +1,5 @@
+class AddTrnAutoVerifiedToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :trn_auto_verified, :boolean, default: false
+  end
+end

--- a/db/npq_registration_migrate/20210823120454_create_local_authorities.rb
+++ b/db/npq_registration_migrate/20210823120454_create_local_authorities.rb
@@ -1,0 +1,22 @@
+class CreateLocalAuthorities < ActiveRecord::Migration[6.1]
+  def change
+    create_table :local_authorities do |t|
+      t.text :ukprn
+      t.text :name
+
+      t.text :address_1
+      t.text :address_2
+      t.text :address_3
+      t.text :town
+      t.text :county
+      t.text :postcode
+      t.text :postcode_without_spaces
+
+      t.boolean :high_pupil_premium, default: false, null: false
+
+      t.timestamps
+    end
+
+    add_index :local_authorities, :ukprn
+  end
+end

--- a/db/npq_registration_migrate/20210824120112_add_ukprn_to_application.rb
+++ b/db/npq_registration_migrate/20210824120112_add_ukprn_to_application.rb
@@ -1,0 +1,5 @@
+class AddUkprnToApplication < ActiveRecord::Migration[6.1]
+  def change
+    add_column :applications, :ukprn, :text, null: true
+  end
+end

--- a/db/npq_registration_migrate/20210825105355_application_school_urn_nullable.rb
+++ b/db/npq_registration_migrate/20210825105355_application_school_urn_nullable.rb
@@ -1,0 +1,5 @@
+class ApplicationSchoolUrnNullable < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :applications, :school_urn, true
+  end
+end

--- a/db/npq_registration_migrate/20210831105602_add_sessions_table.rb
+++ b/db/npq_registration_migrate/20210831105602_add_sessions_table.rb
@@ -1,0 +1,12 @@
+class AddSessionsTable < ActiveRecord::Migration[6.1]
+  def change
+    create_table :sessions do |t|
+      t.string :session_id, null: false
+      t.text :data
+      t.timestamps
+    end
+
+    add_index :sessions, :session_id, unique: true
+    add_index :sessions, :updated_at
+  end
+end

--- a/db/npq_registration_migrate/20210921092011_add_admin_to_users.rb
+++ b/db/npq_registration_migrate/20210921092011_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :admin, :boolean, default: false
+  end
+end

--- a/db/npq_registration_migrate/20210928142225_add_description_to_courses.rb
+++ b/db/npq_registration_migrate/20210928142225_add_description_to_courses.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToCourses < ActiveRecord::Migration[6.1]
+  def change
+    add_column :courses, :description, :text, null: true
+  end
+end

--- a/db/npq_registration_migrate/20211025103506_add_teacher_catchments.rb
+++ b/db/npq_registration_migrate/20211025103506_add_teacher_catchments.rb
@@ -1,0 +1,6 @@
+class AddTeacherCatchments < ActiveRecord::Migration[6.1]
+  def change
+    add_column :applications, :teacher_catchment, :text, null: true
+    add_column :applications, :teacher_catchment_country, :text, null: true
+  end
+end

--- a/db/npq_registration_migrate/20220125143328_create_registration_interests.rb
+++ b/db/npq_registration_migrate/20220125143328_create_registration_interests.rb
@@ -1,0 +1,12 @@
+class CreateRegistrationInterests < ActiveRecord::Migration[6.1]
+  def change
+    enable_extension("citext")
+
+    create_table :registration_interests do |t|
+      t.citext :email, null: false, index: { unique: true }
+      t.boolean :notified, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/npq_registration_migrate/20220224121536_add_work_information_to_applications.rb
+++ b/db/npq_registration_migrate/20220224121536_add_work_information_to_applications.rb
@@ -1,0 +1,7 @@
+class AddWorkInformationToApplications < ActiveRecord::Migration[6.1]
+  def change
+    add_column :applications, :works_in_school, :boolean
+    add_column :applications, :employer_name, :string
+    add_column :applications, :employment_role, :string
+  end
+end

--- a/db/npq_registration_migrate/20220407111331_create_private_childcare_providers.rb
+++ b/db/npq_registration_migrate/20220407111331_create_private_childcare_providers.rb
@@ -1,0 +1,35 @@
+class CreatePrivateChildcareProviders < ActiveRecord::Migration[6.1]
+  def change
+    create_table :private_childcare_providers do |t|
+      t.text :provider_urn, null: false
+      t.text :provider_name
+
+      t.text :registered_person_urn
+      t.text :registered_person_name
+
+      t.text :registration_date
+
+      t.text :provider_status
+
+      t.text :address_1
+      t.text :address_2
+      t.text :address_3
+      t.text :town
+      t.text :postcode
+      t.text :postcode_without_spaces
+      t.text :region
+      t.text :local_authority
+      t.text :ofsted_region
+
+      t.json :early_years_individual_registers, default: []
+      t.boolean :provider_early_years_register_flag
+      t.boolean :provider_compulsory_childcare_register_flag
+
+      t.integer :places
+
+      t.timestamps
+    end
+
+    add_index :private_childcare_providers, :provider_urn
+  end
+end

--- a/db/npq_registration_migrate/20220428100635_add_number_of_pupils_to_schools.rb
+++ b/db/npq_registration_migrate/20220428100635_add_number_of_pupils_to_schools.rb
@@ -1,0 +1,5 @@
+class AddNumberOfPupilsToSchools < ActiveRecord::Migration[6.1]
+  def change
+    add_column :schools, :number_of_pupils, :integer
+  end
+end

--- a/db/npq_registration_migrate/20220428153531_add_targeted_funding_to_apps.rb
+++ b/db/npq_registration_migrate/20220428153531_add_targeted_funding_to_apps.rb
@@ -1,0 +1,5 @@
+class AddTargetedFundingToApps < ActiveRecord::Migration[6.1]
+  def change
+    add_column :applications, :targeted_support_funding_eligibility, :boolean, default: false
+  end
+end

--- a/db/npq_registration_migrate/20220503111659_add_position_to_courses.rb
+++ b/db/npq_registration_migrate/20220503111659_add_position_to_courses.rb
@@ -1,0 +1,5 @@
+class AddPositionToCourses < ActiveRecord::Migration[6.1]
+  def change
+    add_column :courses, :position, :integer, default: 0
+  end
+end

--- a/db/npq_registration_migrate/20220503114606_add_display_to_courses.rb
+++ b/db/npq_registration_migrate/20220503114606_add_display_to_courses.rb
@@ -1,0 +1,5 @@
+class AddDisplayToCourses < ActiveRecord::Migration[6.1]
+  def change
+    add_column :courses, :display, :boolean, default: true
+  end
+end

--- a/db/npq_registration_migrate/20220505113441_add_early_years_columns_to_applications.rb
+++ b/db/npq_registration_migrate/20220505113441_add_early_years_columns_to_applications.rb
@@ -1,0 +1,8 @@
+class AddEarlyYearsColumnsToApplications < ActiveRecord::Migration[6.1]
+  def change
+    add_column :applications, :private_childcare_provider_urn, :text
+    add_column :applications, :works_in_nursery, :boolean
+    add_column :applications, :works_in_childcare, :boolean
+    add_column :applications, :kind_of_nursery, :text
+  end
+end

--- a/db/npq_registration_migrate/20220505133620_add_cohort_to_applications.rb
+++ b/db/npq_registration_migrate/20220505133620_add_cohort_to_applications.rb
@@ -1,0 +1,5 @@
+class AddCohortToApplications < ActiveRecord::Migration[6.1]
+  def change
+    add_column :applications, :cohort, :integer, default: 2021
+  end
+end

--- a/db/npq_registration_migrate/20220513133539_add_dupe_targeted_delivery_flag.rb
+++ b/db/npq_registration_migrate/20220513133539_add_dupe_targeted_delivery_flag.rb
@@ -1,0 +1,5 @@
+class AddDupeTargetedDeliveryFlag < ActiveRecord::Migration[6.1]
+  def change
+    add_column :applications, :targeted_delivery_funding_eligibility, :boolean, default: false
+  end
+end

--- a/db/npq_registration_migrate/20220523100938_add_funding_eligiblity_status_code_to_applications.rb
+++ b/db/npq_registration_migrate/20220523100938_add_funding_eligiblity_status_code_to_applications.rb
@@ -1,0 +1,5 @@
+class AddFundingEligiblityStatusCodeToApplications < ActiveRecord::Migration[6.1]
+  def change
+    add_column :applications, :funding_eligiblity_status_code, :string
+  end
+end

--- a/db/npq_registration_migrate/20220617131203_add_raw_application_data_to_applications.rb
+++ b/db/npq_registration_migrate/20220617131203_add_raw_application_data_to_applications.rb
@@ -1,0 +1,5 @@
+class AddRawApplicationDataToApplications < ActiveRecord::Migration[6.1]
+  def change
+    add_column :applications, :raw_application_data, :jsonb, default: {}
+  end
+end

--- a/db/npq_registration_migrate/20220628094940_add_default_cohort_to_courses.rb
+++ b/db/npq_registration_migrate/20220628094940_add_default_cohort_to_courses.rb
@@ -1,0 +1,5 @@
+class AddDefaultCohortToCourses < ActiveRecord::Migration[6.1]
+  def change
+    add_column :courses, :default_cohort, :integer, default: 2022
+  end
+end

--- a/db/npq_registration_migrate/20220709142735_add_work_setting_to_applications.rb
+++ b/db/npq_registration_migrate/20220709142735_add_work_setting_to_applications.rb
@@ -1,0 +1,5 @@
+class AddWorkSettingToApplications < ActiveRecord::Migration[6.1]
+  def change
+    add_column :applications, :work_setting, :text
+  end
+end

--- a/db/npq_registration_migrate/20220810135738_add_teacher_catchment_synced_to_ecf_to_applications.rb
+++ b/db/npq_registration_migrate/20220810135738_add_teacher_catchment_synced_to_ecf_to_applications.rb
@@ -1,0 +1,5 @@
+class AddTeacherCatchmentSyncedToEcfToApplications < ActiveRecord::Migration[6.1]
+  def change
+    add_column :applications, :teacher_catchment_synced_to_ecf, :boolean, default: false
+  end
+end

--- a/db/npq_registration_migrate/20220826154213_add_employment_type_to_applications.rb
+++ b/db/npq_registration_migrate/20220826154213_add_employment_type_to_applications.rb
@@ -1,0 +1,5 @@
+class AddEmploymentTypeToApplications < ActiveRecord::Migration[6.1]
+  def change
+    add_column :applications, :employment_type, :string
+  end
+end

--- a/db/npq_registration_migrate/20220905130008_add_devise_to_users.rb
+++ b/db/npq_registration_migrate/20220905130008_add_devise_to_users.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AddDeviseToUsers < ActiveRecord::Migration[6.1]
+  def self.up
+    change_table :users do |t|
+      t.string :provider
+      t.string :uid
+    end
+
+    add_index :users, :provider
+    add_index :users, :uid, unique: true
+  end
+
+  def self.down
+    # By default, we don't want to make any assumption about how to roll back a migration when your
+    # model already existed. Please edit below which fields you would like to remove in this migration.
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/npq_registration_migrate/20220929132130_add_raw_tra_provider_data_to_users.rb
+++ b/db/npq_registration_migrate/20220929132130_add_raw_tra_provider_data_to_users.rb
@@ -1,0 +1,5 @@
+class AddRawTraProviderDataToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :raw_tra_provider_data, :jsonb
+  end
+end

--- a/db/npq_registration_migrate/20221020091024_create_flipper_tables.rb
+++ b/db/npq_registration_migrate/20221020091024_create_flipper_tables.rb
@@ -1,0 +1,22 @@
+class CreateFlipperTables < ActiveRecord::Migration[6.1]
+  def self.up
+    create_table :flipper_features do |t|
+      t.string :key, null: false
+      t.timestamps null: false
+    end
+    add_index :flipper_features, :key, unique: true
+
+    create_table :flipper_gates do |t|
+      t.string :feature_key, null: false
+      t.string :key, null: false
+      t.string :value
+      t.timestamps null: false
+    end
+    add_index :flipper_gates, %i[feature_key key value], unique: true
+  end
+
+  def self.down
+    drop_table :flipper_gates
+    drop_table :flipper_features
+  end
+end

--- a/db/npq_registration_migrate/20221020092102_add_flipper_admin_to_users.rb
+++ b/db/npq_registration_migrate/20221020092102_add_flipper_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddFlipperAdminToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :flipper_admin_access, :boolean, default: false
+  end
+end

--- a/db/npq_registration_migrate/20221020102023_add_feature_flag_id_to_users.rb
+++ b/db/npq_registration_migrate/20221020102023_add_feature_flag_id_to_users.rb
@@ -1,0 +1,5 @@
+class AddFeatureFlagIdToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :feature_flag_id, :string, unique: true
+  end
+end

--- a/db/npq_registration_migrate/20221118124435_drop_unique_index_from_users_ecf_id.rb
+++ b/db/npq_registration_migrate/20221118124435_drop_unique_index_from_users_ecf_id.rb
@@ -1,0 +1,6 @@
+class DropUniqueIndexFromUsersEcfId < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :users, :ecf_id, unique: true
+    add_index :users, :ecf_id
+  end
+end

--- a/db/npq_registration_migrate/20221122203458_add_eyl_funding_eligible_to_schools.rb
+++ b/db/npq_registration_migrate/20221122203458_add_eyl_funding_eligible_to_schools.rb
@@ -1,0 +1,5 @@
+class AddEylFundingEligibleToSchools < ActiveRecord::Migration[6.1]
+  def change
+    add_column :schools, :eyl_funding_eligible, :boolean, default: false
+  end
+end

--- a/db/npq_registration_migrate/20221130142333_add_hint_to_lead_providers.rb
+++ b/db/npq_registration_migrate/20221130142333_add_hint_to_lead_providers.rb
@@ -1,0 +1,15 @@
+class AddHintToLeadProviders < ActiveRecord::Migration[6.1]
+  def up
+    add_column :lead_providers, :hint, :string
+
+    school_led_network_lead_provider = LeadProvider.find_by(ecf_id: LeadProvider::ALL_PROVIDERS["School-Led Network"])
+
+    school_led_network_lead_provider.update!(
+      hint: "You can only register with this provider if you already started your NPQ with them in October 2022.",
+    )
+  end
+
+  def down
+    remove_column :lead_providers, :hint
+  end
+end

--- a/db/npq_registration_migrate/20221212192830_create_itt_providers.rb
+++ b/db/npq_registration_migrate/20221212192830_create_itt_providers.rb
@@ -1,0 +1,15 @@
+class CreateIttProviders < ActiveRecord::Migration[6.1]
+  def change
+    create_table :itt_providers do |t|
+      t.text :legal_name, unique: true
+      t.text :operating_name
+      t.date :removed_at
+
+      t.boolean :approved
+
+      t.timestamps
+    end
+
+    add_index :itt_providers, :legal_name, unique: true
+  end
+end

--- a/db/npq_registration_migrate/20221213151804_create_ecf_sync_request_logs.rb
+++ b/db/npq_registration_migrate/20221213151804_create_ecf_sync_request_logs.rb
@@ -1,0 +1,16 @@
+class CreateEcfSyncRequestLogs < ActiveRecord::Migration[6.1]
+  def change
+    create_table :ecf_sync_request_logs do |t|
+      t.integer :syncable_id, null: false
+      t.string :syncable_type, null: false
+      t.string :status, null: false
+      t.string :sync_type, null: false
+      t.jsonb :error_messages, default: []
+      t.jsonb :response_body
+
+      t.index(%i[syncable_id syncable_type])
+
+      t.timestamps
+    end
+  end
+end

--- a/db/npq_registration_migrate/20230105160357_rename_flipper_admin_access_to_superadmin.rb
+++ b/db/npq_registration_migrate/20230105160357_rename_flipper_admin_access_to_superadmin.rb
@@ -1,0 +1,7 @@
+class RenameFlipperAdminAccessToSuperadmin < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :super_admin, :boolean, default: false, null: false
+
+    User.where(flipper_admin_access: true).update_all(super_admin: true)
+  end
+end

--- a/db/npq_registration_migrate/20230106114221_update_default_cohort_for_ehco.rb
+++ b/db/npq_registration_migrate/20230106114221_update_default_cohort_for_ehco.rb
@@ -1,0 +1,7 @@
+class UpdateDefaultCohortForEhco < ActiveRecord::Migration[6.1]
+  def change
+    ehco_course = Course.find_by(identifier: "npq-early-headship-coaching-offer")
+
+    ehco_course&.update!(default_cohort: 2022)
+  end
+end

--- a/db/npq_registration_migrate/20230123182755_add_itt_provider_and_lead_mentor_to_application.rb
+++ b/db/npq_registration_migrate/20230123182755_add_itt_provider_and_lead_mentor_to_application.rb
@@ -1,0 +1,6 @@
+class AddIttProviderAndLeadMentorToApplication < ActiveRecord::Migration[6.1]
+  def change
+    add_column :applications, :itt_provider, :string
+    add_column :applications, :lead_mentor, :boolean, default: false
+  end
+end

--- a/db/npq_registration_migrate/20230131142734_remove_targeted_support_funding_eligibility_from_application.rb
+++ b/db/npq_registration_migrate/20230131142734_remove_targeted_support_funding_eligibility_from_application.rb
@@ -1,0 +1,7 @@
+class RemoveTargetedSupportFundingEligibilityFromApplication < ActiveRecord::Migration[6.1]
+  # Removing to this being a depracted field in favour of targeted_delivery_funding_eligibility
+
+  def change
+    remove_column :applications, :targeted_support_funding_eligibility, type: :string
+  end
+end

--- a/db/npq_registration_migrate/20230206153448_add_get_an_identity_id_sync_bool_to_users.rb
+++ b/db/npq_registration_migrate/20230206153448_add_get_an_identity_id_sync_bool_to_users.rb
@@ -1,0 +1,5 @@
+class AddGetAnIdentityIdSyncBoolToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :get_an_identity_id_synced_to_ecf, :boolean, default: false
+  end
+end

--- a/db/npq_registration_migrate/20230220114340_add_identifier_to_courses.rb
+++ b/db/npq_registration_migrate/20230220114340_add_identifier_to_courses.rb
@@ -1,0 +1,20 @@
+class AddIdentifierToCourses < ActiveRecord::Migration[6.1]
+  def change
+    add_column :courses, :identifier, :string
+
+    {
+      "15c52ed8-06b5-426e-81a2-c2664978a0dc" => "npq-leading-teaching",
+      "7d47a0a6-fa74-4587-92cc-cd1e4548a2e5" => "npq-leading-behaviour-culture",
+      "29fee78b-30ce-4b93-ba21-80be2fde286f" => "npq-leading-teaching-development",
+      "a42736ad-3d0b-401d-aebe-354ef4c193ec" => "npq-senior-leadership",
+      "0f7d6578-a12c-4498-92a0-2ee0f18e0768" => "npq-headship",
+      "aef853f2-9b48-4b6a-9d2a-91b295f5ca9a" => "npq-executive-leadership",
+      "7fbefdd4-dd2d-4a4f-8995-d59e525124b7" => "npq-additional-support-offer",
+      "0222d1a8-a8e1-42e3-a040-2c585f6c194a" => "npq-early-headship-coaching-offer",
+      "66dff4af-a518-498f-9042-36a41f9e8aa7" => "npq-early-years-leadership",
+      "829fcd45-e39d-49a9-b309-26d26debfa90" => "npq-leading-literacy",
+    }.each do |ecf_id, identifier|
+      Course.find_by!(ecf_id:).update(identifier:)
+    end
+  end
+end

--- a/db/npq_registration_migrate/20230323181613_add_school_phase_to_school.rb
+++ b/db/npq_registration_migrate/20230323181613_add_school_phase_to_school.rb
@@ -1,0 +1,6 @@
+class AddSchoolPhaseToSchool < ActiveRecord::Migration[6.1]
+  def change
+    add_column :schools, :phase_type, :integer, default: 0
+    add_column :schools, :phase_name, :string, default: "Not applicable"
+  end
+end

--- a/db/npq_registration_migrate/20230323182922_add_primary_establishment_to_application.rb
+++ b/db/npq_registration_migrate/20230323182922_add_primary_establishment_to_application.rb
@@ -1,0 +1,5 @@
+class AddPrimaryEstablishmentToApplication < ActiveRecord::Migration[6.1]
+  def change
+    add_column :applications, :primary_establishment, :boolean, default: false
+  end
+end

--- a/db/npq_registration_migrate/20230323184035_add_number_of_pupils_to_application.rb
+++ b/db/npq_registration_migrate/20230323184035_add_number_of_pupils_to_application.rb
@@ -1,0 +1,5 @@
+class AddNumberOfPupilsToApplication < ActiveRecord::Migration[6.1]
+  def change
+    add_column :applications, :number_of_pupils, :integer, default: 0
+  end
+end

--- a/db/npq_registration_migrate/20230323184936_add_tsf_primary_eligibility_and_tsf_primary_plus_eligibility_to_application.rb
+++ b/db/npq_registration_migrate/20230323184936_add_tsf_primary_eligibility_and_tsf_primary_plus_eligibility_to_application.rb
@@ -1,0 +1,6 @@
+class AddTsfPrimaryEligibilityAndTsfPrimaryPlusEligibilityToApplication < ActiveRecord::Migration[6.1]
+  def change
+    add_column :applications, :tsf_primary_eligibility, :boolean, default: false
+    add_column :applications, :tsf_primary_plus_eligibility, :boolean, default: false
+  end
+end

--- a/db/npq_registration_migrate/20230328120048_add_updated_from_tra_at_to_users.rb
+++ b/db/npq_registration_migrate/20230328120048_add_updated_from_tra_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddUpdatedFromTraAtToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :updated_from_tra_at, :datetime
+  end
+end

--- a/db/npq_registration_migrate/20230331120924_drop_unused_column_flipper_admin_access.rb
+++ b/db/npq_registration_migrate/20230331120924_drop_unused_column_flipper_admin_access.rb
@@ -1,0 +1,5 @@
+class DropUnusedColumnFlipperAdminAccess < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :users, :flipper_admin_access, :boolean
+  end
+end

--- a/db/npq_registration_migrate/20230404134916_create_get_an_identity_webhook_messages.rb
+++ b/db/npq_registration_migrate/20230404134916_create_get_an_identity_webhook_messages.rb
@@ -1,0 +1,17 @@
+class CreateGetAnIdentityWebhookMessages < ActiveRecord::Migration[6.1]
+  def change
+    create_table :get_an_identity_webhook_messages do |t|
+      t.jsonb :raw
+      t.jsonb :message
+      t.string :message_id
+      t.string :message_type
+      t.string :status, default: "pending"
+      t.string :status_comment
+
+      t.datetime :sent_at
+      t.datetime :processed_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/npq_registration_migrate/20230412110012_change_default_for_applications_cohort.rb
+++ b/db/npq_registration_migrate/20230412110012_change_default_for_applications_cohort.rb
@@ -1,0 +1,5 @@
+class ChangeDefaultForApplicationsCohort < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default :applications, :cohort, from: 2021, to: nil
+  end
+end

--- a/db/npq_registration_migrate/20230412110152_drop_default_cohort_from_courses.rb
+++ b/db/npq_registration_migrate/20230412110152_drop_default_cohort_from_courses.rb
@@ -1,0 +1,9 @@
+class DropDefaultCohortFromCourses < ActiveRecord::Migration[6.1]
+  def up
+    remove_column :courses, :default_cohort
+  end
+
+  def down
+    add_column :courses, :default_cohort, :integer, default: 2022
+  end
+end

--- a/db/npq_registration_migrate/20230412111432_change_cohort_column_name.rb
+++ b/db/npq_registration_migrate/20230412111432_change_cohort_column_name.rb
@@ -1,0 +1,5 @@
+class ChangeCohortColumnName < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :applications, :cohort, :DEPRECATED_cohort
+  end
+end

--- a/db/npq_registration_migrate/20230414121939_add_trn_lookup_status_to_users.rb
+++ b/db/npq_registration_migrate/20230414121939_add_trn_lookup_status_to_users.rb
@@ -1,0 +1,5 @@
+class AddTrnLookupStatusToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :trn_lookup_status, :string
+  end
+end

--- a/db/npq_registration_migrate/20230619162920_add_lead_provider_approval_status_to_applications.rb
+++ b/db/npq_registration_migrate/20230619162920_add_lead_provider_approval_status_to_applications.rb
@@ -1,0 +1,6 @@
+class AddLeadProviderApprovalStatusToApplications < ActiveRecord::Migration[6.1]
+  def change
+    add_column :applications, :lead_provider_approval_status, :text
+    add_column :applications, :participant_outcome_state, :text
+  end
+end

--- a/db/npq_registration_migrate/20230720114510_create_versions.rb
+++ b/db/npq_registration_migrate/20230720114510_create_versions.rb
@@ -1,0 +1,37 @@
+# This migration creates the `versions` table, the only schema PT requires.
+# All other migrations PT provides are optional.
+class CreateVersions < ActiveRecord::Migration[6.1]
+  # The largest text column available in all supported RDBMS is
+  # 1024^3 - 1 bytes, roughly one gibibyte.  We specify a size
+  # so that MySQL will use `longtext` instead of `text`.  Otherwise,
+  # when serializing very large objects, `text` might not be big enough.
+  TEXT_BYTES = 1_073_741_823
+
+  def change
+    create_table :versions do |t|
+      t.string   :item_type, null: false
+      t.bigint   :item_id,   null: false
+      t.string   :event,     null: false
+      t.string   :whodunnit
+      t.text     :object, limit: TEXT_BYTES
+
+      # Known issue in MySQL: fractional second precision
+      # -------------------------------------------------
+      #
+      # MySQL timestamp columns do not support fractional seconds unless
+      # defined with "fractional seconds precision". MySQL users should manually
+      # add fractional seconds precision to this migration, specifically, to
+      # the `created_at` column.
+      # (https://dev.mysql.com/doc/refman/5.6/en/fractional-seconds.html)
+      #
+      # MySQL users should also upgrade to at least rails 4.2, which is the first
+      # version of ActiveRecord with support for fractional seconds in MySQL.
+      # (https://github.com/rails/rails/pull/14359)
+      #
+      # MySQL users should use the following line for `created_at`
+      # t.datetime :created_at, limit: 6
+      t.datetime :created_at
+    end
+    add_index :versions, %i[item_type item_id]
+  end
+end

--- a/db/npq_registration_migrate/20230720141121_update_approved_itt_provider.rb
+++ b/db/npq_registration_migrate/20230720141121_update_approved_itt_provider.rb
@@ -1,0 +1,6 @@
+class UpdateApprovedIttProvider < ActiveRecord::Migration[6.1]
+  def change
+    itt_provider = IttProvider.find_by(legal_name: "St Michael’s Church of England Primary School")
+    itt_provider.update!(legal_name: "Christ Church Primary School Hampstead") if itt_provider.present?
+  end
+end

--- a/db/npq_registration_migrate/20230802120824_create_teaching_primary_mathematics_course_to_courses.rb
+++ b/db/npq_registration_migrate/20230802120824_create_teaching_primary_mathematics_course_to_courses.rb
@@ -1,0 +1,6 @@
+class CreateTeachingPrimaryMathematicsCourseToCourses < ActiveRecord::Migration[6.1]
+  def change
+    course = Course.find_by(identifier: "npq-leading-primary-mathematics")
+    Course.create!(name: "NPQ Leading Primary Mathematics (NPQLPM)", position: 5, display: true, identifier: "npq-leading-primary-mathematics") if course.blank?
+  end
+end

--- a/db/npq_registration_migrate/20231023083939_add_cron_to_delayed_jobs.rb
+++ b/db/npq_registration_migrate/20231023083939_add_cron_to_delayed_jobs.rb
@@ -1,0 +1,9 @@
+class AddCronToDelayedJobs < ActiveRecord::Migration[7.0]
+  def self.up
+    add_column :delayed_jobs, :cron, :string
+  end
+
+  def self.down
+    remove_column :delayed_jobs, :cron
+  end
+end

--- a/db/npq_registration_migrate/20231109124740_remove_uniquenes_from_users_email.rb
+++ b/db/npq_registration_migrate/20231109124740_remove_uniquenes_from_users_email.rb
@@ -1,0 +1,6 @@
+class RemoveUniquenesFromUsersEmail < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :users, :email
+    add_index :users, :email
+  end
+end

--- a/db/npq_registration_migrate/20231205214008_add_user_application_fk.rb
+++ b/db/npq_registration_migrate/20231205214008_add_user_application_fk.rb
@@ -1,0 +1,5 @@
+class AddUserApplicationFk < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :applications, :users, column: :user_id
+  end
+end

--- a/db/npq_registration_migrate/20231205214717_add_application_lead_provider_fk.rb
+++ b/db/npq_registration_migrate/20231205214717_add_application_lead_provider_fk.rb
@@ -1,0 +1,5 @@
+class AddApplicationLeadProviderFk < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :applications, :lead_providers, column: :lead_provider_id
+  end
+end

--- a/db/npq_registration_migrate/20231205221615_add_school_id_to_applications.rb
+++ b/db/npq_registration_migrate/20231205221615_add_school_id_to_applications.rb
@@ -1,0 +1,5 @@
+class AddSchoolIdToApplications < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :applications, :school, null: true, foreign_key: true
+  end
+end

--- a/db/npq_registration_migrate/20231205221901_populate_school_id_in_applications.rb
+++ b/db/npq_registration_migrate/20231205221901_populate_school_id_in_applications.rb
@@ -1,0 +1,13 @@
+class PopulateSchoolIdInApplications < ActiveRecord::Migration[7.0]
+  def up
+    # Use SQL to update the school_id column based on school_urn
+    execute <<-SQL
+      UPDATE applications
+      SET school_id = schools.id
+      FROM schools
+      WHERE applications.school_urn = schools.urn
+    SQL
+  end
+
+  def down; end
+end

--- a/db/npq_registration_migrate/20231205223531_rename_school_urn_from_application.rb
+++ b/db/npq_registration_migrate/20231205223531_rename_school_urn_from_application.rb
@@ -1,0 +1,5 @@
+class RenameSchoolUrnFromApplication < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :applications, :school_urn, :school_urn_old
+  end
+end

--- a/db/npq_registration_migrate/20231205225024_add_application_course_fk.rb
+++ b/db/npq_registration_migrate/20231205225024_add_application_course_fk.rb
@@ -1,0 +1,5 @@
+class AddApplicationCourseFk < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :applications, :courses, column: :course_id
+  end
+end

--- a/db/npq_registration_migrate/20231207110916_add_private_childcare_provider_id_to_applications.rb
+++ b/db/npq_registration_migrate/20231207110916_add_private_childcare_provider_id_to_applications.rb
@@ -1,0 +1,5 @@
+class AddPrivateChildcareProviderIdToApplications < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :applications, :private_childcare_provider, null: true, foreign_key: true
+  end
+end

--- a/db/npq_registration_migrate/20231207111223_populate_private_childcare_provider_id_in_applications.rb
+++ b/db/npq_registration_migrate/20231207111223_populate_private_childcare_provider_id_in_applications.rb
@@ -1,0 +1,13 @@
+class PopulatePrivateChildcareProviderIdInApplications < ActiveRecord::Migration[7.0]
+  def up
+    # Use SQL to update the school_id column based on school_urn
+    execute <<-SQL
+      UPDATE applications
+      SET private_childcare_provider_id = private_childcare_providers.id
+      FROM private_childcare_providers
+      WHERE applications.private_childcare_provider_urn = private_childcare_providers.provider_urn
+    SQL
+  end
+
+  def down; end
+end

--- a/db/npq_registration_migrate/20231207111449_rename_private_childcare_provider_urn_from_application.rb
+++ b/db/npq_registration_migrate/20231207111449_rename_private_childcare_provider_urn_from_application.rb
@@ -1,0 +1,5 @@
+class RenamePrivateChildcareProviderUrnFromApplication < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :applications, :private_childcare_provider_urn, :private_childcare_provider_urn_old
+  end
+end

--- a/db/npq_registration_migrate/20231207114910_add_itt_provider_id_to_applications.rb
+++ b/db/npq_registration_migrate/20231207114910_add_itt_provider_id_to_applications.rb
@@ -1,0 +1,5 @@
+class AddIttProviderIdToApplications < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :applications, :itt_provider, null: true, foreign_key: true
+  end
+end

--- a/db/npq_registration_migrate/20231207115035_populate_itt_provider_id_in_applications.rb
+++ b/db/npq_registration_migrate/20231207115035_populate_itt_provider_id_in_applications.rb
@@ -1,0 +1,13 @@
+class PopulateIttProviderIdInApplications < ActiveRecord::Migration[7.0]
+  def up
+    # Use SQL to update the school_id column based on school_urn
+    execute <<-SQL
+      UPDATE applications
+      SET itt_provider_id = itt_providers.id
+      FROM itt_providers
+      WHERE applications.itt_provider = itt_providers.legal_name
+    SQL
+  end
+
+  def down; end
+end

--- a/db/npq_registration_migrate/20231207115351_rename_itt_provider_from_application.rb
+++ b/db/npq_registration_migrate/20231207115351_rename_itt_provider_from_application.rb
@@ -1,0 +1,5 @@
+class RenameIttProviderFromApplication < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :applications, :itt_provider, :itt_provider_old
+  end
+end

--- a/db/npq_registration_migrate/20231208083903_rename_old_school_urn_into_deprecated_school_urn.rb
+++ b/db/npq_registration_migrate/20231208083903_rename_old_school_urn_into_deprecated_school_urn.rb
@@ -1,0 +1,5 @@
+class RenameOldSchoolUrnIntoDeprecatedSchoolUrn < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :applications, :school_urn_old, :DEPRECATED_school_urn
+  end
+end

--- a/db/npq_registration_migrate/20231208112007_enable_pg_trgm_extension.rb
+++ b/db/npq_registration_migrate/20231208112007_enable_pg_trgm_extension.rb
@@ -1,0 +1,5 @@
+class EnablePgTrgmExtension < ActiveRecord::Migration[7.0]
+  def change
+    enable_extension "pg_trgm"
+  end
+end

--- a/db/npq_registration_migrate/20231208133609_rename_old_childcare_provider_urn_into_deprecated_childcare_provider_urn.rb
+++ b/db/npq_registration_migrate/20231208133609_rename_old_childcare_provider_urn_into_deprecated_childcare_provider_urn.rb
@@ -1,0 +1,5 @@
+class RenameOldChildcareProviderUrnIntoDeprecatedChildcareProviderUrn < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :applications, :private_childcare_provider_urn_old, :DEPRECATED_private_childcare_provider_urn
+  end
+end

--- a/db/npq_registration_migrate/20231208141230_rename_itt_provider_old_into_deprecated_itt_provider.rb
+++ b/db/npq_registration_migrate/20231208141230_rename_itt_provider_old_into_deprecated_itt_provider.rb
@@ -1,0 +1,5 @@
+class RenameIttProviderOldIntoDeprecatedIttProvider < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :applications, :itt_provider_old, :DEPRECATED_itt_provider
+  end
+end

--- a/db/npq_registration_schema.rb
+++ b/db/npq_registration_schema.rb
@@ -1,0 +1,315 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.0].define(version: 2023_12_08_141230) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "btree_gin"
+  enable_extension "citext"
+  enable_extension "pg_trgm"
+  enable_extension "plpgsql"
+
+  create_table "applications", id: false, force: :cascade do |t|
+    t.serial :id, primary_key: true
+    t.bigint "user_id", null: false
+    t.bigint "course_id", null: false
+    t.bigint "lead_provider_id", null: false
+    t.text "DEPRECATED_school_urn"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text "ecf_id"
+    t.text "headteacher_status"
+    t.boolean "eligible_for_funding", default: false, null: false
+    t.text "funding_choice"
+    t.text "ukprn"
+    t.text "teacher_catchment"
+    t.text "teacher_catchment_country"
+    t.boolean "works_in_school"
+    t.string "employer_name"
+    t.string "employment_role"
+    t.text "DEPRECATED_private_childcare_provider_urn"
+    t.boolean "works_in_nursery"
+    t.boolean "works_in_childcare"
+    t.text "kind_of_nursery"
+    t.integer "DEPRECATED_cohort"
+    t.boolean "targeted_delivery_funding_eligibility", default: false
+    t.string "funding_eligiblity_status_code"
+    t.jsonb "raw_application_data", default: {}
+    t.text "work_setting"
+    t.boolean "teacher_catchment_synced_to_ecf", default: false
+    t.string "employment_type"
+    t.string "DEPRECATED_itt_provider"
+    t.boolean "lead_mentor", default: false
+    t.boolean "primary_establishment", default: false
+    t.integer "number_of_pupils", default: 0
+    t.boolean "tsf_primary_eligibility", default: false
+    t.boolean "tsf_primary_plus_eligibility", default: false
+    t.text "lead_provider_approval_status"
+    t.text "participant_outcome_state"
+    t.bigint "private_childcare_provider_id"
+    t.bigint "itt_provider_id"
+    t.bigint "school_id"
+    t.index ["course_id"], name: "index_applications_on_course_id"
+    t.index ["itt_provider_id"], name: "index_applications_on_itt_provider_id"
+    t.index ["lead_provider_id"], name: "index_applications_on_lead_provider_id"
+    t.index ["private_childcare_provider_id"], name: "index_applications_on_private_childcare_provider_id"
+    t.index ["school_id"], name: "index_applications_on_school_id"
+    t.index ["user_id"], name: "index_applications_on_user_id"
+  end
+
+  create_table "courses", id: false, force: :cascade do |t|
+    t.serial :id, primary_key: true
+    t.text "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text "ecf_id"
+    t.text "description"
+    t.integer "position", default: 0
+    t.boolean "display", default: true
+    t.string "identifier"
+  end
+
+  create_table "delayed_jobs", id: false, force: :cascade do |t|
+    t.serial :id, primary_key: true
+    t.integer "priority", default: 0, null: false
+    t.integer "attempts", default: 0, null: false
+    t.text "handler", null: false
+    t.text "last_error"
+    t.datetime "run_at", precision: nil
+    t.datetime "locked_at", precision: nil
+    t.datetime "failed_at", precision: nil
+    t.string "locked_by"
+    t.string "queue"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string "cron"
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
+  end
+
+  create_table "ecf_sync_request_logs", id: false, force: :cascade do |t|
+    t.serial :id, primary_key: true
+    t.integer "syncable_id", null: false
+    t.string "syncable_type", null: false
+    t.string "status", null: false
+    t.string "sync_type", null: false
+    t.jsonb "error_messages", default: []
+    t.jsonb "response_body"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["syncable_id", "syncable_type"], name: "index_ecf_sync_request_logs_on_syncable_id_and_syncable_type"
+  end
+
+  create_table "flipper_features", id: false, force: :cascade do |t|
+    t.serial :id, primary_key: true
+    t.string "key", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_flipper_features_on_key", unique: true
+  end
+
+  create_table "flipper_gates", id: false, force: :cascade do |t|
+    t.serial :id, primary_key: true
+    t.string "feature_key", null: false
+    t.string "key", null: false
+    t.string "value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
+  end
+
+  create_table "get_an_identity_webhook_messages", id: false, force: :cascade do |t|
+    t.serial :id, primary_key: true
+    t.jsonb "raw"
+    t.jsonb "message"
+    t.string "message_id"
+    t.string "message_type"
+    t.string "status", default: "pending"
+    t.string "status_comment"
+    t.datetime "sent_at", precision: nil
+    t.datetime "processed_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "itt_providers", id: false, force: :cascade do |t|
+    t.serial :id, primary_key: true
+    t.text "legal_name"
+    t.text "operating_name"
+    t.datetime "removed_at", precision: nil
+    t.boolean "approved"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["legal_name"], name: "index_itt_providers_on_legal_name", unique: true
+  end
+
+  create_table "lead_providers", id: false, force: :cascade do |t|
+    t.serial :id, primary_key: true
+    t.text "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text "ecf_id"
+    t.string "hint"
+  end
+
+  create_table "local_authorities", id: false, force: :cascade do |t|
+    t.serial :id, primary_key: true
+    t.text "ukprn"
+    t.text "name"
+    t.text "address_1"
+    t.text "address_2"
+    t.text "address_3"
+    t.text "town"
+    t.text "county"
+    t.text "postcode"
+    t.text "postcode_without_spaces"
+    t.boolean "high_pupil_premium", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["ukprn"], name: "index_local_authorities_on_ukprn"
+  end
+
+  create_table "private_childcare_providers", id: false, force: :cascade do |t|
+    t.serial :id, primary_key: true
+    t.text "provider_urn", null: false
+    t.text "provider_name"
+    t.text "registered_person_urn"
+    t.text "registered_person_name"
+    t.text "registration_date"
+    t.text "provider_status"
+    t.text "address_1"
+    t.text "address_2"
+    t.text "address_3"
+    t.text "town"
+    t.text "postcode"
+    t.text "postcode_without_spaces"
+    t.text "region"
+    t.text "local_authority"
+    t.text "ofsted_region"
+    t.json "early_years_individual_registers", default: []
+    t.boolean "provider_early_years_register_flag"
+    t.boolean "provider_compulsory_childcare_register_flag"
+    t.integer "places"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["provider_urn"], name: "index_private_childcare_providers_on_provider_urn"
+  end
+
+  create_table "registration_interests", id: false, force: :cascade do |t|
+    t.serial :id, primary_key: true
+    t.citext "email", null: false
+    t.boolean "notified", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_registration_interests_on_email", unique: true
+  end
+
+  create_table "reports", id: false, force: :cascade do |t|
+    t.serial :id, primary_key: true
+    t.text "identifier", null: false
+    t.text "data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "schools", id: false, force: :cascade do |t|
+    t.serial :id, primary_key: true
+    t.text "urn", null: false
+    t.text "la_code"
+    t.text "la_name"
+    t.text "establishment_number"
+    t.text "name"
+    t.text "establishment_status_code"
+    t.text "establishment_status_name"
+    t.date "close_date"
+    t.text "ukprn"
+    t.date "last_changed_date"
+    t.text "address_1"
+    t.text "address_2"
+    t.text "address_3"
+    t.text "town"
+    t.text "county"
+    t.text "postcode"
+    t.integer "easting"
+    t.integer "northing"
+    t.text "region"
+    t.text "country"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text "establishment_type_code"
+    t.text "establishment_type_name"
+    t.boolean "high_pupil_premium", default: false, null: false
+    t.text "postcode_without_spaces"
+    t.integer "number_of_pupils"
+    t.boolean "eyl_funding_eligible", default: false
+    t.integer "phase_type", default: 0
+    t.string "phase_name", default: "Not applicable"
+    t.index "to_tsvector('english'::regconfig, COALESCE(name, ''::text))", name: "school_name_search_idx", using: :gin
+    t.index ["urn"], name: "index_schools_on_urn"
+  end
+
+  create_table "sessions", id: false, force: :cascade do |t|
+    t.serial :id, primary_key: true
+    t.string "session_id", null: false
+    t.text "data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["session_id"], name: "index_sessions_on_session_id", unique: true
+    t.index ["updated_at"], name: "index_sessions_on_updated_at"
+  end
+
+  create_table "users", id: false, force: :cascade do |t|
+    t.serial :id, primary_key: true
+    t.string "email", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text "ecf_id"
+    t.text "trn"
+    t.text "full_name"
+    t.text "otp_hash"
+    t.datetime "otp_expires_at", precision: nil
+    t.date "date_of_birth"
+    t.boolean "trn_verified", default: false, null: false
+    t.boolean "active_alert", default: false
+    t.text "national_insurance_number"
+    t.boolean "trn_auto_verified", default: false
+    t.boolean "admin", default: false
+    t.string "feature_flag_id"
+    t.string "provider"
+    t.string "uid"
+    t.jsonb "raw_tra_provider_data"
+    t.boolean "get_an_identity_id_synced_to_ecf", default: false
+    t.boolean "super_admin", default: false, null: false
+    t.datetime "updated_from_tra_at", precision: nil
+    t.string "trn_lookup_status"
+    t.index ["ecf_id"], name: "index_users_on_ecf_id"
+    t.index ["email"], name: "index_users_on_email"
+    t.index ["provider"], name: "index_users_on_provider"
+    t.index ["uid"], name: "index_users_on_uid", unique: true
+  end
+
+  create_table "versions", id: false, force: :cascade do |t|
+    t.serial :id, primary_key: true
+    t.string "item_type", null: false
+    t.bigint "item_id", null: false
+    t.string "event", null: false
+    t.string "whodunnit"
+    t.text "object"
+    t.datetime "created_at", precision: nil
+    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
+  end
+
+  add_foreign_key "applications", "courses"
+  add_foreign_key "applications", "itt_providers"
+  add_foreign_key "applications", "lead_providers"
+  add_foreign_key "applications", "private_childcare_providers"
+  add_foreign_key "applications", "schools"
+  add_foreign_key "applications", "users"
+end

--- a/spec/models/npq_registration_model_safety_spec.rb
+++ b/spec/models/npq_registration_model_safety_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "NPQ model safety nets", type: :model do
+  let(:create_npq_registration_user) { Migration::NPQRegistration::User.create!(email: "test@user.com") }
+
+  describe "write protection" do
+    %w[production staging sandbox test review].each do |read_only_env|
+      it "prevents writes in the #{read_only_env} environment" do
+        allow(Rails).to receive(:env) { read_only_env.inquiry }
+        expect { create_npq_registration_user }.to raise_error(ActiveRecord::ReadOnlyRecord)
+      end
+    end
+
+    %w[development].each do |write_env|
+      it "allows writing in the #{write_env} environment" do
+        allow(Rails).to receive(:env) { write_env.inquiry }
+        expect { create_npq_registration_user }.to change(Migration::NPQRegistration::User, :count).by(1)
+      end
+    end
+  end
+
+  describe "analytics protection" do
+    it "does not send DFE Analytics entity events" do
+      allow(Rails).to receive(:env) { "development".inquiry }
+      create_npq_registration_user
+      expect(:create_entity).not_to have_been_enqueued_as_analytics_events
+    end
+  end
+end

--- a/terraform/aks/databases.tf
+++ b/terraform/aks/databases.tf
@@ -81,6 +81,28 @@ module "postgres-snapshot" {
   azure_extensions               = ["citext", "fuzzystrmatch", "pg_stat_statements", "pgcrypto", "plpgsql", "uuid-ossp"]
 }
 
+module "postgres-npq-registration" {
+  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/postgres?ref=testing"
+
+  count                 = var.deploy_npq_registration_database ? 1 : 0
+  name                  = "npq-registration"
+  namespace             = var.namespace
+  environment           = local.environment
+  azure_resource_prefix = var.azure_resource_prefix
+  service_name          = local.service_name
+  service_short         = var.service_short
+  config_short          = var.config_short
+
+  cluster_configuration_map = module.cluster_data.configuration_map
+
+  azure_sku_name                 = var.postgres_npq_registration_flexible_server_sku
+  use_azure                      = var.deploy_azure_backing_services
+  azure_enable_high_availability = false
+  azure_enable_backup_storage    = false
+  azure_enable_monitoring        = false
+  azure_extensions               = ["btree_gin", "citext", "plpgsql", "pg_trgm"]
+}
+
 resource "azurerm_postgresql_flexible_server_database" "analytics" {
   count = var.deploy_azure_backing_services ? 1 : 0
 

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -25,6 +25,11 @@ variable "deploy_snapshot_database" {
   default = false
 }
 
+variable "deploy_npq_registration_database" {
+  type    = string
+  default = false
+}
+
 variable "azure_sp_credentials_json" {
   type    = string
   default = null
@@ -61,6 +66,10 @@ variable "postgres_flexible_server_sku" {
 
 variable "postgres_snapshot_flexible_server_sku" {
   default = "GP_Standard_D2ds_v4"
+}
+
+variable "postgres_npq_registration_flexible_server_sku" {
+  default = "B_Standard_B2ms"
 }
 
 variable "postgres_enable_high_availability" {

--- a/terraform/aks/workspace_variables/production_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/production_aks.tfvars.json
@@ -6,6 +6,7 @@
   "cluster": "production",
   "deploy_azure_backing_services": true,
   "deploy_snapshot_database": true,
+  "deploy_npq_registration_database": false,
   "enable_monitoring": true,
   "namespace": "cpd-production",
   "redis_queue_family": "P",

--- a/terraform/aks/workspace_variables/review_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/review_aks.tfvars.json
@@ -4,5 +4,6 @@
   "deploy_azure_backing_services": false,
   "enable_monitoring": false,
   "namespace": "cpd-development",
-  "db_sslmode": "prefer"
+  "db_sslmode": "prefer",
+  "deploy_npq_registration_database": true
 }

--- a/terraform/aks/workspace_variables/sandbox_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/sandbox_aks.tfvars.json
@@ -7,5 +7,6 @@
   "namespace": "cpd-production",
   "domain": "sb.manage-training-for-early-career-teachers.education.gov.uk",
   "external_hostname": "sb.manage-training-for-early-career-teachers.education.gov.uk/",
-  "webapp_memory_max": "2Gi"
+  "webapp_memory_max": "2Gi",
+  "deploy_npq_registration_database": false
 }

--- a/terraform/aks/workspace_variables/staging_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/staging_aks.tfvars.json
@@ -5,5 +5,6 @@
   "enable_monitoring": false,
   "namespace": "cpd-development",
   "domain": "st.manage-training-for-early-career-teachers.education.gov.uk",
-  "external_hostname": "st.manage-training-for-early-career-teachers.education.gov.uk/"
+  "external_hostname": "st.manage-training-for-early-career-teachers.education.gov.uk/",
+  "deploy_npq_registration_database": false
 }


### PR DESCRIPTION
> ⚠️ we may need to manually exclude the models from dfe-analytics

In order to migrate data from ECF to NPQ reg we need to connect the databases and run a migration process that:

- Reads ECF models
- Reads current (and new) NPQ reg models
- Writes fixed up/restructured data to current/new NPQ reg models

This PR adds an NPQ reg database to environments where there is no corresponding NPQ reg environment (so review, test , dev) and will run migrations. For other hosted environments (sandbox, staging, prod) we will not run any database tasks and instead connect to the corresponding DB in the NPQ reg container.