### PR TITLE
[CST-2166] Add support forms

### DIFF
--- a/app/components/support_form_component.html.erb
+++ b/app/components/support_form_component.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-l"><%= school.name if school.present? %></span>
-    <h1 class="govuk-heading-l">Contact support</h1>
+    <h1 class="govuk-heading-l"><%= t("support_form.title.#{subject}", **i18n_params, default: t("support_form.title.unspecified")) %></h1>
 
     <%= form_for @form, url: support_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
@@ -51,6 +51,17 @@
             </dt>
             <dd class="govuk-summary-list__value">
               <%= participant_profile_full_name %>
+            </dd>
+          </div>
+        <% end %>
+
+        <% if teacher_name.present? %>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Teacher
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <%= teacher_name %>
             </dd>
           </div>
         <% end %>

--- a/app/components/support_form_component.rb
+++ b/app/components/support_form_component.rb
@@ -10,6 +10,7 @@ class SupportFormComponent < BaseComponent
            :participant_profile,
            :current_user,
            :cohort_year,
+           :teacher_name,
            to: :form
   delegate :full_name,
            to: :participant_profile,
@@ -26,6 +27,7 @@ class SupportFormComponent < BaseComponent
       cohort_year_range:,
       support_email: Rails.application.config.support_email,
       school_name: school_name,
+      teacher_name:,
     }
   end
 

--- a/app/components/support_form_component.rb
+++ b/app/components/support_form_component.rb
@@ -15,12 +15,17 @@ class SupportFormComponent < BaseComponent
            to: :participant_profile,
            prefix: true,
            allow_nil: true
+  delegate :name,
+           to: :school,
+           prefix: true,
+           allow_nil: true
 
   def i18n_params
     @i18n_params ||= {
       participant_name: participant_profile_full_name,
       cohort_year_range:,
       support_email: Rails.application.config.support_email,
+      school_name: school_name,
     }
   end
 

--- a/app/components/support_form_component.rb
+++ b/app/components/support_form_component.rb
@@ -26,7 +26,7 @@ class SupportFormComponent < BaseComponent
       participant_name: participant_profile_full_name,
       cohort_year_range:,
       support_email: Rails.application.config.support_email,
-      school_name: school_name,
+      school_name:,
       teacher_name:,
     }
   end

--- a/app/controllers/challenge_partnerships_controller.rb
+++ b/app/controllers/challenge_partnerships_controller.rb
@@ -42,7 +42,7 @@ private
 
   def set_form
     @school_name = @partnership.school.name
-    redirect_to already_challenged_challenge_partnership_path(school_name: @school_name) and return if @partnership.challenged?
+    redirect_to already_challenged_challenge_partnership_path(school_name: @school_name, cohort: @partnership.cohort.start_year, school_id: @partnership.school.id) and return if @partnership.challenged?
 
     redirect_to link_expired_challenge_partnership_path and return unless @partnership.in_challenge_window?
 

--- a/app/forms/support_form.rb
+++ b/app/forms/support_form.rb
@@ -3,7 +3,7 @@
 class SupportForm
   include ActiveModel::Model
 
-  attr_accessor :message, :participant_profile_id, :school_id, :current_user, :cohort_year
+  attr_accessor :message, :participant_profile_id, :school_id, :current_user, :cohort_year, :teacher_name
   attr_reader :subject
 
   validates :message, presence: { message: "Enter your message" }
@@ -31,7 +31,7 @@ class SupportForm
   end
 
   def subject=(new_subject)
-    @subject = if SupportQuery::VALID_SUBJECTS.include?(new_subject)
+    @subject = if SupportQuery::VALID_SUBJECTS.include?(new_subject.to_s)
                  new_subject
                else
                  :unspecified
@@ -43,6 +43,7 @@ class SupportForm
       school_id: school&.id,
       participant_profile_id: participant_profile&.id,
       cohort_year:,
+      teacher_name:,
     }.reject { |_k, v| v.blank? }
   end
 

