### PR TITLE
Fix participant query filtering by cohort

### DIFF
--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -7,6 +7,14 @@ weight: 8
 
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
 
+## 6 February 2024
+
+We’ve done an update to ensure that early career teacher (ECT) participant records only ever appear in one cohort. 
+
+Some providers had found it confusing because participants who’d moved cohort were appearing multiple times when they filtered by cohort in the ‘GET participants’ endpoint. 
+
+Training providers will now only see the ECT in the latest cohort they’ve been assigned to.
+
 ## 30 January 2024
 
 We’ve fixed an issue with merging duplicate user accounts that meant existing declarations were not being redirected to the newly merged account correctly.

--- a/spec/services/api/v3/ecf/participants_query_spec.rb
+++ b/spec/services/api/v3/ecf/participants_query_spec.rb
@@ -49,15 +49,16 @@ RSpec.describe Api::V3::ECF::ParticipantsQuery do
         let(:new_cohort) { Cohort.next }
 
         before do
+          partnership = create(:partnership,
+                               school: induction_record.school,
+                               lead_provider:,
+                               cohort: new_cohort,
+                               relationship: false)
+          default_induction_programme = create(:induction_programme, :fip, partnership:)
           create(:school_cohort,
-                 default_induction_programme: induction_programme,
+                 default_induction_programme:,
                  school: induction_record.school,
                  cohort: new_cohort)
-          create(:partnership,
-                 school: induction_record.school,
-                 lead_provider:,
-                 cohort: new_cohort,
-                 relationship: false)
           new_schedule = create(:ecf_schedule, name: "new-schedule", cohort: new_cohort)
 
           ChangeSchedule.new({

--- a/spec/services/api/v3/ecf/participants_query_spec.rb
+++ b/spec/services/api/v3/ecf/participants_query_spec.rb
@@ -47,16 +47,26 @@ RSpec.describe Api::V3::ECF::ParticipantsQuery do
 
       context "when the user has induction records against multiple cohorts" do
         let(:new_cohort) { Cohort.next }
-        let(:new_schedule) { create(:schedule, name: "new-schedule", cohort: new_cohort) }
 
         before do
-          Induction::ChangeInductionRecord.call(
-            induction_record:,
-            changes: {
-              schedule: new_schedule,
-              induction_programme:,
-            },
-          )
+          create(:school_cohort,
+                 default_induction_programme: induction_programme,
+                 school: induction_record.school,
+                 cohort: new_cohort)
+          create(:partnership,
+                 school: induction_record.school,
+                 lead_provider:,
+                 cohort: new_cohort,
+                 relationship: false)
+          new_schedule = create(:ecf_schedule, name: "new-schedule", cohort: new_cohort)
+
+          ChangeSchedule.new({
+            cpd_lead_provider:,
+            participant_id: participant_profile.participant_identity.external_identifier,
+            course_identifier: "ecf-induction",
+            schedule_identifier: new_schedule.schedule_identifier,
+            cohort: new_cohort.start_year,
+          }).call
         end
 
         context "when filtering by a historical cohort" do


### PR DESCRIPTION
### Context

Currently, if we filter by cohort the participants query will return a user if _any_ of their induction records have a schedule with that cohort.

Instead, we only want to return a user if their **latest** induction record schedule has the matching cohort.

### Changes proposed in this pull request

- Fix participant query filtering by cohort

Remove `where` clause from `latest_induction_record_query` and apply it in the `participants_for_pagination` (after joining on the latest induction record). 

Remove cohort filtering from `participants_from` method as this always receives the `participants_for_pagination` result as its argument and so the filtering is already applied.

- Switch specs to use ChangeSchedule service

The setup for this is way more verbose, but its probably a better solution in case that service ever changes behaviour.

### Guidance to review

I compared this branch against `main` when querying the participants by cohort for the same lead provider on the snapshot DB and it seems to add in the region of 3-500ms to the response time (though the tests were far from scientific!).

Based on Mook's spike #4286 