### PR TITLE
Fix the Change Induction Tutor action

### DIFF
--- a/app/forms/nominate_induction_tutor_form.rb
+++ b/app/forms/nominate_induction_tutor_form.rb
@@ -63,10 +63,7 @@ private
 
   def remove_current_sits
     school.induction_coordinators.each do |sit|
-      next sit.induction_coordinator_profile.schools.delete(school) if sit.schools.count > 1
-      next sit.induction_coordinator_profile.destroy! if sit.teacher_profile.present? || sit.npq_registered?
-
-      sit.destroy!
+      sit.induction_coordinator_profile.schools.delete(school)
     end
   end
 

--- a/spec/forms/nominate_induction_tutor_form_spec.rb
+++ b/spec/forms/nominate_induction_tutor_form_spec.rb
@@ -103,32 +103,6 @@ RSpec.describe NominateInductionTutorForm, type: :model do
       let(:previous_sit) { NewSeeds::Scenarios::Schools::School.new.build.with_an_induction_tutor.induction_tutor }
       let(:school) { previous_sit.schools.first }
       let(:sit_profile) { previous_sit.induction_coordinator_profile }
-
-      context "when the previous SIT has a teacher_profile" do
-        before do
-          create(:teacher_profile, user: previous_sit)
-        end
-
-        it "destroys their SIT profile" do
-          expect { subject.save! }.to change { previous_sit.reload.induction_coordinator_profile }.from(sit_profile).to(nil)
-        end
-      end
-
-      context "when the previous SIT is NPQ registered" do
-        before do
-          create(:npq_participant_profile, user: previous_sit)
-        end
-
-        it "destroys their SIT profile" do
-          expect { subject.save! }.to change { previous_sit.reload.induction_coordinator_profile }.from(sit_profile).to(nil)
-        end
-      end
-
-      context "when the previous SIT has no other profiles" do
-        it "removes the SIT from the service" do
-          expect { subject.save! }.to change { User.exists?(previous_sit.id) }.from(true).to(false)
-        end
-      end
     end
 
     context "when the new SIT is not registered yet" do

--- a/spec/requests/schools/change_sit_spec.rb
+++ b/spec/requests/schools/change_sit_spec.rb
@@ -85,12 +85,6 @@ RSpec.describe "Schools::ChangeSit", type: :request do
       expect(created_user.schools).to include school
     end
 
-    it "deletes the current user" do
-      post "/schools/#{school.slug}/change-sit/confirm"
-
-      expect(User.where(id: user.id)).to be_empty
-    end
-
     context "when the acting user has multiple schools" do
       let(:other_school) { create(:school) }
       before do


### PR DESCRIPTION
### Context

- Ticket: CST-2321

### Changes proposed in this pull request

When nominating a new SIT the previous one won't be deleted but just removed from the school.


