### PR TITLE
[CST-2181] Build automated emails admin dashboard

### DIFF
--- a/app/controllers/admin/performance/email_schedules_controller.rb
+++ b/app/controllers/admin/performance/email_schedules_controller.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+class Admin::Performance::EmailSchedulesController < Admin::BaseController
+  skip_after_action :verify_authorized
+  skip_after_action :verify_policy_scoped
+  before_action :set_email_schedule, only: %i[show edit update delete]
+
+  def index
+    @upcoming_emails = EmailSchedule.queued.order(:scheduled_at)
+    @recently_sent = EmailSchedule.where.not(status: :queued).order(scheduled_at: :desc).limit(20)
+  end
+
+  def show; end
+
+  def new
+    @email_schedule = EmailSchedule.new
+  end
+
+  def edit; end
+
+  def create
+    @email_schedule = EmailSchedule.new(email_schedule_params)
+
+    if @email_schedule.save
+      set_success_message content: "Email has been scheduled"
+      redirect_to admin_performance_email_schedules_url
+    else
+      render :new
+    end
+  end
+
+  def update
+    if @email_schedule.update(email_schedule_params)
+      set_success_message content: "Email scheduled has been updated"
+      redirect_to admin_performance_email_schedules_url
+    else
+      render :edit
+    end
+  end
+
+  def delete
+    @email_schedule.destroy!
+    redirect_to admin_performance_email_schedules_url, status: :see_other
+  end
+
+private
+
+  def set_email_schedule
+    @email_schedule = EmailSchedule.find(params[:id])
+  end
+
+  def email_schedule_params
+    params.fetch(:email_schedule, {}).permit(:mailer_name, :scheduled_at)
+  end
+end

--- a/app/controllers/admin/performance/email_schedules_controller.rb
+++ b/app/controllers/admin/performance/email_schedules_controller.rb
@@ -6,8 +6,8 @@ class Admin::Performance::EmailSchedulesController < Admin::BaseController
   before_action :set_email_schedule, only: %i[show edit update destroy]
 
   def index
-    @upcoming_emails = EmailSchedule.queued.order(:scheduled_at)
-    @recently_sent = EmailSchedule.where.not(status: :queued).order(scheduled_at: :desc).limit(20)
+    @upcoming_emails = EmailSchedule.upcoming_emails
+    @recently_sent = EmailSchedule.recently_sent
   end
 
   def show; end

--- a/app/controllers/admin/performance/email_schedules_controller.rb
+++ b/app/controllers/admin/performance/email_schedules_controller.rb
@@ -3,7 +3,7 @@
 class Admin::Performance::EmailSchedulesController < Admin::BaseController
   skip_after_action :verify_authorized
   skip_after_action :verify_policy_scoped
-  before_action :set_email_schedule, only: %i[show edit update delete]
+  before_action :set_email_schedule, only: %i[show edit update destroy]
 
   def index
     @upcoming_emails = EmailSchedule.queued.order(:scheduled_at)
@@ -38,9 +38,10 @@ class Admin::Performance::EmailSchedulesController < Admin::BaseController
     end
   end
 
-  def delete
+  def destroy
     @email_schedule.destroy!
-    redirect_to admin_performance_email_schedules_url, status: :see_other
+    set_success_message(content: "Email schedule deleted", title: "Success")
+    redirect_to admin_performance_email_schedules_url
   end
 
 private

--- a/app/helpers/admin/performance/email_schedules_helper.rb
+++ b/app/helpers/admin/performance/email_schedules_helper.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Admin::Performance::EmailSchedulesHelper
+  def email_schedule_bounced(email_schedule)
+    bounced_count = Email.failed.associated_with(email_schedule).count
+    sent_count = email_schedule.emails_sent_count
+
+    percentage = calculate_percentage(bounced_count, sent_count)
+
+    "#{bounced_count} (#{percentage}%)"
+  end
+
+  def email_schedule_sent(email_schedule)
+    pluralize(number_with_delimiter(email_schedule.emails_sent_count), "email")
+  end
+
+  def email_schedule_estimated(email_schedule)
+    cohort = Cohort.containing_date(email_schedule.scheduled_at)
+
+    estimate_count = BulkMailers::SchoolReminderComms
+      .new(cohort:, dry_run: true)
+      .send(email_schedule.mailer_method)
+
+    pluralize(number_with_delimiter(estimate_count), "email")
+  end
+
+  def calculate_percentage(part, whole)
+    return 0 if whole.to_f.zero? # Prevent division by zero
+
+    ((part.to_f / whole) * 100).round(2)
+  end
+end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -115,4 +115,10 @@ module AdminHelper
     policy(participant_presenter.participant_profile).edit_induction_status? &&
       %w[withdrawn leaving].include?(participant_presenter.relevant_induction_record&.induction_status)
   end
+
+  def govuk_link_to_notify(text, template_id)
+    template_url = "https://www.notifications.service.gov.uk/services/d1207ebf-ac0c-47b8-b1bf-16dc899e0923/templates/#{template_id}"
+
+    govuk_link_to(text, template_url, target: "_blank")
+  end
 end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -121,4 +121,10 @@ module AdminHelper
 
     govuk_link_to(text, template_url, target: "_blank")
   end
+
+  def estimate_bulk_emails_count(email_schedule)
+    BulkMailers::SchoolReminderComms
+      .new(cohort: Cohort.containing_date(email_schedule.scheduled_at), dry_run: true)
+      .send(email_schedule.mailer_method)
+  end
 end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -127,4 +127,8 @@ module AdminHelper
       .new(cohort: Cohort.containing_date(email_schedule.scheduled_at), dry_run: true)
       .send(email_schedule.mailer_method)
   end
