### PR TITLE
Remove types from `pull_request` config on deployment flow

### DIFF
--- a/.github/workflows/aks_deploy.yml
+++ b/.github/workflows/aks_deploy.yml
@@ -21,11 +21,6 @@ on:
   pull_request:
     branches:
       - main
-    types:
-      - labeled
-      - opened
-      - synchronize
-      - reopened
 
 jobs:
   lint:


### PR DESCRIPTION
This is an attempt to reduce the number of duplicate workflow runs that happen on Dependabot PRs. My hunch is that the flow is kicked off at least twice, once when the PR is opened, once when the `dependencies` label is added and once when the `ruby` label is added, [giving us 3 runs](https://github.com/DFE-Digital/early-careers-framework/pull/4439/checks).

The [default types](https://github.com/DFE-Digital/early-careers-framework/pull/4439/checks) are `opened`, `synchronize`, or `reopened` so we're only really removing `labeled` here.
