### PR TITLE
[CST-2166] Add support form link to the footer

### DIFF
--- a/app/components/support_form_component.html.erb
+++ b/app/components/support_form_component.html.erb
@@ -85,5 +85,7 @@
 
       <%= f.govuk_submit "Send message to support" %>
     <% end %>
+
+    <p class="govuk-body-s">If you do not want to use this form, you can email <%= render(MailToSupportComponent.new(Rails.application.config.support_email)) %></p>
   </div>
 </div>

--- a/app/components/support_form_component.rb
+++ b/app/components/support_form_component.rb
@@ -20,6 +20,7 @@ class SupportFormComponent < BaseComponent
     @i18n_params ||= {
       participant_name: participant_profile_full_name,
       cohort_year_range:,
+      support_email: Rails.application.config.support_email,
     }
   end
 

--- a/app/views/layouts/_support_links.html.erb
+++ b/app/views/layouts/_support_links.html.erb
@@ -1,7 +1,11 @@
 <h2 class="govuk-heading-m">Support and guidance</h2>
 <p class="govuk-body-s">
-  If you have a question, or you’ve had a problem using this service, please contact us at
-  <%= mail_to Rails.application.config.support_email, Rails.application.config.support_email, class: "govuk-footer__link govuk-link--no-visited-state" %>
+  <% if current_user.present? %>
+    If you have a question, or you’ve had a problem using this service, please <%= govuk_link_to("click here", support_path) %> to contact us.
+  <% else %>
+    If you have a question, or you’ve had a problem using this service, please contact us at
+    <%= mail_to Rails.application.config.support_email, Rails.application.config.support_email, class: "govuk-footer__link govuk-link--no-visited-state" %>
+  <% end %>
 </p>
 <ul class="govuk-footer__inline-list">
   <li class="govuk-footer__inline-list-item">

--- a/app/views/layouts/_support_links.html.erb
+++ b/app/views/layouts/_support_links.html.erb
@@ -3,7 +3,7 @@
   <% if current_user.present? %>
     If you have a question, or you’ve had a problem using this service, please <%= govuk_link_to("click here", support_path) %> to contact us.
   <% else %>
-    If you have a question, or you’ve had a problem using this service, please contact us at
+    If you have a question, or you’ve had a problem using this service, contact us at
     <%= mail_to Rails.application.config.support_email, Rails.application.config.support_email, class: "govuk-footer__link govuk-link--no-visited-state" %>
   <% end %>
 </p>

--- a/app/views/layouts/_support_links.html.erb
+++ b/app/views/layouts/_support_links.html.erb
@@ -1,7 +1,7 @@
 <h2 class="govuk-heading-m">Support and guidance</h2>
 <p class="govuk-body-s">
   <% if current_user.present? %>
-    If you have a question, or you’ve had a problem using this service, please <%= govuk_link_to("click here", support_path) %> to contact us.
+    If you have a question, or you’ve had a problem using this service,  <%= govuk_link_to("contact support", support_path) %>.
   <% else %>
     If you have a question, or you’ve had a problem using this service, contact us at
     <%= mail_to Rails.application.config.support_email, Rails.application.config.support_email, class: "govuk-footer__link govuk-link--no-visited-state" %>


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CST-2166

### Changes proposed in this pull request

- When logged in user will now see a link to the support form page in the footer instead of seeing the contact us email address.

