### PR TITLE
Upgrade govuk_design_system_formbuilder to 5.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ gem "mail-notify", "~> 1.2"
 gem "tzinfo-data"
 
 gem "govuk-components", "~> 5.0.1"
-gem "govuk_design_system_formbuilder", "~> 4.1.1"
+gem "govuk_design_system_formbuilder", "~> 5.0.0"
 gem "view_component", require: "view_component/engine"
 
 # Fetching from APIs

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,7 +244,7 @@ GEM
       html-attributes-utils (~> 1.0.0, >= 1.0.0)
       pagy (~> 6.0)
       view_component (>= 3.9, < 3.10)
-    govuk_design_system_formbuilder (4.1.1)
+    govuk_design_system_formbuilder (5.0.0)
       actionview (>= 6.1)
       activemodel (>= 6.1)
       activesupport (>= 6.1)
@@ -668,7 +668,7 @@ DEPENDENCIES
   google-cloud-bigquery
   googleauth
   govuk-components (~> 5.0.1)
-  govuk_design_system_formbuilder (~> 4.1.1)
+  govuk_design_system_formbuilder (~> 5.0.0)
   httpclient (~> 2.8, >= 2.8.3)
   jsbundling-rails
   json-diff (~> 0.4.1)


### PR DESCRIPTION
Nothing really changed form builder wise between 4.7 and 5.0.