### PR TITLE
[CST-2163] Stop sending transferring in and out emails to participants

### DIFF
--- a/app/controllers/schools/transfer_out_controller.rb
+++ b/app/controllers/schools/transfer_out_controller.rb
@@ -19,7 +19,6 @@ module Schools
 
     def check_answers
       @induction_record.leaving!(@transfer_out_form.end_date, transferring_out: true)
-      ParticipantTransferMailer.with(induction_record: @induction_record).participant_transfer_out_notification.deliver_later
 
       store_form_redirect_to_next_step(:complete)
     end

--- a/app/mailers/participant_transfer_mailer.rb
+++ b/app/mailers/participant_transfer_mailer.rb
@@ -6,10 +6,6 @@ class ParticipantTransferMailer < ApplicationMailer
   TRANSFER_OUT_FOR_ECT_TEMPLATE         = "7d46c3d2-bf80-4b48-a8cd-94902bbb31b8"
   TRANSFER_OUT_FOR_MENTOR_TEMPLATE      = "5341d978-1d81-45d7-9734-4f799f6742ab"
 
-  # participant_transfer_in_notification
-  TRANSFER_IN_FOR_ECT_TEMPLATE          = "1f7baa1d-d684-4499-be8c-7cdeaa967f1b"
-  TRANSFER_IN_FOR_MENTOR_TEMPLATE       = "19bd6887-0313-4e74-8945-5c8f627fec97"
-
   # provider_transfer_out_notification
   TRANSFER_OUT_FOR_PROVIDER_TEMPLATE    = "17d23e1f-9e71-4f27-8b33-33c05958c566"
 
@@ -48,35 +44,6 @@ class ParticipantTransferMailer < ApplicationMailer
         current_school_name: induction_record.school.name,
       },
     ).tag(:participant_transfer_out_notification).associate_with(participant_profile, as: :participant_profile)
-  end
-
-  # This mailer switches on ECT and mentor-specific templates, though the inputs are the same,
-  # there are minor copy changes between the templates.
-  #
-  # Reference: 3, 4
-  def participant_transfer_in_notification
-    induction_record = params[:induction_record]
-
-    participant_profile = induction_record.participant_profile
-    preferred_identity_email = induction_record.preferred_identity.email
-
-    template_id = if participant_profile.ect?
-                    TRANSFER_IN_FOR_ECT_TEMPLATE
-                  else
-                    TRANSFER_IN_FOR_MENTOR_TEMPLATE
-                  end
-
-    template_mail(
-      template_id,
-      to: preferred_identity_email,
-      rails_mailer: mailer_name,
-      rails_mail_template: action_name,
-      personalisation: {
-        transferring_ppt_name: participant_profile.user.full_name,
-        joining_date: induction_record.start_date.to_date.to_fs(:govuk),
-        new_school_name: induction_record.school.name,
-      },
-    ).tag(:participant_transfer_in_notification).associate_with(participant_profile, as: :participant_profile)
   end
 
   # Sent to the *outgoing* lead provider, when it changes.

--- a/app/mailers/participant_transfer_mailer.rb
+++ b/app/mailers/participant_transfer_mailer.rb
@@ -2,10 +2,6 @@
 
 # NOTE: These are currently all for FIP <> FIP.
 class ParticipantTransferMailer < ApplicationMailer
-  # participant_transfer_out_notification
-  TRANSFER_OUT_FOR_ECT_TEMPLATE         = "7d46c3d2-bf80-4b48-a8cd-94902bbb31b8"
-  TRANSFER_OUT_FOR_MENTOR_TEMPLATE      = "5341d978-1d81-45d7-9734-4f799f6742ab"
-
   # provider_transfer_out_notification
   TRANSFER_OUT_FOR_PROVIDER_TEMPLATE    = "17d23e1f-9e71-4f27-8b33-33c05958c566"
 
@@ -17,34 +13,6 @@ class ParticipantTransferMailer < ApplicationMailer
 
   # provider_existing_school_transfer_notification
   EXISTING_SCHOOL_TRANSFER_FOR_PROVIDER = "80cae2bf-658b-44ed-b3f6-337cc77fb953"
