### PR TITLE
CST-2199: re-process eligible ects with an error in SyncDQTInductionS…

### DIFF
--- a/app/jobs/check_eligible_ects_that_failed_permanent_cohort_setup_job.rb
+++ b/app/jobs/check_eligible_ects_that_failed_permanent_cohort_setup_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CheckEligibleEctsThatFailedPermanentCohortSetupJob < ApplicationJob
+  def perform
+    ect_errors.find_each do |error|
+      ect = error.participant_profile
+      Participants::SyncDQTInductionStartDate.call(ect.induction_start_date, ect)
+    end
+  end
+
+private
+
+  def ect_errors
+    SyncDQTInductionStartDateError.joins(participant_profile: :ecf_participant_eligibility)
+                                  .where(ecf_participant_eligibilities: { status: :eligible })
+  end
+end

--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -18,6 +18,10 @@ check_no_induction_or_no_qts_participants:
   cron: "0 7 * * 1"
   class: "CheckParticipantsInductionAndQtsJob"
   queue: default
+check_eligible_ects_that_failed_permanent_cohort_setup:
+  cron: "0 11 * * 1"
+  class: "CheckEligibleEctsThatFailedPermanentCohortSetupJob"
+  queue: default
 enrol_school_cohorts:
   cron: "0 3 * * *"
   class: "EnrolSchoolCohortsJob"

--- a/spec/factories/sync_dqt_induction_start_date_errors.rb
+++ b/spec/factories/sync_dqt_induction_start_date_errors.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :sync_dqt_induction_start_date_error, class: SyncDQTInductionStartDateError do
+    association :participant_profile, factory: :ect_participant_profile
+
+    message { "sync failed!" }
+  end
+end

--- a/spec/jobs/check_eligible_ects_that_failed_permanent_cohort_setup_job_spec.rb
+++ b/spec/jobs/check_eligible_ects_that_failed_permanent_cohort_setup_job_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CheckEligibleEctsThatFailedPermanentCohortSetupJob do
+  let(:eligible_ect) { create(:ecf_participant_eligibility, status: :eligible).participant_profile }
+  let(:non_eligible_ect) { error_for_non_eligible_ect.participant_profile }
+  let!(:error_for_eligible_ect) { create(:sync_dqt_induction_start_date_error, participant_profile: eligible_ect) }
+  let!(:error_for_non_eligible_ect) { create(:sync_dqt_induction_start_date_error) }
+
+  before do
+    allow(Participants::SyncDQTInductionStartDate).to receive(:call)
+    subject.perform_now
+  end
+
+  it "process errors about eligible participants" do
+    expect(Participants::SyncDQTInductionStartDate)
+      .to have_received(:call).with(eligible_ect.induction_start_date, eligible_ect)
+  end
+
+  it "do not process errors about non-eligible participants" do
+    expect(Participants::SyncDQTInductionStartDate)
+      .not_to have_received(:call).with(non_eligible_ect.induction_start_date, non_eligible_ect)
+  end
+end


### PR DESCRIPTION
…tartDateError

### Context

Participants that failed sitting them in their permanent cohort (Monday eligibility checks process) but became “Eligible” as part of that process, have an entry in the SyncDQTInductionStartDateError table and won’t be picked anymore in the next Monday eligibility checks.

Therefore, it would be good to put a periodic process in place to retry sitting them in their right cohort because things might change at any moment in time (schools setting a school cohort, a participant reactivation,…) perhaps making the cohort change succeed this time.

- [Ticket](https://dfedigital.atlassian.net/browse/CST-2199)

### Changes proposed in this pull request

### Guidance to review

