### PR TITLE
Make tags lowercase

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -30,10 +30,6 @@ $govuk-new-link-styles: true;
 @import "components/statement_selector";
 @import "tabs";
 
-.govuk-tag {
-  white-space: nowrap;
-}
-
 .error-message {
   color: $govuk-error-colour;
 }

--- a/config/locales/status_tags/school_participant_status.yml
+++ b/config/locales/status_tags/school_participant_status.yml
@@ -5,190 +5,190 @@ en:
       # validation
 
       validation_not_started:
-        label: "WAITING FOR TRN"
+        label: "Waiting for TRN"
         description: "We’re waiting for the school to provide a TRN so we can check the participant is eligible for this programme."
         colour: "blue"
 
       request_for_details_submitted:
-        label: "WAITING FOR TRN"
+        label: "Waiting for TRN"
         description: "We’ve asked this person to use our service to provide their TRN so we can check the participant is eligible for this programme."
         colour: "blue"
 
       request_for_details_failed:
-        label: "CHECK EMAIL ADDRESS"
+        label: "Check email address"
         description: "We could not send an email to this address. Please check it’s correct."
         colour: "blue"
 
       request_for_details_delivered:
-        label: "WAITING FOR TRN"
+        label: "Waiting for TRN"
         description: "We’ve asked this person to use our service to provide their TRN so we can check the participant is eligible for this programme."
         colour: "blue"
 
       internal_error:
-        label: "PENDING"
+        label: "Pending"
         description: "We are doing some manual checks and will contact you for more information."
         colour: "blue"
 
       checks_not_complete:
-        label: "PENDING"
+        label: "Pending"
         description: "We are doing some manual checks and will contact you for more information."
         colour: "blue"
 
       different_trn:
-        label: "PENDING"
+        label: "Pending"
         description: "We are doing some manual checks and will contact you for more information."
         colour: "blue"
 
       tra_record_not_found:
-        label: "PENDING"
+        label: "Pending"
         description: "We are doing some manual checks and will contact you for more information."
         colour: "blue"
 
       duplicate_profile:
-        label: "PENDING"
+        label: "Pending"
         description: "We are doing some manual checks and will contact you for more information."
         colour: "blue"
 
       # TRA Record checks
 
       active_flags:
-        label: "PENDING"
+        label: "Pending"
         description: "We are doing some manual checks and will contact you for more information."
         colour: "blue"
 
       not_allowed:
-        label: "NO LONGER BEING TRAINED"
+        label: "No longer being trained"
         description: "Your provider reported that they’re not training the people listed below. If this is wrong, contact the relevant provider."
         colour: "grey"
 
       exempt_from_induction:
-        label: "EXEMPT"
+        label: "Exempt"
         description: "The participant does not need to complete statutory induction."
         colour: "grey"
 
       not_qualified:
-        label: "WAITING FOR CONFIRMATION OF QTS"
+        label: "Waiting for confirmation of QTS"
         description: "We do not yet have qualified teacher status for the participant. Contact your appropriate body and ask them to send us proof of the participant’s qualified teacher status."
         colour: "blue"
 
       no_induction_start:
-        label: "WAITING FOR INDUCTION TO BE RECORDED"
+        label: "Waiting for induction to be recorded"
         description: "We’re waiting for the school’s appropriate body to record the participant’s induction. Contact your appropriate body and remind them to register the ECT’s induction with the Teaching Regulation Agency (TRA)."
         colour: "blue"
 
       # FIP ECTs
 
       registered_for_fip_no_partner:
-        label: "ELIGIBLE FOR TRAINING"
+        label: "Eligible for training"
         description: "We’ve confirmed this person is eligible for this programme. Once you choose a training provider, they’ll contact this person directly."
         colour: "turquoise"
 
       registered_for_fip_training:
-        label: "ELIGIBLE FOR TRAINING"
+        label: "Eligible for training"
         description: "We’ve confirmed the participant is eligible for this programme. Your training provider will contact them directly."
         colour: "turquoise"
 
       active_fip_training:
-        label: "TRAINING"
+        label: "Training"
         description: "We’ve confirmed the participant is eligible for this programme."
         colour: "turquoise"
 
       # CIP ECTs
 
       registered_for_cip_training:
-        label: "ELIGIBLE FOR TRAINING"
+        label: "Eligible for training"
         description: "We’ve confirmed the participant is eligible for this programme."
         colour: "turquoise"
 
       active_cip_training:
