### PR TITLE
[CST-2291] Add new model to support scheduling chaser comms emails

### DIFF
--- a/app/models/email_schedule.rb
+++ b/app/models/email_schedule.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class EmailSchedule < ApplicationRecord
+  MAILERS = {
+    assign_a_mentor_to_each_ect: :contact_sits_that_need_to_assign_mentors,
+    register_ects_and_mentors: :contact_sits_that_have_not_added_participants,
+    contract_with_a_training_provider: :contact_sits_that_have_chosen_fip_but_not_partnered,
+  }.freeze
+
+  validates :mailer_name, inclusion: { in: MAILERS.keys.map(&:to_s) }
+  validates :scheduled_at, presence: true
+
+  enum status: {
+    queued: "queued",
+    sending: "sending",
+    sent: "sent",
+  }
+
+  scope :to_send_today, -> { queued.where(scheduled_at: ..Date.current) }
+end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -463,3 +463,12 @@
   - get_an_identity_id
   - archived_email
   - archived_at
+  :email_schedules:
+  - id
+  - mailer_name
+  - scheduled_at
+  - status
+  - actual_email_count
+  - failed_email_count
+  - created_at
+  - updated_at

--- a/db/migrate/20240123152026_create_email_schedules.rb
+++ b/db/migrate/20240123152026_create_email_schedules.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateEmailSchedules < ActiveRecord::Migration[7.0]
+  def change
+    create_table :email_schedules do |t|
+      t.string :mailer_name, null: false
+      t.date :scheduled_at, null: false
+      t.string :status, null: false, default: "queued"
+      t.integer :actual_email_count
+      t.integer :failed_email_count
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_05_142733) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_23_152026) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -453,6 +453,16 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_05_142733) do
     t.datetime "updated_at", null: false
     t.index ["email_id"], name: "index_email_associations_on_email_id"
     t.index ["object_type", "object_id"], name: "index_email_associations_on_object"
+  end
+
+  create_table "email_schedules", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "mailer_name", null: false
+    t.date "scheduled_at", null: false
+    t.string "status", default: "queued", null: false
+    t.integer "actual_email_count"
+    t.integer "failed_email_count"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "emails", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/seeds/email_schedule_factory.rb
+++ b/spec/factories/seeds/email_schedule_factory.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory(:seed_email_factory, class: "EmailSchedule") do
+    mailer_name { EmailSchedule::MAILERS.keys.sample.to_s }
+    scheduled_at { 1.week.from_now }
+    status { "queued" }
+
+    trait(:scheduled_for_today) do
+      scheduled_at { Date.current }
+      status { "queued" }
+    end
+
+    trait(:sending) do
+      scheduled_at { Date.current }
+      status { "sending" }
+    end
+
+    trait(:sent) do
+      scheduled_at { 1.month.ago }
+      status { "sent" }
+    end
+
+    trait(:valid) {}
+
+    after(:build) do
+      Rails.logger.debug("created email schedule")
+    end
+  end
+end

--- a/spec/models/email_schedule_spec.rb
+++ b/spec/models/email_schedule_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe EmailSchedule, type: :model do
+  it { is_expected.to validate_inclusion_of(:mailer_name).in_array(EmailSchedule::MAILERS.keys.map(&:to_s)) }
+  it { is_expected.to validate_presence_of(:scheduled_at) }
+
+  describe "scopes" do
+    let!(:scheduled_today) { create(:seed_email_factory, :scheduled_for_today) }
+    let!(:scheduled_later) { create(:seed_email_factory) }
+    let!(:already_sent) { create(:seed_email_factory, :sent) }
+    let!(:currently_sending) { create(:seed_email_factory, :sending) }
+
+    describe ".to_send_today" do
+      it "returns the queued schedules for today" do
+        expect(described_class.to_send_today).to match_array [scheduled_today]
+      end
+
+      it "does not include schedules for a later date" do
+        expect(described_class.to_send_today).not_to include [scheduled_later]
+      end
+
+      it "does not include schedules that are in progress" do
+        expect(described_class.to_send_today).not_to include [currently_sending]
+      end
+
+      it "does not include schedules that have already been sent" do
+        expect(described_class.to_send_today).not_to include [already_sent]
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-2291)
This is the first part of the ticket to add a new model that can be used to schedule the chaser comms

### Changes proposed in this pull request
New DB table `email_schedules`
New model `EmailSchedule`

### Guidance to review
Not much to see yet, a separate story is handling the admin UI changes that will create/edit the schedules.