+
+  def bounced_bulk_emails_count(email_schedule)
+    Email.failed.associated_with(email_schedule).count
+  end
 end

--- a/app/jobs/admin/mail_schedule_job.rb
+++ b/app/jobs/admin/mail_schedule_job.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Admin::MailScheduleJob < ApplicationJob
+  def perform
+    Admin::DailyEmailSchedulesProcessor.call
+  end
+end

--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -142,6 +142,7 @@ class SchoolMailer < ApplicationMailer
   def remind_sit_to_assign_mentors_to_ects_email
     induction_coordinator = params[:induction_coordinator]
     school = params[:school]
+    email_schedule = params[:email_schedule]
     school_name = school.name
     email_address = induction_coordinator.user.email
     name = induction_coordinator.user.full_name
@@ -156,12 +157,13 @@ class SchoolMailer < ApplicationMailer
         email_address:,
         school_name:,
       },
-    ).tag(:remind_sits_to_assign_mentors_to_ects).associate_with(induction_coordinator, as: :induction_coordinator_profile)
+    ).tag(:remind_sits_to_assign_mentors_to_ects).associate_with(email_schedule, induction_coordinator, as: :induction_coordinator_profile)
   end
 
   def remind_sit_to_add_ects_and_mentors_email
     induction_coordinator = params[:induction_coordinator]
     school = params[:school]
+    email_schedule = params[:email_schedule]
     school_name = school.name
     email_address = induction_coordinator.user.email
     name = induction_coordinator.user.full_name
@@ -176,7 +178,7 @@ class SchoolMailer < ApplicationMailer
         email_address:,
         school_name:,
       },
-    ).tag(:remind_sits_to_add_ects_and_mentors).associate_with(induction_coordinator, as: :induction_coordinator_profile)
+    ).tag(:remind_sits_to_add_ects_and_mentors).associate_with(email_schedule, induction_coordinator, as: :induction_coordinator_profile)
   end
 
   def cohortless_pilot_2023_survey_email
@@ -433,6 +435,7 @@ class SchoolMailer < ApplicationMailer
 
   def sit_needs_to_chase_partnership
     school = params[:school]
+    email_schedule = params[:email_schedule]
     induction_coordinator = school.induction_coordinators.first
     sit_name = induction_coordinator.full_name
     sit_email_address = induction_coordinator.email
@@ -450,7 +453,7 @@ class SchoolMailer < ApplicationMailer
     )
     email
       .tag(:sit_needs_to_chase_partnership)
-      .associate_with(induction_coordinator, as: :induction_coordinator)
+      .associate_with(email_schedule, induction_coordinator, as: :induction_coordinator)
   end
 
   ## Finance amendments mailers - One off mailers

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -10,6 +10,7 @@ class Email < ApplicationRecord
 
   scope :associated_with, ->(object) { where(id: Association.where(object:).select(:email_id)) }
   scope :tagged_with, ->(*tags) { tags.inject(self) { |scope, tag| scope.where("? = ANY (tags)", tag) } }
+  scope :failed, -> { where(status: FAILED_STATUSES) }
 
   FAILED_STATUSES = %w[permanent-failure temporary-failure technical-failure].freeze
 

--- a/app/models/email_schedule.rb
+++ b/app/models/email_schedule.rb
@@ -19,6 +19,8 @@ class EmailSchedule < ApplicationRecord
   }
 
   scope :to_send_today, -> { queued.where(scheduled_at: ..Date.current) }
+  scope :upcoming_emails, -> { queued.order(:scheduled_at) }
+  scope :recently_sent, -> { sending.or(sent).order(scheduled_at: :desc).limit(20) }
 
   def mailer_method
     MAILERS[mailer_name.to_sym]

--- a/app/models/email_schedule.rb
+++ b/app/models/email_schedule.rb
@@ -20,6 +20,10 @@ class EmailSchedule < ApplicationRecord
 
   scope :to_send_today, -> { queued.where(scheduled_at: ..Date.current) }
 
+  def mailer_method
+    MAILERS[mailer_name.to_sym]
+  end
+
 private
 
   def validate_future_schedule_date

--- a/app/services/admin/daily_email_schedules_processor.rb
+++ b/app/services/admin/daily_email_schedules_processor.rb
@@ -14,11 +14,11 @@ module Admin
       email_schedules.find_each do |email_schedule|
         email_schedule.sending!
 
-        BulkMailers::SchoolReminderComms
+        emails_sent = BulkMailers::SchoolReminderComms
           .new(cohort: Cohort.current, email_schedule:)
           .send(email_schedule.mailer_method)
 
-        email_schedule.sent!
+        email_schedule.update!(status: :sent, emails_sent_count: emails_sent.to_i)
       end
     end
   end

--- a/app/services/admin/daily_email_schedules_processor.rb
+++ b/app/services/admin/daily_email_schedules_processor.rb
@@ -12,12 +12,12 @@ module Admin
 
     def call
       email_schedules.find_each do |email_schedule|
-        mailer_name = email_schedule.mailer_name.to_sym
-        mailer_method = EmailSchedule::MAILERS[mailer_name]
-        cohort = Cohort.current
-
         email_schedule.sending!
-        BulkMailers::SchoolReminderComms.new(cohort:, email_schedule:).send(mailer_method)
+
+        BulkMailers::SchoolReminderComms
+          .new(cohort: Cohort.current, email_schedule:)
+          .send(email_schedule.mailer_method)
+
         email_schedule.sent!
       end
     end

