### PR TITLE
Bump up azure CPU threshold for alerting from 60 to 70%

### DIFF
--- a/terraform/aks/databases.tf
+++ b/terraform/aks/databases.tf
@@ -53,6 +53,7 @@ module "postgres" {
 
   azure_sku_name                 = var.postgres_flexible_server_sku
   azure_storage_mb               = var.azure_storage_mb
+  azure_cpu_threshold            = var.azure_cpu_threshold
   azure_enable_high_availability = var.postgres_enable_high_availability
   azure_enable_backup_storage    = var.azure_enable_backup_storage
   use_azure                      = var.deploy_azure_backing_services

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -130,3 +130,8 @@ variable "azure_storage_mb" {
   type    = number
   default = 32768
 }
+
+variable "azure_cpu_threshold" {
+  type    = number
+  default = 60
+}

--- a/terraform/aks/workspace_variables/production_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/production_aks.tfvars.json
@@ -17,5 +17,6 @@
   "worker_replicas": 4,
   "webapp_memory_max": "4Gi",
   "worker_memory_max": "2Gi",
-  "azure_storage_mb": "65536"
+  "azure_storage_mb": "65536",
+  "azure_cpu_threshold": 70
 }


### PR DESCRIPTION
### Context

We know providers are using the API heavily, until the behaviour changes, we are ok to bump to 70% for now


- Ticket: https://trello.com/c/HAxSWYMT/889-stop-ecf-db-alerts

### Changes proposed in this pull request

Add new variable to set cpu threshold and set to 70% on prod

### Guidance to review

