### PR TITLE
Clear the TeacherProfile trn on archiving a user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -224,6 +224,7 @@ class User < ApplicationRecord
       self.archived_email = email
       self.email = "user#{id}@example.org"
       self.archived_at = Time.zone.now
+      teacher_profile&.update!(trn: nil)
       save!
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -486,6 +486,15 @@ RSpec.describe User, type: :model do
         user.archive!
         expect(user.archived_at).to be_within(2.seconds).of(Time.zone.now)
       end
+
+      it "clears the teacher profile trn" do
+        expect { user.archive! }.to change { user.teacher_profile.reload.trn }.to(nil)
+      end
+
+      it "does not raise an error when the teacher_profile is nil" do
+        user.teacher_profile.destroy!
+        expect { user.reload.archive! }.not_to raise_error
+      end
     end
 
     describe "#archived?" do


### PR DESCRIPTION
[Jira-2798](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-2798)

### Context

When we archive a user we want to nullify the `TeacherProfile.trn` so that the user isn't picked up in any future `Identity::Transfer` calls. This currently happens as we find the oldest `UserProfile` by matching the `trn` when transferring a user.

### Changes proposed in this pull request

- Clear the TeacherProfile trn on archiving a user

### Guidance to review

Archiving users happens as part of the [DeduplicationService](https://github.com/DFE-Digital/early-careers-framework/blob/main/app/services/deduplication_service.rb).