### PR TITLE
[CPDLP-2700] Send provider id to BigQuery when api rate limited

### DIFF
--- a/spec/requests/rate_limiting_spec.rb
+++ b/spec/requests/rate_limiting_spec.rb
@@ -16,6 +16,10 @@ describe "Rate limiting" do
     def change_condition
       set_request_ip(other_ip)
     end
+
+    def current_user
+      nil
+    end
   end
 
   context "login attempts" do
@@ -27,6 +31,10 @@ describe "Rate limiting" do
       def change_condition
         set_request_ip(other_ip)
       end
+
+      def current_user
+        nil
+      end
     end
   end
 
@@ -37,6 +45,10 @@ describe "Rate limiting" do
 
     def change_condition
       set_request_ip(other_ip)
+    end
+
+    def current_user
+      nil
     end
   end
 
@@ -65,6 +77,10 @@ describe "Rate limiting" do
         def change_condition
           set_auth_token(bearer_token2)
         end
+
+        def current_user
+          cpd_lead_provider1
+        end
       end
     end
   end
@@ -87,6 +103,10 @@ describe "Rate limiting" do
 
       def change_condition
         set_auth_token(bearer_token2)
+      end
+
+      def current_user
+        nil
       end
     end
   end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-2700

### Changes proposed in this pull request

* Updated rack attack initializer to include correct `user_id` (from API token)
* Added test

### Guidance to review

