### PR TITLE
[CST-2110] Delete the dup completed induction records by participant

### DIFF
--- a/app/jobs/delete_completed_induction_records_job.rb
+++ b/app/jobs/delete_completed_induction_records_job.rb
@@ -1,33 +1,48 @@
 # frozen_string_literal: true
 
 class DeleteCompletedInductionRecordsJob < ApplicationJob
-  def perform
+  def perform(no_of_participants: nil)
     bug_introduced_at = "2023-09-04"
     job_running_window = { from: "00:00:00", to: "11:00:00" }
 
     deleted_count = 0
     failed_count = 0
 
-    # Potential dup records created by the bug that was running from 4 Sept 2023, between midnight and 11am
-    dup_induction_records = InductionRecord
-      .joins(:participant_profile)
-      .joins(:versions)
-      .where.not(participant_profile: { induction_completion_date: nil })
-      .where(induction_status: :changed, school_transfer: false)
-      .where("induction_records.created_at >= ?", bug_introduced_at)
-      .where("induction_records.created_at::time >= :from AND induction_records.created_at::time <= :to ", job_running_window)
-      .where("versions.object_changes ->> 'induction_status' ILIKE '[%completed%changed%]'")
-      .where("versions.whodunnit IS NULL")
+    participants = ParticipantProfile::ECT
+      .where.not(induction_completion_date: nil)
+      .where(id: InductionRecord
+        .joins(:versions)
+        .where(induction_status: :changed, school_transfer: false)
+        .where("induction_records.created_at >= ?", bug_introduced_at)
+        .where("induction_records.created_at::time >= :from AND induction_records.created_at::time <= :to ", job_running_window)
+        .where("versions.object_changes ->> 'induction_status' ILIKE '[%completed%changed%]'")
+        .where("versions.whodunnit IS NULL")
+        .select(:participant_profile_id))
+      .limit(no_of_participants)
 
-    dup_induction_records.in_batches(of: 500).each_record do |induction_record|
-      # Try to safely delete the record without breaking the induction records sequence
-      Induction::DeleteDupRecord.new(induction_record:).call
+    if participants.empty?
+      Rails.logger.info "### No ECT participants found with dup completed induction records"
+      return
+    end
 
-      Rails.logger.info "### Removed #{induction_record.id} record from #{induction_record.participant_profile_id} participant"
-      deleted_count += 1
-    rescue StandardError => e
-      Rails.logger.debug "### Failed to remove #{induction_record.id} record from #{induction_record.participant_profile_id} participant: #{e.inspect}"
-      failed_count += 1
+    participants.in_batches.each_record do |pp|
+      # Potential dup records created by the bug that was running from 4 Sept 2023, between midnight and 11am
+      pp.induction_records
+        .joins(:versions)
+        .where(induction_status: :changed, school_transfer: false)
+        .where("induction_records.created_at >= ?", bug_introduced_at)
+        .where("induction_records.created_at::time >= :from AND induction_records.created_at::time <= :to ", job_running_window)
+        .where("versions.object_changes ->> 'induction_status' ILIKE '[%completed%changed%]'")
+        .where("versions.whodunnit IS NULL").find_each do |induction_record|
+          # Try to safely delete the record without breaking the induction records sequence
+          Induction::DeleteDupRecord.new(induction_record:).call
+
+          Rails.logger.info "### Removed #{induction_record.id} record from #{induction_record.participant_profile_id} participant"
+          deleted_count += 1
+      rescue StandardError => e
+        Rails.logger.debug "### Failed to remove #{induction_record.id} record from #{induction_record.participant_profile_id} participant: #{e.inspect}"
+        failed_count += 1
+        end
     end
 
     Rails.logger.info "### Records deleted: #{deleted_count}"

--- a/app/services/induction/delete_dup_record.rb
+++ b/app/services/induction/delete_dup_record.rb
@@ -7,7 +7,6 @@ class Induction::DeleteDupRecord < BaseService
 
   def call
     ActiveRecord::Base.transaction do
-      # binding.pry
       check_record_is_deletable!
 
       update_previous_record

--- a/lib/tasks/deduping.rake
+++ b/lib/tasks/deduping.rake
@@ -7,7 +7,7 @@ namespace :deduping do
   end
 
   desc "Delete the dup completed induction records created by the set participant completion date bug"
-  task dedup_completed_induction_records: :environment do
-    DeleteCompletedInductionRecordsJob.perform_later
+  task :dedup_completed_induction_records, [:no_of_participants] => :environment do |_task, args|
+    DeleteCompletedInductionRecordsJob.perform_later(no_of_participants: args.no_of_participants&.to_i)
   end
 end


### PR DESCRIPTION
### Context

- Ticket: CST-2110

This changes the code a bit to process the records by participant and add a limit to run the deletion in a smaller scale.
