### PR TITLE
Prevent duplicate NPQ applications from being created

### DIFF
--- a/app/models/npq_application.rb
+++ b/app/models/npq_application.rb
@@ -129,9 +129,11 @@ class NPQApplication < ApplicationRecord
   end
 
   def save_and_dedupe_participant
-    result = save
-    NPQ::DedupeParticipant.new(npq_application: self, trn: teacher_reference_number).call if result
-    result
+    ActiveRecord::Base.transaction do
+      result = save
+      NPQ::DedupeParticipant.new(npq_application: self, trn: teacher_reference_number).call if result
+      result
+    end
   end
 
 private


### PR DESCRIPTION
### Context

[Jira-2750](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-2750)

The NPQ registration application calls an internal API in ECF that will create an application. At the moment, the `NPQApplication` is persisted and then the user is deduped. Its possible for the deduping process to raise an
exception; if this happens the application will have been persisted but the API will return a non-200 response. This causes the NPQ registration app to retry the application creation and results in a duplicate record.

Instead, we want to wrap this operation in a transaction so that if any part of the application creation or dedupe process fails the changes made will not be persisted and the NPQ registration service can safely retry the
operation.

### Changes proposed in this pull request

- Prevent duplicate NPQ applications from being created

Also adds test coverage for the `save_and_dedupe_participant` method.

### Guidance to review

