### PR TITLE
[CST-1878] - Display archived records

### DIFF
--- a/app/presenters/archive/participant_identity_presenter.rb
+++ b/app/presenters/archive/participant_identity_presenter.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
 module Archive
-  class ParticipantIdentityPresenter < RelicPresenter; end
+  class ParticipantIdentityPresenter < RelicPresenter
+    def email
+      @email ||= attribute("email")
+    end
+  end
 end

--- a/app/views/admin/archive/relics/show.html.erb
+++ b/app/views/admin/archive/relics/show.html.erb
@@ -18,6 +18,11 @@
     <% row.with_key { "Roles" } %>
     <% row.with_value { @presenter.roles } %>
   <% end %>
+
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Archive reason" } %>
+    <% row.with_value { @relic.reason } %>
+  <% end %>
 <% end %>
 
 <% if @presenter.type == "user" %>

--- a/spec/presenters/archive/participant_identity_presenter_spec.rb
+++ b/spec/presenters/archive/participant_identity_presenter_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Archive::ParticipantIdentityPresenter do
+  include ArchiveHelper
+
+  let(:participant_identity) { create(:seed_participant_identity, :valid) }
+  # to JSON and parse back to ensure keys are strings not symbols
+  let(:serialized_data) { JSON.parse(Archive::ParticipantIdentitySerializer.new(participant_identity).serializable_hash.to_json)["data"] }
+  subject(:presenter) { described_class.new(serialized_data) }
+
+  describe "#email" do
+    it "returns the email" do
+      expect(presenter.email).to eq participant_identity.email
+    end
+  end
+
+  describe "#external_identifier" do
+    it "returns the external_identifier" do
+      expect(presenter.external_identifier).to eq participant_identity.external_identifier
+    end
+  end
+
+  describe "#origin" do
+    it "returns the origin" do
+      expect(presenter.origin).to eq participant_identity.origin
+    end
+  end
+
+  describe "#created_at" do
+    it "returns the creation date" do
+      expect(Time.zone.parse(presenter.created_at)).to be_within(1.second).of participant_identity.created_at
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-1878)
- This ticket was left to mop up a few tweaks to the view of an archived participant.  It surfaces the archive reason in the details view and also fixes an issue where email addresses for identity records weren't being displayed correctly.

### Changes proposed in this pull request
Add archive reason
Fix issue with displaying email addresses on archived participant identity records

### Guidance to review

