### PR TITLE
Cleanup participant declarations for NPQ users

### DIFF
--- a/app/services/oneoffs/npq/cleanup_participant_declaration.rb
+++ b/app/services/oneoffs/npq/cleanup_participant_declaration.rb
@@ -5,7 +5,9 @@ module Oneoffs::NPQ
     def migrate
       ActiveRecord::Base.transaction do
         incorrect_participant_declarations.in_batches.each_record do |declaration|
-          declaration.update(user_id: declaration.participant_profile.user.id)
+          if declaration.user.participant_identities.empty? && declaration.participant_profile.user.participant_identities.map(&:external_identifier).include?(declaration.user.id)
+            declaration.update!(user_id: declaration.participant_profile.user.id)
+          end
         end
       end
     end
@@ -13,7 +15,7 @@ module Oneoffs::NPQ
   private
 
     def incorrect_participant_declarations
-      ParticipantDeclaration.joins(participant_profile: :participant_identity).where("participant_declarations.user_id != participant_identities.user_id")
+      ParticipantDeclaration::NPQ.joins(participant_profile: :participant_identity).where("participant_declarations.user_id != participant_identities.user_id")
     end
   end
 end

--- a/app/services/oneoffs/npq/cleanup_participant_declaration.rb
+++ b/app/services/oneoffs/npq/cleanup_participant_declaration.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Oneoffs::NPQ
+  class CleanupParticipantDeclaration
+    def migrate
+      ActiveRecord::Base.transaction do
+        incorrect_participant_declarations.in_batches.each_record do |declaration|
+          declaration.update(user_id: declaration.participant_profile.user.id)
+        end
+      end
+    end
+
+  private
+
+    def incorrect_participant_declarations
+      ParticipantDeclaration.joins(participant_profile: :participant_identity).where("participant_declarations.user_id != participant_identities.user_id")
+    end
+  end
+end

--- a/spec/services/oneoffs/npq/cleanup_participant_declaration_spec.rb
+++ b/spec/services/oneoffs/npq/cleanup_participant_declaration_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+describe Oneoffs::NPQ::CleanupParticipantDeclaration do
+  # create declaration with participant profile and participant identity
+  # create second user
+  # attach profile to the second user via user_id
+  # run script and see that participant declaration belongs to correct user
+  let(:npq_participant_declaration) { create(:npq_participant_declaration) }
+  let(:user) { npq_participant_declaration.participant_profile.participant_identity.user }
+  let(:npq_user) { create(:user, :npq) }
+
+  before do
+    npq_participant_declaration.update(user_id: npq_user.id)
+  end
+
+  it "reassigns records properly" do
+    expect {
+      described_class.new.migrate
+    }.to change { npq_participant_declaration.reload.user_id }.from(npq_user.id).to(user.id)
+  end
+end

--- a/spec/services/oneoffs/npq/cleanup_participant_declaration_spec.rb
+++ b/spec/services/oneoffs/npq/cleanup_participant_declaration_spec.rb
@@ -1,16 +1,14 @@
 # frozen_string_literal: true
 
 describe Oneoffs::NPQ::CleanupParticipantDeclaration do
-  # create declaration with participant profile and participant identity
-  # create second user
-  # attach profile to the second user via user_id
-  # run script and see that participant declaration belongs to correct user
   let(:npq_participant_declaration) { create(:npq_participant_declaration) }
   let(:user) { npq_participant_declaration.participant_profile.participant_identity.user }
+  let(:participant_identity) { user.participant_identities.first }
   let(:npq_user) { create(:user, :npq) }
 
   before do
-    npq_participant_declaration.update(user_id: npq_user.id)
+    npq_participant_declaration.update!(user_id: npq_user.id)
+    participant_identity.update!(external_identifier: npq_user.id)
   end
 
   it "reassigns records properly" do


### PR DESCRIPTION
### Changes proposed in this pull request

Participant declarations have 2 different ways to determine its user (which in general is denormalization we don't need). 
User of `ParticipantDeclaration` might be accessed in 2 ways:
`participant_declaration.user` (via `user_id` field in participant declaration)
or via
`participant_declaration.participant_profile.participant_identity.user` - this is correct way.
During deduping some of them become incorrect. This code fixes any denormalization.