-        label: "TRAINING"
+        label: "Training"
         description: "We’ve confirmed the participant is eligible for this programme."
         colour: "turquoise"
 
       # DIY ECTs
 
       registered_for_diy_training:
-        label: "ELIGIBLE FOR TRAINING"
+        label: "Eligible for training"
         description: "We’ve confirmed the participant is eligible for this programme."
         colour: "turquoise"
 
       active_diy_training:
-        label: "TRAINING"
+        label: "Training"
         description: "We’ve confirmed the participant is eligible for this programme."
         colour: "turquoise"
 
       # Mentoring
 
       active_mentoring:
-        label: "MENTORING"
+        label: "Mentoring"
         description: "The participant is currently mentoring ECTs."
         colour: "turquoise"
 
       not_yet_mentoring:
-        label: "NOT MENTORING"
+        label: "Not mentoring"
         description: "The participant is not currently mentoring any ECTs."
         colour: "purple"
 
       active_mentoring_ero:
-        label: "MENTORING"
+        label: "Mentoring"
         description: "The participant is currently mentoring ECTs."
         colour: "turquoise"
 
       not_yet_mentoring_ero:
-        label: "NOT MENTORING"
+        label: "Not mentoring"
         description: "The participant is not currently mentoring any ECTs."
         colour: "turquoise"
 
       # changes of circumstance
 
       leaving:
-        label: "LEAVING YOUR SCHOOL"
+        label: "Leaving your schoool"
         description: "The participant will be leaving your school" #  on xx/xx/xxxx.
         colour: "grey"
 
       joining:
-        label: "JOINING YOUR SCHOOL"
+        label: "Joining your school"
         description: "The participant is joining your school and will start training. If this is wrong, contact the relevant provider." #  on xx/xx/xxxx.
         colour: "blue"
 
       deferred_training:
-        label: "TRAINING DEFERRED"
+        label: "Training deferred"
         description: "The participant has deferred their training. This could be for several reasons such as maternity leave, sabbatical leave, sickness etc."
         colour: "grey"
 
       withdrawn_training:
-        label: "NO LONGER BEING TRAINED"
+        label: "No longer being trained"
         description: "Your provider reported that they’re not training the people listed below. If this is wrong, contact the relevant provider."
         colour: "grey"
 
       left:
-        label: "NO LONGER BEING TRAINED"
+        label: "No longer being trained"
         description: "The participant left your school." # on xx/xx/xxxx."
         colour: "grey"
 
       withdrawn_programme:
-        label: "NO LONGER BEING TRAINED"
+        label: "No longer being trained"
         description: "The participant left your school." # on xx/xx/xxxx."
         colour: "grey"
 
       no_longer_involved:
-        label: "NO LONGER BEING TRAINED"
+        label: "No longer being trained"
         description: "The participant left your school." # on xx/xx/xxxx."
         colour: "grey"
 
       not_registered_for_training:
-        label: "NO LONGER BEING TRAINED"
+        label: "No longer being trained"
         description: "The participant left your school." # on xx/xx/xxxx."
         colour: "grey"
 
       # completion
 
       previous_induction:
-        label: "STATUTORY INDUCTION COMPLETED"
+        label: "Statutory induction completed"
         description: "The participant has completed their full programme of statutory induction."
         colour: "grey"
 
       completed_training:
-        label: "TRAINING COMPLETED"
+        label: "Training completed"
         description: "%{appropriate_body_name} confirmed that this person completed their induction and training on %{induction_completion_date}"
         colour: "grey"

--- a/spec/features/scenarios/participants/ect_doing_cip/after_cohort_transfer_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_cip/after_cohort_transfer_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature "ECT doing CIP: after cohort transfer", type: :feature do
   let(:participant_status) { "active" }
   let(:training_status) { "active" }
   let(:training_record_state) { "Eligible to start" }
-  let(:school_record_state) { "ELIGIBLE FOR TRAINING" }
+  let(:school_record_state) { "Eligible for training" }
   let(:delivery_partner_record_state) { "" }
   let(:appropriate_body_Record_state) { "Training or eligible for training" }
 

--- a/spec/features/scenarios/participants/ect_doing_cip/in_training_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_cip/in_training_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature "ECT doing CIP: in training", type: :feature do
   let(:participant_status) { "active" }
   let(:training_status) { "active" }
   let(:training_record_state) { "Eligible to start" }
-  let(:school_record_state) { "ELIGIBLE FOR TRAINING" }
+  let(:school_record_state) { "Eligible for training" }
   let(:delivery_partner_record_state) { "" }
   let(:appropriate_body_Record_state) { "Training or eligible for training" }
 

