### PR TITLE
Limit the width of admin screens

### DIFF
--- a/app/views/admin/participants/change_log/show.html.erb
+++ b/app/views/admin/participants/change_log/show.html.erb
@@ -7,8 +7,14 @@
 
 <%= render partial: "admin/participants/nav" %>
 
-<% if @event_list.present? %>
-  <%= render Admin::Participants::AuditTrailComponent.new(audited_thing: @event_list) %>
-<% else %>
-  <p>No audit trail available for <%= @participant_profile.full_name %>.</p>
-<% end %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+
+    <% if @event_list.present? %>
+      <%= render Admin::Participants::AuditTrailComponent.new(audited_thing: @event_list) %>
+    <% else %>
+      <p>No audit trail available for <%= @participant_profile.full_name %>.</p>
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/admin/participants/details/show.html.erb
+++ b/app/views/admin/participants/details/show.html.erb
@@ -5,14 +5,20 @@
   )
 %>
 
-<% if @participant_profile.npq? %>
-  <%= render partial: "show_npq" %>
-<% else %>
-  <%= render partial: "admin/participants/nav" %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
 
-  <%= render partial: "show_ecf" %>
-<% end %>
+    <% if @participant_profile.npq? %>
+      <%= render partial: "show_npq" %>
+    <% else %>
+      <%= render partial: "admin/participants/nav" %>
 
-<% if @participant_profile.policy_class.new(current_user, @participant_profile).withdraw_record? %>
-  <%= govuk_button_link_to "Delete participant", remove_admin_participant_path(@participant_profile), warning: true %>
-<% end %>
+      <%= render partial: "show_ecf" %>
+    <% end %>
+
+    <% if @participant_profile.policy_class.new(current_user, @participant_profile).withdraw_record? %>
+      <%= govuk_button_link_to "Delete participant", remove_admin_participant_path(@participant_profile), warning: true %>
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/admin/participants/school/show.html.erb
+++ b/app/views/admin/participants/school/show.html.erb
@@ -7,65 +7,71 @@
 
 <%= render partial: "admin/participants/nav" %>
 
-<% if @participant_presenter.all_induction_records.any? %>
-  <h2 class="govuk-heading-m">Current training record</h2>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
 
-  <%= render partial: "admin/participants/induction_records/show", locals: { induction_record:  @participant_presenter.all_induction_records[0] } %>
-<% else %>
-  <p>No training records for  for <%= @participant_presenter.full_name %>.</p>
-<% end %>
+    <% if @participant_presenter.all_induction_records.any? %>
+      <h2 class="govuk-heading-m">Current training record</h2>
 
-<% if @participant_presenter.historical_induction_records.present? %>
-<h2 class="govuk-heading-m">Previous training records</h2>
-  <% @participant_presenter.historical_induction_records.each do |induction_record| %>
-    <%= render partial: "admin/participants/induction_records/show", locals: { induction_record: induction_record } %>
-  <% end %>
-<% end %>
+      <%= render partial: "admin/participants/induction_records/show", locals: { induction_record:  @participant_presenter.all_induction_records[0] } %>
+    <% else %>
+      <p>No training records for  for <%= @participant_presenter.full_name %>.</p>
+    <% end %>
 
-<%=
-  govuk_button_link_to(
-    "Transfer to another school",
-    select_school_admin_participant_school_transfer_path(@participant_profile),
-    secondary: true,
-    )
-%>
+    <% if @participant_presenter.historical_induction_records.present? %>
+    <h2 class="govuk-heading-m">Previous training records</h2>
+      <% @participant_presenter.historical_induction_records.each do |induction_record| %>
+        <%= render partial: "admin/participants/induction_records/show", locals: { induction_record: induction_record } %>
+      <% end %>
+    <% end %>
 
-<%=
-  govuk_button_link_to(
-    "Add to a school mentor pool",
-    new_admin_participant_add_to_school_mentor_pool_path(@participant_profile),
-    secondary: true,
-    ) if @participant_presenter.mentor?
-%>
+    <%=
+      govuk_button_link_to(
+        "Transfer to another school",
+        select_school_admin_participant_school_transfer_path(@participant_profile),
+        secondary: true,
+        )
+    %>
 
-<h2 class="govuk-heading-m">Cohort</h2>
+    <%=
+      govuk_button_link_to(
+        "Add to a school mentor pool",
+        new_admin_participant_add_to_school_mentor_pool_path(@participant_profile),
+        secondary: true,
+        ) if @participant_presenter.mentor?
+    %>
 
