### PR TITLE
Fix flip/flopping of users in Identity::Transfer

### DIFF
--- a/app/services/identity/primary_user.rb
+++ b/app/services/identity/primary_user.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Identity
+  class PrimaryUser < BaseService
+    class << self
+      def find_by(trn:)
+        TeacherProfile
+          .includes(:user)
+          .oldest_first
+          .where(trn:)
+          .first
+          &.user
+      end
+    end
+  end
+end

--- a/app/services/identity/transfer.rb
+++ b/app/services/identity/transfer.rb
@@ -5,6 +5,9 @@ module Identity
 
   class Transfer < BaseService
     def call
+      return if to_user == from_user
+      return unless [to_user, from_user].all?(&:present?)
+
       ActiveRecord::Base.transaction do
         transfer_identities!
         transfer_induction_coordinator_profile!

--- a/app/services/npq/dedupe_participant.rb
+++ b/app/services/npq/dedupe_participant.rb
@@ -8,37 +8,20 @@ module NPQ
     attribute :npq_application
     attribute :trn
 
-    validates :npq_application, presence: { message: I18n.t(:missing_npq_application) }
-    validates :trn, presence: { message: I18n.t(:missing_trn) }
-    validates :primary_user_for_trn, presence: { message: I18n.t(:missing_primary_user_for_trn) }
-    validates :application_user, presence: { message: I18n.t(:missing_application_user) }
+    validates :trn, presence: true
+    validates :npq_application, presence: true
     validate :trn_validated
-    validate :duplication_exists
 
     def call
       return if invalid?
 
-      Identity::Transfer.call(from_user: application_user, to_user: primary_user_for_trn)
+      Identity::Transfer.call(from_user: npq_application.user, to_user: primary_user_for_trn)
     end
 
   private
 
-    def application_user
-      @application_user ||= User.find_by(id: npq_application&.user_id)
-    end
-
     def primary_user_for_trn
-      @primary_user_for_trn ||= TeacherProfile
-        .joins(:user)
-        .includes(:user)
-        .oldest_first
-        .where(trn:)
-        .first
-        &.user
-    end
-
-    def duplication_exists
-      errors.add(:trn, I18n.t(:no_dedupe_required)) if primary_user_for_trn == application_user
+      Identity::PrimaryUser.find_by(trn:)
     end
 
     def trn_validated

--- a/app/services/npq/dedupe_participant.rb
+++ b/app/services/npq/dedupe_participant.rb
@@ -10,45 +10,39 @@ module NPQ
 
     validates :npq_application, presence: { message: I18n.t(:missing_npq_application) }
     validates :trn, presence: { message: I18n.t(:missing_trn) }
-    validates :to_user, presence: { message: I18n.t(:missing_to_user) }
-    validates :from_user, presence: { message: I18n.t(:missing_from_user) }
+    validates :primary_user_for_trn, presence: { message: I18n.t(:missing_primary_user_for_trn) }
+    validates :application_user, presence: { message: I18n.t(:missing_application_user) }
     validate :trn_validated
-    validate :dedupe_already_taken
+    validate :duplication_exists
 
     def call
       return if invalid?
 
-      Identity::Transfer.call(from_user:, to_user:)
+      Identity::Transfer.call(from_user: application_user, to_user: primary_user_for_trn)
     end
 
   private
 
-    def from_user
-      @from_user ||= User.find_by(id: npq_application&.user_id)
+    def application_user
+      @application_user ||= User.find_by(id: npq_application&.user_id)
     end
 
-    def to_user
-      @to_user ||= TeacherProfile
+    def primary_user_for_trn
+      @primary_user_for_trn ||= TeacherProfile
         .joins(:user)
         .includes(:user)
         .oldest_first
         .where(trn:)
-        .where.not(users: { id: from_user&.id })
         .first
         &.user
     end
 
-    def trn_validated
-      return if npq_application&.teacher_reference_number_verified?
-
-      errors.add(:trn, I18n.t(:trn_not_validated))
+    def duplication_exists
+      errors.add(:trn, I18n.t(:no_dedupe_required)) if primary_user_for_trn == application_user
     end
 
