### PR TITLE
[CST-1875] Comms relating to archiving participants

### DIFF
--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -45,6 +45,7 @@ class SchoolMailer < ApplicationMailer
       personalisation: {
         school_name:,
         sit_name:,
+        sit_email_address: email_address,
         participant_name:,
         role:,
         sign_in:,

--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -24,6 +24,35 @@ class SchoolMailer < ApplicationMailer
   FINANCE_ERRORS_WITH_THE_ECF_YEAR_2_GRANT = "2324145f-b679-4c40-b64a-08b0c05990d5"
   FINANCE_ERRORS_WITH_NQT_PLUS_ONE_AND_ECF_YEAR_2_SCHOOLS_VERSION = "94bec423-027b-4cf4-a501-9de61dde4905"
   FINANCE_ERRORS_WITH_NQT_PLUS_ONE_AND_ECF_YEAR_2_LOCAL_AUTHORITY_VERSION = "9953ed6b-4853-4be2-9ac2-692f07906166"
+  NOTIFY_SIT_WE_HAVE_ARCHIVED_PARTICIPANT = "558eafd2-7f8f-407d-a3a8-60649fb26ea8"
+
+  def notify_sit_we_have_archived_participant
+    school = params[:school]
+    induction_coordinator = params[:induction_coordinator]
+    participant_name = params[:participant_name]
+    role = params[:role]
+    sign_in = params[:sign_in_url]
+
+    school_name = school.name
+    sit_name = induction_coordinator.user.full_name
+    email_address = induction_coordinator.user.email
+
+    template_mail(
+      NOTIFY_SIT_WE_HAVE_ARCHIVED_PARTICIPANT,
+      to: email_address,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        school_name:,
+        sit_name:,
+        participant_name:,
+        role:,
+        sign_in:,
+      },
+    ).tag(:notify_sit_we_have_archived_participant)
+        .associate_with(school)
+        .associate_with(induction_coordinator, as: :induction_coordinator_profile)
+  end
 
   def ask_gias_contact_to_validate_sit_details
     school = params[:school]

--- a/spec/mailers/school_mailer_spec.rb
+++ b/spec/mailers/school_mailer_spec.rb
@@ -3,6 +3,36 @@
 require "rails_helper"
 
 RSpec.describe SchoolMailer, type: :mailer do
+  describe "#notify_sit_we_have_archived_participant" do
+    let(:school) { create(:seed_school, :valid) }
+    let(:induction_coordinator) { create(:seed_induction_coordinator_profile, :with_user) }
+    let(:sign_in_url) { "https://ecf-dev.london.cloudapps" }
+    let(:participant_name) { "Jessica Walnut" }
+    let(:role) { "Early career teacher" }
+
+    let(:email) do
+      SchoolMailer
+        .with(school:, induction_coordinator:, sign_in_url:, participant_name:, role:)
+        .notify_sit_we_have_archived_participant
+        .deliver_now
+    end
+
+    it "renders the right headers" do
+      expect(email.from).to eq(["mail@example.com"])
+      expect(email.to).to eq([induction_coordinator.user.email])
+    end
+
+    it "has the correct personalisation" do
+      personalisation = email[:personalisation].unparsed_value
+
+      expect(personalisation[:school_name]).to eq school.name
+      expect(personalisation[:sit_name]).to eq induction_coordinator.user.full_name
+      expect(personalisation[:participant_name]).to eq participant_name
+      expect(personalisation[:role]).to eq role
+      expect(personalisation[:sign_in]).to eq sign_in_url
+    end
+  end
+
   describe "#ask_gias_contact_to_validate_sit_details" do
     let(:school) { create(:seed_school, :valid, primary_contact_email: "mary.gias@example.com") }
     let(:induction_coordinator) { create(:seed_induction_coordinator_profile, :with_user) }

--- a/spec/mailers/school_mailer_spec.rb
+++ b/spec/mailers/school_mailer_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe SchoolMailer, type: :mailer do
 
       expect(personalisation[:school_name]).to eq school.name
       expect(personalisation[:sit_name]).to eq induction_coordinator.user.full_name
+      expect(personalisation[:sit_email_address]).to eq induction_coordinator.user.email
       expect(personalisation[:participant_name]).to eq participant_name
       expect(personalisation[:role]).to eq role
       expect(personalisation[:sign_in]).to eq sign_in_url


### PR DESCRIPTION
### Context

- Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-1875)
- We want to send comms to SITs and providers when we archive a participant (as part of the cleaning up of unvalidated, undeclared participants task).
- This PR adds the mailer for sending comms to the SIT.

### Changes proposed in this pull request
New mailer for notifying SITs that we've archived a participant.

### Guidance to review