--- a/app/models/support_query.rb
+++ b/app/models/support_query.rb
@@ -14,6 +14,7 @@ class SupportQuery < ApplicationRecord
     add-participant-requires-manual-transfer-mentor
     add-participant-dqt-mismatch-ect
     add-participant-dqt-mismatch-mentor
+    partnership-issue
   ].freeze
 
   belongs_to :user

--- a/app/models/support_query.rb
+++ b/app/models/support_query.rb
@@ -9,6 +9,7 @@ class SupportQuery < ApplicationRecord
     change-cohort-lead-provider
     change-cohort-delivery-partner
     change-cohort-induction-programme-choice
+    trouble-nominating-induction-coordinator
   ].freeze
 
   belongs_to :user

--- a/app/models/support_query.rb
+++ b/app/models/support_query.rb
@@ -15,6 +15,7 @@ class SupportQuery < ApplicationRecord
     add-participant-dqt-mismatch-ect
     add-participant-dqt-mismatch-mentor
     partnership-issue
+    partnership-already-challenged
   ].freeze
 
   belongs_to :user

--- a/app/models/support_query.rb
+++ b/app/models/support_query.rb
@@ -10,6 +10,10 @@ class SupportQuery < ApplicationRecord
     change-cohort-delivery-partner
     change-cohort-induction-programme-choice
     trouble-nominating-induction-coordinator
+    add-participant-requires-manual-transfer-ect
+    add-participant-requires-manual-transfer-mentor
+    add-participant-dqt-mismatch-ect
+    add-participant-dqt-mismatch-mentor
   ].freeze
 
   belongs_to :user

--- a/app/views/challenge_partnerships/already_challenged.html.erb
+++ b/app/views/challenge_partnerships/already_challenged.html.erb
@@ -1,4 +1,4 @@
 <% content_for :title, "Error: mistake reported" %>
 
 <h1 class="govuk-heading-l">Someone at <%= @school_name %> has already reported this issue</h1>
-<p class="govuk-body">If you still need to report that your school has been confirmed incorrectly contact: <%= render MailToSupportComponent.new %></p>
+<p class="govuk-body">If you still need to report that your school has been confirmed incorrectly <%= govuk_link_to "contact support", support_path(cohort_year: params[:cohort], school_id: params[:school_id], subject: :"partnership-already-challenged") %>.

--- a/app/views/layouts/_support_links.html.erb
+++ b/app/views/layouts/_support_links.html.erb
@@ -1,7 +1,7 @@
 <h2 class="govuk-heading-m">Support and guidance</h2>
 <p class="govuk-body-s">
   <% if current_user.present? %>
-    If you have a question, or you’ve had a problem using this service,  <%= govuk_link_to("contact support", support_path) %>.
+    If you have a question, or you’ve had a problem using this service, <%= govuk_link_to("contact support", support_path) %>.
   <% else %>
     If you have a question, or you’ve had a problem using this service, contact us at
     <%= mail_to Rails.application.config.support_email, Rails.application.config.support_email, class: "govuk-footer__link govuk-link--no-visited-state" %>

--- a/app/views/nominations/nominate_induction_coordinator/email.html.erb
+++ b/app/views/nominations/nominate_induction_coordinator/email.html.erb
@@ -6,25 +6,31 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-
         <span class="govuk-caption-l"><%= @nominate_induction_tutor_form.school.name %></span>
 
         <%= form_for @nominate_induction_tutor_form, url: { action: :check_email }, method: :put do |f| %>
-        <%= f.govuk_error_summary %>
-            <div class="govuk-form-group">
-              <%= f.govuk_text_field(
-                :email,
-                label: { text: "What’s #{possessive_name(@nominate_induction_tutor_form.full_name)} email address?",
-                tag: "h1",
-                size: "l" },
-                width: "two-thirds") do %>
+          <%= f.govuk_error_summary %>
 
