### PR TITLE
Add script to transfer away from archived users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -190,6 +190,7 @@ class User < ApplicationRecord
   scope :for_lead_provider, -> { includes(:lead_provider).joins(:lead_provider) }
   scope :admins, -> { joins(:admin_profile) }
   scope :finance_users, -> { joins(:finance_profile) }
+  scope :archived, -> { where.not(archived_email: nil) }
 
   scope :changed_since, lambda { |timestamp|
     if timestamp.present?

--- a/app/services/identity/primary_user.rb
+++ b/app/services/identity/primary_user.rb
@@ -8,6 +8,7 @@ module Identity
           .includes(:user)
           .oldest_first
           .where(trn:)
+          .where(user: { archived_email: nil })
           .first
           &.user
       end

--- a/app/services/oneoffs/transfer_away_from_archived_users.rb
+++ b/app/services/oneoffs/transfer_away_from_archived_users.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Oneoffs
+  class TransferAwayFromArchivedUsers
+    include HasRecordableInformation
+
+    def perform_change(dry_run: true)
+      reset_recorded_info
+
+      record_info("~~~ DRY RUN ~~~") if dry_run
+
+      ActiveRecord::Base.transaction do
+        archived_users_with_participant_profiles.each do |archived_user|
+          transfer_archived_user_on_teacher_profile(archived_user.teacher_profile)
+        end
+
+        raise ActiveRecord::Rollback if dry_run
+      end
+
+      recorded_info
+    end
+
+  private
+
+    def transfer_archived_user_on_teacher_profile(teacher_profile)
+      primary_user = primary_user_for_trn(teacher_profile.trn)
+
+      return record_info("teacher profile #{teacher_profile.id} does not have a trn") unless teacher_profile.trn
+      return record_info("primary user not found for trn #{teacher_profile.trn}") unless primary_user
+
+      # Transfer the archived user teacher profile to the primary.
+      Identity::Transfer.call(from_user: teacher_profile.user, to_user: primary_user)
+
+      # The TRN should have been cleared during the initial archiving of the user.
+      teacher_profile.update!(trn: nil)
+
+      record_info("Transferred archived user #{teacher_profile.user_id} to #{primary_user.id}")
+    end
+
+    def primary_user_for_trn(trn)
+      Identity::PrimaryUser.find_by(trn:)
+    end
+
+    def archived_users_with_participant_profiles
+      @archived_users_with_participant_profiles ||= User
+        .archived
+        .includes(:participant_profiles)
+        .where.not(participant_profiles: { id: nil })
+    end
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -32,6 +32,10 @@ FactoryBot.define do
       end
     end
 
+    trait :archived do
+      archived_email { Faker::Internet.unique.email }
+    end
+
     trait :lead_provider do
       lead_provider_profile
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -61,6 +61,15 @@ RSpec.describe User, type: :model do
         expect(described_class.email_matches("xyz").to_sql).to include("users.email like '%xyz%'")
       end
     end
+
+    describe "#archived" do
+      subject { described_class.archived }
+
+      let!(:archived_user) { create(:user).tap(&:archive!) }
+      let!(:active_user) { create(:user) }
+
+      it { is_expected.to contain_exactly(archived_user) }
+    end
   end
 
   describe "whitespace stripping" do

--- a/spec/services/identity/primary_user_spec.rb
+++ b/spec/services/identity/primary_user_spec.rb
@@ -25,5 +25,14 @@ RSpec.describe Identity::PrimaryUser do
         is_expected.to eq(oldest_matching_teacher_profile.user)
       end
     end
+
+    context "when there are matching users that are archived" do
+      it "excludes archived users" do
+        create(:teacher_profile, trn:)
+        travel_to(4.weeks.ago) { create(:teacher_profile, trn:, user: create(:user, :archived)) }
+
+        is_expected.to eq(teacher_profile.user)
+      end
+    end
   end
 end

--- a/spec/services/oneoffs/transfer_away_from_archived_users_spec.rb
+++ b/spec/services/oneoffs/transfer_away_from_archived_users_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+RSpec.describe Oneoffs::TransferAwayFromArchivedUsers do
+  before { allow(Rails.logger).to receive(:info) }
+
+  let(:instance) { described_class.new }
+
+  describe "#perform_change" do
+    let(:dry_run) { false }
+
+    subject(:perform_change) { instance.perform_change(dry_run:) }
+
+    let(:archived_user_teacher_profile) { participant_profile_on_archived_user.teacher_profile }
+    let!(:participant_profile_on_archived_user) { create(:ect_participant_profile, user: create(:user, :archived)) }
+    let!(:primary_teacher_profile) { travel_to(1.day.ago) { create(:teacher_profile, trn: archived_user_teacher_profile.trn) } }
+
+    it { is_expected.to eq(instance.recorded_info) }
+    it { expect { perform_change }.to change { archived_user_teacher_profile.reload.trn }.to(nil) }
+    it { expect { perform_change }.not_to change { primary_teacher_profile.reload.trn } }
+
+    it "transfers away from the archived user" do
+      expect(Identity::Transfer).to receive(:call).with(
+        from_user: participant_profile_on_archived_user.user,
+        to_user: primary_teacher_profile.user,
+      )
+
+      perform_change
+    end
+
+    it "logs out information" do
+      perform_change
+
+      expect(instance).to have_recorded_info([
+        "Transferred archived user #{archived_user_teacher_profile.user_id} to #{primary_teacher_profile.user_id}",
+      ])
+    end
+
+    it "logs out when the teacher profile does not have a trn" do
+      archived_user_teacher_profile.update!(trn: nil)
+      perform_change
+      expect(instance).to have_recorded_info([
+        "teacher profile #{archived_user_teacher_profile.id} does not have a trn",
+      ])
+    end
+
+    it "logs out when the trn cannot be matched to a primary user" do
+      primary_teacher_profile.update!(trn: "different-trn")
+      perform_change
+      expect(instance).to have_recorded_info([
+        "primary user not found for trn #{archived_user_teacher_profile.trn}",
+      ])
+    end
+
+    context "when dry_run is true" do
+      let(:dry_run) { true }
+
+      it "does not make any changes, but records the changes it would make" do
+        expect { perform_change }.not_to change { archived_user_teacher_profile.reload.trn }
+
+        expect(instance).to have_recorded_info([
+          "~~~ DRY RUN ~~~",
+          "Transferred archived user #{archived_user_teacher_profile.user_id} to #{primary_teacher_profile.user_id}",
+        ])
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Jira-2797](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-2797)

### Context

Due to a bug where the `TeacherProfile.trn` was not being cleared on archiving the associated user (#4524) we now have a number of archived users with associated participant profiles.

As of #4524 we now nullify the `TeacherProfile.trn` on archiving, so all that remains is to archived users onto the correct primary user record.

### Changes proposed in this pull request

- Add script to transfer away from archived users

### Guidance to review

The dry-run output of the script running against the snapshot DB is on the Jira ticket; all but 5 users can be fixed.

Branches off #4522 