### PR TITLE
Fix change log so that CPD lead providers show up by name instead of ID

### DIFF
--- a/app/components/admin/participants/audit_trail_item_component.rb
+++ b/app/components/admin/participants/audit_trail_item_component.rb
@@ -23,6 +23,7 @@ module Admin
 
         return "(Unknown user)" if user.nil?
         return "#{user} (Unknown user)" if user.is_a?(String)
+        return "#{user.name} (Lead Provider)" if user.is_a?(CpdLeadProvider)
 
         if user.induction_coordinator?
           "#{user.email} (SIT user)"

--- a/app/services/participants/history_builder.rb
+++ b/app/services/participants/history_builder.rb
@@ -175,12 +175,16 @@ private
     entity.versions&.each do |version|
       # TODO: if the version is of type "create" then we need to record the default values that were not overridden
 
-      user = User.find_by(id: version.whodunnit) || version.whodunnit
+      user = whodunnit(version)
 
       version.object_changes&.each do |key, value|
         record_event(version.created_at, version.event, entity, key, value, user)
       end
     end
+  end
+
+  def whodunnit(version)
+    User.find_by(id: version.whodunnit) || CpdLeadProvider.find_by(id: version.whodunnit) || version.whodunnit
   end
 
   def record_event(date, action, entity, key, value, actor)


### PR DESCRIPTION
### Context

Little fix to look up to see if a `whodunnit` from a version record is a `CpdLeadProvider` if it is not a `User` for the changes log

### Changes proposed in this pull request
Look up `CpdLeadProvider` if `User` look up fails

### Guidance to review