--- a/app/services/admin/daily_email_schedules_processor.rb
+++ b/app/services/admin/daily_email_schedules_processor.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# This service doesn't have any  protections against triggering the mailers
+# multiple times. Does it need a safeguard to send each mailer only once?
+module Admin
+  class DailyEmailSchedulesProcessor < BaseService
+    attr_reader :email_schedules
+
+    def initialize
+      @email_schedules = EmailSchedule.to_send_today
+    end
+
+    def call
+      email_schedules.find_each do |email_schedule|
+        mailer_name = email_schedule.mailer_name.to_sym
+        mailer_method = EmailSchedule::MAILERS[mailer_name]
+        cohort = Cohort.current
+
+        email_schedule.sending!
+        BulkMailers::SchoolReminderComms.new(cohort:, email_schedule:).send(mailer_method)
+        email_schedule.sent!
+      end
+    end
+  end
+end

--- a/app/services/bulk_mailers/school_reminder_comms.rb
+++ b/app/services/bulk_mailers/school_reminder_comms.rb
@@ -4,12 +4,13 @@ module BulkMailers
   class SchoolReminderComms
     SCHOOL_TYPES_TO_INCLUDE = [1, 2, 3, 5, 6, 7, 8, 12, 28, 33, 34, 35, 36, 40, 44].freeze
 
-    attr_reader :cohort, :dry_run
+    attr_reader :cohort, :dry_run, :email_schedule
 
     # Set dry_run = true to just return the number of emails that would be sent but don't send any emails
-    def initialize(cohort:, dry_run: false)
+    def initialize(cohort:, dry_run: false, email_schedule: nil)
       @cohort = cohort
       @dry_run = dry_run
+      @email_schedule = email_schedule
     end
 
     def contact_sits_that_need_to_chase_their_ab_to_register_ects
@@ -77,7 +78,7 @@ module BulkMailers
             email_count += 1
             next if dry_run
 
-            SchoolMailer.with(school:, induction_coordinator:).remind_sit_to_assign_mentors_to_ects_email.deliver_later
+            SchoolMailer.with(school:, induction_coordinator:, email_schedule:).remind_sit_to_assign_mentors_to_ects_email.deliver_later
           end
         end
 
@@ -98,7 +99,7 @@ module BulkMailers
             email_count += 1
             next if dry_run
 
-            SchoolMailer.with(school:, induction_coordinator:).remind_sit_to_add_ects_and_mentors_email.deliver_later
+            SchoolMailer.with(school:, induction_coordinator:, email_schedule:).remind_sit_to_add_ects_and_mentors_email.deliver_later
           end
         end
 
@@ -184,7 +185,7 @@ module BulkMailers
           email_count += 1
           next if dry_run
 
-          SchoolMailer.with(school:).sit_needs_to_chase_partnership.deliver_later
+          SchoolMailer.with(school:, email_schedule:).sit_needs_to_chase_partnership.deliver_later
         end
 
       email_count

--- a/app/views/admin/performance/_nav.html.erb
+++ b/app/views/admin/performance/_nav.html.erb
@@ -2,9 +2,15 @@
   <%= component.with_nav_item(path: admin_performance_overview_path) do %>
     Overview
   <% end %>
+
   <%= component.with_nav_item(path: admin_performance_validation_errors_path) do %>
     Validation errors
   <% end %>
+
+  <%= component.with_nav_item(path: admin_performance_email_schedules_path) do %>
+    Email Schedule
+  <% end %>
+
   <%= component.with_nav_item(path: admin_performance_support_queries_path) do %>
     Support form stats
   <% end %>