-<%= govuk_summary_list do |sl|
-  sl.with_row do |row|
-    row.with_key(text: "Cohort via induction record")
-    row.with_value(text: @participant_presenter.start_year)
-  end
+    <h2 class="govuk-heading-m">Cohort</h2>
 
-  sl.with_row do |row|
-    row.with_key(text: "Cohort via schedule")
-    row.with_value(text: @participant_presenter&.relevant_induction_record&.schedule&.cohort&.start_year)
-  end
-end %>
+    <%= govuk_summary_list do |sl|
+      sl.with_row do |row|
+        row.with_key(text: "Cohort via induction record")
+        row.with_value(text: @participant_presenter.start_year)
+      end
 
-<% if policy(@participant_profile).edit_cohort? %>
-  <%= govuk_button_link_to("Change cohort", edit_admin_participant_change_cohort_path(@participant_presenter.participant_profile), secondary: true) %>
-<% end %>
+      sl.with_row do |row|
+        row.with_key(text: "Cohort via schedule")
+        row.with_value(text: @participant_presenter&.relevant_induction_record&.schedule&.cohort&.start_year)
+      end
+    end %>
 
-<h3 class="govuk-heading-m">Relevant induction record statuses</h3>
-<%= govuk_summary_list(actions: true) do |sl|
-  sl.with_row do |row|
-    row.with_key(text: "induction status")
-    row.with_value(text: govuk_tag(text: @participant_presenter.relevant_induction_record&.induction_status&.capitalize || "No Induction Record Found", colour: "grey"))
-    if allowed_to_change_induction_status?(@participant_presenter)
-      row.with_action(
-        href: edit_admin_participant_change_induction_status_path(@participant_presenter.participant_profile),
-        visually_hidden_text: "induction status"
-      )
-    end
-  end
-end %>
+    <% if policy(@participant_profile).edit_cohort? %>
+      <%= govuk_button_link_to("Change cohort", edit_admin_participant_change_cohort_path(@participant_presenter.participant_profile), secondary: true) %>
+    <% end %>
+
+    <h3 class="govuk-heading-m">Relevant induction record statuses</h3>
+    <%= govuk_summary_list(actions: true) do |sl|
+      sl.with_row do |row|
+        row.with_key(text: "induction status")
+        row.with_value(text: govuk_tag(text: @participant_presenter.relevant_induction_record&.induction_status&.capitalize || "No Induction Record Found", colour: "grey"))
+        if allowed_to_change_induction_status?(@participant_presenter)
+          row.with_action(
+            href: edit_admin_participant_change_induction_status_path(@participant_presenter.participant_profile),
+            visually_hidden_text: "induction status"
+          )
+        end
+      end
+    end %>
+
+  </div>
+</div>

--- a/app/views/admin/participants/validation_data/show.html.erb
+++ b/app/views/admin/participants/validation_data/show.html.erb
@@ -7,125 +7,131 @@
 
 <%= render partial: "admin/participants/nav" %>
 
-<% can_be_updated = policy(@participant_profile).update_validation_data? %>
-<% states = DetermineTrainingRecordStateLegacy.call(participant_profile: @participant_profile) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
 
-<%= govuk_summary_list(actions: true) do |sl|
-  sl.with_row do |row|
-    row.with_key(text: "Full name")
-    row.with_value(text: @participant_presenter.validation_data.full_name)
 
-    if can_be_updated
-      row.with_action(
-        href: full_name_admin_participant_validation_data_path(@participant_presenter.validation_data.participant_profile),
-        visually_hidden_text: "name used for validation"
-      )
-    end
-  end
+    <% can_be_updated = policy(@participant_profile).update_validation_data? %>
+    <% states = DetermineTrainingRecordStateLegacy.call(participant_profile: @participant_profile) %>
 
-  sl.with_row do |row|
-    row.with_key(text: "Teacher Reference Number (TRN)")
-    row.with_value(text: @participant_presenter.validation_data.trn)
-    if can_be_updated
-      row.with_action(
-        href: trn_admin_participant_validation_data_path(@participant_presenter.validation_data.participant_profile),
-        visually_hidden_text: "teacher reference number"
-      )
-    end
-  end
-
-  sl.with_row do |row|
-    row.with_key(text: "Date of birth")
-    row.with_value(text: @participant_presenter.validation_data.date_of_birth&.to_fs(:govuk))
-    if can_be_updated
-      row.with_action(
-        href: date_of_birth_admin_participant_validation_data_path(@participant_presenter.validation_data.participant_profile),
-        visually_hidden_text: "date of birth"
-      )
-    end
-  end
-
-  sl.with_row do |row|
-    row.with_key(text: "National Insurance Number")
-    row.with_value(text: @participant_presenter.validation_data.nino)
-    if can_be_updated
-      row.with_action(
-        href: nino_admin_participant_validation_data_path(@participant_presenter.validation_data.participant_profile),
-        visually_hidden_text: "National Insurance number"
-      )
-    end
-  end
-
-  sl.with_row do |row|
-    row.with_key(text: "Validation state")
-    row.with_value(text: states.validation_state)
-  end
-end %>
-
-<% if !states.validation_status_valid? || current_user.super_user? %>
-  <% if @participant_presenter.eligibility_data.present? %>
-    <h3 class="govuk-heading-m">Eligibility data</h3>
     <%= govuk_summary_list(actions: true) do |sl|
       sl.with_row do |row|
