### PR TITLE
Add task to refresh migration DB from production

### DIFF
--- a/.github/actions/refresh-migration-database/action.yml
+++ b/.github/actions/refresh-migration-database/action.yml
@@ -1,0 +1,42 @@
+name: Refresh migration DB
+description: Backup production DB and restore to migration DB
+
+inputs:
+  environment:
+    description: The name of the environment
+    required: true
+  azure-credentials:
+    description: Azure credentials
+    required: true
+
+runs:
+  using: composite
+
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Login
+      uses: azure/login@v1
+      with:
+        creds: ${{ inputs.azure-credentials }}
+
+    - name: Install kubectl
+      uses: azure/setup-kubectl@v3
+
+    - name: Install konduit
+      shell: bash
+      run: make install-konduit
+
+    - name: Set AKS credentials (production)
+      shell: bash
+      run: az aks get-credentials -g s189p01-tsc-pd-rg -n s189p01-tsc-production-aks
+
+    - name: Backup production DB
+      shell: bash
+      run: |
+        bin/konduit.sh cpd-ecf-${{ inputs.environment }}-web -- pg_dump -E utf8 --compress=1 --clean --if-exists --no-privileges --no-owner --verbose -f backup-${{ inputs.environment }}.sql.gz
+
+    - name: Restore to migration DB
+      shell: bash
+      run: bin/konduit.sh -d s189p01-cpdecf-mg-pg -k s189p01-cpdecf-mg-app-kv -i backup-${{ inputs.environment }}.sql.gz -c -t 7200 cpd-ecf-migration-web -- psql

--- a/.github/workflows/refresh_migration_database.yml
+++ b/.github/workflows/refresh_migration_database.yml
@@ -1,0 +1,25 @@
+name: Refresh migration DB from production DB
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: GitHub environment to refresh from
+        type: choice
+        default: production
+        options:
+          - production
+        required: true
+
+jobs:
+  refresh-migration-db:
+    runs-on: ubuntu-20.04
+    environment: production
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Refresh migration DB
+        uses: ./.github/actions/refresh-migration-database
+        with:
+          environment: production
+          azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}

--- a/Makefile
+++ b/Makefile
@@ -208,17 +208,25 @@ konduit-cleanup:
 	sed -i '' -e '/url\: "postgres/d' config/database.yml; \
 	exit 0
 
-# Creates a konduit to the snapshot DB and points development to
-# it. The konduit URL is removed when the konduit is closed.
-konduit-snapshot: get-cluster-credentials
+define KONDUIT_CONNECT
 	trap 'make konduit-cleanup' INT; \
 	tmp_file=$$(mktemp); \
 	$(MAKE) konduit-cleanup; \
 	{ \
-			(tail -f -n0 "$$tmp_file" & ) | grep -q "postgres://"; \
-			postgres_url=$$(grep -o 'postgres://[^ ]*' "$$tmp_file"); \
-			echo "$$postgres_url"; \
-			sed -i '' -e "s|database: \"early_careers_framework_development\"|&\\n  url: \"$$postgres_url\"|g" config/database.yml; \
+		(tail -f -n0 "$$tmp_file" & ) | grep -q "postgres://"; \
+		postgres_url=$$(grep -o 'postgres://[^ ]*' "$$tmp_file"); \
+		echo "$$postgres_url"; \
+		sed -i '' -e "s|database: \"early_careers_framework_development\"|&\\n  url: \"$$postgres_url\"|g" config/database.yml; \
 	} & \
-	bin/konduit.sh -d s189p01-cpdecf-pd-pg-snapshot -k s189p01-cpdecf-pd-app-kv cpd-ecf-production-web -- psql > "$$tmp_file"
+	bin/konduit.sh -d
+endef
+
+# Creates a konduit to the DB and points development to it. The konduit URL is removed when the konduit is closed.
+konduit: get-cluster-credentials
+	$(KONDUIT_CONNECT) ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-pg -k ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-app-kv cpd-ecf-${CONFIG_LONG}-web -- psql > "$$tmp_file"
+	exit 0
+
+# Creates a konduit to the snapshot DB and points development to it. The konduit URL is removed when the konduit is closed.
+konduit-snapshot: get-cluster-credentials
+	$(KONDUIT_CONNECT) ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-pg-snapshot -k ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-app-kv cpd-ecf-${CONFIG_LONG}-web -- psql > "$$tmp_file"
 	exit 0


### PR DESCRIPTION
### Context

We have a migration environment that we will be using for the ECF -> NPQ migration testing. Prior to running this in production we want to test it in a production-like environment.

### Changes proposed in this pull request

- Add task to refresh migration DB from production

Add a GitHub action to allow us to populate the migration database from the production database. Update `Makefile` to include command to connect to the migration DB.

### Guidance to review

I've ran the GitHub action manually as part of this PR so the migration DB is populated. You can connect to it with the new make commands:

```
make migration konduit
```

You can also connect to the snapshot DB:

```
make ci production konduit-snapshot
```