### PR TITLE
[CST-2191] Remove duplicate school transfer flag logic

### DIFF
--- a/app/services/induction/induction_statuses_activator.rb
+++ b/app/services/induction/induction_statuses_activator.rb
@@ -22,12 +22,9 @@ private
   end
 
   def update_the_induction_record
-    changes = { induction_status: :active }
-    changes[:school_transfer] = true if induction_record&.leaving_induction_status?
-
     Induction::ChangeInductionRecord.call(
       induction_record:,
-      changes:,
+      changes: { induction_status: :active },
     )
   end
 

--- a/spec/features/admin/participants/update_induction_status_to_active_spec.rb
+++ b/spec/features/admin/participants/update_induction_status_to_active_spec.rb
@@ -38,7 +38,6 @@ RSpec.feature "Super user admins should be able to update participants induction
       then_i_should_be_in_the_admin_participants_statuses_dashboard
       and_admin_should_be_shown_a_success_message
       and_i_should_see_the_induction_statuses_are_active
-      and_the_induction_record_should_have_school_transfer_true
     end
   end
 

--- a/spec/services/induction/induction_statuses_activator_spec.rb
+++ b/spec/services/induction/induction_statuses_activator_spec.rb
@@ -36,10 +36,6 @@ RSpec.describe Induction::InductionStatusesActivator do
           expect(participant_profile.latest_induction_record.induction_status).to eq("active")
           expect(participant_profile.status).to eq("active")
         end
-
-        it "sets the inductιon record school transfer to true" do
-          expect(participant_profile.latest_induction_record.school_transfer).to be true
-        end
       end
 
       context "when participant's induction record has not withdrawn or leaving induction status" do


### PR DESCRIPTION
### Context

- Ticket: CST-2191

The InductionStatusesActivator wrongly sets the school transfer flag to true when the current induction status is leaving. It should just let the `ChangeInductionRecord` handle it.

### Changes proposed in this pull request
- Remove the logic from the InductionStatusesActivator

### Guidance to review

