### PR TITLE
CPLD-2748 Update declarations when transferring identities

### DIFF
--- a/app/services/identity/transfer.rb
+++ b/app/services/identity/transfer.rb
@@ -27,8 +27,9 @@ module Identity
 
       from_user.participant_identities.each do |identity|
         identity.update!(user: to_user)
-        identity.participant_profiles.each do |profile|
-          profile.update!(teacher_profile:)
+        identity.participant_profiles.each do |participant_profile|
+          participant_profile.update!(teacher_profile:)
+          transfer_declarations!(participant_profile:)
         end
       end
     end
@@ -57,6 +58,12 @@ module Identity
         from_user.update_attribute(:get_an_identity_id, nil) # rubocop:disable Rails/SkipsModelValidations
         to_user.update!(get_an_identity_id: from_id)
       end
+    end
+
+    def transfer_declarations!(participant_profile:)
+      return unless participant_profile.participant_declarations
+
+      participant_profile.participant_declarations.update!(user: to_user)
     end
 
     def create_participant_id_change!

--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -7,6 +7,14 @@ weight: 8
 
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
 
+## 30 January 2024
+
+We’ve fixed an issue with merging duplicate user accounts that meant existing declarations were not being redirected to the newly merged account correctly.
+
+Participant records in merged accounts will now point to the right declarations in the [ECF](/api-reference/reference-v3.html#api-v3-participants-ecf-get) and [NPQ](/api-reference/reference-v3.html#api-v3-participants-npq-get) GET participant endpoints.
+
+This will ensure that all participant declarations are consistent.
+
 ## 17 January 2024
 
 We’ve fixed a bug that had prevented some providers from changing schedules for participants they are training who have not been registered in a default partnership. In such instances they’d have seen the following 422 error message:

--- a/spec/services/identity/transfer_spec.rb
+++ b/spec/services/identity/transfer_spec.rb
@@ -43,6 +43,21 @@ RSpec.describe Identity::Transfer do
           expect(user2.teacher_profile.participant_profiles).to match_array [participant_profile]
         end
       end
+
+      context "when the previous user has declarations" do
+        let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
+        let!(:participant_profile) { create(:ect, lead_provider: cpd_lead_provider.lead_provider, user: user1) }
+        let!(:declaration) { create(:ect_participant_declaration, participant_profile:, user: user1, cpd_lead_provider:) }
+        let!(:another_participant_profile) { create(:mentor, lead_provider: cpd_lead_provider.lead_provider, user: user1) }
+        let!(:another_declaration) { create(:mentor_participant_declaration, participant_profile: another_participant_profile, user: user1, cpd_lead_provider:) }
+
+        it "moves the declarations to the new user" do
+          service.call(from_user: user1, to_user: user2)
+
+          expect(declaration.reload.user).to eq(user2)
+          expect(another_declaration.reload.user).to eq(user2)
+        end
+      end
     end
 
     context "when the from user is an induction coordinator" do


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-2748

To ensure participant declarations are consistent with profile users when transferring identities, update the user id on any declarations attached to transferred profiles.

### Changes proposed in this pull request
For each profile attached to a transferred identity, update participant declaration user id as well

### Guidance to review

