### PR TITLE
[CPDLP-2684] Amend `ParticipantIdentityResolver` to fetch accepted NPQ applications only

### DIFF
--- a/app/services/participant_identity_resolver.rb
+++ b/app/services/participant_identity_resolver.rb
@@ -31,7 +31,7 @@ class ParticipantIdentityResolver
         ParticipantIdentity
          .joins(:npq_participant_profiles, npq_applications: [:npq_course, { npq_lead_provider: :cpd_lead_provider }])
          .where(npq_courses: { identifier: course_identifier })
-         .where(npq_applications: { npq_lead_providers: { cpd_lead_provider: } })
+         .where(npq_applications: { lead_provider_approval_status: "accepted", npq_lead_providers: { cpd_lead_provider: } })
          .where(user_id: participant_id)
          .first
       end

--- a/spec/services/participant_identity_resolver_spec.rb
+++ b/spec/services/participant_identity_resolver_spec.rb
@@ -106,5 +106,23 @@ RSpec.describe ParticipantIdentityResolver, :with_support_for_ect_examples do
         expect(result).to eql(participant_identity)
       end
     end
+
+    context "when participant has multiple npq applications to the same course and multiple identities" do
+      let(:participant_identity_1) { create(:participant_identity, id: "zz0a97ff-d2a9-4779-a397-9bfd9063072e", user:, email: Faker::Internet.email) } # id defined to ensure it is selected second in lookup order
+      let(:participant_identity_2) { create(:participant_identity, :secondary, id: "000a97ff-d2a9-4779-a397-9bfd9063072e", user:) } # id defined to ensure it is selected first in lookup order
+      let(:npq_senior_leadership) { create(:npq_course, identifier: "npq-senior-leadership") }
+      let(:npq_leading_teaching) { create(:npq_course, identifier: "npq-leading-teaching") }
+
+      let!(:npq_application_1) { create(:npq_application, :accepted, participant_identity: participant_identity_1, npq_lead_provider:, npq_course: npq_senior_leadership) }
+      let!(:npq_application_2) { create(:npq_application, :accepted, participant_identity: participant_identity_2, npq_lead_provider:, npq_course: npq_leading_teaching) }
+      let!(:rejected_npq_application) { create(:npq_application, :rejected, participant_identity: participant_identity_2, npq_lead_provider:, npq_course: npq_senior_leadership) }
+      let!(:course_identifier) { npq_senior_leadership.identifier }
+
+      it "correctly selects npq participant identity" do
+        result = subject.call
+
+        expect(result).to eql(participant_identity_1)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-2684

We can have multiple NPQ applications to the same course with the same provider, but only one is accepted. If there are multiple identities linked to the user, the resolver will sometimes pick the wrong identity if there is another profile attached to that identity. 

### Changes proposed in this pull request

To ensure we account for multiple identities and multiple NPQ applications to the same course, ensure the application is accepted.

### Guidance to review
I will test this on the snapshot with the failing id in the ticket to ensure it works for the provider