-        row.with_key(text: "Primary reason")
-        row.with_value(text: @participant_presenter.eligibility_data.reason)
-      end
+        row.with_key(text: "Full name")
+        row.with_value(text: @participant_presenter.validation_data.full_name)
 
-      sl.with_row do |row|
-        row.with_key(text: "Active Flags")
-        row.with_value(text: @participant_presenter.eligibility_data.active_flags)
-      end
-
-      if @participant_presenter.eligibility_data.mentor?
-        sl.with_row do |row|
-          row.with_key(text: "Previous participation (ERO)")
-          row.with_value(text: @participant_presenter.eligibility_data.previous_participation)
-        end
-
-        sl.with_row do |row|
-          row.with_key(text: "Secondary mentor profile")
-          row.with_value(text: @participant_presenter.eligibility_data.duplicate_profile)
-        end
-      end
-
-      if @participant_presenter.eligibility_data.ect?
-        sl.with_row do |row|
-          row.with_key(text: "Previous induction (NQT+1)")
-          row.with_value(text: @participant_presenter.eligibility_data.previous_induction)
-        end
-
-        sl.with_row do |row|
-          row.with_key(text: "Qualified teacher status (QTS)")
-          row.with_value(text: @participant_presenter.eligibility_data.qts)
-        end
-
-        sl.with_row do |row|
-          row.with_key(text: "Exempt from induction")
-          row.with_value(text: @participant_presenter.eligibility_data.exempt_from_induction)
-        end
-
-        sl.with_row do |row|
-          row.with_key(text: "Induction is registered with TRA")
-          row.with_value(text: @participant_presenter.eligibility_data.registered_induction)
+        if can_be_updated
+          row.with_action(
+            href: full_name_admin_participant_validation_data_path(@participant_presenter.validation_data.participant_profile),
+            visually_hidden_text: "name used for validation"
+          )
         end
       end
 
       sl.with_row do |row|
-        row.with_key(text: "Teacher profile has different TRN")
-        row.with_value(text: @participant_presenter.eligibility_data.different_trn)
+        row.with_key(text: "Teacher Reference Number (TRN)")
+        row.with_value(text: @participant_presenter.validation_data.trn)
+        if can_be_updated
+          row.with_action(
+            href: trn_admin_participant_validation_data_path(@participant_presenter.validation_data.participant_profile),
+            visually_hidden_text: "teacher reference number"
+          )
+        end
+      end
+
+      sl.with_row do |row|
+        row.with_key(text: "Date of birth")
+        row.with_value(text: @participant_presenter.validation_data.date_of_birth&.to_fs(:govuk))
+        if can_be_updated
+          row.with_action(
+            href: date_of_birth_admin_participant_validation_data_path(@participant_presenter.validation_data.participant_profile),
+            visually_hidden_text: "date of birth"
+          )
+        end
+      end
+
+      sl.with_row do |row|
+        row.with_key(text: "National Insurance Number")
+        row.with_value(text: @participant_presenter.validation_data.nino)
+        if can_be_updated
+          row.with_action(
+            href: nino_admin_participant_validation_data_path(@participant_presenter.validation_data.participant_profile),
+            visually_hidden_text: "National Insurance number"
+          )
+        end
+      end
+
+      sl.with_row do |row|
+        row.with_key(text: "Validation state")
+        row.with_value(text: states.validation_state)
       end
     end %>
 
-    <% button_label = "Revalidate details" %>
-  <% else %>
-    <% button_label = "Validate details" %>
-  <% end %>
+    <% if !states.validation_status_valid? || current_user.super_user? %>
+      <% if @participant_presenter.eligibility_data.present? %>
+        <h3 class="govuk-heading-m">Eligibility data</h3>
+        <%= govuk_summary_list(actions: true) do |sl|
+          sl.with_row do |row|
+            row.with_key(text: "Primary reason")
+            row.with_value(text: @participant_presenter.eligibility_data.reason)
+          end
 
