### PR TITLE
[CST-2195] Avoid duplicating participant profile states when enrolling participants

### DIFF
--- a/app/services/induction/enrol.rb
+++ b/app/services/induction/enrol.rb
@@ -3,7 +3,7 @@
 class Induction::Enrol < BaseService
   def call
     ActiveRecord::Base.transaction do
-      record_active_profile_participant_state!
+      record_active_profile_participant_state! unless participant_profile_state_already_correct?
 
       participant_profile.training_status_active!
 
@@ -23,7 +23,7 @@ class Induction::Enrol < BaseService
 
 private
 
-  attr_reader :participant_profile, :induction_programme, :start_date, :preferred_email, :mentor_profile, :school_transfer, :appropriate_body_id
+  attr_reader :participant_profile, :induction_programme, :start_date, :preferred_email, :mentor_profile, :school_transfer, :appropriate_body_id, :cpd_lead_provider_id
 
   # preferred_email can be supplied if the participant_profile.participant_identity does not have
   # the required email for the induction i.e. a participant transferring schools might have a new email
@@ -31,6 +31,7 @@ private
   def initialize(participant_profile:, induction_programme:, start_date: nil, preferred_email: nil, mentor_profile: nil, school_transfer: false, appropriate_body_id: nil)
     @participant_profile = participant_profile
     @induction_programme = induction_programme
+    @cpd_lead_provider_id = induction_programme&.lead_provider&.cpd_lead_provider_id
     @start_date = start_date || schedule_start_date
     @preferred_email = preferred_email
     @mentor_profile = mentor_profile
@@ -53,8 +54,18 @@ private
 
   def record_active_profile_participant_state!
     ParticipantProfileState.create!(participant_profile:,
-                                    state: ParticipantProfileState.states[:active],
-                                    cpd_lead_provider: induction_programme&.lead_provider&.cpd_lead_provider)
+                                    state: active_participant_profile_state,
+                                    cpd_lead_provider_id:)
+  end
+
+  def participant_profile_state_already_correct?
+    profile_state = participant_profile.participant_profile_states.most_recent
+
+    profile_state.pluck(:state, :cpd_lead_provider_id).last == [active_participant_profile_state, cpd_lead_provider_id]
+  end
+
+  def active_participant_profile_state
+    ParticipantProfileState.states[:active]
   end
 
   def schedule_start_date


### PR DESCRIPTION
### Context

- Ticket: CST-2195

The Enrol class doesn't check if a participant_profile_state already exists before creating a new one, which may result in creating duplicate records.


### Changes proposed in this pull request
- Check if the latest participant_profile_state of the participant is already active with the same CPD Lead Provider, before create a new one.

### Guidance to review

