### PR TITLE
[CST-2265] (part 2) Add services and queries to support bulk mailer for AB comms

### DIFF
--- a/app/models/induction_record.rb
+++ b/app/models/induction_record.rb
@@ -92,8 +92,10 @@ class InductionRecord < ApplicationRecord
   end
 
   # Instance Methods
-  # appropriate_body_name
-  delegate :name, to: :appropriate_body, allow_nil: true, prefix: true
+
+  def appropriate_body_name
+    appropriate_body&.name || school_cohort.appropriate_body&.name
+  end
 
   def active?
     active_induction_status? && (end_unknown? || end_date.future?) && !transferring_in?

--- a/app/models/induction_record.rb
+++ b/app/models/induction_record.rb
@@ -92,10 +92,8 @@ class InductionRecord < ApplicationRecord
   end
 
   # Instance Methods
-
-  def appropriate_body_name
-    appropriate_body&.name || school_cohort.appropriate_body&.name
-  end
+  # appropriate_body_name
+  delegate :name, to: :appropriate_body, allow_nil: true, prefix: true
 
   def active?
     active_induction_status? && (end_unknown? || end_date.future?) && !transferring_in?

--- a/app/queries/ects/with_an_appropriate_body_and_unregistered_query.rb
+++ b/app/queries/ects/with_an_appropriate_body_and_unregistered_query.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Ects
+  class WithAnAppropriateBodyAndUnregisteredQuery < BaseService
+    def call
+      InductionRecord
+        .active
+        .training_status_active
+        .joins(:participant_profile)
+        .where(participant_profile: { induction_start_date: nil, type: "ParticipantProfile::ECT" })
+        .joins(induction_programme: :school_cohort)
+        .where(induction_programme: { training_programme: training_programme_types })
+        .where("induction_records.appropriate_body_id IS NOT NULL OR school_cohorts.appropriate_body_id IS NOT NULL")
+    end
+
+  private
+
+    attr_reader :include_fip, :include_cip
+
+    def initialize(include_fip: true, include_cip: true)
+      @include_fip = include_fip
+      @include_cip = include_cip
+    end
+
+    def training_programme_types
+      training_programmes = []
+      training_programmes << "full_induction_programme" if include_fip
+      training_programmes << "core_induction_programme" if include_cip
+      training_programmes
+    end
+  end
+end

--- a/app/queries/ects/without_an_appropriate_body_and_unregistered_query.rb
+++ b/app/queries/ects/without_an_appropriate_body_and_unregistered_query.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Ects
+  class WithoutAnAppropriateBodyAndUnregisteredQuery < BaseService
+    def call
+      InductionRecord
+        .active
+        .training_status_active
+        .joins(:participant_profile)
+        .where(participant_profile: { induction_start_date: nil, type: "ParticipantProfile::ECT" })
+        .joins(induction_programme: :school_cohort)
+        .where(induction_programme: { training_programme: training_programme_types })
+        .where(appropriate_body_id: nil)
+        .where(school_cohort: { appropriate_body_id: nil })
+    end
+
+  private
+
+    attr_reader :include_fip, :include_cip
+
+    def initialize(include_fip: true, include_cip: true)
+      @include_fip = include_fip
+      @include_cip = include_cip
+    end
+
+    def training_programme_types
+      training_programmes = []
+      training_programmes << "full_induction_programme" if include_fip
+      training_programmes << "core_induction_programme" if include_cip
+      training_programmes
+    end
+  end
+end

--- a/app/services/bulk_mailers/school_reminder_comms.rb
+++ b/app/services/bulk_mailers/school_reminder_comms.rb
@@ -21,7 +21,7 @@ module BulkMailers
         .find_each do |induction_record|
           ect_name = induction_record.user.full_name
           school = induction_record.school
-          appropriate_body_name = induction_record.appropriate_body_name
+          appropriate_body_name = appropriate_body_name(induction_record)
           lead_provider_name = induction_record.lead_provider_name
           delivery_partner_name = induction_record.delivery_partner_name
 
@@ -204,6 +204,10 @@ module BulkMailers
     def opt_in_out_url(email:, school:)
       Rails.application.routes.url_helpers.choose_how_to_continue_url(token: nomination_token(email:, school:),
                                                                       host: Rails.application.config.domain)
+    end
+
+    def appropriate_body_name(induction_record)
+      induction_record.appropriate_body&.name || induction_record.school_cohort.appropriate_body&.name
     end
   end
 end