-  <%=
-    govuk_link_to(
-      button_label,
-      new_admin_participant_validate_details_path(participant_id: params[:participant_id]),
-      class: "govuk-button"
-    ) if can_be_updated
-  %>
-<% end %>
+          sl.with_row do |row|
+            row.with_key(text: "Active Flags")
+            row.with_value(text: @participant_presenter.eligibility_data.active_flags)
+          end
+
+          if @participant_presenter.eligibility_data.mentor?
+            sl.with_row do |row|
+              row.with_key(text: "Previous participation (ERO)")
+              row.with_value(text: @participant_presenter.eligibility_data.previous_participation)
+            end
+
+            sl.with_row do |row|
+              row.with_key(text: "Secondary mentor profile")
+              row.with_value(text: @participant_presenter.eligibility_data.duplicate_profile)
+            end
+          end
+
+          if @participant_presenter.eligibility_data.ect?
+            sl.with_row do |row|
+              row.with_key(text: "Previous induction (NQT+1)")
+              row.with_value(text: @participant_presenter.eligibility_data.previous_induction)
+            end
+
+            sl.with_row do |row|
+              row.with_key(text: "Qualified teacher status (QTS)")
+              row.with_value(text: @participant_presenter.eligibility_data.qts)
+            end
+
+            sl.with_row do |row|
+              row.with_key(text: "Exempt from induction")
+              row.with_value(text: @participant_presenter.eligibility_data.exempt_from_induction)
+            end
+
+            sl.with_row do |row|
+              row.with_key(text: "Induction is registered with TRA")
+              row.with_value(text: @participant_presenter.eligibility_data.registered_induction)
+            end
+          end
+
+          sl.with_row do |row|
+            row.with_key(text: "Teacher profile has different TRN")
+            row.with_value(text: @participant_presenter.eligibility_data.different_trn)
+          end
+        end %>
+
+        <% button_label = "Revalidate details" %>
+      <% else %>
+        <% button_label = "Validate details" %>
+      <% end %>
+
+      <%=
+        govuk_link_to(
+          button_label,
+          new_admin_participant_validate_details_path(participant_id: params[:participant_id]),
+          class: "govuk-button"
+        ) if can_be_updated
+      %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/schools/participants/index.html.erb
+++ b/app/views/admin/schools/participants/index.html.erb
@@ -2,32 +2,36 @@
 
 <h1 class="govuk-heading-l"><%= @school.name %></h1>
 <%= render partial: "admin/schools/shared/navigation" %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
 
-<h2 class="govuk-heading-m">Participants</h2>
+    <h2 class="govuk-heading-m">Participants</h2>
 
-<% if @participant_profiles.present? %>
-  <table class="govuk-table">
-    <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header">Full name</th>
-        <th scope="col" class="govuk-table__header">Type</th>
-        <th scope="col" class="govuk-table__header">Cohort</th>
-        <th scope="col" class="govuk-table__header">Validation status</th>
-      </tr>
-    </thead>
-    <tbody class="govuk-table__body">
-      <% @participant_profiles.each do |participant| %>
-        <tr class="govuk-table__row">
-          <th scope="row" class="govuk-table__header"><%= govuk_link_to participant.user.full_name, admin_participant_path(participant) %></th>
-          <td class="govuk-table__cell"><%= t participant.participant_type, scope: "schools.participants.type" %></td>
-          <td class="govuk-table__cell"><%= participant.cohort&.start_year %></td>
-          <td class="govuk-table__cell">
-            <%= render StatusTags::AdminParticipantStatusTag.new(participant_profile: participant, school: @school) %>
-          </td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
-<% else %>
-  <p class="govuk-body">No participants found for this school.</p>
-<% end %>
+    <% if @participant_profiles.present? %>
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Full name</th>
+            <th scope="col" class="govuk-table__header">Type</th>
+            <th scope="col" class="govuk-table__header">Cohort</th>
+            <th scope="col" class="govuk-table__header">Validation status</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <% @participant_profiles.each do |participant| %>
+            <tr class="govuk-table__row">
+              <th scope="row" class="govuk-table__header"><%= govuk_link_to participant.user.full_name, admin_participant_path(participant) %></th>
+              <td class="govuk-table__cell"><%= t participant.participant_type, scope: "schools.participants.type" %></td>
+              <td class="govuk-table__cell"><%= participant.cohort&.start_year %></td>
+              <td class="govuk-table__cell">
+                <%= render StatusTags::AdminParticipantStatusTag.new(participant_profile: participant, school: @school) %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% else %>
+      <p class="govuk-body">No participants found for this school.</p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/schools/show.html.erb
+++ b/app/views/admin/schools/show.html.erb
@@ -2,60 +2,66 @@
 
 <h1 class="govuk-heading-l"><%= @school.name %></h1>
 <%= render partial: "admin/schools/shared/navigation" %>
