### PR TITLE
[CST-2201] add additional mailer for start of year comms

### DIFF
--- a/app/services/bulk_mailers/school_reminder_comms.rb
+++ b/app/services/bulk_mailers/school_reminder_comms.rb
@@ -101,10 +101,30 @@ module BulkMailers
       email_count
     end
 
+    def contact_sits_that_have_chosen_fip_but_not_partnered_at_year_start
+      email_count = 0
+
+      # we don't email those that partnered last year but havent this year
+      # as yet
+      Schools::UnpartneredLastYearAndHaveNotPartneredThisYearQuery
+        .call(cohort:, school_type_codes: SCHOOL_TYPES_TO_INCLUDE)
+        .joins(:induction_coordinator_profiles)
+        .find_each do |school|
+          email_count += 1
+          next if dry_run
+
+          SchoolMailer.with(school:).sit_needs_to_chase_partnership.deliver_later
+        end
+
+      email_count
+    end
+
     def contact_sits_that_have_chosen_fip_but_not_partnered
       email_count = 0
 
-      Schools::UnpartneredLastYearAndHaveNotPartneredThisYearQuery
+      # in year we want to email if they haven't partnered regardless
+      # of whether they partnered last year or not
+      Schools::UnpartneredQuery
         .call(cohort:, school_type_codes: SCHOOL_TYPES_TO_INCLUDE)
         .joins(:induction_coordinator_profiles)
         .find_each do |school|

--- a/spec/services/bulk_mailers/school_reminder_comms_spec.rb
+++ b/spec/services/bulk_mailers/school_reminder_comms_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe BulkMailers::SchoolReminderComms, type: :mailer do
     end
   end
 
-  describe "#contact_sits_that_have_chosen_fip_but_not_partnered" do
+  describe "#contact_sits_that_have_chosen_fip_but_not_partnered_at_year_start" do
     context "when the school has chosen fip but not partnered" do
       let(:previous_cohort) { create(:seed_cohort, start_year: cohort.start_year - 1) }
 
@@ -148,7 +148,7 @@ RSpec.describe BulkMailers::SchoolReminderComms, type: :mailer do
 
         it "mails the induction coordinator" do
           expect {
-            service.contact_sits_that_have_chosen_fip_but_not_partnered
+            service.contact_sits_that_have_chosen_fip_but_not_partnered_at_year_start
           }.to have_enqueued_mail(SchoolMailer, :sit_needs_to_chase_partnership)
             .with(params: { school: }, args: [])
         end
@@ -158,12 +158,12 @@ RSpec.describe BulkMailers::SchoolReminderComms, type: :mailer do
 
           it "does not mail the induction coordinator" do
             expect {
-              service.contact_sits_that_have_chosen_fip_but_not_partnered
+              service.contact_sits_that_have_chosen_fip_but_not_partnered_at_year_start
             }.not_to have_enqueued_mail
           end
 
           it "returns the count of emails that would be sent" do
-            expect(service.contact_sits_that_have_chosen_fip_but_not_partnered).to eq 1
+            expect(service.contact_sits_that_have_chosen_fip_but_not_partnered_at_year_start).to eq 1
           end
         end
       end
@@ -174,8 +174,33 @@ RSpec.describe BulkMailers::SchoolReminderComms, type: :mailer do
 
         it "does not mail the induction coordinator" do
           expect {
+            service.contact_sits_that_have_chosen_fip_but_not_partnered_at_year_start
+          }.not_to have_enqueued_mail
+        end
+      end
+    end
+  end
+
+  describe "#contact_sits_that_have_chosen_fip_but_not_partnered" do
+    context "when the school has chosen fip but not partnered" do
+      it "mails the induction coordinator" do
+        expect {
+          service.contact_sits_that_have_chosen_fip_but_not_partnered
+        }.to have_enqueued_mail(SchoolMailer, :sit_needs_to_chase_partnership)
+          .with(params: { school: }, args: [])
+      end
+
+      context "when the dry_run flag is set" do
+        let(:dry_run) { true }
+
+        it "does not mail the induction coordinator" do
+          expect {
             service.contact_sits_that_have_chosen_fip_but_not_partnered
           }.not_to have_enqueued_mail
+        end
+
+        it "returns the count of emails that would be sent" do
+          expect(service.contact_sits_that_have_chosen_fip_but_not_partnered).to eq 1
         end
       end
     end


### PR DESCRIPTION
### Context

- Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-2201)

### Changes proposed in this pull request
When reviewing comms schedule we realised that the query used for unpartnered FIP schools was only applicable for the start of the academic year comms. The in-year chasers should not consider whether the school was partnered or not in the previous year.

Refactored so we have 2 methods, one for year start , one for in year usage.

### Guidance to review

