### PR TITLE
Add spacing between page elements for improved section visibility

### DIFF
--- a/app/views/admin/participants/induction_records/_show.html.erb
+++ b/app/views/admin/participants/induction_records/_show.html.erb
@@ -1,5 +1,6 @@
 <% training_record_states = DetermineTrainingRecordState.call(induction_records: induction_record) %>
 
+<div class="govuk-!-margin-bottom-9">
 <%=
   govuk_summary_list do |sl|
     sl.with_row do |row|
@@ -94,3 +95,4 @@
     end
   end
 %>
+</div>

--- a/app/views/admin/participants/school/show.html.erb
+++ b/app/views/admin/participants/school/show.html.erb
@@ -45,6 +45,7 @@
       end
     end %>
 
+    <div class="govuk-!-margin-bottom-9">
     <%=
       govuk_button_link_to(
         "Transfer to another school",
@@ -60,50 +61,57 @@
         secondary: true,
         ) if @participant_presenter.mentor?
     %>
+    </div>
 
-    <h2 class="govuk-heading-m">Cohort</h2>
+    <div class="govuk-!-margin-bottom-9">
+      <h2 class="govuk-heading-m">Cohort</h2>
 
-    <%= govuk_summary_list do |sl|
-      sl.with_row do |row|
-        row.with_key(text: "Cohort via induction record")
-        row.with_value(text: @participant_presenter.start_year)
-      end
-
-      sl.with_row do |row|
-        row.with_key(text: "Cohort via schedule")
-        row.with_value(text: @participant_presenter&.relevant_induction_record&.schedule&.cohort&.start_year)
-      end
-    end %>
-
-    <% if policy(@participant_profile).edit_cohort? %>
-      <%= govuk_button_link_to("Change cohort", edit_admin_participant_change_cohort_path(@participant_presenter.participant_profile), secondary: true) %>
-    <% end %>
-
-    <h3 class="govuk-heading-m">Relevant induction record statuses</h3>
-    <%= govuk_summary_list(actions: true) do |sl|
-      sl.with_row do |row|
-        row.with_key(text: "induction status")
-        row.with_value(text: govuk_tag(text: @participant_presenter.relevant_induction_record&.induction_status&.capitalize || "No Induction Record Found", colour: "grey"))
-        if allowed_to_change_induction_status?(@participant_presenter)
-          row.with_action(
-            href: edit_admin_participant_change_induction_status_path(@participant_presenter.participant_profile),
-            visually_hidden_text: "induction status"
-          )
+      <%= govuk_summary_list do |sl|
+        sl.with_row do |row|
+          row.with_key(text: "Cohort via induction record")
+          row.with_value(text: @participant_presenter.start_year)
         end
-      end
-    end %>
 
-    <%= govuk_table(
-      caption: "Previous schools",
-      head: ["School name", "Induction programme", "Start date", "End date"],
-      rows: @participant_presenter.historical_induction_records.map do |r|
-        [
-          r.school_cohort.school.name,
-          r.induction_programme.training_programme.humanize,
-          r.start_date.to_date.to_fs(:govuk),
-          r.end_date&.to_date&.to_fs(:govuk),
-        ]
-      end,
+        sl.with_row do |row|
+          row.with_key(text: "Cohort via schedule")
+          row.with_value(text: @participant_presenter&.relevant_induction_record&.schedule&.cohort&.start_year)
+        end
+      end %>
+
+      <% if policy(@participant_profile).edit_cohort? %>
+        <%= govuk_button_link_to("Change cohort", edit_admin_participant_change_cohort_path(@participant_presenter.participant_profile), secondary: true) %>
+      <% end %>
+    </div>
+
+    <div class="govuk-!-margin-bottom-9">
+      <h3 class="govuk-heading-m">Relevant induction record statuses</h3>
+      <%= govuk_summary_list(actions: true) do |sl|
+        sl.with_row do |row|
+          row.with_key(text: "induction status")
+          row.with_value(text: govuk_tag(text: @participant_presenter.relevant_induction_record&.induction_status&.capitalize || "No Induction Record Found", colour: "grey"))
+          if allowed_to_change_induction_status?(@participant_presenter)
+            row.with_action(
+              href: edit_admin_participant_change_induction_status_path(@participant_presenter.participant_profile),
+              visually_hidden_text: "induction status"
+            )
+          end
+        end
+      end %>
+    </div>
+
+    <div class="govuk-!-margin-bottom-9">
+      <%= govuk_table(
+        caption: "Previous schools",
+        head: ["School name", "Induction programme", "Start date", "End date"],
+        rows: @participant_presenter.historical_induction_records.map do |r|
+          [
+            r.school_cohort.school.name,
+            r.induction_programme.training_programme.humanize,
+            r.start_date.to_date.to_fs(:govuk),
+            r.end_date&.to_date&.to_fs(:govuk),
+          ]
+        end,
       ) %>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
### Context

- Ticket: N/A

This PR addresses the issue of poor visual separation between different sections on the Admin->Participant->Training page, which currently makes it challenging to distinguish between sections at a glance.

### Changes proposed in this pull request
Increase spacing below each section

### Guidance to review
|before|after|
|-|-|
|![before](https://github.com/DFE-Digital/early-careers-framework/assets/951947/ae1d3e84-8823-4061-9ed5-4305592ccec7)|![after](https://github.com/DFE-Digital/early-careers-framework/assets/951947/dc3d3de4-7af1-463f-ba06-be9170ba12eb)|