-<h2 class="govuk-heading-m">Details</h2>
 
-<% if @induction_coordinator && ImpersonationPolicy.new(current_user, @induction_coordinator).create? %>
-  <%= govuk_button_to("Impersonate induction tutor", admin_impersonate_path,
-                      params: {
-                        impersonated_user_id: @induction_coordinator.id,
-                      },
-                      "data-test": "impersonate-button") %>
-<% end %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
 
-<%=
-  govuk_summary_list do |sl|
-    sl.with_row do |row|
-      row.with_key(text: "URN")
-      row.with_value(text: @school.urn)
-      if @school.urn.present?
-        row.with_action(
-          text: "Open in GIAS",
-          href: "https://get-information-schools.service.gov.uk/Establishments/Establishment/Details/#{@school.urn}",
-          html_attributes: { rel: "noreferrer noopener", target: "_blank" },
-        )
-      end
-    end
+    <h2 class="govuk-heading-m">Details</h2>
 
-    sl.with_row do |row|
-      row.with_key(text: "Induction tutor")
-      row.with_value do
-        if @induction_coordinator.present?
-          safe_join([@induction_coordinator.full_name, tag.br, govuk_mail_to(@induction_coordinator.email, @induction_coordinator.email)])
+    <% if @induction_coordinator && ImpersonationPolicy.new(current_user, @induction_coordinator).create? %>
+      <%= govuk_button_to("Impersonate induction tutor", admin_impersonate_path,
+                          params: {
+                            impersonated_user_id: @induction_coordinator.id,
+                          },
+                          "data-test": "impersonate-button") %>
+    <% end %>
+
+    <%=
+      govuk_summary_list do |sl|
+        sl.with_row do |row|
+          row.with_key(text: "URN")
+          row.with_value(text: @school.urn)
+          if @school.urn.present?
+            row.with_action(
+              text: "Open in GIAS",
+              href: "https://get-information-schools.service.gov.uk/Establishments/Establishment/Details/#{@school.urn}",
+              html_attributes: { rel: "noreferrer noopener", target: "_blank" },
+            )
+          end
+        end
+
+        sl.with_row do |row|
+          row.with_key(text: "Induction tutor")
+          row.with_value do
+            if @induction_coordinator.present?
+              safe_join([@induction_coordinator.full_name, tag.br, govuk_mail_to(@induction_coordinator.email, @induction_coordinator.email)])
+            end
+          end
+
+          if @induction_coordinator.present?
+            row.with_action(text: "Change", visually_hidden_text: "induction tutor", href: admin_school_replace_or_update_induction_tutor_path(@school))
+          else
+            row.with_action(text: "Add", visually_hidden_text: "induction tutor", href: new_admin_school_induction_coordinator_path(@school))
+          end
+        end
+
+        sl.with_row do |row|
+          row.with_key(text: "Local authority")
+          row.with_value(text: @school.local_authority&.name)
+        end
+
+        sl.with_row do |row|
+          row.with_key(text: "Address")
+          row.with_value(
+            text: format_address(
+              @school.address_line1,
+              @school.address_line2,
+              @school.address_line3,
+              @school.postcode,
+            )
+          )
         end
       end
-
-      if @induction_coordinator.present?
-        row.with_action(text: "Change", visually_hidden_text: "induction tutor", href: admin_school_replace_or_update_induction_tutor_path(@school))
-      else
-        row.with_action(text: "Add", visually_hidden_text: "induction tutor", href: new_admin_school_induction_coordinator_path(@school))
-      end
-    end
-
-    sl.with_row do |row|
-      row.with_key(text: "Local authority")
-      row.with_value(text: @school.local_authority&.name)
-    end
-
-    sl.with_row do |row|
-      row.with_key(text: "Address")
-      row.with_value(
-        text: format_address(
-          @school.address_line1,
-          @school.address_line2,
-          @school.address_line3,
-          @school.postcode,
-        )
-      )
-    end
-  end
-%>
+    %>
+  </div>
+</div>


### PR DESCRIPTION
Some of the admin screens are suuuper wide - which can be good for tables, but is less for for detail views, as it makes the summary lists harder to scan.

| Before | After |
| ------ | ------ |
|  | <img width="1422" alt="Screenshot 2024-01-24 at 14 32 47" src="https://github.com/DFE-Digital/early-careers-framework/assets/30665/7e49aec0-a2a5-441a-bf20-18e2818b8108"> | 
