### PR TITLE
Allow restricting by provider on declaration migration

### DIFF
--- a/app/services/oneoffs/npq/migrate_declarations_between_statements.rb
+++ b/app/services/oneoffs/npq/migrate_declarations_between_statements.rb
@@ -8,10 +8,11 @@ module Oneoffs::NPQ
 
     include HasRecordableInformation
 
-    def initialize(cohort:, from_statement_name:, to_statement_name:, to_statement_updates: {}, restrict_to_lead_providers: nil, restrict_to_declaration_types: nil)
+    def initialize(cohort:, from_statement_name:, to_statement_name:, from_statement_output_fee: false, to_statement_updates: {}, restrict_to_lead_providers: nil, restrict_to_declaration_types: nil)
       @cohort = cohort
       @from_statement_name = from_statement_name
       @to_statement_name = to_statement_name
+      @from_statement_output_fee = from_statement_output_fee
       @to_statement_updates = to_statement_updates
       @restrict_to_lead_providers = restrict_to_lead_providers
       @restrict_to_declaration_types = restrict_to_declaration_types
@@ -34,7 +35,7 @@ module Oneoffs::NPQ
 
   private
 
-    attr_reader :cohort, :from_statement_name, :to_statement_name, :to_statement_updates, :restrict_to_lead_providers, :restrict_to_declaration_types
+    attr_reader :cohort, :from_statement_name, :to_statement_name, :to_statement_updates, :restrict_to_lead_providers, :restrict_to_declaration_types, :from_statement_output_fee
 
     def update_to_statement_attributes!
       return if to_statement_updates.blank?
@@ -48,7 +49,7 @@ module Oneoffs::NPQ
     def migrate_declarations_between_statements!
       each_statements_by_provider do |provider, from_statement, to_statement|
         migrate_line_items!(provider, from_statement, to_statement)
-        from_statement.update!(output_fee: false)
+        from_statement.update!(output_fee: from_statement_output_fee) if from_statement.output_fee != from_statement_output_fee
       end
     end
 

--- a/app/services/oneoffs/npq/migrate_declarations_between_statements.rb
+++ b/app/services/oneoffs/npq/migrate_declarations_between_statements.rb
@@ -8,12 +8,13 @@ module Oneoffs::NPQ
 
     include HasRecordableInformation
 
-    def initialize(cohort:, from_statement_name:, to_statement_name:, to_statement_updates: {}, restrict_to_lead_providers: nil)
+    def initialize(cohort:, from_statement_name:, to_statement_name:, to_statement_updates: {}, restrict_to_lead_providers: nil, restrict_to_declaration_types: nil)
       @cohort = cohort
       @from_statement_name = from_statement_name
       @to_statement_name = to_statement_name
       @to_statement_updates = to_statement_updates
       @restrict_to_lead_providers = restrict_to_lead_providers
+      @restrict_to_declaration_types = restrict_to_declaration_types
     end
 
     def migrate(dry_run: true)
@@ -33,7 +34,7 @@ module Oneoffs::NPQ
 
   private
 
-    attr_reader :cohort, :from_statement_name, :to_statement_name, :to_statement_updates, :restrict_to_lead_providers
+    attr_reader :cohort, :from_statement_name, :to_statement_name, :to_statement_updates, :restrict_to_lead_providers, :restrict_to_declaration_types
 
     def update_to_statement_attributes!
       return if to_statement_updates.blank?
@@ -46,14 +47,23 @@ module Oneoffs::NPQ
 
     def migrate_declarations_between_statements!
       each_statements_by_provider do |provider, from_statement, to_statement|
-        record_declarations_info(provider, from_statement.participant_declarations)
-        migrate_line_items!(from_statement, to_statement)
+        migrate_line_items!(provider, from_statement, to_statement)
         from_statement.update!(output_fee: false)
       end
     end
 
-    def migrate_line_items!(from_statement, to_statement)
-      from_statement.statement_line_items.update!(statement_id: to_statement.id)
+    def migrate_line_items!(provider, from_statement, to_statement)
+      statement_line_items = from_statement.statement_line_items
+
+      if restrict_to_declaration_types
+        statement_line_items = statement_line_items
+          .includes(:participant_declaration)
+          .where(participant_declaration: { declaration_type: restrict_to_declaration_types })
+      end
+
+      record_line_items_info(provider, statement_line_items)
+
+      statement_line_items.update!(statement_id: to_statement.id)
     end
 
     def each_statements_by_provider
@@ -68,8 +78,8 @@ module Oneoffs::NPQ
       record_info("Migrating declarations from #{from_statement_name} to #{to_statement_name} for #{provider_count} providers")
     end
 
-    def record_declarations_info(provider, declarations)
-      record_info("Migrating #{declarations.size} declarations for #{provider.name}")
+    def record_line_items_info(provider, statement_line_items)
+      record_info("Migrating #{statement_line_items.size} declarations for #{provider.name}")
     end
 
     def ensure_statements_align!

--- a/spec/services/oneoffs/npq/migrate_declarations_between_statements_spec.rb
+++ b/spec/services/oneoffs/npq/migrate_declarations_between_statements_spec.rb
@@ -10,8 +10,9 @@ describe Oneoffs::NPQ::MigrateDeclarationsBetweenStatements do
   let(:to_statement_name) { to_statement.name }
   let(:cohort) { Cohort.current }
   let(:restrict_to_lead_providers) { nil }