--- a/spec/queries/ects/with_an_appropriate_body_and_unregistered_query_spec.rb
+++ b/spec/queries/ects/with_an_appropriate_body_and_unregistered_query_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Ects::WithAnAppropriateBodyAndUnregisteredQuery do
+  describe "#call" do
+    let(:fip_ab) { create(:seed_appropriate_body, :valid) }
+    let(:cip_ab) { create(:seed_appropriate_body, :valid) }
+
+    let(:fip_school_cohort) { create(:seed_school_cohort, :fip, :valid, appropriate_body: fip_ab) }
+    let(:cip_school_cohort) { create(:seed_school_cohort, :cip, :valid, appropriate_body: cip_ab) }
+    let(:fip_induction_programme) { create(:seed_induction_programme, :fip, school_cohort: fip_school_cohort) }
+    let(:cip_induction_programme) { create(:seed_induction_programme, :cip, school_cohort: cip_school_cohort) }
+
+    let(:fip_participant_profile) { create(:seed_ect_participant_profile, :valid, school_cohort: fip_school_cohort) }
+    let(:cip_participant_profile) { create(:seed_ect_participant_profile, :valid, school_cohort: cip_school_cohort) }
+
+    let(:include_fip) { true }
+    let(:include_cip) { true }
+
+    let!(:fip_induction_record) do
+      create(:seed_induction_record, :valid, participant_profile: fip_participant_profile, induction_programme: fip_induction_programme)
+    end
+
+    let!(:cip_induction_record) do
+      create(:seed_induction_record, :valid, participant_profile: cip_participant_profile, induction_programme: cip_induction_programme)
+    end
+
+    subject(:query_result) { described_class.call(include_fip:, include_cip:) }
+
+    context "when there are ECTs without induction start dates" do
+      context "when the school has an AB selected" do
+        it "returns the induction records for the participants without induction start dates" do
+          expect(query_result).to match_array [fip_induction_record, cip_induction_record]
+        end
+
+        context "when CIP is not included" do
+          let(:include_cip) { false }
+
+          it "does not return CIP participants" do
+            expect(query_result).to match_array [fip_induction_record]
+          end
+        end
+
+        context "when FIP is not included" do
+          let(:include_fip) { false }
+
+          it "does not return FIP participants" do
+            expect(query_result).to match_array [cip_induction_record]
+          end
+        end
+      end
+
+      context "when the participant has an AB selected" do
+        before do
+          fip_induction_record.update!(appropriate_body: fip_ab)
+          cip_induction_record.update!(appropriate_body: cip_ab)
+          fip_school_cohort.update!(appropriate_body: nil)
+          cip_school_cohort.update!(appropriate_body: nil)
+        end
+
+        it "returns the induction records for the participants without induction start dates" do
+          expect(query_result).to match_array [fip_induction_record, cip_induction_record]
+        end
+
+        context "when CIP is not included" do
+          let(:include_cip) { false }
+
+          it "does not return CIP participants" do
+            expect(query_result).to match_array [fip_induction_record]
+          end
+        end
+
+        context "when FIP is not included" do
+          let(:include_fip) { false }
+
+          it "does not return FIP participants" do
+            expect(query_result).to match_array [cip_induction_record]
+          end
+        end
+      end
+
+      context "when an AB is not selected" do
+        let(:fip_ab) { nil }
+
+        it "does not return participants" do
+          expect(query_result).to match_array [cip_induction_record]
+        end
+      end
+    end
+
+    context "when there are ECTs with induction start dates" do
+      before do
+        cip_participant_profile.update!(induction_start_date: 1.week.ago)
+      end
+
+      it "does not return those participants" do
+        expect(query_result).to match_array [fip_induction_record]
+      end
+    end
+  end
+end

--- a/spec/queries/ects/without_an_appropriate_body_and_unregistered_query_spec.rb
+++ b/spec/queries/ects/without_an_appropriate_body_and_unregistered_query_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Ects::WithoutAnAppropriateBodyAndUnregisteredQuery do
+  describe "#call" do
+    let(:fip_school_cohort) { create(:seed_school_cohort, :fip, :valid) }
+    let(:cip_school_cohort) { create(:seed_school_cohort, :cip, :valid) }
+    let(:fip_induction_programme) { create(:seed_induction_programme, :fip, school_cohort: fip_school_cohort) }
+    let(:cip_induction_programme) { create(:seed_induction_programme, :cip, school_cohort: cip_school_cohort) }
+
+    let(:fip_participant_profile) { create(:seed_ect_participant_profile, :valid, school_cohort: fip_school_cohort) }
+    let(:cip_participant_profile) { create(:seed_ect_participant_profile, :valid, school_cohort: cip_school_cohort) }
+
+    let(:include_fip) { true }
+    let(:include_cip) { true }
+
+    let!(:fip_induction_record) do
+      create(:seed_induction_record, :valid, participant_profile: fip_participant_profile, induction_programme: fip_induction_programme)
+    end
+
+    let!(:cip_induction_record) do
+      create(:seed_induction_record, :valid, participant_profile: cip_participant_profile, induction_programme: cip_induction_programme)
+    end
+
+    subject(:query_result) { described_class.call(include_fip:, include_cip:) }
+
+    context "when there are ECTs without induction start dates" do
+      context "when no AB is selected" do
+        it "returns the induction records for the participants without induction start dates" do
+          expect(query_result).to match_array [fip_induction_record, cip_induction_record]
+        end
+
+        context "when CIP is not included" do
+          let(:include_cip) { false }
+
+          it "does not return CIP participants" do
+            expect(query_result).to match_array [fip_induction_record]
+          end
+        end
+
+        context "when FIP is not included" do
+          let(:include_fip) { false }
+
+          it "does not return FIP participants" do
+            expect(query_result).to match_array [cip_induction_record]
+          end
+        end
+      end
+
+      context "when the school has an AB" do
+        before do
+          fip_school_cohort.update!(appropriate_body: create(:seed_appropriate_body, :valid))
+        end
+
+        it "does not return those participants" do
+          expect(query_result).to match_array [cip_induction_record]
+        end
+      end
+
+      context "when the participant has an AB" do
+        before do
+          cip_induction_record.update!(appropriate_body: create(:seed_appropriate_body, :valid))
+        end
+
+        it "does not return those participants" do
+          expect(query_result).to match_array [fip_induction_record]
+        end
+      end
+    end
+
+    context "when there are ECTs with induction start dates" do
+      before do
+        cip_participant_profile.update!(induction_start_date: 1.week.ago)
+      end
+
+      it "does not return those participants" do
+        expect(query_result).to match_array [fip_induction_record]
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-2265)
Second part of this to add the queries and methods to the `BulkMailer::SchoolReminderComms` service to support the mailers to SITs for participants without a registered induction

### Changes proposed in this pull request
Adds new query objects
Updates the bulk mailer to add methods for sending the AB related comms to SITs.

### Guidance to review