--- a/spec/features/scenarios/participants/ect_doing_cip/no_validation_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_cip/no_validation_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature "ECT doing CIP: no validation", type: :feature do
   let(:participant_status) { "active" }
   let(:training_status) { "active" }
   let(:training_record_state) { "Validation not started" }
-  let(:school_record_state) { "WAITING FOR TRN" }
+  let(:school_record_state) { "Waiting for TRN" }
   let(:delivery_partner_record_state) { "" }
   let(:appropriate_body_Record_state) { "Training or eligible for training" }
 

--- a/spec/features/scenarios/participants/ect_doing_fip/after_cohort_transfer_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_fip/after_cohort_transfer_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature "ECT doing FIP: after cohort transfer", type: :feature do
   let(:registration_completed) { true }
   let(:participant_status) { "active" }
   let(:training_record_state) { "Eligible to start" }
-  let(:school_record_state) { "ELIGIBLE FOR TRAINING" }
+  let(:school_record_state) { "Eligible for training" }
   let(:delivery_partner_record_state) { "Training or eligible for training" }
   let(:appropriate_body_record_state) { "Training or eligible for training" }
 

--- a/spec/features/scenarios/participants/ect_doing_fip/in_training_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_fip/in_training_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature "ECT doing FIP: in training", type: :feature do
   let(:registration_completed) { true }
   let(:participant_status) { "active" }
   let(:training_record_state) { "Eligible to start" }
-  let(:school_record_state) { "ELIGIBLE FOR TRAINING" }
+  let(:school_record_state) { "Eligible for training" }
   let(:delivery_partner_record_state) { "Training or eligible for training" }
   let(:appropriate_body_record_state) { "Training or eligible for training" }
 

--- a/spec/features/scenarios/participants/ect_doing_fip/no_validation_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_fip/no_validation_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature "ECT doing FIP: no validation", type: :feature do
   let(:registration_completed) { true }
   let(:participant_status) { "active" }
   let(:training_record_state) { "Eligible to start" }
-  let(:school_record_state) { "ELIGIBLE FOR TRAINING" }
+  let(:school_record_state) { "Eligible for training" }
   let(:delivery_partner_record_state) { "Training or eligible for training" }
   let(:appropriate_body_record_state) { "Training or eligible for training" }
 