--- a/app/views/admin/performance/email_schedules/edit.html.erb
+++ b/app/views/admin/performance/email_schedules/edit.html.erb
@@ -1,0 +1,15 @@
+<% content_for :title, "Schedule an email" %>
+<%= render partial: "admin/performance/nav" %>
+<%= govuk_back_link(text: "Back", href: admin_performance_email_schedules_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(model: @email_schedule, url: admin_performance_email_schedule_path(@email_schedule), method: :patch) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_date_field :scheduled_at, legend: { text: 'When should this be sent?', size: 'l'}, caption: { text: @email_schedule.mailer_name.humanize } %>
+
+      <%= f.govuk_submit "Update scheduled email" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/performance/email_schedules/index.html.erb
+++ b/app/views/admin/performance/email_schedules/index.html.erb
@@ -1,0 +1,54 @@
+<%= render partial: "admin/performance/nav" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Email schedule</h1>
+    <%= govuk_table do |table|
+      table.with_caption(size: 'm', text: 'Upcoming emails')
+
+      table.with_head do |head|
+        head.with_row do |row|
+          row.with_cell(text: 'Email subject')
+          row.with_cell(text: 'Date scheduled')
+        end
+      end
+      @upcoming_emails.each do |email_schedule|
+        table.with_body do |body|
+          body.with_row do |row|
+            row.with_cell(text: govuk_link_to(email_schedule.mailer_name.humanize, admin_performance_email_schedule_path(email_schedule)))
+            row.with_cell(text: email_schedule.scheduled_at.to_fs(:govuk))
+          end
+        end
+      end
+    end
+    %>
+
+    <p><%= govuk_button_link_to "Schedule an email", new_admin_performance_email_schedule_path, secondary: true %></p>
+
+    <%= govuk_table do |table|
+      table.with_caption(size: 'm', text: 'Recently sent emails')
+
+      table.with_head do |head|
+        head.with_row do |row|
+          row.with_cell(text: 'Email subject')
+          row.with_cell(text: 'Date sent')
+          row.with_cell(text: 'Sent to')
+        end
+      end
+      @recently_sent.each do |email_schedule|
+        table.with_body do |body|
+          body.with_row do |row|
+            row.with_cell(text: govuk_link_to(email_schedule.mailer_name.humanize, admin_performance_email_schedule_path(email_schedule)))
+            row.with_cell(text: email_schedule.scheduled_at.to_fs(:govuk))
+            if email_schedule.sending?
+              row.with_cell(text: "Sending")
+            else
+              row.with_cell(text: email_schedule.actual_email_count)
+            end
+          end
+        end
+      end
+    end
+    %>
+  </div>
+</div>

--- a/app/views/admin/performance/email_schedules/index.html.erb
+++ b/app/views/admin/performance/email_schedules/index.html.erb
@@ -43,7 +43,7 @@
             if email_schedule.sending?
               row.with_cell(text: "Sending")
             else
-              row.with_cell(text: email_schedule.actual_email_count)
+              row.with_cell(text: email_schedule.emails_sent_count)
             end
           end
         end

--- a/app/views/admin/performance/email_schedules/mailers_info/_assign_a_mentor_to_each_ect.html.erb
+++ b/app/views/admin/performance/email_schedules/mailers_info/_assign_a_mentor_to_each_ect.html.erb
@@ -1,0 +1,17 @@
+<%
+summary_list.with_row do |row|
+  row.with_key(text: 'GOV.UK Notify Template')
+  row.with_value(text: govuk_link_to_notify("Added ECTs but not assigned mentors", "ae0b1c48-de11-4231-b394-0288bb779987"))
+end
+
+summary_list.with_row do |row|
+  row.with_key(text: 'Recipient criteria')
+  row.with_value do %>
+    School induction tutors who:
+    <ul>
+      <li>SITs receive one per relevant school</li>
+      <li>School selected FIP or CIP for the current academic year</li>
+      <li>School has one or more ECTs in current year who are not paired with a mentor</li>
+    </ul>
+  <% end %>
+<% end %>

--- a/app/views/admin/performance/email_schedules/mailers_info/_contract_with_a_training_provider.html.erb
+++ b/app/views/admin/performance/email_schedules/mailers_info/_contract_with_a_training_provider.html.erb
@@ -1,0 +1,17 @@
+<%
+summary_list.with_row do |row|
+  row.with_key(text: 'GOV.UK Notify Template')
+  row.with_value(text: govuk_link_to_notify("Chosen FIP but provider not registered with DfE", "c640e594-21f6-4de3-be41-ebb74b2c8306"))
+end
+
+summary_list.with_row do |row|
+  row.with_key(text: 'Recipient criteria')
+  row.with_value do %>
+    School induction tutors who:
+    <ul>
+      <li>SITs receive on per relevant school</li>
+      <li>School selected FIP for the current academic year</li>
+      <li>No partnership has been reported yet</li>
+    </ul>
+  <% end %>
+<% end %>

--- a/app/views/admin/performance/email_schedules/mailers_info/_register_ects_and_mentors.html.erb
+++ b/app/views/admin/performance/email_schedules/mailers_info/_register_ects_and_mentors.html.erb
@@ -1,0 +1,17 @@
+<%
+summary_list.with_row do |row|
+  row.with_key(text: 'GOV.UK Notify Template')
+  row.with_value(text: govuk_link_to_notify("Not added ECTs yet", "19b5a258-e615-4371-9e55-f9cc58187448"))
+end
+
+summary_list.with_row do |row|
+  row.with_key(text: 'Recipient criteria')
+  row.with_value do %>
+    School induction tutors who:
+    <ul>
+      <li>SITs receive one per relevant school</li>
+      <li>School selected FIP or CIP for the current academic year</li>
+      <li>No ECTs have been registered for the current year</li>
+    </ul>
+  <% end %>
+<% end %>

--- a/app/views/admin/performance/email_schedules/new.html.erb
+++ b/app/views/admin/performance/email_schedules/new.html.erb
@@ -1,0 +1,23 @@
+<% content_for :title, "Schedule an email" %>
+<%= render partial: "admin/performance/nav" %>
+<%= govuk_back_link(text: "Back", href: admin_performance_email_schedules_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(model: @email_schedule, url: admin_performance_email_schedules_path) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1>Schedule an email</h1>
+
+      <%= f.govuk_radio_buttons_fieldset :mailer_name, legend: { text: "Type of email" } do %>
+        <% EmailSchedule::MAILERS.keys.map(&:to_s).each_with_index do |mailer, i| %>
+          <%= f.govuk_radio_button :mailer_name, mailer, label: { text: mailer.humanize }, link_errors: i == 0 %>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_date_field :scheduled_at, legend: { text: 'When should this be sent?' } %>
+
+      <%= f.govuk_submit "Schedule email" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/performance/email_schedules/show.html.erb
+++ b/app/views/admin/performance/email_schedules/show.html.erb
@@ -25,7 +25,7 @@
       if @email_schedule.queued?
         summary_list.with_row do |row|
           row.with_key(text: 'Estimated size')
-          row.with_value(text: estimate_bulk_emails_count(@email_schedule))
+          row.with_value(text: email_schedule_estimated(@email_schedule))
         end
       else
         summary_list.with_row do |row|
@@ -33,14 +33,14 @@
           if @email_schedule.sending?
             row.with_value(text: "Sending")
           else
-            row.with_value(text: @email_schedule.actual_email_count)
+            row.with_value(text: email_schedule_sent(@email_schedule))
           end
         end
       end
       if @email_schedule.sent?
         summary_list.with_row do |row|
           row.with_key(text: 'Bounced')
-          row.with_value(text: @email_schedule.failed_email_count)
+          row.with_value(text: email_schedule_bounced(@email_schedule))
         end
       end
     end

--- a/app/views/admin/performance/email_schedules/show.html.erb
+++ b/app/views/admin/performance/email_schedules/show.html.erb
@@ -25,11 +25,7 @@
       if @email_schedule.queued?
         summary_list.with_row do |row|
           row.with_key(text: 'Estimated size')
-          row.with_value(text:
-            BulkMailers::SchoolReminderComms
-              .new(cohort: Cohort.containing_date(@email_schedule.scheduled_at), dry_run: true)
-              .send(@email_schedule.mailer_method)
-          )
+          row.with_value(text: estimate_bulk_emails_count(@email_schedule))
         end
       else
         summary_list.with_row do |row|

--- a/app/views/admin/performance/email_schedules/show.html.erb
+++ b/app/views/admin/performance/email_schedules/show.html.erb
@@ -1,0 +1,53 @@
+<% content_for :title, "Email schedule" %>
+<%= render partial: "admin/performance/nav" %>
+<%= govuk_back_link(text: "Back", href: admin_performance_email_schedules_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= @email_schedule.mailer_name.humanize %></h1>
+
+    <%= govuk_summary_list do |summary_list|
+      summary_list.with_row do |row|
+        row.with_key(text: 'Subject')
+        row.with_value(text: @email_schedule.mailer_name.humanize)
+      end
+      summary_list.with_row do |row|
+        row.with_key(text: 'Date scheduled')
+        row.with_value(text: @email_schedule.scheduled_at.to_fs(:govuk))
+        row.with_action(text: "Change", href: edit_admin_performance_email_schedule_path(@email_schedule), visually_hidden_text: 'date scheduled') if @email_schedule.queued?
+      end
+
+      render(
+        partial: "admin/performance/email_schedules/mailers_info/#{@email_schedule.mailer_name}",
+        locals: { summary_list: }
+      )
+
+      if @email_schedule.queued?
+        summary_list.with_row do |row|
+          row.with_key(text: 'Estimated size')
+          row.with_value(text: BulkMailers::SchoolReminderComms.new(cohort: Cohort.containing_date(@email_schedule.scheduled_at), dry_run: true).send(EmailSchedule::MAILERS[@email_schedule.mailer_name.to_sym]))
+        end
+      else
+        summary_list.with_row do |row|
+          row.with_key(text: 'Sent to')
+          if @email_schedule.sending?
+            row.with_value(text: "Sending")
+          else
+            row.with_value(text: @email_schedule.actual_email_count)
+          end
+        end
+      end
+      if @email_schedule.sent?
+        summary_list.with_row do |row|
+          row.with_key(text: 'Bounced')
+          row.with_value(text: @email_schedule.failed_email_count)
+        end
+      end
+    end
+    %>
+
+    <div>
+      <%= govuk_button_link_to "Remove this from the schedule", delete_admin_performance_email_schedule_path(@email_schedule), class: "govuk-button--warning" if @email_schedule.queued? %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/performance/email_schedules/show.html.erb
+++ b/app/views/admin/performance/email_schedules/show.html.erb
@@ -25,7 +25,11 @@
       if @email_schedule.queued?
         summary_list.with_row do |row|
           row.with_key(text: 'Estimated size')
-          row.with_value(text: BulkMailers::SchoolReminderComms.new(cohort: Cohort.containing_date(@email_schedule.scheduled_at), dry_run: true).send(EmailSchedule::MAILERS[@email_schedule.mailer_name.to_sym]))
+          row.with_value(text:
+            BulkMailers::SchoolReminderComms
+              .new(cohort: Cohort.containing_date(@email_schedule.scheduled_at), dry_run: true)
+              .send(@email_schedule.mailer_method)
+          )
         end
       else
         summary_list.with_row do |row|

--- a/app/views/admin/performance/email_schedules/show.html.erb
+++ b/app/views/admin/performance/email_schedules/show.html.erb
@@ -46,8 +46,12 @@
     end
     %>
 
-    <div>
-      <%= govuk_button_link_to "Remove this from the schedule", delete_admin_performance_email_schedule_path(@email_schedule), class: "govuk-button--warning" if @email_schedule.queued? %>
-    </div>
+    <% if @email_schedule.queued? %>
+      <div>
+        <%= form_for :delete, url: admin_performance_email_schedule_path(@email_schedule), method: :delete do |f| %>
+          <%= f.govuk_submit "Remove this from the schedule", class: "govuk-button--warning" %>
+        <% end %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -430,8 +430,7 @@
   - mailer_name
   - scheduled_at
   - status
-  - actual_email_count
-  - failed_email_count
+  - emails_sent_count
   - created_at
   - updated_at
   :analytics_school_cohorts:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -288,11 +288,7 @@ Rails.application.routes.draw do
   get "admin/performance", to: "admin/performance/overview#show"
   namespace :admin do
     namespace :performance do
-      resources :email_schedules do
-        member do
-          get "delete", action: :delete
-        end
-      end
+      resources :email_schedules
       resource :overview, only: :show, controller: :overview
       get "/errors", to: "validation_errors#index", as: "validation_errors"
       get "/errors/:form/:attribute", to: "validation_errors#show", as: "validation_error"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -288,6 +288,11 @@ Rails.application.routes.draw do
   get "admin/performance", to: "admin/performance/overview#show"
   namespace :admin do
     namespace :performance do
+      resources :email_schedules do
+        member do
+          get "delete", action: :delete
+        end
+      end
       resource :overview, only: :show, controller: :overview
       get "/errors", to: "validation_errors#index", as: "validation_errors"
       get "/errors/:form/:attribute", to: "validation_errors#show", as: "validation_error"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -288,7 +288,7 @@ Rails.application.routes.draw do
   get "admin/performance", to: "admin/performance/overview#show"
   namespace :admin do
     namespace :performance do
-      resources :email_schedules
+      resources :email_schedules, path: "email-schedules"
       resource :overview, only: :show, controller: :overview
       get "/errors", to: "validation_errors#index", as: "validation_errors"
       get "/errors/:form/:attribute", to: "validation_errors#show", as: "validation_error"

--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -53,3 +53,7 @@ send_entity_table_checks_to_bigquery:
   cron: "30 0 * * *"
   class: "DfE::Analytics::EntityTableCheckJob"
   queue: dfe_analytics
+send_email_schedules:
+  cron: "0 12 * * *"
+  class: "Admin::MailScheduleJob"
+  queue: default

--- a/db/migrate/20240322182315_create_email_schedules.rb
+++ b/db/migrate/20240322182315_create_email_schedules.rb
@@ -6,8 +6,7 @@ class CreateEmailSchedules < ActiveRecord::Migration[7.0]
       t.string :mailer_name, null: false
       t.date :scheduled_at, null: false
       t.string :status, null: false, default: "queued"
-      t.integer :actual_email_count
-      t.integer :failed_email_count
+      t.integer :emails_sent_count
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_26_135601) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_22_182315) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -460,8 +460,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_26_135601) do
     t.string "mailer_name", null: false
     t.date "scheduled_at", null: false
     t.string "status", default: "queued", null: false