-                <p class="govuk-body">We’ll use this address to contact them with more information.</p>
-                <% end %>
-            </div>
-            <%= f.hidden_field :token, value: @nominate_induction_tutor_form.token %>
-            <%= f.govuk_submit "Continue" %>
+          <div class="govuk-form-group">
+            <%= f.govuk_text_field(
+              :email,
+              label: { text: "What’s #{possessive_name(@nominate_induction_tutor_form.full_name)} email address?",
+              tag: "h1",
+              size: "l" },
+              width: "two-thirds") do %>
+
+              <p class="govuk-body">We’ll use this address to contact them with more information.</p>
+            <% end %>
+          </div>
+
+          <%= f.hidden_field :token, value: @nominate_induction_tutor_form.token %>
+          <%= f.govuk_submit "Continue" %>
+
+          <% if @nominate_induction_tutor_form.errors.present? %>
+            <p class="govuk-body">
+              Having trouble? <%= govuk_link_to("Contact support", support_path(school_id: @nominate_induction_tutor_form.school.id, subject: :"trouble-nominating-induction-coordinator")) %>
+            </p>
+          <% end %>
         <% end %>
-
     </div>
 </div>

--- a/app/views/schools/add_participants/cannot_add_manual_transfer.html.erb
+++ b/app/views/schools/add_participants/cannot_add_manual_transfer.html.erb
@@ -3,28 +3,15 @@
 
 <% content_for :before_content, govuk_back_link( text: "Back", href: wizard_back_link_path) %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-l"><%= @school.name %></span>
-    <h1 class="govuk-heading-l"><%= title %></h1>
+<%=
+  render SupportFormComponent.new(
+    form: SupportForm.new(
+      school_id: @wizard.school.id,
+      teacher_name: @wizard.full_name,
+      current_user:,
+      subject: @wizard.ect_participant? ? :"add-participant-requires-manual-transfer-ect" : :"add-participant-requires-manual-transfer-mentor",
+    )
+  )
+%>
 
-    <p class="govuk-body"><%= @wizard.possessive_name %> record needs to be transferred manually.</p>
-    <p class="govuk-body">Contact us for help to register this person at your school: <%= render MailToSupportComponent.new %></p>
-    <p class="govuk-body">Include their:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>full name</li>
-      <li>teacher reference number</li>
-      <li>date of birth</li>
-      <li>email address (personal or school)</li>
-      <li>start date at your school</li>
-      <li>previous school's name</li>
-    </ul>
-    <p class="govuk-body">Tell us:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>how <%= @wizard.full_name %> will continue their ECF-based training at your school - for example, with a DfE-funded training provider</li>
-      <li>the lead provider and delivery partner you’ve chosen for their training, if applicable</li>
-    </ul>
-
-    <%= govuk_link_to "Return to your ECTs and mentors", @wizard.dashboard_path, no_visited_state: true %>
-  </div>
-</div>
+<%= govuk_link_to "Return to your ECTs and mentors", @wizard.dashboard_path, no_visited_state: true %>

--- a/app/views/schools/add_participants/cannot_add_mismatch.html.erb
+++ b/app/views/schools/add_participants/cannot_add_mismatch.html.erb
@@ -3,14 +3,15 @@
 
 <% content_for :before_content, govuk_back_link( text: "Back", href: wizard_back_link_path) %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-l"><%= @school.name %></span>
-    <h1 class="govuk-heading-l"><%= title %></h1>
+<%=
+  render SupportFormComponent.new(
+    form: SupportForm.new(
+      school_id: @wizard.school.id,
+      teacher_name: @wizard.full_name,
+      current_user:,
+      subject: @wizard.ect_participant? ? :"add-participant-dqt-mismatch-ect" : :"add-participant-dqt-mismatch-mentor",
+    )
+  )
+%>
 
