### PR TITLE
Add migration environment config for Azure

### DIFF
--- a/.github/workflows/aks_deploy.yml
+++ b/.github/workflows/aks_deploy.yml
@@ -175,6 +175,25 @@ jobs:
           current-commit-sha: ${{ github.sha }}
           statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}
 
+  deploy_migration:
+    name: Deploy migration
+    needs: [deploy_staging]
+    runs-on: ubuntu-latest
+    environment:
+      name: migration
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: ./.github/actions/deploy-environment-to-aks
+        id: deploy
+        with:
+          environment: migration
+          docker-image: ${{ needs.deploy_staging.outputs.docker-image }}
+          azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
+          current-commit-sha: ${{ github.sha }}
+          statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}
+
   deploy_production:
     name: Deploy production
     needs: [deploy_staging]

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,6 @@ sandbox: production-cluster
 .PHONY: migration
 migration: production-cluster
 	$(eval include global_config/migration_aks.sh)
-	$(eval SPACE=early-careers-framework-migration)
 
 .PHONY: production
 production: production-cluster

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,11 @@ sandbox: production-cluster
 	$(eval include global_config/sandbox_aks.sh)
 	$(eval SPACE=early-careers-framework-sandbox)
 
+.PHONY: migration
+migration: production-cluster
+	$(eval include global_config/migration_aks.sh)
+	$(eval SPACE=early-careers-framework-migration)
+
 .PHONY: production
 production: production-cluster
 	$(eval include global_config/production_aks.sh)

--- a/config/credentials/migration.yml.enc
+++ b/config/credentials/migration.yml.enc
@@ -1,1 +1,1 @@
-VheEW39+12tw/s5Md/RSstMteEt9mv+w+Ez7atRwY06woq8HiBSrQTt8gC0xziTwl12wEwUAUX9N6Ew1IZJIeI4GDoo=--PaiDlYsKLXjojRC4--sxJ5tDIDFDS5rrg1aW0VpQ==
+HI3DTWdlNGaqEsXsvVxLzPfPUTlJTbQEiW3Qvpe7ohP/Aoa4Gd2KGYpprhQpNCYgx9b8o/BJy1LU/YdNl/HKtZNthpCsEnsi5MCjLuXSY1tTczQdYlgEfFCt5Q2BOWsa/PZbzq3ErNdyoxaEs1o75onDUIOnd1Xod06JUCmfpM9ib6s5wqVxO87xi8EcNK07fNknoP7vlxi+--HEowcDCDkEnsN+G+--Zr73tpvRj8tBswtKqlb05w==

--- a/config/credentials/migration.yml.enc
+++ b/config/credentials/migration.yml.enc
@@ -1,0 +1,1 @@
+VheEW39+12tw/s5Md/RSstMteEt9mv+w+Ez7atRwY06woq8HiBSrQTt8gC0xziTwl12wEwUAUX9N6Ew1IZJIeI4GDoo=--PaiDlYsKLXjojRC4--sxJ5tDIDFDS5rrg1aW0VpQ==

--- a/global_config/migration_aks.sh
+++ b/global_config/migration_aks.sh
@@ -1,0 +1,9 @@
+AZURE_RESOURCE_PREFIX=s189p01
+AZURE_SUBSCRIPTION=s189-teacher-services-cloud-production
+CONFIG=migration_aks
+CONFIG_SHORT=mg
+CONFIG_LONG=migration
+DEPLOY_ENV=${CONFIG}
+ENV_TAG=Production
+PLATFORM=aks
+NAMESPACE=cpd-production

--- a/terraform/aks/workspace_variables/migration_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/migration_aks.tfvars.json
@@ -1,0 +1,9 @@
+{
+  "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
+  "app_environment": "migration",
+  "cluster": "production",
+  "deploy_azure_backing_services": true,
+  "enable_monitoring": false,
+  "namespace": "cpd-production",
+  "webapp_memory_max": "2Gi"
+}

--- a/terraform/aks/workspace_variables/migration_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/migration_aks.tfvars.json
@@ -1,5 +1,5 @@
 {
-  "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
+  "postgres_flexible_server_sku": "B_Standard_B1ms",
   "app_environment": "migration",
   "cluster": "production",
   "deploy_azure_backing_services": true,

--- a/terraform/aks/workspace_variables/migration_aks_backend.tfvars
+++ b/terraform/aks/workspace_variables/migration_aks_backend.tfvars
@@ -1,0 +1,4 @@
+resource_group_name  = "s189p01-cpdecf-mg-rg"
+storage_account_name = "s189p01cpdecftfstatemgsa"
+container_name       = "cpdecf-tfstate"
+key                  = "terraform.tfstate"


### PR DESCRIPTION
This environment, and the corresponding one in NPQ, will be used to repeatedly test the migration process.

It's a copy of `sandbox`.

The long name will be `migration` and the short name `mg`

The tfvars are copied from sandbox but we don't need domains/external hostnames. This is just for internal use.
