### PR TITLE
Fix bug when :target_cohort_start_year param given as string to Induction::AmendParticipantCohort

### DIFF
--- a/app/services/induction/amend_participant_cohort.rb
+++ b/app/services/induction/amend_participant_cohort.rb
@@ -101,7 +101,7 @@ module Induction
 
     def initialize(*)
       super
-      @target_cohort_start_year ||= @schedule&.cohort_start_year
+      @target_cohort_start_year = (@target_cohort_start_year || @schedule&.cohort_start_year).to_i
     end
 
     def all_records_in_target?
@@ -192,7 +192,7 @@ module Induction
     end
 
     def in_target_cohort?(induction_record)
-      induction_record.cohort_start_year == target_cohort_start_year.to_i
+      induction_record.cohort_start_year == target_cohort_start_year
     end
 
     def in_target_schedule?(induction_record)

--- a/spec/services/induction/amend_participant_cohort_spec.rb
+++ b/spec/services/induction/amend_participant_cohort_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Induction::AmendParticipantCohort do
     end
 
     context "when the target_cohort_start_year is older than 2020" do
-      let(:target_cohort_start_year) { 2019 }
+      let(:target_cohort_start_year) { "2019" }
 
       it "returns false and set errors" do
         expect(form.save).to be_falsey


### PR DESCRIPTION
### Context

Fix a bug in `Induction::AmendParticipantCohort` when the target year provided is a string instead of an integer.

### Changes proposed in this pull request

### Guidance to review

