### PR TITLE
Don't clear TRN if teacher profile has declarations

### DIFF
--- a/app/models/teacher_profile.rb
+++ b/app/models/teacher_profile.rb
@@ -31,4 +31,8 @@ class TeacherProfile < ApplicationRecord
   def self.ransackable_attributes(_auth_object = nil)
     %w[trn]
   end
+
+  def has_participant_profile_with_declarations?
+    participant_profiles.any? { |profile| profile.participant_declarations.any? }
+  end
 end

--- a/app/services/admin/participants/validate_details.rb
+++ b/app/services/admin/participants/validate_details.rb
@@ -34,8 +34,7 @@ module Admin
         return unless validation_data_permits_validation?
 
         ActiveRecord::Base.transaction do
-          @participant_profile.teacher_profile.update!(trn: nil) unless has_npq_profile?
-          @participant_profile.ecf_participant_eligibility&.destroy!
+          clear_existing_validation_data!
           # this returns either nil, false on failure or an ECFParticipantEligibility record on success
           @validation_form = build_validation_form
           run_validation
@@ -89,12 +88,11 @@ module Admin
         validation_data.present? && validation_data.can_validate_participant?
       end
 
-      def has_npq_profile?
-        @participant_profile.teacher_profile.npq_profiles.any?
-      end
+      def clear_existing_validation_data!
+        npq_profiles = @participant_profile.teacher_profile.participant_profiles.npqs.any?
+        declarations = @participant_profile.teacher_profile.has_participant_profile_with_declarations?
 
-      def clear_existing_validation_data
-        @participant_profile.teacher_profile.update!(trn: nil) unless has_npq_profile?
+        @participant_profile.teacher_profile.update!(trn: nil) unless npq_profiles || declarations
         @participant_profile.ecf_participant_eligibility&.destroy!
       end
 

--- a/app/services/importers/ecf_manual_validation.rb
+++ b/app/services/importers/ecf_manual_validation.rb
@@ -61,7 +61,10 @@ private
     # reset TRN if present on teacher profile to avoid "different trn" errors
     # unless already set via NPQ
     teacher_profile = participant_profile.teacher_profile
-    if teacher_profile.trn.present? && teacher_profile.participant_profiles.npqs.none?
+    npq_profiles = teacher_profile.participant_profiles.npqs.any?
+    declarations = teacher_profile.has_participant_profile_with_declarations?
+
+    if teacher_profile.trn.present? && !npq_profiles && !declarations
       teacher_profile.update!(trn: nil)
     end
 

--- a/spec/models/teacher_profile_spec.rb
+++ b/spec/models/teacher_profile_spec.rb
@@ -8,4 +8,21 @@ RSpec.describe(TeacherProfile, type: :model) do
       expect(TeacherProfile.oldest_first.to_sql).to match(/ORDER BY "teacher_profiles"."created_at" ASC/)
     end
   end
+
+  describe "#has_participant_profile_with_declarations?" do
+    let!(:participant_profile) { create(:ect, :eligible_for_funding, user: teacher_profile.user) }
+
+    subject(:teacher_profile) { create(:teacher_profile) }
+
+    it { is_expected.not_to have_participant_profile_with_declarations }
+
+    context "when there is a participant profile with declarations" do
+      before do
+        cpd_lead_provider = participant_profile.lead_provider.cpd_lead_provider
+        create(:ect_participant_declaration, participant_profile:, cpd_lead_provider:)
+      end
+
+      it { is_expected.to have_participant_profile_with_declarations }
+    end
+  end
 end


### PR DESCRIPTION
[Jira-2802](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-2802)

### Context

Currently, we check to ensure that there are no NPQ profiles on the `TeacherProfile` before we clear the `trn`, however we also need to check that the associated participant profiles do not have any declarations (as declarations should be tied back to a `TeacherProfile` with a `trn`).

### Changes proposed in this pull request

- Don't clear TRN if teacher profile has declarations

Update the `ValidateDetails` and `EcfManualValidation` services to check for declarations prior to clearing a `trn`.

### Guidance to review