-    <p class="govuk-body">We cannot add this person based on the information you’ve entered.</p>
-    <p class="govuk-body">Contact us for help to register this <%= @wizard.ect_or_mentor_label %> at your school: <%= render MailToSupportComponent.new %></p>
-
-    <%= govuk_link_to "Return to your ECTs and mentors", @wizard.dashboard_path, no_visited_state: true %>
-  </div>
-</div>
+<%= govuk_link_to "Return to your ECTs and mentors", @wizard.dashboard_path, no_visited_state: true %>

--- a/app/views/schools/change_sit/email.html.erb
+++ b/app/views/schools/change_sit/email.html.erb
@@ -14,5 +14,10 @@
       <%= f.govuk_submit "Continue" %>
     <% end %>
 
+    <% if @induction_tutor_form.errors.present? %>
+      <p class="govuk-body">
+        Having trouble? <%= govuk_link_to("Contact support", support_path(school_id: @induction_tutor_form.school.id, subject: :"trouble-nominating-induction-coordinator")) %>
+      </p>
+    <% end %>
   </div>
 </div>

--- a/app/views/schools/partnerships/_signed_up_with_provider.html.erb
+++ b/app/views/schools/partnerships/_signed_up_with_provider.html.erb
@@ -24,6 +24,6 @@
   </p>
 <% else %>
   <p class="govuk-body">
-    If this doesn’t look right, contact: <%= render MailToSupportComponent.new %>
+    If this doesn’t look right, <%= govuk_link_to "contact support", support_path(cohort_year: @partnership.cohort.start_year, school_id: @partnership.school.id, subject: :"partnership-issue") %>.
   </p>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -863,6 +863,7 @@ en:
   support_form:
     introduction:
       unspecified_html: "If you have a question about the Manage training for early career teachers service, you can contact the DfE using this form."
+      trouble-nominating-induction-coordinator_html: "Complete this form to request a change to %{school_name}'s induction coordinator."
       change-participant-lead-provider_html: "Complete this form to request a change to %{participant_name}’s registered training provider."
       change-participant-date-of-birth_html: "Complete this request form to change an ECT or mentor's date of birth"
       change-participant-trn_html: "Complete this request form to change an ECT or mentor's TRN"
@@ -874,6 +875,8 @@ en:
         You can view your options here: <a class="govuk-link" target="_blank" rel="noopener noreferrer" href="https://www.gov.uk/guidance/how-to-set-up-training-for-early-career-teachers#choose-a-training-option">https://www.gov.uk/guidance/how-to-set-up-training-for-early-career-teachers#choose-a-training-option</a>.
     instructions:
       unspecified_html: ""
+      trouble-nominating-induction-coordinator_html: |
+        Enter the name and email for the new induction coordinator.
       change-participant-lead-provider_html: |
         Tell us:
         <ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -992,3 +992,4 @@ en:
       add-participant-dqt-mismatch-mentor: Request to add a mentor with a DQT mismatch
       partnership-issue: SIT reporting issue with a partnership
       partnership-already-challenged: Request related to a challenged partnership
+      trouble-nominating-induction-coordinator: Request to change induction coordinator for a school

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -883,7 +883,8 @@ en:
       add-participant-requires-manual-transfer-mentor_html: "Complete this request form to register %{teacher_name} as a mentor at your school."
       add-participant-dqt-mismatch-ect_html: "Complete this request form to register %{teacher_name} as an ECT at your school."
       add-participant-dqt-mismatch-mentor_html:  "Complete this request form to register %{teacher_name} as a mentor at your school."
-      partnership-issue_html: "If you there is an issue with %{cohort_year_range}'s partnership, you can contact the DfE using this form."
+      partnership-issue_html: "Complete this request form to change your training provider for the %{cohort_year_range} academic year."
+      partnership-already-challenged_html: "Complete this request form to amend your school's training partnership details for the %{cohort_year_range} academic year."
 
     instructions:
       unspecified_html: ""
@@ -968,6 +969,12 @@ en:
           <li>start date at your school</li>
           <li>previous school's name</li>
         </ul>
