### PR TITLE
Add NPQ lead provider name to logs

### DIFF
--- a/app/services/oneoffs/npq/migrate_declarations_between_statements.rb
+++ b/app/services/oneoffs/npq/migrate_declarations_between_statements.rb
@@ -39,7 +39,7 @@ module Oneoffs::NPQ
 
       to_statements_by_provider.each_value do |statement|
         statement.update!(to_statement_updates)
-        record_info("Statement #{statement.name} updated with #{to_statement_updates}")
+        record_info("Statement #{statement.name} for #{statement.npq_lead_provider.name} updated with #{to_statement_updates}")
       end
     end
 

--- a/spec/services/oneoffs/npq/migrate_declarations_between_statements_spec.rb
+++ b/spec/services/oneoffs/npq/migrate_declarations_between_statements_spec.rb
@@ -67,7 +67,7 @@ describe Oneoffs::NPQ::MigrateDeclarationsBetweenStatements do
 
         expect(to_statement.reload).to have_attributes(to_statement_updates)
         expect(instance).to have_recorded_info([
-          "Statement #{to_statement.name} updated with #{to_statement_updates}",
+          "Statement #{to_statement.name} for #{to_statement.npq_lead_provider.name} updated with #{to_statement_updates}",
         ])
       end
     end


### PR DESCRIPTION
To make it possible to differentiate the statements we're adding the NPQ lead provider name.