+  let(:restrict_to_declaration_types) { nil }
 
-  let(:instance) { described_class.new(cohort:, from_statement_name:, to_statement_name:, to_statement_updates:, restrict_to_lead_providers:) }
+  let(:instance) { described_class.new(cohort:, from_statement_name:, to_statement_name:, to_statement_updates:, restrict_to_lead_providers:, restrict_to_declaration_types:) }
 
   before { allow(Rails.logger).to receive(:info) }
 
@@ -31,12 +32,12 @@ describe Oneoffs::NPQ::MigrateDeclarationsBetweenStatements do
     end
 
     context "when there are declarations" do
-      let(:declaration) { create(:npq_participant_declaration, :payable, cohort:, cpd_lead_provider:) }
+      let(:declaration) { create(:npq_participant_declaration, :payable, cohort:, cpd_lead_provider:, declaration_type: :started) }
       let(:from_statement) { declaration.statements.first }
 
       let(:cpd_lead_provider2) { declaration2.cpd_lead_provider }
       let(:npq_lead_provider2) { cpd_lead_provider2.npq_lead_provider }
-      let(:declaration2) { create(:npq_participant_declaration, :payable, cohort:) }
+      let(:declaration2) { create(:npq_participant_declaration, :payable, cohort:, declaration_type: :"retained-1") }
       let!(:from_statement2) { declaration2.statements.first.tap { |s| s.update!(name: from_statement.name) } }
       let!(:to_statement2) { create(:npq_statement, name: to_statement.name, cpd_lead_provider: cpd_lead_provider2, cohort:, output_fee: true) }
 
@@ -76,6 +77,38 @@ describe Oneoffs::NPQ::MigrateDeclarationsBetweenStatements do
             "Migrating declarations from #{from_statement_name} to #{to_statement_name} for 1 providers",
             "Migrating 1 declarations for #{npq_lead_provider.name}",
           ])
+        end
+      end
+
+      context "when restrict_to_declaration_types is provided" do
+        let(:restrict_to_declaration_types) { [:started] }
+
+        it "migrates only the declarations with the given declaration type" do
+          migrate
+
+          expect(declaration.statement_line_items.map(&:statement)).to all(eq(to_statement))
+          expect(declaration2.statement_line_items.map(&:statement)).to all(eq(from_statement2))
+        end
+
+        it "records information" do
+          migrate
+
+          expect(instance).to have_recorded_info([
+            "Migrating declarations from #{from_statement_name} to #{to_statement_name} for 2 providers",
+            "Migrating 1 declarations for #{npq_lead_provider.name}",
+            "Migrating 0 declarations for #{npq_lead_provider2.name}",
+          ])
+        end
+
+        context "when restrict_to_declaration_types contains a string" do
+          let(:restrict_to_declaration_types) { %w[retained-1] }
+
+          it "migrates only the declarations with the given declaration type" do
+            migrate
+
+            expect(declaration2.statement_line_items.map(&:statement)).to all(eq(to_statement2))
+            expect(declaration.statement_line_items.map(&:statement)).to all(eq(from_statement))
+          end
         end
       end
     end

--- a/spec/services/oneoffs/npq/migrate_declarations_between_statements_spec.rb
+++ b/spec/services/oneoffs/npq/migrate_declarations_between_statements_spec.rb
@@ -8,11 +8,12 @@ describe Oneoffs::NPQ::MigrateDeclarationsBetweenStatements do
   let(:to_statement) { create(:npq_statement, name: "May 2023", cpd_lead_provider:, cohort:, output_fee: true) }
   let(:from_statement_name) { from_statement.name }
   let(:to_statement_name) { to_statement.name }
+  let(:from_statement_output_fee) { false }
   let(:cohort) { Cohort.current }
   let(:restrict_to_lead_providers) { nil }
   let(:restrict_to_declaration_types) { nil }
 
-  let(:instance) { described_class.new(cohort:, from_statement_name:, to_statement_name:, to_statement_updates:, restrict_to_lead_providers:, restrict_to_declaration_types:) }
+  let(:instance) { described_class.new(cohort:, from_statement_name:, to_statement_name:, from_statement_output_fee:, to_statement_updates:, restrict_to_lead_providers:, restrict_to_declaration_types:) }
 
   before { allow(Rails.logger).to receive(:info) }
 
@@ -58,6 +59,12 @@ describe Oneoffs::NPQ::MigrateDeclarationsBetweenStatements do
           "Migrating 1 declarations for #{npq_lead_provider.name}",
           "Migrating 1 declarations for #{npq_lead_provider2.name}",
         ])
+      end
+
+      context "when from_statement_output_fee result in no changes" do
+        let(:from_statement_output_fee) { from_statement.output_fee }
+
+        it { expect { migrate }.not_to change { from_statement.reload.output_fee } }
       end
 
       context "when restrict_to_lead_providers is provided" do


### PR DESCRIPTION
[Jira-2811](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-2811)

### Context

We have a use case where we only want to migrate declarations from one statement to another for a particular lead provider.

### Changes proposed in this pull request

- Allow restricting by provider on declaration migration

### Guidance to review

Screenshots of migration ran on snapshot DB are in the Jira ticket.