-
-  # This mailer switches on ECT and mentor-specific templates, though the inputs are the same,
-  # there are minor copy changes between the templates.
-  #
-  # Reference: 1, 2
-  def participant_transfer_out_notification
-    induction_record = params[:induction_record]
-
-    participant_profile = induction_record.participant_profile
-    preferred_identity_email = induction_record.preferred_identity.email
-
-    template_id = if induction_record.participant_profile.ect?
-                    TRANSFER_OUT_FOR_ECT_TEMPLATE
-                  else
-                    TRANSFER_OUT_FOR_MENTOR_TEMPLATE
-                  end
-
-    template_mail(
-      template_id,
-      to: preferred_identity_email,
-      rails_mailer: mailer_name,
-      rails_mail_template: action_name,
-      personalisation: {
-        transferring_ppt_name: participant_profile.user.full_name,
-        current_school_name: induction_record.school.name,
-      },
-    ).tag(:participant_transfer_out_notification).associate_with(participant_profile, as: :participant_profile)
-  end
 
   # Sent to the *outgoing* lead provider, when it changes.
   #

--- a/app/services/induction/send_transfer_notification_emails.rb
+++ b/app/services/induction/send_transfer_notification_emails.rb
@@ -55,7 +55,6 @@ module Induction
 
     def call
       send_provider_notifications!
-      send_participant_notification!
     end
 
   private
@@ -75,10 +74,6 @@ module Induction
 
     def matching_lead_provider_and_delivery_partner?
       same_provider? && same_delivery_partner?
-    end
-
-    def send_participant_notification!
-      ParticipantTransferMailer.with(induction_record:).participant_transfer_in_notification.deliver_later
     end
 
     # emails to current lead provider profiles

--- a/spec/features/schools/participants/transfer_out/ppt_transferred_in_and_transferred_out_spec.rb
+++ b/spec/features/schools/participants/transfer_out/ppt_transferred_in_and_transferred_out_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe "old and new SIT transferring the same participant", type: :featu
 
       click_on "Confirm and continue"
       then_i_should_be_on_the_complete_page
-      and_the_participant_should_be_notified_that_theyre_transferred_out
 
       click_on "View your ECTs and mentors"
       then_i_am_taken_to_manage_mentors_and_ects_page
@@ -163,11 +162,6 @@ RSpec.describe "old and new SIT transferring the same participant", type: :featu
 
     def and_they_should_not_be_under_their_previous_heading
       expect(page).not_to have_selector("h2", text: "Contacted for information")
-    end
-
-    def and_the_participant_should_be_notified_that_theyre_transferred_out
-      expect(ParticipantTransferMailer).to have_received(:with)
-                                             .with(induction_record: @induction_record)
     end
 
     def allow_participant_transfer_mailers

--- a/spec/features/schools/participants/transfer_out/transfer_out_only_spec.rb
+++ b/spec/features/schools/participants/transfer_out/transfer_out_only_spec.rb
@@ -40,7 +40,6 @@ RSpec.describe "transfer out participants", type: :feature, js: true, rutabaga: 
 
       click_on "Confirm and continue"
       then_i_should_be_on_the_complete_page
-      and_the_participant_should_be_notified_that_theyre_transferred_out
 
       click_on "View your ECTs and mentors"
       then_i_am_taken_to_manage_mentors_and_ects_page
@@ -141,11 +140,6 @@ RSpec.describe "transfer out participants", type: :feature, js: true, rutabaga: 
 
     def and_select_2021_to_2022_cohort
       click_on("2021 to 2022")
-    end
-
-    def and_the_participant_should_be_notified_that_theyre_transferred_out
-      expect(ParticipantTransferMailer).to have_received(:with)
-                                             .with(hash_including(induction_record: @ect.latest_induction_record))
     end
 
     def allow_participant_transfer_mailers

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/allow_withdrawn_participant_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/allow_withdrawn_participant_spec.rb
@@ -61,7 +61,6 @@ RSpec.describe "transferring a withdrawn participant", type: :feature, js: true 
     click_on "Confirm and add"
     then_i_should_be_on_the_complete_page
 
-    and_the_participant_should_be_notified
     and_the_schools_current_provider_is_notified
 
     click_on "View your ECTs and mentors"
@@ -221,11 +220,6 @@ RSpec.describe "transferring a withdrawn participant", type: :feature, js: true 
 
   def and_it_should_list_the_schools_mentors
     expect(page).to have_text(@mentor.user.full_name)
-  end
-
-  def and_the_participant_should_be_notified
-    expect(ParticipantTransferMailer).to have_received(:with)
-      .with(induction_record: @participant_profile_ect.induction_records.latest)
   end
 
   def and_the_schools_current_provider_is_notified

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_different_partner_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_different_partner_spec.rb
@@ -71,7 +71,6 @@ RSpec.describe "Transferring ECT is with a different lead provider", type: :feat
     click_on "Confirm and add"
 
     then_i_should_be_on_the_complete_page
-    and_the_participant_should_be_notified
     and_the_schools_current_provider_is_notified
     and_the_participants_current_provider_is_notified
 