-    def dedupe_already_taken
-      return if from_user&.participant_id_changes.blank?
-      return unless from_user.participant_id_changes.where(from_participant: [from_user, to_user], to_participant: [from_user, to_user]).any?
-
-      errors.add(:trn, I18n.t(:dedupe_has_already_taken_place))
+    def trn_validated
+      errors.add(:trn, I18n.t(:trn_not_validated)) unless npq_application&.teacher_reference_number_verified?
     end
   end
 end

--- a/app/services/store_validation_result.rb
+++ b/app/services/store_validation_result.rb
@@ -76,17 +76,19 @@ private
     participant_profile.ecf_participant_validation_data&.destroy!
   end
 
-  def same_trn_user
-    @same_trn_user ||= User
-      .left_outer_joins(:teacher_profile)
-      .where(teacher_profile: { trn: participant_profile.teacher_profile.trn })
-      .where.not(teacher_profile: { id: participant_profile.teacher_profile.id })
+  def primary_user_for_trn
+    @primary_user_for_trn ||= TeacherProfile
+      .joins(:user)
+      .includes(:user)
+      .oldest_first
+      .where(trn: participant_profile.teacher_profile.trn)
       .first
+      &.user
   end
 
   def deduplicate_by_trn!
-    return unless same_trn_user
+    return unless primary_user_for_trn && primary_user_for_trn != participant_profile.user
 
-    Identity::Transfer.call(from_user: participant_profile.user, to_user: same_trn_user)
+    Identity::Transfer.call(from_user: participant_profile.user, to_user: primary_user_for_trn)
   end
 end

--- a/app/services/store_validation_result.rb
+++ b/app/services/store_validation_result.rb
@@ -76,19 +76,8 @@ private
     participant_profile.ecf_participant_validation_data&.destroy!
   end
 
-  def primary_user_for_trn
-    @primary_user_for_trn ||= TeacherProfile
-      .joins(:user)
-      .includes(:user)
-      .oldest_first
-      .where(trn: participant_profile.teacher_profile.trn)
-      .first
-      &.user
-  end
-
   def deduplicate_by_trn!
-    return unless primary_user_for_trn && primary_user_for_trn != participant_profile.user
-
+    primary_user_for_trn = Identity::PrimaryUser.find_by(trn: participant_profile.teacher_profile.trn)
     Identity::Transfer.call(from_user: participant_profile.user, to_user: primary_user_for_trn)
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -101,11 +101,11 @@ en:
   admin_nqt_1_email_used_ect: "A user with this email address is currently participating as an ECT at school with urn %{urn}"
   admin_nqt_1_email_used_nqt: "A user with this email address is currently participating as an NQT+1 at school with urn %{urn}"
   trn_not_validated: "Teacher reference number (TRN) has not been validated"
-  dedupe_has_already_taken_place: "Deduplication has already taken place from these users"
+  no_dedupe_required: "There is no duplication in this instance"
   missing_npq_application: "The npq application must be present"
   missing_trn: "The teacher reference number (TRN) must be present"
-  missing_from_user: "The user to be deduped from must be present"
-  missing_to_user: "The user to be deduped to must be present"
+  missing_application_user: "The application must have a user"
+  missing_primary_user_for_trn: "There must be a primary user for this trn"
   estimate_participants_default_message: &default_message "Enter a number between 0 and 1000"
   estimate_participants_defaults: &defaults
     not_a_number: *default_message

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -101,11 +101,6 @@ en:
   admin_nqt_1_email_used_ect: "A user with this email address is currently participating as an ECT at school with urn %{urn}"
   admin_nqt_1_email_used_nqt: "A user with this email address is currently participating as an NQT+1 at school with urn %{urn}"
   trn_not_validated: "Teacher reference number (TRN) has not been validated"
-  no_dedupe_required: "There is no duplication in this instance"
-  missing_npq_application: "The npq application must be present"
-  missing_trn: "The teacher reference number (TRN) must be present"
-  missing_application_user: "The application must have a user"
-  missing_primary_user_for_trn: "There must be a primary user for this trn"
   estimate_participants_default_message: &default_message "Enter a number between 0 and 1000"
   estimate_participants_defaults: &defaults
     not_a_number: *default_message