-    t.integer "actual_email_count"
-    t.integer "failed_email_count"
+    t.integer "emails_sent_count"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/factories/seeds/email_schedule_factory.rb
+++ b/spec/factories/seeds/email_schedule_factory.rb
@@ -27,7 +27,7 @@ FactoryBot.define do
     trait(:sent) do
       scheduled_at { 1.month.ago }
       status { "sent" }
-      actual_email_count { rand(15_000) }
+      emails_sent_count { rand(15_000) }
 
       skip_validations
     end

--- a/spec/factories/seeds/email_schedule_factory.rb
+++ b/spec/factories/seeds/email_schedule_factory.rb
@@ -6,19 +6,30 @@ FactoryBot.define do
     scheduled_at { 1.week.from_now }
     status { "queued" }
 
+    trait :skip_validations do
+      to_create { |instance| instance.save(validate: false) }
+    end
+
     trait(:scheduled_for_today) do
       scheduled_at { Date.current }
       status { "queued" }
+
+      skip_validations
     end
 
     trait(:sending) do
       scheduled_at { Date.current }
       status { "sending" }
+
+      skip_validations
     end
 
     trait(:sent) do
       scheduled_at { 1.month.ago }
       status { "sent" }
+      actual_email_count { rand(15_000) }
+
+      skip_validations
     end
 
     trait(:valid) {}