+      partnership-already-challenged_html: |
+        <p class="govuk-body">Tell us:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>which details are incorrect</li>
+          <li>the correct partnership details</li>
+        </ul>
       partnership-issue_html: "Tell us the delivery partner and lead provider your school will be working with."
 
   support_query:
@@ -984,3 +991,4 @@ en:
       add-participant-dqt-mismatch-ect: Request to add a mentor with a DQT mismatch
       add-participant-dqt-mismatch-mentor: Request to add a mentor with a DQT mismatch
       partnership-issue: SIT reporting issue with a partnership
+      partnership-already-challenged: Request related to a challenged partnership

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -868,7 +868,7 @@ en:
       add-participant-dqt-mismatch-mentor: "Contact Support: You cannot add %{teacher_name}"
     introduction:
       unspecified_html: "If you have a question about the Manage training for early career teachers service, you can contact the DfE using this form."
-      trouble-nominating-induction-coordinator_html: "Complete this form to request a change to %{school_name}'s induction coordinator."
+      trouble-nominating-induction-coordinator_html: "Complete this form to request a change to %{school_name}’s induction coordinator."
       change-participant-lead-provider_html: "Complete this form to request a change to %{participant_name}’s registered training provider."
       change-participant-date-of-birth_html: "Complete this request form to change an ECT or mentor's date of birth"
       change-participant-trn_html: "Complete this request form to change an ECT or mentor's TRN"
@@ -884,7 +884,7 @@ en:
       add-participant-dqt-mismatch-ect_html: "Complete this request form to register %{teacher_name} as an ECT at your school."
       add-participant-dqt-mismatch-mentor_html:  "Complete this request form to register %{teacher_name} as a mentor at your school."
       partnership-issue_html: "Complete this request form to change your training provider for the %{cohort_year_range} academic year."
-      partnership-already-challenged_html: "Complete this request form to amend your school's training partnership details for the %{cohort_year_range} academic year."
+      partnership-already-challenged_html: "Complete this request form to amend your school’s training partnership details for the %{cohort_year_range} academic year."
 
     instructions:
       unspecified_html: ""
@@ -927,12 +927,12 @@ en:
           <li>date of birth</li>
           <li>email address (personal or school)</li>
           <li>start date at your school</li>
-          <li>previous school's name</li>
+          <li>previous school’s name</li>
         </ul>
 
         <p class="govuk-body">Tell us:
-          <li>how they'll continue their ECF-based training at your school (for example, with a DfE-funded training provider)</li>
-          <li>which lead provider and delivery partner you've chosen for their training, if applicable</li>
+          <li>how they’ll continue their ECF-based training at your school (for example, with a DfE-funded training provider)</li>
+          <li>which lead provider and delivery partner you’ve chosen for their training, if applicable</li>
         </ul>
       add-participant-requires-manual-transfer-mentor_html: |
         <p class="govuk-body">Include their:</p>
@@ -942,12 +942,12 @@ en:
           <li>date of birth</li>
           <li>email address (personal or school)</li>
           <li>start date at your school</li>
-          <li>previous school's name</li>
+          <li>previous school’s name</li>
         </ul>
 
         <p class="govuk-body">Tell us:
-          <li>how they'll continue their ECF-based training at your school (for example, with a DfE-funded training provider)</li>
-          <li>which lead provider and delivery partner you've chosen for their training, if applicable</li>
+          <li>how they’ll continue their ECF-based training at your school (for example, with a DfE-funded training provider)</li>
+          <li>which lead provider and delivery partner you’ve chosen for their training, if applicable</li>
         </ul>
       add-participant-dqt-mismatch-ect_html: |
         <p class="govuk-body">Include their:</p>
@@ -957,7 +957,7 @@ en:
           <li>date of birth</li>
           <li>email address (personal or school)</li>
           <li>start date at your school</li>
-          <li>previous school's name</li>
+          <li>previous school’s name</li>
         </ul>
       add-participant-dqt-mismatch-mentor_html: |
         <p class="govuk-body">Include their:</p>