@@ -127,7 +126,6 @@ RSpec.describe "Transferring ECT is with a different lead provider", type: :feat
 
     click_on "Confirm and add"
     then_i_should_be_on_the_complete_page_for_an_existing_induction
-    and_the_participant_should_be_notified
     and_the_participants_current_provider_is_notified
 
     click_on "View your ECTs and mentors"
@@ -322,10 +320,6 @@ RSpec.describe "Transferring ECT is with a different lead provider", type: :feat
 
   def and_it_should_list_the_schools_mentors
     expect(page).to have_text(@mentor.user.full_name)
-  end
-
-  def and_the_participant_should_be_notified
-    expect(ParticipantTransferMailer).to have_received(:with).with(induction_record: @participant_profile_ect.induction_records.latest)
   end
 
   def and_the_participants_current_provider_is_notified

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_no_change_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_no_change_spec.rb
@@ -111,7 +111,6 @@ RSpec.describe "ECT has matching lead provider and delivery partner", type: :fea
     click_on "Confirm and add"
     then_i_should_be_on_the_complete_page
     then_the_page_should_be_accessible
-    and_the_participant_should_be_notified
     and_the_schools_current_provider_is_notified
 
     click_on "View your ECTs and mentors"
@@ -346,13 +345,6 @@ RSpec.describe "ECT has matching lead provider and delivery partner", type: :fea
 
   def and_it_should_list_the_schools_mentors
     expect(page).to have_text(@mentor.user.full_name)
-  end
-
-  def and_the_participant_should_be_notified
-    expect(ParticipantTransferMailer).to have_received(:with)
-                                         .with(
-                                           induction_record: @participant_profile_ect.induction_records.latest,
-                                         )
   end
 
   def and_the_schools_current_provider_is_notified

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_different_partner_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_different_partner_spec.rb
@@ -65,7 +65,6 @@ RSpec.describe "Transferring a mentor with a different provider", type: :feature
 
     click_on "Confirm and add"
     then_i_should_be_on_the_complete_page
-    and_the_participant_should_be_notified
     and_the_schools_current_provider_is_notified
     and_the_participants_current_provider_is_notified
 
@@ -114,7 +113,6 @@ RSpec.describe "Transferring a mentor with a different provider", type: :feature
 
     click_on "Confirm and add"
     then_i_should_be_on_the_complete_page_for_an_existing_induction
-    and_the_participant_should_be_notified
     and_the_participants_current_provider_is_notified
 
     click_on "View your ECTs and mentors"
@@ -299,10 +297,6 @@ RSpec.describe "Transferring a mentor with a different provider", type: :feature
 
     create(:ecf_participant_validation_data, participant_profile: @participant_profile_mentor, full_name: "Sally Mentor", trn: "1001000", date_of_birth: Date.new(1990, 10, 24))
     @participant_profile_mentor.teacher_profile.update!(trn: "1001000")
-  end
-
-  def and_the_participant_should_be_notified
-    expect(ParticipantTransferMailer).to have_received(:with).with(induction_record: @participant_profile_mentor.induction_records.latest)
   end
 
   def and_the_participants_current_provider_is_notified

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_no_change_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_no_change_spec.rb
@@ -55,7 +55,6 @@ RSpec.describe "Transferring a mentor weith matching lead provider and delivery 
 
     click_on "Confirm and add"
     then_i_should_be_on_the_complete_page
-    and_the_participant_should_be_notified
     and_the_schools_current_provider_is_notified
 
     click_on "View your ECTs and mentors"
@@ -220,10 +219,6 @@ RSpec.describe "Transferring a mentor weith matching lead provider and delivery 
 
     create(:ecf_participant_validation_data, participant_profile: @participant_profile_mentor, full_name: "Sally Mentor", trn: "1001000", date_of_birth: Date.new(1990, 10, 24))
     @participant_profile_mentor.teacher_profile.update!(trn: "1001000")
-  end
-
-  def and_the_participant_should_be_notified
-    expect(ParticipantTransferMailer).to have_received(:with).with(induction_record: @participant_profile_mentor.induction_records.latest)
   end
 
   def and_the_schools_current_provider_is_notified

--- a/spec/forms/admin/school_transfer_form_spec.rb
+++ b/spec/forms/admin/school_transfer_form_spec.rb
@@ -71,7 +71,6 @@ RSpec.describe Admin::SchoolTransferForm, type: :model do
        .and have_enqueued_mail(ParticipantTransferMailer, :provider_transfer_out_notification)
               .with(params: hash_including(lead_provider_profile: lead_provider_out.lead_provider_profiles.first),
                     args: [])
