### PR TITLE
[CST-2263] Replace the Admin Home page with the Performance pages

### DIFF
--- a/app/controllers/admin/performance/overview_controller.rb
+++ b/app/controllers/admin/performance/overview_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-module Admin
-  class HomeController < Admin::BaseController
+module Admin::Performance
+  class OverviewController < Admin::BaseController
     skip_after_action :verify_authorized, only: :show
     skip_after_action :verify_policy_scoped, only: :show
 

--- a/app/views/admin/performance/_nav.html.erb
+++ b/app/views/admin/performance/_nav.html.erb
@@ -1,0 +1,5 @@
+<%= render SubnavComponent.new do |component| %>
+  <%= component.with_nav_item(path: admin_performance_overview_path) do %>
+    Overview
+  <% end %>
+<% end %>

--- a/app/views/admin/performance/overview/show.html.erb
+++ b/app/views/admin/performance/overview/show.html.erb
@@ -1,3 +1,5 @@
+<%= render partial: "admin/performance/nav" %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -1,7 +1,7 @@
 <% content_for :nav_bar do %>
   <%= render PrimaryNavComponent.new(wide: true) do |component| %>
     <%= component.with_nav_item(path: "/admin", selected: current_page?('/admin')) do %>
-      Overview
+      Performance
     <% end %>
     <%= component.with_nav_item(path: "/admin/schools") do %>
       Schools

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -284,9 +284,12 @@ Rails.application.routes.draw do
     end
   end
 
-  get "admin", to: "admin/home#show"
+  get "admin", to: "admin/performance/overview#show"
+  get "admin/performance", to: "admin/performance/overview#show"
   namespace :admin do
-    resource :home, only: :show, controller: "home"
+    namespace :performance do
+      resource :overview, only: :show, controller: :overview
+    end
     resources :schools, only: %i[index show] do
       resources :induction_coordinators, controller: "schools/induction_coordinators", only: %i[new create edit update], path: "induction-coordinators"
       get "/replace-or-update-induction-tutor", to: "schools/replace_or_update_induction_tutor#show"


### PR DESCRIPTION
### Context

- Ticket: CST-2263

We want to build multiple new stat pages and group them together, rather than continually adding to the main nav.

The new design replaces the Admin homepage with a multinav page that hosts all the new stat pages we want to build, including the current Overview page.

This PR refactors the admin default page and lays the groundwork for the new stat pages.

### Changes proposed in this pull request
- Move the Admin Overview page in the Performance namespace 
- Remove the old admin home route and make the `/admin/performance/overview` the new default admin page
- Create a subnav to be used in all the Performance stat pages
- Update the main menu

### Guidance to review
|before|after|
|-|-|
|![image](https://github.com/DFE-Digital/early-careers-framework/assets/951947/a7c79f4a-07f4-49c7-a27b-7a4b9fcd35ae)|![image](https://github.com/DFE-Digital/early-careers-framework/assets/951947/a2d44960-40d4-4e9b-b31b-ec5a352f53a1)|