--- a/spec/factories/seeds/email_schedule_factory.rb
+++ b/spec/factories/seeds/email_schedule_factory.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory(:seed_email_factory, class: "EmailSchedule") do
     mailer_name { EmailSchedule::MAILERS.keys.sample.to_s }
-    scheduled_at { 1.week.from_now }
+    scheduled_at { rand(1..10).weeks.from_now }
     status { "queued" }
 
     trait :skip_validations do

--- a/spec/factories/seeds/email_schedule_factory.rb
+++ b/spec/factories/seeds/email_schedule_factory.rb
@@ -32,8 +32,6 @@ FactoryBot.define do
       skip_validations
     end
 
-    trait(:valid) {}
-
     after(:build) do
       Rails.logger.debug("created email schedule")
     end

--- a/spec/helpers/admin/performance/email_schedules_helper_spec.rb
+++ b/spec/helpers/admin/performance/email_schedules_helper_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::Performance::EmailSchedulesHelper, type: :helper do
+  let(:cohort) { Cohort.current }
+  let(:sent_schedule) { build(:seed_email_factory, :sent, emails_sent_count: 10) }
+
+  describe "#email_schedule_estimated" do
+    let(:school_bulk_mailers) { instance_double(BulkMailers::SchoolReminderComms) }
+    let(:today_schedule) { build(:seed_email_factory, :scheduled_for_today) }
+
+    it "returns the estimated emails the email schedule will sent" do
+      expect(BulkMailers::SchoolReminderComms).to receive(:new).with(cohort:, dry_run: true).and_return(school_bulk_mailers)
+      allow(school_bulk_mailers).to receive(today_schedule.mailer_method).and_return(10)
+
+      expect(email_schedule_estimated(today_schedule)).to eq("10 emails")
+    end
+  end
+
+  describe "#email_schedule_sent" do
+    it "returns the emails sent by the email schedule" do
+      expect(email_schedule_sent(sent_schedule)).to eq("10 emails")
+    end
+  end
+
+  describe "#email_schedule_bounced" do
+    it "returns a string in the correct format" do
+      allow(Email).to receive_message_chain(:failed, :associated_with, :count).and_return(5)
+
+      expect(email_schedule_bounced(sent_schedule)).to eq("5 (50.0%)")
+    end
+  end
+
+  describe "#calculate_percentage" do
+    it "calculates the percentage correctly" do
+      expect(calculate_percentage(50, 100)).to eq(50.0)
+    end
+
+    it "returns 0.0 if the whole is 0 to avoid division by zero" do
+      expect(calculate_percentage(50, 0)).to eq(0)
+    end
+
+    it "returns 0.0 if the part is 0" do
+      expect(calculate_percentage(0, 100)).to eq(0)
+    end
+
+    it "handles decimals correctly" do
+      expect(calculate_percentage(2.5, 10)).to eq(25.0)
+    end
+
+    it "returns a float value" do
+      expect(calculate_percentage(1, 3)).to be_a(Float)
+    end
+  end
+end