-       .and have_enqueued_mail(ParticipantTransferMailer, :participant_transfer_in_notification)
     end
 
     context "when continuing current programme" do
@@ -89,7 +88,6 @@ RSpec.describe Admin::SchoolTransferForm, type: :model do
         }.to have_enqueued_mail(ParticipantTransferMailer, :provider_existing_school_transfer_notification)
                .with(params: hash_including(lead_provider_profile: lead_provider_out.lead_provider_profiles.first),
                      args: [])
-         .and have_enqueued_mail(ParticipantTransferMailer, :participant_transfer_in_notification)
       end
 
       context "when a matching programme already exists" do

--- a/spec/mailers/participant_transfer_mailer_spec.rb
+++ b/spec/mailers/participant_transfer_mailer_spec.rb
@@ -7,22 +7,6 @@ RSpec.describe ParticipantTransferMailer, type: :mailer do
   let(:induction_record)      { participant_profile.current_induction_record }
   let(:lead_provider_profile) { create(:lead_provider_profile) }
 
-  describe "#participant_transfer_out_notification" do
-    let(:participant_profile) { create(:ect_participant_profile) }
-    let(:induction_programme) { create(:induction_programme) }
-    let(:induction_record) { Induction::Enrol.call(participant_profile:, induction_programme:) }
-    let(:participant_transfer_out_notification) do
-      ParticipantTransferMailer.with(
-        induction_record:,
-      ).participant_transfer_out_notification
-    end
-
-    it "renders the right headers" do
-      expect(participant_transfer_out_notification.from).to eq(["mail@example.com"])
-      expect(participant_transfer_out_notification.to).to eq([induction_record.preferred_identity.email])
-    end
-  end
-
   describe "#provider_transfer_in_notification" do
     let(:provider_transfer_in_notification) do
       ParticipantTransferMailer.with(

--- a/spec/mailers/participant_transfer_mailer_spec.rb
+++ b/spec/mailers/participant_transfer_mailer_spec.rb
@@ -7,19 +7,6 @@ RSpec.describe ParticipantTransferMailer, type: :mailer do
   let(:induction_record)      { participant_profile.current_induction_record }
   let(:lead_provider_profile) { create(:lead_provider_profile) }
 
-  describe "#participant_transfer_in_notification" do
-    let(:participant_transfer_in_notification) do
-      ParticipantTransferMailer.with(
-        induction_record:,
-      ).participant_transfer_in_notification
-    end
-
-    it "renders the right headers" do
-      expect(participant_transfer_in_notification.from).to eq(["mail@example.com"])
-      expect(participant_transfer_in_notification.to).to eq([induction_record.preferred_identity.email])
-    end
-  end
-
   describe "#participant_transfer_out_notification" do
     let(:participant_profile) { create(:ect_participant_profile) }
     let(:induction_programme) { create(:induction_programme) }

--- a/spec/services/induction/send_transfer_notification_emails_spec.rb
+++ b/spec/services/induction/send_transfer_notification_emails_spec.rb
@@ -10,21 +10,6 @@ RSpec.describe(Induction::SendTransferNotificationEmails) do
 
   before do
     allow(ParticipantTransferMailer).to receive(template).and_return(provider_mailer)
-    allow(ParticipantTransferMailer).to receive(:participant_transfer_in_notification).and_return(participant_mailer)
-  end
-
-  shared_examples "notifying the participant" do
-    it "sends a 'particicpant transfter in notification' email to the participant" do
-      expect {
-        subject.call
-      }.to have_enqueued_mail(ParticipantTransferMailer, :participant_transfer_in_notification)
-        .with(
-          params: {
-            induction_record:,
-          },
-          args: [],
-        ).once
-    end
   end
 
   # defaults
@@ -102,8 +87,6 @@ RSpec.describe(Induction::SendTransferNotificationEmails) do
           ).once
       end
     end
-
-    include_examples "notifying the participant"
   end
 
   context "when it's a switch to schools programme" do
@@ -147,8 +130,6 @@ RSpec.describe(Induction::SendTransferNotificationEmails) do
         end
       end
     end
-
-    include_examples "notifying the participant"
   end
 
   context "when it's a new school transfer" do
@@ -168,7 +149,5 @@ RSpec.describe(Induction::SendTransferNotificationEmails) do
           ).once
       end
     end
-
-    include_examples "notifying the participant"
   end
 end


### PR DESCRIPTION
### Context

- Ticket: CST-2163

We want to stop sending the transferring in and out emails to participants.

### Changes proposed in this pull request
- Remove the `participant_transfer_in_notification` mailer
- Remove the `participant_transfer_out_notification` mailer

### Guidance to review