--- a/spec/features/schools/participant_dashboard/manage_cip_participants_spec.rb
+++ b/spec/features/schools/participant_dashboard/manage_cip_participants_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "Manage CIP participants", js: true, with_feature_flags: { eligib
       when_i_navigate_to_participants_dashboard
       when_i_click_on_the_participants_name "Eligible With-mentor"
       then_i_am_taken_to_view_details_page
-      then_i_can_view_participant_with_status(:active_cip_training)
+      then_i_can_view_participant_with_status(:registered_for_cip_training)
     end
   end
 
@@ -104,7 +104,7 @@ RSpec.describe "Manage CIP participants", js: true, with_feature_flags: { eligib
       when_i_navigate_to_participants_dashboard
       when_i_click_on_the_participants_name "Eligible Without-mentor"
       then_i_am_taken_to_view_details_page
-      then_i_can_view_participant_with_status(:active_cip_training)
+      then_i_can_view_participant_with_status(:registered_for_cip_training)
     end
   end
 

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -979,7 +979,7 @@ module ManageTrainingSteps
   alias_method :and_i_see_the_participants_filtered_by, :then_i_see_the_participants_filtered_by
 
   def and_i_see_mentors_not_training_and_ects_not_being_trained_sorted_by_name
-    expect(page).to have_content("Not mentoring or being mentored\nDeferred participant TRAINING DEFERRED")
+    expect(page).to have_content("Not mentoring or being mentored\nDeferred participant Training deferred")
   end
 
   def and_i_see_ects_with_induction_completed_sorted_by_decreasing_completion_date
@@ -989,13 +989,13 @@ module ManageTrainingSteps
   def then_i_see_the_participants_sorted_by_mentor
     expect(page).to have_content("Sort by: Mentor (A-Z)")
     expect(page).to have_link(text: "Induction start date")
-    expect(page).to have_content("You need to assign a mentor to these ECTs.\nEligible Without-mentor\n\nMentor group\nMentor\n- Billy Mentor\nBilly Mentor MENTORING\nECTs\nmentored by Billy Mentor\nTraining ECT With-mentor PENDING\nInduction started #{2.years.ago.to_date.to_fs(:govuk)}\n\nMentor group\nMentor\n- CFI Mentor\nCFI Mentor WAITING FOR TRN\nECTs\nmentored by CFI Mentor\nAnother training With-mentor TRAINING\nInduction started #{1.year.ago.to_date.to_fs(:govuk)}")
+    expect(page).to have_content("You need to assign a mentor to these ECTs.\nEligible Without-mentor\n\nMentor group\nMentor\n- Billy Mentor\nBilly Mentor Mentoring\nECTs\nmentored by Billy Mentor\nTraining ECT With-mentor Pending\nInduction started #{2.years.ago.to_date.to_fs(:govuk)}\n\nMentor group\nMentor\n- CFI Mentor\nCFI Mentor Waiting for TRN\nECTs\nmentored by CFI Mentor\nAnother training With-mentor Training\nInduction started #{1.year.ago.to_date.to_fs(:govuk)}")
   end
   alias_method :and_i_see_the_participants_sorted_by_mentor, :then_i_see_the_participants_sorted_by_mentor
 
   def then_i_see_the_participants_sorted_by_induction_start_date
     expect(page).to have_link("Mentor (A-Z)")
-    expect(page).to have_content("Eligible Without-mentor\nStatus ELIGIBLE FOR TRAINING\nMentor\nNo mentor assigned\nAssign a mentor\nAnother training With-mentor\nStatus TRAINING\nInduction started #{1.year.ago.to_date.to_fs(:govuk)}\nMentor CFI Mentor\nTraining ECT With-mentor\nStatus PENDING\nInduction started #{2.years.ago.to_date.to_fs(:govuk)}\nMentor Billy Mentor")
+    expect(page).to have_content("Eligible Without-mentor\nStatus Eligible for training\nMentor\nNo mentor assigned\nAssign a mentor\nAnother training With-mentor\nStatus Training\nInduction started #{1.year.ago.to_date.to_fs(:govuk)}\nMentor CFI Mentor\nTraining ECT With-mentor\nStatus Pending\nInduction started #{2.years.ago.to_date.to_fs(:govuk)}\nMentor Billy Mentor")
   end
   alias_method :and_i_see_the_participants_sorted_by_induction_start_date, :then_i_see_the_participants_sorted_by_induction_start_date
 
@@ -1262,7 +1262,7 @@ module ManageTrainingSteps
     label = I18n.t(:label, scope: "status_tags.school_participant_status.#{status_key}")
     description = I18n.t(:description, scope: "status_tags.school_participant_status.#{status_key}")
 
-    expect(page).to have_text(label.upcase)
+    expect(page).to have_text(label)
     expect(page).to have_text(Array.wrap(description).first)
   end
 

--- a/spec/support/shared_examples/manage_fip_partnered_participants.rb
+++ b/spec/support/shared_examples/manage_fip_partnered_participants.rb
@@ -88,7 +88,7 @@ RSpec.shared_examples "manage fip participants example", js: true do
       when_i_navigate_to_participants_dashboard
       when_i_click_on_the_participants_name "Eligible With-mentor"
       then_i_am_taken_to_view_details_page
-      then_i_can_view_participant_with_status(:active_fip_training)
+      then_i_can_view_participant_with_status(:registered_for_fip_training)
       and_the_participant_is_displayed_mentored_by(@contacted_for_info_mentor.full_name)
     end
   end
@@ -105,7 +105,7 @@ RSpec.shared_examples "manage fip participants example", js: true do
       when_i_navigate_to_participants_dashboard
       when_i_click_on_the_participants_name "Eligible Without-mentor"
       then_i_am_taken_to_view_details_page
-      then_i_can_view_participant_with_status(:active_fip_training)
+      then_i_can_view_participant_with_status(:registered_for_fip_training)
     end
   end
 


### PR DESCRIPTION
With the update to GOV.UK Frontend version5, the [Tag component](https://design-system.service.gov.uk/components/tag/) is now recommended to use capitalised phrases rather than UPPERCASE.

### Before

<img width="1039" alt="Screenshot 2024-01-10 at 16 52 32" src="https://github.com/DFE-Digital/early-careers-framework/assets/30665/c74b6507-fbd4-4682-81f7-24d38ecd7e33">

### After

<img width="1044" alt="Screenshot 2024-01-10 at 16 52 18" src="https://github.com/DFE-Digital/early-careers-framework/assets/30665/e8325079-ef17-4991-a378-b7e55c1a11c2">
