### PR TITLE
Include deleted duplicate data when archiving unvalidated/undeclared profiles

### DIFF
--- a/app/serializers/archive/participant_profile_serializer.rb
+++ b/app/serializers/archive/participant_profile_serializer.rb
@@ -39,5 +39,10 @@ module Archive
     attribute :participant_profile_states do |participant_profile|
       ParticipantProfileStateSerializer.new(participant_profile.participant_profile_states).serializable_hash[:data]
     end
+
+    attribute :deleted_duplicates do |participant_profile|
+      # these are already serialized so just take the JSON data
+      participant_profile.deleted_duplicates.map { |deleted_duplicate| deleted_duplicate.data["data"] }
+    end
   end
 end

--- a/app/services/archive/destroy_ecf_profile_data.rb
+++ b/app/services/archive/destroy_ecf_profile_data.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# !! ATTENTION !!
+#
+# This is DANGEROUS. Please DO NOT use this in production unless you are 100% sure you need to
+# remove a ParticipantProfile record and its associated objects and have CONFIRMATION
+# it is OK to do so.
+#
+# Ensure an archive has been made BEFORE using this if there needs to be one
+#
+# This service is BRUTAL and HEARTLESS and will revel in your misery if you make a mistake.
+#
+module Archive
+  class DestroyECFProfileData < ::BaseService
+    def call
+      if profile_has_mentees?
+        raise ArchiveError, "Profile #{participant_profile.id} has mentees"
+      else
+        destroy_profile!
+      end
+    end
+
+  private
+
+    attr_reader :participant_profile
+
+    def initialize(participant_profile:)
+      @participant_profile = participant_profile
+    end
+
+    def profile_has_mentees?
+      participant_profile.mentor? && InductionRecord.where(mentor_profile: participant_profile).any?
+    end
+
+    def destroy_profile!
+      ActiveRecord::Base.transaction do
+        participant_profile.ecf_participant_validation_data&.destroy!
+        participant_profile.ecf_participant_eligibility&.destroy!
+        participant_profile.participant_profile_states.destroy_all
+        participant_profile.participant_profile_schedules.destroy_all
+        participant_profile.participant_declarations.destroy_all
+        participant_profile.induction_records.destroy_all
+        participant_profile.validation_decisions.destroy_all
+        participant_profile.deleted_duplicates.destroy_all
+
+        participant_profile.school_mentors.destroy_all if participant_profile.mentor?
+        participant_profile.destroy!
+      end
+    end
+  end
+end

--- a/app/services/archive/unvalidated_profile.rb
+++ b/app/services/archive/unvalidated_profile.rb
@@ -52,16 +52,7 @@ module Archive
     end
 
     def destroy_profile!
-      participant_profile.ecf_participant_validation_data&.destroy!
-      participant_profile.ecf_participant_eligibility&.destroy!
-      participant_profile.participant_profile_states.destroy_all
-      participant_profile.participant_profile_schedules.destroy_all
-      participant_profile.participant_declarations.destroy_all
-      participant_profile.induction_records.destroy_all
-      participant_profile.validation_decisions.destroy_all
-
-      participant_profile.school_mentors.destroy_all if participant_profile.mentor?
-      participant_profile.destroy!
+      DestroyECFProfileData.call(participant_profile:)
     end
   end
 end

--- a/app/services/archive/unvalidated_user.rb
+++ b/app/services/archive/unvalidated_user.rb
@@ -92,16 +92,7 @@ module Archive
     end
 
     def destroy_profile_data!(participant_profile)
-      participant_profile.ecf_participant_validation_data&.destroy!
-      participant_profile.ecf_participant_eligibility&.destroy!
-      participant_profile.participant_profile_states.destroy_all
-      participant_profile.participant_profile_schedules.destroy_all
-      participant_profile.participant_declarations.destroy_all
-      participant_profile.induction_records.destroy_all
-      participant_profile.validation_decisions.destroy_all
-
-      participant_profile.school_mentors.destroy_all if participant_profile.mentor?
-      participant_profile.destroy!
+      DestroyECFProfileData.call(participant_profile:)
     end
   end
 end