--- a/spec/services/identity/primary_user_spec.rb
+++ b/spec/services/identity/primary_user_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Identity::PrimaryUser do
+  describe ".find_by" do
+    let(:teacher_profile) { create(:teacher_profile) }
+    let(:trn) { teacher_profile.trn }
+
+    subject { described_class.find_by(trn:) }
+
+    context "when there are no matching users" do
+      let(:trn) { "no-match" }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when there are matching users" do
+      it "returns the user from the oldest TeacherProfile with the given TRN" do
+        create(:teacher_profile, trn: "76564321")
+        create(:teacher_profile, trn:)
+        oldest_matching_teacher_profile = travel_to(4.weeks.ago) { create(:teacher_profile, trn:) }
+        create(:teacher_profile, trn:)
+
+        is_expected.to eq(oldest_matching_teacher_profile.user)
+      end
+    end
+  end
+end

--- a/spec/services/identity/transfer_spec.rb
+++ b/spec/services/identity/transfer_spec.rb
@@ -173,5 +173,16 @@ RSpec.describe Identity::Transfer do
         end
       end
     end
+
+    context "when the to_user and from_user are the same" do
+      let(:user2) { user1 }
+
+      it { expect { service.call(from_user: user1, to_user: user2) }.not_to change(ParticipantIdChange, :count) }
+    end
+
+    context "when the to_user or from_user are nil" do
+      it { expect { service.call(from_user: user1, to_user: nil) }.not_to change(ParticipantIdChange, :count) }
+      it { expect { service.call(from_user: nil, to_user: user2) }.not_to change(ParticipantIdChange, :count) }
+    end
   end
 end

--- a/spec/services/npq/dedupe_participant_spec.rb
+++ b/spec/services/npq/dedupe_participant_spec.rb
@@ -7,98 +7,69 @@ RSpec.describe NPQ::DedupeParticipant do
   let(:npq_lead_provider) { cpd_lead_provider.npq_lead_provider }
   let(:npq_application) { create(:npq_application, :eligible_for_funding, npq_lead_provider:) }
   let(:trn) { npq_application&.teacher_reference_number }
-  let(:user) { npq_application&.user.presence || create(:user) }
-  let!(:teacher_profile) { create(:teacher_profile, user:, trn:) }
-  let!(:same_trn_teacher_profile) { create(:teacher_profile, trn:) }
+  let!(:application_teacher_profile) { travel_to(1.day.from_now) { create(:teacher_profile, user: npq_application.user, trn:) } }
+  let!(:primary_teacher_profile) { create(:teacher_profile, trn:) }
 
-  let(:params) do
-    {
-      npq_application:,
-      trn:,
-    }
+  subject(:service) { described_class.new(npq_application:, trn:) }
+
+  def expect_error(attribute, message)
+    expect(service).to be_invalid
+    expect(service.errors.messages_for(attribute)).to include(message)
   end
 
-  subject(:service) { described_class.new(params) }
+  describe "validations" do
+    it { is_expected.to be_valid }
 
-  describe "#call" do
     context "when the npq application is missing" do
+      let(:application_teacher_profile) {}
       let(:npq_application) {}
 
-      it "is invalid returning a meaningful error message" do
-        is_expected.to be_invalid
-
-        expect(service.errors.messages_for(:npq_application)).to include("The npq application must be present")
-      end
+      it { expect_error(:npq_application, "The npq application must be present") }
     end
 
     context "when the trn is missing" do
       let(:trn) {}
 
-      it "is invalid returning a meaningful error message" do
-        is_expected.to be_invalid
-
-        expect(service.errors.messages_for(:trn)).to include("The teacher reference number (TRN) must be present")
-      end
+      it { expect_error(:trn, "The teacher reference number (TRN) must be present") }
     end
 
-    context "when the from_user is missing" do
-      before do
-        allow(npq_application).to receive(:user_id).and_return(nil)
-      end
+    context "when the application user is missing" do
+      before { allow(npq_application).to receive(:user_id).and_return(nil) }
 
-      it "is invalid returning a meaningful error message" do
-        is_expected.to be_invalid
-
-        expect(service.errors.messages_for(:from_user)).to include("The user to be deduped from must be present")
-      end
+      it { expect_error(:application_user, "The application must have a user") }
     end
 
-    context "when the to_user is missing" do
-      before do
-        same_trn_teacher_profile.update!(trn: "A23456")
-      end
+    context "when the primary_user_for_trn is missing" do
+      before { TeacherProfile.destroy_all }
 
