### PR TITLE
[CPDLP-2799] Fix declarations to point to correct user

### DIFF
--- a/app/services/oneoffs/fix_participant_declaration_user.rb
+++ b/app/services/oneoffs/fix_participant_declaration_user.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Oneoffs
+  class FixParticipantDeclarationUser
+    def call
+      ActiveRecord::Base.transaction do
+        incorrect_participant_declarations.in_batches.each_record do |declaration|
+          declaration.update!(user_id: declaration.participant_profile.participant_identity.user_id)
+        end
+      end
+    end
+
+    def incorrect_participant_declarations
+      ParticipantDeclaration
+        .joins(participant_profile: :participant_identity)
+        .where("participant_declarations.user_id != participant_identities.user_id")
+    end
+  end
+end

--- a/spec/services/oneoffs/fix_participant_declaration_user_spec.rb
+++ b/spec/services/oneoffs/fix_participant_declaration_user_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec.describe Oneoffs::FixParticipantDeclarationUser do
+  let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
+  let(:declaration1) { create(:ect_participant_declaration, cpd_lead_provider:) }
+  let(:user1) { declaration1.user }
+  let(:declaration2) { create(:ect_participant_declaration, cpd_lead_provider:) }
+  let(:user2) { declaration2.user }
+
+  subject { described_class.new }
+
+  before do
+    teacher_profile = TeacherProfile.find_or_create_by!(user: user2)
+    user1.participant_identities.each do |identity|
+      identity.update!(user: user2)
+      identity.participant_profiles.each do |participant_profile|
+        participant_profile.update!(teacher_profile:)
+      end
+    end
+    user1.reload
+    user2.reload
+    declaration1.reload
+    declaration2.reload
+  end
+
+  describe "#call" do
+    it "fixes the user mismatch on declaration" do
+      expect(declaration1.user).to eql(user1)
+      expect(declaration2.user).to eql(user2)
+      subject.call
+      expect(declaration1.reload.user).to eql(user2)
+      expect(declaration2.reload.user).to eql(user2)
+    end
+  end
+
+  describe "#incorrect_participant_declarations" do
+    it "returns declarations" do
+      expect(subject.incorrect_participant_declarations.to_a).to eql([declaration1])
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-2799

### Changes proposed in this pull request

* Created `Oneoffs::FixParticipantDeclarationUser` with tests
* There are total 7208 declarations
  * 81 declarations have a `declaration.participant_identities.size > 1`
    * 47 declarations have `declaration.user.id` that does not match `declaration.participant_profile.user.participant_identities.user_id`

### Guidance to review

