### PR TITLE
Add migration rails env

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -148,7 +148,7 @@ group :development, :test do
   gem "erb_lint", ">= 0.1.1", require: false
 end
 
-group :development, :test, :staging, :sandbox, :review, :performance do
+group :development, :test, :staging, :sandbox, :review, :performance, :migration do
   gem "factory_bot_rails", "~> 6.4.2"
   gem "faker"
   gem "timecop"

--- a/config/database.yml
+++ b/config/database.yml
@@ -14,6 +14,10 @@ development:
   <<: *default
   database: "early_careers_framework_development"
 
+migration:
+  <<: *default
+  database: "early_careers_framework_migration"
+
 test:
   <<: *default
   database: early_careers_framework_test<%= ENV['TEST_ENV_NUMBER'] %>

--- a/config/environments/migration.rb
+++ b/config/environments/migration.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require Rails.root.join("config/environments/production")
+
+Rails.application.configure do
+  config.log_level = :debug
+  config.ssl_options = { redirect: { exclude: ->(request) { request.path.include?("/check") } } }
+end

--- a/config/seed_quantities.yml
+++ b/config/seed_quantities.yml
@@ -40,6 +40,9 @@ development:
 sandbox:
   <<: *default
 
+migration:
+  <<: *default
+
 test:
   <<: *default
   local_authorities: 1

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,7 +7,7 @@ if ENV["LEGACY_SEEDS"] == "true"
   load Rails.root.join(*seed_path, "initial_seed.rb").to_s
   load Rails.root.join(*seed_path, "schedules.rb").to_s
 
-  if Rails.env.in?(%w[development test sandbox staging review])
+  if Rails.env.in?(%w[development test sandbox staging migration review])
     %w[test_data dummy_structures appropriate_bodies].each do |seed|
       load Rails.root.join(*seed_path, "#{seed}.rb").to_s
     end


### PR DESCRIPTION
### Context

This environment will be used in the upcoming `migration` environment in Azure, and used to test the NPQ separation work.

### Changes proposed in this pull request

- Add database config
- Add migration env config
- Add migration env to Gemfile, seeds and seed quantities