-      it "is invalid returning a meaningful error message" do
-        is_expected.to be_invalid
-
-        expect(service.errors.messages_for(:to_user)).to include("The user to be deduped to must be present")
-      end
+      it { expect_error(:primary_user_for_trn, "There must be a primary user for this trn") }
     end
 
     context "when the TRN has not been validated yet" do
-      before do
-        npq_application.update!(teacher_reference_number_verified: false)
-      end
+      before { npq_application.update!(teacher_reference_number_verified: false) }
 
-      it "is invalid returning a meaningful error message" do
-        is_expected.to be_invalid
-
-        expect(service.errors.messages_for(:trn)).to include("Teacher reference number (TRN) has not been validated")
-      end
+      it { expect_error(:trn, "Teacher reference number (TRN) has not been validated") }
     end
 
-    context "when a dedupe with same users already took place" do
-      before do
-        user.participant_id_changes.create!(from_participant: user, to_participant: same_trn_teacher_profile.user)
-      end
+    context "when there application_user is the primary_user_for_trn (not a duplicate)" do
+      let!(:application_teacher_profile) {}
+      let!(:primary_teacher_profile) { create(:teacher_profile, trn:, user: npq_application.user) }
 
-      it "is invalid returning a meaningful error message" do
-        is_expected.to be_invalid
+      it { expect_error(:trn, "There is no duplication in this instance") }
+    end
+  end
 
-        expect(service.errors.messages_for(:trn)).to include("Deduplication has already taken place from these users")
-      end
+  describe "#call" do
+    it "calls Identity::Transfer" do
+      expect(Identity::Transfer).to receive(:call).with(from_user: application_teacher_profile.user, to_user: primary_teacher_profile.user)
+
+      service.call
     end
 
-    context "with correct params" do
-      it "is valid" do
-        is_expected.to be_valid
-      end
+    context "when the dedupe has previously been performed" do
+      before { described_class.new(npq_application:, trn:).call }
 
-      it "calls Identity::Transfer with correct params" do
-        expect(Identity::Transfer).to receive(:call).with(from_user: user, to_user: same_trn_teacher_profile.user)
-
-        subject.call
-      end
+      it { expect { service.call }.not_to change(ParticipantIdChange, :count) }
     end
   end
 end


### PR DESCRIPTION
[Jira-2793](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-2793)

### Context

There are two places where users can flip/flop via the `Identity::Transfer` service; `NPQ::DedupeParticipant` and `StoreValidationResult`. This happens because we exclude the 'current' user in each of these services from the query to find the primary user for the TRN. If the current user _is_ the primary user for the TRN, we will always select a newer `TeacherProfile` and transfer the primary user to that.

### Changes proposed in this pull request

- Prevent flip/flop when deduping NPQ participants

Currently, if we call `NPQP::DedupeParticipant` with an `NPQApplication` that is associated with the oldest `TeacherProfile` it will always transfer this user onto a more recent `TeacherProfile` (as we exclude the `from_user` from the `to_user` lookup).

This results in users flip/flopping on `TeacherProfile` records. Instead, we should never exclude the oldest `TeacherProfile` and only transfer if the `NPQApplication` user is more recent.

- Prevent flip/flop on StoreValidationResult

When we call `StoreValidationResult` it will dedupe the participant profile by default. If it happens to be called with the primary user (that has the oldest `TeacherProfile`) then this can result in the user transferring to a newer, duplicate user.

Always find the oldest `TeacherProfile` with a matching `trn` to dedupe to, and only dedupe if that user is not the same as the one on the `participant_profile`.

- Make Identity::Transfer more robust

We would never want to transfer to/from the same user, but currently we don't prevent this and it results in a `ParticipantIdChange`.

Do nothing if the `to_user` and `from_user` are the same.

Protect against service being called with a `nil` to/from user.

- Extract primary user lookup to service/simplify

Pull the primary user lookup into a service so that we can DRY up the callers.

Simplify the logic in the `DedupeParticipant` service (as the `Transfer::Identity` service is now more robust we can cut a lot of the validation here).

### Guidance to review

I thought about modifying the `Transfer::Identity` to prevent a transfer if the `TeacherProfile` of the `to_user` is newer than that of the `from_user`, but I'm not sure that this service should be that restrictive (there may be cases where we want to intentionally do this?).

Best reviewed by-commit.