@@ -967,7 +967,7 @@ en:
           <li>date of birth</li>
           <li>email address (personal or school)</li>
           <li>start date at your school</li>
-          <li>previous school's name</li>
+          <li>previous school’s name</li>
         </ul>
       partnership-already-challenged_html: |
         <p class="govuk-body">Tell us:</p>
@@ -983,9 +983,9 @@ en:
       change-participant-lead-provider: Request to change lead provider for a participant profile
       change-participant-date-of-birth: Request to change Date of Birth for a participant profile
       change-participant-trn: Request to change TRN for a participant profile
-      change-cohort-lead-provider: Request to change lead provider for a cohort
-      change-cohort-delivery-partner: Request to change delivery partner for a cohort
-      change-cohort-induction-programme-choice: Request to change induction programme choice for a cohort
+      change-cohort-lead-provider: Request to change lead provider for an academic year
+      change-cohort-delivery-partner: Request to change delivery partner for an academic year
+      change-cohort-induction-programme-choice: Request to change induction programme choice for an academic year
       add-participant-requires-manual-transfer-ect: Request to add an ECT that requires a manual transfer
       add-participant-requires-manual-transfer-mentor: Request to add a mentor that requires a manual transfer
       add-participant-dqt-mismatch-ect: Request to add a mentor with a DQT mismatch

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -883,7 +883,7 @@ en:
       add-participant-requires-manual-transfer-mentor_html: "Complete this request form to register %{teacher_name} as a mentor at your school."
       add-participant-dqt-mismatch-ect_html: "Complete this request form to register %{teacher_name} as an ECT at your school."
       add-participant-dqt-mismatch-mentor_html:  "Complete this request form to register %{teacher_name} as a mentor at your school."
-
+      partnership-issue_html: "If you there is an issue with %{cohort_year_range}'s partnership, you can contact the DfE using this form."
 
     instructions:
       unspecified_html: ""
@@ -968,6 +968,7 @@ en:
           <li>start date at your school</li>
           <li>previous school's name</li>
         </ul>
+      partnership-issue_html: "Tell us the delivery partner and lead provider your school will be working with."
 
   support_query:
     subjects:
@@ -982,3 +983,4 @@ en:
       add-participant-requires-manual-transfer-mentor: Request to add a mentor that requires a manual transfer
       add-participant-dqt-mismatch-ect: Request to add a mentor with a DQT mismatch
       add-participant-dqt-mismatch-mentor: Request to add a mentor with a DQT mismatch
+      partnership-issue: SIT reporting issue with a partnership

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -861,6 +861,11 @@ en:
           submit: "View"
 
   support_form:
+    title:
+      unspecified: Contact support
+      add-participant-requires-manual-transfer: "Contact Support: You cannot add %{teacher_name}"
+      add-participant-dqt-mismatch-ect: "Contact Support: You cannot add %{teacher_name}"
+      add-participant-dqt-mismatch-mentor: "Contact Support: You cannot add %{teacher_name}"
     introduction:
       unspecified_html: "If you have a question about the Manage training for early career teachers service, you can contact the DfE using this form."
       trouble-nominating-induction-coordinator_html: "Complete this form to request a change to %{school_name}'s induction coordinator."
@@ -873,6 +878,13 @@ en:
         Complete this form to tell us that you want to use a different training programme option for ECTs and mentors who started their training in the %{cohort_year_range} academic year.
         <br><br>
         You can view your options here: <a class="govuk-link" target="_blank" rel="noopener noreferrer" href="https://www.gov.uk/guidance/how-to-set-up-training-for-early-career-teachers#choose-a-training-option">https://www.gov.uk/guidance/how-to-set-up-training-for-early-career-teachers#choose-a-training-option</a>.