--- a/spec/services/archive/destroy_ecf_profile_data_spec.rb
+++ b/spec/services/archive/destroy_ecf_profile_data_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+RSpec.describe Archive::DestroyECFProfileData do
+  let(:participant_profile) { create(:seed_ect_participant_profile, :valid) }
+  let!(:induction_record) { create_list(:seed_induction_record, 2, :valid, participant_profile:) }
+  let!(:user) { participant_profile.user }
+
+  subject(:service_call) { described_class.call(participant_profile:) }
+
+  it "removes the ParticipantProfile record" do
+    expect { service_call }.to change { ParticipantProfile.count }.by(-1)
+  end
+
+  it "removes the induction records" do
+    expect { service_call }.to change { InductionRecord.count }.by(-2)
+  end
+
+  it "does not remove the any ParticipantIdentity records" do
+    # participant_profile
+    expect { service_call }.not_to change { ParticipantIdentity.count }
+  end
+
+  it "does not remove the User" do
+    # user
+    expect { service_call }.not_to change { User.count }
+  end
+
+  context "when the profile has a declaration" do
+    let(:state) { "submitted" }
+    let!(:declaration) { create(:seed_ecf_participant_declaration, :with_cpd_lead_provider, state:, user:, participant_profile:) }
+
+    it "destroys the declarations" do
+      expect { service_call }.to change { ParticipantDeclaration.count }.by(-1)
+    end
+  end
+
+  context "when the profile has an eligibility record" do
+    let!(:eligibility) { create(:ecf_participant_eligibility, participant_profile:) }
+
+    it "destroys the eligibility record" do
+      expect { service_call }.to change { ECFParticipantEligibility.count }.by(-1)
+    end
+  end
+
+  context "when the profile has validation data" do
+    let!(:validation_data) { create(:ecf_participant_validation_data, participant_profile:) }
+
+    it "destroys the validation data" do
+      expect { service_call }.to change { ECFParticipantValidationData.count }.by(-1)
+    end
+  end
+
+  context "when the profile is a mentor" do
+    let(:participant_profile) { create(:seed_mentor_participant_profile, :valid) }
+    let!(:school_mentor) { create(:seed_school_mentor, :with_school, preferred_identity: participant_profile.participant_identity, participant_profile:) }
+
+    it "removes their school mentor relations" do
+      expect {
+        service_call
+      }.to change { SchoolMentor.count }.by(-1)
+    end
+
+    context "when the profile has mentees" do
+      let!(:mentee) { create(:seed_induction_record, :valid, mentor_profile: participant_profile) }
+
+      it "raises an ArchiveError" do
+        expect {
+          service_call
+        }.to raise_error Archive::ArchiveError
+      end
+    end
+  end
+
+  context "when the profile has schedule records" do
+    let!(:schedule) { ParticipantProfileSchedule.create!(schedule: participant_profile.schedule, participant_profile:) }
+
+    it "removes the participant profile schedules" do
+      expect {
+        service_call
+      }.to change { ParticipantProfileSchedule.count }.by(-1)
+    end
+  end
+
+  context "when the profile has states" do
+    let!(:states) { create_list(:seed_ect_participant_profile_state, 3, participant_profile:) }
+
+    it "removes the participant profile states" do
+      expect {
+        service_call
+      }.to change { ParticipantProfileState.count }.by(-3)
+    end
+  end
+
+  context "when the profile has validation decisions" do
+    let!(:decision) do
+      ProfileValidationDecision.create!(participant_profile_id: participant_profile.id, note: "yes", approved: true,
+                                        validation_step: :something)
+    end
+
+    it "removes the profile validation decision" do
+      expect {
+        service_call
+      }.to change { ProfileValidationDecision.count }.by(-1)
+    end
+  end
+
+  context "when the profile has deleted duplicates" do
+    before do
+      Finance::ECF::DeletedDuplicate.create!(data: { some: "data" }.to_json, primary_participant_profile: participant_profile)
+    end
+
+    it "removes the deleted duplicates" do
+      expect {
+        service_call
+      }.to change { Finance::ECF::DeletedDuplicate.count }.by(-1)
+    end
+  end
+end

--- a/spec/services/archive/unvalidated_profile_spec.rb
+++ b/spec/services/archive/unvalidated_profile_spec.rb
@@ -141,4 +141,16 @@ RSpec.describe Archive::UnvalidatedProfile do
       }.to change { ParticipantProfileState.count }.by(-3)
     end
   end
+
+  context "when the profile has deleted duplicates" do
+    before do
+      Finance::ECF::DeletedDuplicate.create!(data: { some: "data" }.to_json, primary_participant_profile: participant_profile)
+    end
+
+    it "removes the deleted duplicates" do
+      expect {
+        service_call
+      }.to change { Finance::ECF::DeletedDuplicate.count }.by(-1)
+    end
+  end
 end


### PR DESCRIPTION
### Context

As part of finishing off archiving unvalidated/undeclared participants, some of the remaining participants have deleted duplicate records. It was decided that we will include the serialised data from the deleted duplicate record in the archive for the "primary" profile and enable us to continue archiving and removing these users/profiles.

**Note**: I have refactored duplication of the destruction of the participant_profile and associated records into it's own service in the `Archive` module. This also allows it to tested in one place but it may not be desirable to be so accessible that the routine could be misused. I have added a warning message in the service code but would appreciate some comments/feedback/opinions on this.

### Changes proposed in this pull request
- Include deleted duplicates in participant profile archive
- Remove associated `Finance::ECF::DeletedDuplicate` records during archival
- Adds `Archive::DestroyECFProfileData` service

### Guidance to review

