### PR TITLE
CST-2348: keep schedule when the participant is already in the target…

### DIFF
--- a/app/services/induction/amend_participant_cohort.rb
+++ b/app/services/induction/amend_participant_cohort.rb
@@ -232,7 +232,11 @@ module Induction
     end
 
     def schedule
-      @schedule ||= Finance::Schedule::ECF.default_for(cohort: target_cohort)
+      @schedule ||= if induction_record && in_target_cohort?(induction_record)
+                      induction_record.schedule
+                    else
+                      Finance::Schedule::ECF.default_for(cohort: target_cohort)
+                    end
     end
 
     def source_cohort


### PR DESCRIPTION
… cohort

### Context

Currently, the amend participant cohort service sets the received schedule to the participant or the default one for the target cohort, otherwise.
However that is not correct when the participant is already in the target cohort (maybe not all their historical records).
In such a case the tool should keep the participant's current schedule and make sure the historical records moved to the target cohort get assigned that current schedule.

[Ticket](https://dfedigital.atlassian.net/browse/CST-2348)

### Changes proposed in this pull request

### Guidance to review