+
+      add-participant-requires-manual-transfer-ect_html: "Complete this request form to register %{teacher_name} as an ECT at your school."
+      add-participant-requires-manual-transfer-mentor_html: "Complete this request form to register %{teacher_name} as a mentor at your school."
+      add-participant-dqt-mismatch-ect_html: "Complete this request form to register %{teacher_name} as an ECT at your school."
+      add-participant-dqt-mismatch-mentor_html:  "Complete this request form to register %{teacher_name} as a mentor at your school."
+
+
     instructions:
       unspecified_html: ""
       trouble-nominating-induction-coordinator_html: |
@@ -906,6 +918,56 @@ en:
           <li>the confirmed date when the programme will change for ECTs (and their mentors if relevant)</li>
           <li>the years you want to apply the change to (year 1, year 2, or both years)</li>
         </ul>
+      add-participant-requires-manual-transfer-ect_html: |
+        <p class="govuk-body">Include their:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>full name</li>
+          <li>teacher reference number (TRN)</li>
+          <li>date of birth</li>
+          <li>email address (personal or school)</li>
+          <li>start date at your school</li>
+          <li>previous school's name</li>
+        </ul>
+
+        <p class="govuk-body">Tell us:
+          <li>how they'll continue their ECF-based training at your school (for example, with a DfE-funded training provider)</li>
+          <li>which lead provider and delivery partner you've chosen for their training, if applicable</li>
+        </ul>
+      add-participant-requires-manual-transfer-mentor_html: |
+        <p class="govuk-body">Include their:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>full name</li>
+          <li>teacher reference number (TRN)</li>
+          <li>date of birth</li>
+          <li>email address (personal or school)</li>
+          <li>start date at your school</li>
+          <li>previous school's name</li>
+        </ul>
+
+        <p class="govuk-body">Tell us:
+          <li>how they'll continue their ECF-based training at your school (for example, with a DfE-funded training provider)</li>
+          <li>which lead provider and delivery partner you've chosen for their training, if applicable</li>
+        </ul>
+      add-participant-dqt-mismatch-ect_html: |
+        <p class="govuk-body">Include their:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>full name</li>
+          <li>teacher reference number (TRN)</li>
+          <li>date of birth</li>
+          <li>email address (personal or school)</li>
+          <li>start date at your school</li>
+          <li>previous school's name</li>
+        </ul>
+      add-participant-dqt-mismatch-mentor_html: |
+        <p class="govuk-body">Include their:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>full name</li>
+          <li>teacher reference number (TRN)</li>
+          <li>date of birth</li>
+          <li>email address (personal or school)</li>
+          <li>start date at your school</li>
+          <li>previous school's name</li>
+        </ul>
 
   support_query:
     subjects:
@@ -916,3 +978,7 @@ en:
       change-cohort-lead-provider: Request to change lead provider for a cohort
       change-cohort-delivery-partner: Request to change delivery partner for a cohort
       change-cohort-induction-programme-choice: Request to change induction programme choice for a cohort
+      add-participant-requires-manual-transfer-ect: Request to add an ECT that requires a manual transfer
+      add-participant-requires-manual-transfer-mentor: Request to add a mentor that requires a manual transfer
+      add-participant-dqt-mismatch-ect: Request to add a mentor with a DQT mismatch
+      add-participant-dqt-mismatch-mentor: Request to add a mentor with a DQT mismatch

--- a/spec/requests/challenge_partnership_spec.rb
+++ b/spec/requests/challenge_partnership_spec.rb
@@ -36,14 +36,14 @@ RSpec.describe "Challenging a partnership", type: :request do
       it "redirects to already-challenged" do
         get "/report-incorrect-partnership", params: { token: partnership_notification_email.token }
 
-        expect(response).to redirect_to(/\/report-incorrect-partnership\/already-challenged\?school_name=.*/)
+        expect(response).to redirect_to(/\/report-incorrect-partnership\/already-challenged\?cohort=.*&school_id=.*&school_name=.*/)
       end
 
       it "redirects to already-challenged even if the token has expired" do
         travel 15.days
         get "/report-incorrect-partnership", params: { token: partnership_notification_email.token }
 