--- a/spec/helpers/admin_helper_spec.rb
+++ b/spec/helpers/admin_helper_spec.rb
@@ -141,4 +141,20 @@ RSpec.describe AdminHelper, type: :helper do
       end
     end
   end
+
+  describe "#estimate_bulk_emails_count" do
+    let(:school_reminder_comms) { instance_double(BulkMailers::SchoolReminderComms) }
+    let(:mailer_name) { EmailSchedule::MAILERS.keys.sample }
+    let(:today_schedule) { create(:seed_email_factory, :scheduled_for_today, mailer_name:) }
+    let(:cohort) { Cohort.current }
+
+    before do
+      allow(BulkMailers::SchoolReminderComms).to receive(:new).with(cohort:, dry_run: true).and_return(school_reminder_comms)
+      allow(school_reminder_comms).to receive(today_schedule.mailer_method).and_return(10)
+    end
+
+    it "calls the school reminder bulk mailer to send comms" do
+      expect(estimate_bulk_emails_count(today_schedule)).to eq(10)
+    end
+  end
 end

--- a/spec/jobs/admin/mail_schedule_job_spec.rb
+++ b/spec/jobs/admin/mail_schedule_job_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::MailScheduleJob do
+  subject(:job) { described_class.perform_later }
+
+  describe "#perform" do
+    it "queues the job" do
+      expect { job }.to have_enqueued_job
+    end
+
+    it "executes perform" do
+      expect(Admin::DailyEmailSchedulesProcessor).to receive(:call)
+      perform_enqueued_jobs { job }
+    end
+  end
+end

--- a/spec/models/email_schedule_spec.rb
+++ b/spec/models/email_schedule_spec.rb
@@ -48,6 +48,46 @@ RSpec.describe EmailSchedule, type: :model do
         expect(described_class.to_send_today).not_to include(already_sent)
       end
     end
+
+    describe ".upcoming_emails" do
+      it "returns all the queued schedules" do
+        expect(described_class.upcoming_emails).to match_array [scheduled_today, scheduled_later]
+      end
+
+      it "does not include schedules that are in progress" do
+        expect(described_class.upcoming_emails).not_to include(currently_sending)
+      end
+
+      it "does not include schedules that have already been sent" do
+        expect(described_class.upcoming_emails).not_to include(already_sent)
+      end
+    end
+
+    describe ".recently_sent" do
+      it "does not include the queued schedules" do
+        expect(described_class.recently_sent).not_to include(scheduled_today)
+      end
+
+      it "does not include schedules for a later date" do
+        expect(described_class.recently_sent).not_to include(scheduled_later)
+      end
+
+      it "returns schedules that are in progress" do
+        expect(described_class.recently_sent).to include(currently_sending)
+      end
+
+      it "returns schedules that have already been sent" do
+        expect(described_class.recently_sent).to include(already_sent)
+      end
+
+      context "when more than 20 results" do
+        before { create_list(:seed_email_factory, 21, :sent) }
+
+        it "returns 20 results" do
+          expect(described_class.recently_sent.count).to eq(20)
+        end
+      end
+    end
   end
 
   describe "#mailer_method" do

--- a/spec/models/email_schedule_spec.rb
+++ b/spec/models/email_schedule_spec.rb
@@ -6,6 +6,25 @@ RSpec.describe EmailSchedule, type: :model do
   it { is_expected.to validate_inclusion_of(:mailer_name).in_array(EmailSchedule::MAILERS.keys.map(&:to_s)) }
   it { is_expected.to validate_presence_of(:scheduled_at) }
 
+  describe "custom validations" do
+    describe "#validate_future_schedule_date" do
+      let(:past_scheduled_email) { build(:seed_email_factory, scheduled_at: Time.current.yesterday.midday) }
+      let(:future_scheduled_email) { build(:seed_email_factory, scheduled_at: Time.current.tomorrow.midday) }
+
+      it "adds an error when scheduled_at is not in the future" do
+        past_scheduled_email.valid?
+
+        expect(past_scheduled_email.errors[:scheduled_at]).to include("The schedule date must be in the future")
+      end
+
+      it "does not add an error when scheduled_at is in the future" do
+        future_scheduled_email.valid?
+
+        expect(future_scheduled_email.errors[:scheduled_at]).to be_empty
+      end
+    end
+  end
+
   describe "scopes" do
     let!(:scheduled_today) { create(:seed_email_factory, :scheduled_for_today) }
     let!(:scheduled_later) { create(:seed_email_factory) }

--- a/spec/models/email_schedule_spec.rb
+++ b/spec/models/email_schedule_spec.rb
@@ -37,15 +37,15 @@ RSpec.describe EmailSchedule, type: :model do
       end
 
       it "does not include schedules for a later date" do
-        expect(described_class.to_send_today).not_to include [scheduled_later]
+        expect(described_class.to_send_today).not_to include(scheduled_later)
       end
 
       it "does not include schedules that are in progress" do
-        expect(described_class.to_send_today).not_to include [currently_sending]
+        expect(described_class.to_send_today).not_to include(currently_sending)
       end
 
       it "does not include schedules that have already been sent" do
-        expect(described_class.to_send_today).not_to include [already_sent]
+        expect(described_class.to_send_today).not_to include(already_sent)
       end
     end
   end

--- a/spec/models/email_schedule_spec.rb
+++ b/spec/models/email_schedule_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe EmailSchedule, type: :model do
 
   describe "custom validations" do
     describe "#validate_future_schedule_date" do
