### PR TITLE
[CPDLP-2753] Fix change schedule service to update all cohorts on all Induction records

### DIFF
--- a/app/services/change_schedule.rb
+++ b/app/services/change_schedule.rb
@@ -158,18 +158,21 @@ private
                         delivery_partner: historical_record.delivery_partner)
   end
 
-  def historical_school_cohort_induction_programme(historical_record, partnership)
-    school_cohort = historical_target_school_cohort(historical_record.school)
-
-    InductionProgramme.full_induction_programme.find_or_create_by!(school_cohort:, partnership:)
-  end
-
   def historical_induction_programme(historical_record)
     return historical_record.induction_programme if in_target_cohort?(historical_record)
 
-    partnership = historical_school_cohort_partnership(historical_record)
+    historical_school_cohort = historical_target_school_cohort(historical_record.school)
 
-    historical_school_cohort_induction_programme(historical_record, partnership)
+    set_default_programme = !historical_record.enrolled_in_fip? || !historical_record.lead_provider_id || !historical_record.delivery_partner_id
+
+    if set_default_programme
+      historical_school_cohort.default_induction_programme
+    else
+      historical_partnership = historical_school_cohort_partnership(historical_record)
+      historical_partnership.induction_programmes.first.presence || InductionProgramme
+                                                                    .full_induction_programme
+                                                                    .find_or_create_by!(school_cohort: historical_school_cohort, partnership: historical_partnership)
+    end
   end
 
   def update_historical_induction_records!

--- a/spec/services/change_schedule_spec.rb
+++ b/spec/services/change_schedule_spec.rb
@@ -199,6 +199,32 @@ RSpec.describe ChangeSchedule do
                 service.call
               }.to change { participant_profile.reload.school_cohort }.to(new_school_cohort)
             end
+
+            it "updates the cohort on the historic induction record induction programme" do
+              service.call
+
+              historic_induction_record = participant_profile.induction_records.order(created_at: :desc).last
+
+              expect(historic_induction_record.reload.induction_programme.cohort).to eq(new_school_cohort.cohort)
+            end
+
+            it "updates the cohort on the historic induction record schedule" do
+              service.call
+
+              historic_induction_record = participant_profile.induction_records.order(created_at: :desc).last
+
+              expect(historic_induction_record.reload.schedule.cohort).to eq(new_school_cohort.cohort)
+            end
+
+            it "creates a relationship partnership for the historic induction record school cohort" do
+              historic_induction_record = participant_profile.induction_records.order(created_at: :desc).last
+
+              expect(historic_induction_record.partnership.cohort).not_to eq(new_schedule.cohort)
+
+              service.call
+
+              expect(historic_induction_record.reload.partnership.cohort).to eq(new_schedule.cohort)
+            end
           end
         end
 
@@ -445,6 +471,32 @@ RSpec.describe ChangeSchedule do
               expect {
                 service.call
               }.to change { participant_profile.reload.school_cohort }.to(new_school_cohort)
+            end
+
+            it "updates the cohort on the historic induction record induction programme" do
+              service.call
+
+              historic_induction_record = participant_profile.induction_records.order(created_at: :desc).last
+
+              expect(historic_induction_record.reload.induction_programme.cohort).to eq(new_school_cohort.cohort)
+            end
+
+            it "updates the cohort on the historic induction record schedule" do
+              service.call
+
+              historic_induction_record = participant_profile.induction_records.order(created_at: :desc).last
+
+              expect(historic_induction_record.reload.schedule.cohort).to eq(new_school_cohort.cohort)
+            end
+
+            it "creates a relationship partnership for the historic induction record school cohort" do
+              historic_induction_record = participant_profile.induction_records.order(created_at: :desc).last
+
+              expect(historic_induction_record.partnership.cohort).not_to eq(new_schedule.cohort)
+
+              service.call
+
+              expect(historic_induction_record.reload.partnership.cohort).to eq(new_schedule.cohort)
             end
           end
         end

--- a/spec/services/change_schedule_spec.rb
+++ b/spec/services/change_schedule_spec.rb
@@ -302,10 +302,10 @@ RSpec.describe ChangeSchedule do
                 create(:school_cohort, :with_induction_programme, cohort: new_cohort, school: historical_school)
               end
 
-              it "moves all the historical records to the target schedule" do
+              it "moves all the other historical records to the target schedule" do
                 service.call
 
-                participant_profile.reload.induction_records.active.each do |induction_record|
+                participant_profile.reload.induction_records.active.excluding(historical_record).each do |induction_record|
                   expect(induction_record.schedule).to eq(new_schedule)
                 end
               end
@@ -660,10 +660,10 @@ RSpec.describe ChangeSchedule do
                 create(:school_cohort, :with_induction_programme, cohort: new_cohort, school: historical_school)
               end
 
-              it "moves all the historical records to the target schedule" do
+              it "moves all the other historical records to the target schedule" do
                 service.call
 
-                participant_profile.reload.induction_records.active.each do |induction_record|
+                participant_profile.reload.induction_records.active.excluding(historical_record).each do |induction_record|
                   expect(induction_record.schedule).to eq(new_schedule)
                 end
               end


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-2753](https://dfedigital.atlassian.net/browse/CPDLP-2753)

The schools team flagged to us that their amend cohort service is inconsistent with our change schedule service. 
Their service amends all IRs to point to a certain cohort, and select the default induction programme for that cohort meaning providers might change (via partnership).

Our service amends only the latest IR, meaning that another cohort exists in older IRs.

### Changes proposed in this pull request

We’ve decided to make our approaches consistent, and to amend our service to update all induction records.


[CPDLP-2753]: https://dfedigital.atlassian.net/browse/CPDLP-2753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