-        expect(response).to redirect_to(/\/report-incorrect-partnership\/already-challenged\?school_name=.*/)
+        expect(response).to redirect_to(/\/report-incorrect-partnership\/already-challenged\?cohort=.*&school_id=.*&school_name=.*/)
       end
     end
   end
@@ -76,14 +76,14 @@ RSpec.describe "Challenging a partnership", type: :request do
       it "redirects to already-challenged" do
         get "/report-incorrect-partnership", params: { partnership: partnership.id }
 
-        expect(response).to redirect_to(/\/report-incorrect-partnership\/already-challenged\?school_name=.*/)
+        expect(response).to redirect_to(/\/report-incorrect-partnership\/already-challenged\?cohort=.*&school_id=.*&school_name=.*/)
       end
 
       it "redirect to already-challenged even if it is outside the challenge window" do
         travel 15.days
         get "/report-incorrect-partnership", params: { partnership: partnership.id }
 
-        expect(response).to redirect_to(/\/report-incorrect-partnership\/already-challenged\?school_name=.*/)
+        expect(response).to redirect_to(/\/report-incorrect-partnership\/already-challenged\?cohort=.*&school_id=.*&school_name=.*/)
       end
     end
   end

--- a/spec/requests/nominations/nominate_induction_coordinator_spec.rb
+++ b/spec/requests/nominations/nominate_induction_coordinator_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe "Nominating an induction coordinator", type: :request do
       context "when an induction coordinator already exists with the provided email" do
         let!(:existing_induction_coordinator) { create(:user, :induction_coordinator, email:) }
 
-        it "redirects to the name-different page when the form name does not match our records" do
+        it "does not set the coordinator" do
           expect {
             put "/nominations/email", params: { nominate_induction_tutor_form: {
               full_name: "Different Name",
@@ -169,13 +169,16 @@ RSpec.describe "Nominating an induction coordinator", type: :request do
 
           expect(existing_induction_coordinator.schools.count).to eql 1
           expect(existing_induction_coordinator.schools).not_to include nomination_email.school
+
+          expect(response).to render_template("nominations/nominate_induction_coordinator/email")
+          expect(response.body).to include(CGI.escapeHTML("There is a problem"))
         end
       end
 
       context "when an ECT user already exists with the provided email" do
         let!(:existing_user) { create(:ect_participant_profile, user: create(:user, email:)).user }
 
-        it "redirects to the email-used page" do
+        it "does not set the coordinator" do
           expect {
             put "/nominations/email", params: { nominate_induction_tutor_form: {
               full_name: name,
@@ -183,6 +186,9 @@ RSpec.describe "Nominating an induction coordinator", type: :request do
               token:,
             } }
           }.not_to(change { User.count })
+
+          expect(response).to render_template("nominations/nominate_induction_coordinator/email")
+          expect(response.body).to include(CGI.escapeHTML("There is a problem"))
         end
       end
     end

--- a/spec/requests/schools/partnerships_spec.rb
+++ b/spec/requests/schools/partnerships_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe "Schools::Partnerships", type: :request do
 
             expect(response.body).not_to include("This link will expire on")
             expect(response.body).not_to include("?token=abc123")
-            expect(response.body).to include("contact: ")
+            expect(response.body).to include("contact support")
           end
         end
       end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CST-2166

### Changes proposed in this pull request

Add support forms for the following situations:

(1) The nominate induction coordinator flow has a link to contact us via email if a tutor has already been nominated with a given email address with a different name.

(2) The add participants flow has multiple points where the user is directed to contact us via email where the SIT reaches a point where a user cannot be added. For example:

When they need manually transferring.

When there's a mismatch.

When there is a data mismatch with TRA.

(3) Viewing partnership details page displays a link to contact us via email if the partnership has been created and is outside the challenge window.

(4) On a couple pages related to challenging partnerships there is a link to contact us via email. (When the user is being told a partnership has already been challenged or when their link has expired.

