### PR TITLE
Only backfill verified TRNs

### DIFF
--- a/spec/services/oneoffs/npq/backfill_trn_to_teacher_profile_spec.rb
+++ b/spec/services/oneoffs/npq/backfill_trn_to_teacher_profile_spec.rb
@@ -3,42 +3,58 @@
 RSpec.describe Oneoffs::NPQ::BackfillTrnToTeacherProfile do
   let(:application1) { create(:npq_application, :funded, :accepted) }
   let(:user_with_application1) { application1.user }
-  let(:teacher_profile1) { user_with_application1.teacher_profile }
+  let!(:teacher_profile1) { user_with_application1.teacher_profile.tap { |tp| tp.update!(trn: nil) } }
 
   let(:application2) { create(:npq_application, :funded, :accepted) }
   let(:user_with_application2) { application2.user }
-  let(:teacher_profile2) { user_with_application2.teacher_profile }
+  let!(:teacher_profile2) { user_with_application2.teacher_profile.tap { |tp| tp.update!(trn: nil) } }
 
-  let(:application3) { create(:npq_application, :funded, :accepted, user: user_with_application2) }
+  let!(:application3) { create(:npq_application, :funded, :accepted, user: user_with_application2) }
 
-  let(:trn1) { "1234567" }
-  let(:trn2) { "1234568" }
-  let(:trn3) { "1234569" }
-
-  before do
-    application1
-    application2
-    application3
-
-    teacher_profile1.update!(trn: nil)
-    teacher_profile2.update!(trn: nil)
-
-    application1.update!(teacher_reference_number: trn1)
-    application2.update!(teacher_reference_number: trn2)
-    application3.update!(teacher_reference_number: trn3)
+  it "backfills the missing trn when the trn can be determined and is verified" do
+    expect {
+      subject.migrate
+    }.to change { teacher_profile1.reload.trn }.from(nil).to(application1.teacher_reference_number)
   end
 
-  context "when script is applied" do
-    it "backfills the missing trn when trn can be determined" do
-      expect {
-        subject.migrate
-      }.to change { teacher_profile1.reload.trn }.from(nil).to(trn1)
-    end
+  it "does not backfill the missing trn when trn can not be determined" do
+    expect {
+      subject.migrate
+    }.not_to change { teacher_profile2.reload.trn }
+  end
 
-    it "doesn't backfills the missing trn when trn can not be determined" do
-      expect {
-        subject.migrate
-      }.not_to change { teacher_profile2.reload.trn }
-    end
+  it "does not backfill the missing trn with an unverified trn" do
+    application1.update!(teacher_reference_number_verified: false)
+
+    expect {
+      subject.migrate
+    }.not_to change { teacher_profile1.reload.trn }
+  end
+
+  it "does not backfill the missing trn if the verified trn is not valid" do
+    application1.update!(teacher_reference_number: "invalid-trn")
+
+    expect {
+      subject.migrate
+    }.not_to change { teacher_profile1.reload.trn }
+  end
+
+  it "does not backfill the missing trn if there are multiple applications with different, verified trns" do
+    application2.update!(participant_identity: user_with_application1.participant_identities.sample)
+
+    expect {
+      subject.migrate
+    }.not_to change { teacher_profile1.reload.trn }
+  end
+
+  it "backfills the missing trn if there are multiple applications with the same, verified trn" do
+    application2.update!(
+      teacher_reference_number: application1.teacher_reference_number,
+      participant_identity: user_with_application1.participant_identities.sample,
+    )
+
+    expect {
+      subject.migrate
+    }.to change { teacher_profile1.reload.trn }.from(nil).to(application1.teacher_reference_number)
   end
 end


### PR DESCRIPTION
Currently, the `BackfillTrnToTeacherProfile` service will populate unverified trns from applications. Instead, we want to ignore these and only populate verified trns. Adds missing test coverage.

