### PR TITLE
Populate ITT providers

### DIFF
--- a/lib/tasks/oneoff/cleanup_itt_providers_npq_06_02_2023.rake
+++ b/lib/tasks/oneoff/cleanup_itt_providers_npq_06_02_2023.rake
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# lib/tasks/read_csv.rake
+
+require "csv"
+
+# Namespace for tasks related to NPQ applications.
+namespace :npq_applications do
+  # This task restores the ITT providers for NPQ applications.
+  # It reads a CSV file where each row contains an application ID and the corresponding ITT provider name.
+  # For each row, it finds the application with the given ID and updates its ITT provider.
+  #
+  # Usage:
+  # Run this task from the command line in your Rails application directory using:
+  # `rake npq_applications:restore_itt_providers['/path/to/your/file.csv']`
+  #
+  # @param file_path [String] the path to the CSV file
+  desc "Restore itt providers"
+  task :restore_itt_providers, [:file_path] => :environment do |_, args|
+    require "csv"
+    require "logger"
+
+    logger = Logger.new($stdout)
+    file_path = args[:file_path]
+
+    unless file_path && File.exist?(file_path)
+      raise ArgumentError, "File not found: #{file_path}"
+    end
+
+    csv_data = CSV.read(file_path)
+    csv_data.each do |row|
+      application_id, itt_provider_name = row
+
+      logger.info("Processing application: #{application_id}")
+      application = NPQApplication.find_by(id: application_id)
+      if application
+        application.update!(itt_provider: itt_provider_name)
+        logger.info("Application #{application_id} updated with ITT provider: #{itt_provider_name}")
+      else
+        logger.warn("Application not found! #{application_id}")
+      end
+    end
+  end
+end

--- a/spec/tasks/oneoff/cleanup_itt_providers_npq_06_02_2023_spec.rb
+++ b/spec/tasks/oneoff/cleanup_itt_providers_npq_06_02_2023_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe "npq_applications:restore_itt_providers" do
+  before :all do
+    Rake.application.rake_require "tasks/oneoff/cleanup_itt_providers_npq_06_02_2023"
+    Rake::Task.define_task(:environment)
+    @csv_file_path = Rails.root.join("tmp/test.csv")
+  end
+
+  describe "restore_itt_providers" do
+    it "should update the ITT provider for the application" do
+      application = create :npq_application, itt_provider: "Old Provider"
+      CSV.open(@csv_file_path, "w") { |csv| csv << [application.id, "New Provider"] }
+
+      Rake::Task["npq_applications:restore_itt_providers"].reenable
+      Rake.application.invoke_task "npq_applications:restore_itt_providers[#{@csv_file_path}]"
+
+      expect(application.reload.itt_provider).to eq "New Provider"
+    end
+
+    after :all do
+      File.delete(@csv_file_path) if File.exist?(@csv_file_path)
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-2794
- Analysis: https://dfedigital.atlassian.net/browse/CPDLP-2777

### Changes proposed in this pull request

Creates a `one-off` rake task that restores the correct ITT provider in ECF. The ITT provider
has been retrieved from NPQ (source of Itt providers)

### How to

```rdoc
  # Usage:
  # Run this task from the command line in your Rails application directory using:
  # `rake npq_applications:restore_itt_providers['/path/to/your/file.csv']`
  #
  # @param file_path [String] the path to the CSV file
```