-      let(:past_scheduled_email) { build(:seed_email_factory, scheduled_at: Time.current.yesterday.midday) }
-      let(:future_scheduled_email) { build(:seed_email_factory, scheduled_at: Time.current.tomorrow.midday) }
+      let(:past_scheduled_email) { build(:seed_email_factory, scheduled_at: Date.yesterday) }
+      let(:future_scheduled_email) { build(:seed_email_factory, scheduled_at: Date.tomorrow) }
 
       it "adds an error when scheduled_at is not in the future" do
         past_scheduled_email.valid?
@@ -47,6 +47,24 @@ RSpec.describe EmailSchedule, type: :model do
       it "does not include schedules that have already been sent" do
         expect(described_class.to_send_today).not_to include [already_sent]
       end
+    end
+  end
+
+  describe "#mailer_method" do
+    let(:email_schedule) { build(:seed_email_factory, mailer_name: :assign_a_mentor_to_each_ect) }
+
+    it "returns the name of the mapped bulk mailer method to be called" do
+      expect(email_schedule.mailer_method).to eq(:contact_sits_that_need_to_assign_mentors)
+    end
+  end
+
+  describe ".MAILERS" do
+    it "returns a hash that associates each mailer name with its corresponding bulk mailer method" do
+      expect(described_class::MAILERS).to eq({
+        assign_a_mentor_to_each_ect: :contact_sits_that_need_to_assign_mentors,
+        register_ects_and_mentors: :contact_sits_that_have_not_added_participants,
+        contract_with_a_training_provider: :contact_sits_that_have_chosen_fip_but_not_partnered,
+      })
     end
   end
 end

--- a/spec/services/admin/daily_email_schedules_processor_spec.rb
+++ b/spec/services/admin/daily_email_schedules_processor_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::DailyEmailSchedulesProcessor do
+  let(:mailer_name) { EmailSchedule::MAILERS.keys.sample }
+  let(:mailer_method) { EmailSchedule::MAILERS[mailer_name] }
+  let(:today_schedule) { create(:seed_email_factory, :scheduled_for_today, mailer_name:) }
+  let(:future_schedule) { create(:seed_email_factory) }
+  let(:past_schedule) { create(:seed_email_factory, :sent) }
+  let(:running_schedule) { create(:seed_email_factory, :sending) }
+  let(:cohort) { Cohort.current }
+
+  subject { described_class.new }
+
+  describe "#initialize" do
+    it "retrieves the email schedules to be sent today" do
+      expect(subject.email_schedules).to include(today_schedule)
+    end
+
+    it "doesn't retrieves email schedules not schedueled to be sent today" do
+      expect(subject.email_schedules).to_not include([running_schedule, past_schedule, future_schedule])
+    end
+  end
+
+  describe "#call" do
+    let(:school_reminder_comms) { instance_double(BulkMailers::SchoolReminderComms) }
+
+    before do
+      allow(BulkMailers::SchoolReminderComms).to receive(:new).with(cohort:, email_schedule: today_schedule).and_return(school_reminder_comms)
+      allow(school_reminder_comms).to receive(mailer_method)
+    end
+
+    it "calls the school reminder bulk mailer to send comms" do
+      expect(school_reminder_comms).to receive(:send).with(mailer_method)
+      subject.call
+    end
+
+    it "changes the status of the email schedule to sent" do
+      expect { subject.call }.to change { today_schedule.reload.status }.to("sent")
+    end
+  end
+end

--- a/spec/services/bulk_mailers/school_reminder_comms_spec.rb
+++ b/spec/services/bulk_mailers/school_reminder_comms_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe BulkMailers::SchoolReminderComms, type: :mailer do
   let(:cohort) { create(:seed_cohort) }
   let(:query_cohort) { cohort }
   let(:dry_run) { false }
+  let(:email_schedule) { nil }
 
   let(:school_cohort) { create(:seed_school_cohort, :fip, :with_school, cohort:) }
   let(:school) { school_cohort.school }
@@ -202,7 +203,7 @@ RSpec.describe BulkMailers::SchoolReminderComms, type: :mailer do
         expect {
           service.contact_sits_that_need_to_assign_mentors
         }.to have_enqueued_mail(SchoolMailer, :remind_sit_to_assign_mentors_to_ects_email)
-          .with(params: { school:, induction_coordinator: sit_profile }, args: [])
+          .with(params: { school:, induction_coordinator: sit_profile, email_schedule: }, args: [])
       end
 
       context "when the dry_run flag is set" do
@@ -237,7 +238,7 @@ RSpec.describe BulkMailers::SchoolReminderComms, type: :mailer do
         expect {
           service.contact_sits_that_have_not_added_participants
         }.to have_enqueued_mail(SchoolMailer, :remind_sit_to_add_ects_and_mentors_email)
-          .with(params: { school:, induction_coordinator: sit_profile }, args: [])
+          .with(params: { school:, induction_coordinator: sit_profile, email_schedule: }, args: [])
       end
     end
 
@@ -359,7 +360,7 @@ RSpec.describe BulkMailers::SchoolReminderComms, type: :mailer do
         expect {
           service.contact_sits_that_have_chosen_fip_but_not_partnered
         }.to have_enqueued_mail(SchoolMailer, :sit_needs_to_chase_partnership)
-          .with(params: { school: }, args: [])
+          .with(params: { school:, email_schedule: }, args: [])
       end
 
       context "when the dry_run flag is set" do


### PR DESCRIPTION
### Context

- Ticket: CST-2181

This PR implements the [Email Schedule dashboard](https://github.com/DFE-Digital/manage-training-for-early-career-teachers-prototype/pull/53)

The `sent to` and `bounce` stats need more work design wise, so I've left them out of this PR until the design is worked out.

### Changes proposed in this pull request
Add the EmailSchedule model to persist email schedules
Add basic CRUD functionality for the admins to manage the email schedules
Add a daily job to run every midday to process the daily email schedules

