### PR TITLE
[Bug-Fix] Modify queries to exclude ineligible ppts from chaser email

### DIFF
--- a/app/models/ecf_participant_eligibility.rb
+++ b/app/models/ecf_participant_eligibility.rb
@@ -31,6 +31,7 @@ class ECFParticipantEligibility < ApplicationRecord
 
   # Scopes
   scope :updated_before, ->(timestamp) { where(updated_at: ..timestamp) }
+  scope :waiting_for_induction, -> { manual_check_status.no_induction_reason }
 
   # Instance Methods
   def duplicate_profile?

--- a/app/models/participant_profile/ect.rb
+++ b/app/models/participant_profile/ect.rb
@@ -6,9 +6,9 @@ class ParticipantProfile::ECT < ParticipantProfile::ECF
   belongs_to :mentor_profile, class_name: "Mentor", optional: true
   has_one :mentor, through: :mentor_profile, source: :user
 
-  scope :awaiting_induction_registration, -> do
+  scope :awaiting_induction_registration, lambda {
     where(induction_start_date: nil).joins(:ecf_participant_eligibility).merge(ECFParticipantEligibility.waiting_for_induction)
-  end
+  }
 
   def ect?
     true

--- a/app/models/participant_profile/ect.rb
+++ b/app/models/participant_profile/ect.rb
@@ -6,6 +6,10 @@ class ParticipantProfile::ECT < ParticipantProfile::ECF
   belongs_to :mentor_profile, class_name: "Mentor", optional: true
   has_one :mentor, through: :mentor_profile, source: :user
 
+  scope :awaiting_induction_registration, -> do
+    where(induction_start_date: nil).joins(:ecf_participant_eligibility).merge(ECFParticipantEligibility.waiting_for_induction)
+  end
+
   def ect?
     true
   end

--- a/app/queries/ects/with_an_appropriate_body_and_unregistered_query.rb
+++ b/app/queries/ects/with_an_appropriate_body_and_unregistered_query.rb
@@ -6,9 +6,8 @@ module Ects
       InductionRecord
         .active
         .training_status_active
-        .joins(participant_profile: :ecf_participant_eligibility)
-        .where(participant_profile: { induction_start_date: nil, type: "ParticipantProfile::ECT" })
-        .where(ecf_participant_eligibility: { qts: true, active_flags: false, different_trn: false, previous_induction: false, no_induction: true })
+        .joins(:particpant_profile)
+        .merge(ParticipantProfile::ECT.awaiting_induction_registration)
         .joins(induction_programme: :school_cohort)
         .where(induction_programme: { training_programme: training_programme_types })
         .where("induction_records.appropriate_body_id IS NOT NULL OR school_cohorts.appropriate_body_id IS NOT NULL")

--- a/app/queries/ects/with_an_appropriate_body_and_unregistered_query.rb
+++ b/app/queries/ects/with_an_appropriate_body_and_unregistered_query.rb
@@ -6,8 +6,9 @@ module Ects
       InductionRecord
         .active
         .training_status_active
-        .joins(:participant_profile)
+        .joins(participant_profile: :ecf_participant_eligibility)
         .where(participant_profile: { induction_start_date: nil, type: "ParticipantProfile::ECT" })
+        .where(ecf_participant_eligibility: { qts: true, active_flags: false, different_trn: false, previous_induction: false, no_induction: true })
         .joins(induction_programme: :school_cohort)
         .where(induction_programme: { training_programme: training_programme_types })
         .where("induction_records.appropriate_body_id IS NOT NULL OR school_cohorts.appropriate_body_id IS NOT NULL")

--- a/app/queries/ects/with_an_appropriate_body_and_unregistered_query.rb
+++ b/app/queries/ects/with_an_appropriate_body_and_unregistered_query.rb
@@ -6,7 +6,7 @@ module Ects
       InductionRecord
         .active
         .training_status_active
-        .joins(:particpant_profile)
+        .joins(:participant_profile)
         .merge(ParticipantProfile::ECT.awaiting_induction_registration)
         .joins(induction_programme: :school_cohort)
         .where(induction_programme: { training_programme: training_programme_types })

--- a/app/queries/ects/without_an_appropriate_body_and_unregistered_query.rb
+++ b/app/queries/ects/without_an_appropriate_body_and_unregistered_query.rb
@@ -6,9 +6,8 @@ module Ects
       InductionRecord
         .active
         .training_status_active
-        .joins(participant_profile: :ecf_participant_eligibility)
-        .where(participant_profile: { induction_start_date: nil, type: "ParticipantProfile::ECT" })
-        .where(ecf_participant_eligibility: { qts: true, active_flags: false, different_trn: false, previous_induction: false, no_induction: true })
+        .joins(:participant_profile)
+        .merge(ParticipantProfile::ECT.awaiting_induction_registration)
         .joins(induction_programme: :school_cohort)
         .where(induction_programme: { training_programme: training_programme_types })
         .where(appropriate_body_id: nil)

--- a/app/queries/ects/without_an_appropriate_body_and_unregistered_query.rb
+++ b/app/queries/ects/without_an_appropriate_body_and_unregistered_query.rb
@@ -6,8 +6,9 @@ module Ects
       InductionRecord
         .active
         .training_status_active
-        .joins(:participant_profile)
+        .joins(participant_profile: :ecf_participant_eligibility)
         .where(participant_profile: { induction_start_date: nil, type: "ParticipantProfile::ECT" })
+        .where(ecf_participant_eligibility: { qts: true, active_flags: false, different_trn: false, previous_induction: false, no_induction: true })
         .joins(induction_programme: :school_cohort)
         .where(induction_programme: { training_programme: training_programme_types })
         .where(appropriate_body_id: nil)

--- a/spec/factories/seeds/ecf_participant_eligibility_factory.rb
+++ b/spec/factories/seeds/ecf_participant_eligibility_factory.rb
@@ -11,6 +11,8 @@ FactoryBot.define do
     previous_participation { false }
     previous_induction { false }
     no_induction { false }
+    different_trn { false }
+    exempt_from_induction { false }
 
     status { :eligible }
     reason { :none }

--- a/spec/models/ecf_participant_eligibility_spec.rb
+++ b/spec/models/ecf_participant_eligibility_spec.rb
@@ -75,4 +75,32 @@ RSpec.describe ECFParticipantEligibility, type: :model do
       end
     end
   end
+
+  describe ".waiting_for_induction scope" do
+    let(:status) { :manual_check }
+    let(:reason) { :no_induction }
+    let!(:eligibility) { create(:seed_ecf_participant_eligibility, :with_participant_profile, status:, reason:) }
+
+    it "returns records that would be valid if they had an induction registered" do
+      expect(described_class.waiting_for_induction).to match_array [eligibility]
+    end
+
+    context "when the status is not manual_check" do
+      it "does not return awaiting induction records" do
+        described_class.statuses.except(:manual_check).each_value do |status|
+          eligibility.update!(status:)
+          expect(described_class.waiting_for_induction).not_to include eligibility
+        end
+      end
+    end
+
+    context "when the reason is not no_induction" do
+      it "does not return awaiting induction records" do
+        described_class.reasons.except(:no_induction).each_value do |reason|
+          eligibility.update!(reason:)
+          expect(described_class.waiting_for_induction).not_to include eligibility
+        end
+      end
+    end
+  end
 end

--- a/spec/queries/ects/with_an_appropriate_body_and_unregistered_query_spec.rb
+++ b/spec/queries/ects/with_an_appropriate_body_and_unregistered_query_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe Ects::WithAnAppropriateBodyAndUnregisteredQuery do
 
     context "when there is no QTS" do
       let!(:fip_eligibility) do
-        create(:seed_ecf_participant_eligibility, :no_induction, :no_qts, participant_profile: fip_participant_profile)
+        create(:seed_ecf_participant_eligibility, :no_qts, no_induction: true, participant_profile: fip_participant_profile)
       end
 
       it "does not return those participants" do
@@ -127,7 +127,7 @@ RSpec.describe Ects::WithAnAppropriateBodyAndUnregisteredQuery do
 
     context "when there are active flags" do
       let!(:fip_eligibility) do
-        create(:seed_ecf_participant_eligibility, :no_induction, :active_flags, participant_profile: fip_participant_profile)
+        create(:seed_ecf_participant_eligibility, :active_flags, no_induction: true, participant_profile: fip_participant_profile)
       end
 
       it "does not return those participants" do
@@ -137,7 +137,7 @@ RSpec.describe Ects::WithAnAppropriateBodyAndUnregisteredQuery do
 
     context "when a previous induction is flagged" do
       let!(:fip_eligibility) do
-        create(:seed_ecf_participant_eligibility, :no_induction, :previous_induction, participant_profile: fip_participant_profile)
+        create(:seed_ecf_participant_eligibility, :previous_induction, no_induction: true, participant_profile: fip_participant_profile)
       end
 
       it "does not return those participants" do

--- a/spec/queries/ects/with_an_appropriate_body_and_unregistered_query_spec.rb
+++ b/spec/queries/ects/with_an_appropriate_body_and_unregistered_query_spec.rb
@@ -26,6 +26,14 @@ RSpec.describe Ects::WithAnAppropriateBodyAndUnregisteredQuery do
       create(:seed_induction_record, :valid, participant_profile: cip_participant_profile, induction_programme: cip_induction_programme)
     end
 
+    let!(:fip_eligibility) do
+      create(:seed_ecf_participant_eligibility, :no_induction, participant_profile: fip_participant_profile)
+    end
+
+    let!(:cip_eligibility) do
+      create(:seed_ecf_participant_eligibility, :no_induction, participant_profile: cip_participant_profile)
+    end
+
     subject(:query_result) { described_class.call(include_fip:, include_cip:) }
 
     context "when there are ECTs without induction start dates" do
@@ -96,6 +104,44 @@ RSpec.describe Ects::WithAnAppropriateBodyAndUnregisteredQuery do
 
       it "does not return those participants" do
         expect(query_result).to match_array [fip_induction_record]
+      end
+    end
+
+    context "when there is no QTS" do
+      let!(:fip_eligibility) do
+        create(:seed_ecf_participant_eligibility, :no_induction, :no_qts, participant_profile: fip_participant_profile)
+      end
+
+      it "does not return those participants" do
+        expect(query_result).to match_array [cip_induction_record]
+      end
+    end
+
+    context "when there is no eligibility record" do
+      let!(:fip_eligibility)  { nil }
+
+      it "does not return those participants" do
+        expect(query_result).to match_array [cip_induction_record]
+      end
+    end
+
+    context "when there are active flags" do
+      let!(:fip_eligibility) do
+        create(:seed_ecf_participant_eligibility, :no_induction, :active_flags, participant_profile: fip_participant_profile)
+      end
+
+      it "does not return those participants" do
+        expect(query_result).to match_array [cip_induction_record]
+      end
+    end
+
+    context "when a previous induction is flagged" do
+      let!(:fip_eligibility) do
+        create(:seed_ecf_participant_eligibility, :no_induction, :previous_induction, participant_profile: fip_participant_profile)
+      end
+
+      it "does not return those participants" do
+        expect(query_result).to match_array [cip_induction_record]
       end
     end
   end

--- a/spec/queries/ects/without_an_appropriate_body_and_unregistered_query_spec.rb
+++ b/spec/queries/ects/without_an_appropriate_body_and_unregistered_query_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Ects::WithoutAnAppropriateBodyAndUnregisteredQuery do
 
     context "when there is no QTS" do
       let!(:fip_eligibility) do
-        create(:seed_ecf_participant_eligibility, :no_induction, :no_qts, participant_profile: fip_participant_profile)
+        create(:seed_ecf_participant_eligibility, :no_qts, no_induction: true, participant_profile: fip_participant_profile)
       end
 
       it "does not return those participants" do
@@ -107,7 +107,7 @@ RSpec.describe Ects::WithoutAnAppropriateBodyAndUnregisteredQuery do
 
     context "when there are active flags" do
       let!(:fip_eligibility) do
-        create(:seed_ecf_participant_eligibility, :no_induction, :active_flags, participant_profile: fip_participant_profile)
+        create(:seed_ecf_participant_eligibility, :active_flags, no_induction: true, participant_profile: fip_participant_profile)
       end
 
       it "does not return those participants" do
@@ -117,7 +117,7 @@ RSpec.describe Ects::WithoutAnAppropriateBodyAndUnregisteredQuery do
 
     context "when a previous induction is flagged" do
       let!(:fip_eligibility) do
-        create(:seed_ecf_participant_eligibility, :no_induction, :previous_induction, participant_profile: fip_participant_profile)
+        create(:seed_ecf_participant_eligibility, :previous_induction, no_induction: true, participant_profile: fip_participant_profile)
       end
 
       it "does not return those participants" do

--- a/spec/queries/ects/without_an_appropriate_body_and_unregistered_query_spec.rb
+++ b/spec/queries/ects/without_an_appropriate_body_and_unregistered_query_spec.rb
@@ -23,6 +23,14 @@ RSpec.describe Ects::WithoutAnAppropriateBodyAndUnregisteredQuery do
       create(:seed_induction_record, :valid, participant_profile: cip_participant_profile, induction_programme: cip_induction_programme)
     end
 
+    let!(:fip_eligibility) do
+      create(:seed_ecf_participant_eligibility, :no_induction, participant_profile: fip_participant_profile)
+    end
+
+    let!(:cip_eligibility) do
+      create(:seed_ecf_participant_eligibility, :no_induction, participant_profile: cip_participant_profile)
+    end
+
     subject(:query_result) { described_class.call(include_fip:, include_cip:) }
 
     context "when there are ECTs without induction start dates" do
@@ -76,6 +84,44 @@ RSpec.describe Ects::WithoutAnAppropriateBodyAndUnregisteredQuery do
 
       it "does not return those participants" do
         expect(query_result).to match_array [fip_induction_record]
+      end
+    end
+
+    context "when there is no QTS" do
+      let!(:fip_eligibility) do
+        create(:seed_ecf_participant_eligibility, :no_induction, :no_qts, participant_profile: fip_participant_profile)
+      end
+
+      it "does not return those participants" do
+        expect(query_result).to match_array [cip_induction_record]
+      end
+    end
+
+    context "when there is no eligibility record" do
+      let!(:fip_eligibility)  { nil }
+
+      it "does not return those participants" do
+        expect(query_result).to match_array [cip_induction_record]
+      end
+    end
+
+    context "when there are active flags" do
+      let!(:fip_eligibility) do
+        create(:seed_ecf_participant_eligibility, :no_induction, :active_flags, participant_profile: fip_participant_profile)
+      end
+
+      it "does not return those participants" do
+        expect(query_result).to match_array [cip_induction_record]
+      end
+    end
+
+    context "when a previous induction is flagged" do
+      let!(:fip_eligibility) do
+        create(:seed_ecf_participant_eligibility, :no_induction, :previous_induction, participant_profile: fip_participant_profile)
+      end
+
+      it "does not return those participants" do
+        expect(query_result).to match_array [cip_induction_record]
       end
     end
   end

--- a/spec/services/bulk_mailers/school_reminder_comms_spec.rb
+++ b/spec/services/bulk_mailers/school_reminder_comms_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe BulkMailers::SchoolReminderComms, type: :mailer do
 
     let(:ect_appropriate_body) { nil }
     let(:school_appropriate_body) { nil }
+    let!(:eligibility) { create(:seed_ecf_participant_eligibility, :no_induction, participant_profile:) }
     let!(:induction_record) { create(:seed_induction_record, :valid, participant_profile:, induction_programme:, appropriate_body: ect_appropriate_body) }
 
     before do
@@ -89,6 +90,20 @@ RSpec.describe BulkMailers::SchoolReminderComms, type: :mailer do
           expect(service.contact_sits_that_need_to_chase_their_ab_to_register_ects).to eq 0
         end
       end
+
+      context "when there are no eligible participants without a registered induction" do
+        let!(:eligibility) { create(:seed_ecf_participant_eligibility, :no_induction, :no_qts, participant_profile:) }
+
+        it "does not mail the induction coordinator" do
+          expect {
+            service.contact_sits_that_need_to_chase_their_ab_to_register_ects
+          }.not_to have_enqueued_mail(SchoolMailer, :remind_sit_that_ab_has_not_registered_ect)
+        end
+
+        it "returns the count of emails sent" do
+          expect(service.contact_sits_that_need_to_chase_their_ab_to_register_ects).to eq 0
+        end
+      end
     end
   end
 
@@ -98,6 +113,7 @@ RSpec.describe BulkMailers::SchoolReminderComms, type: :mailer do
 
     let(:ect_appropriate_body) { nil }
     let(:school_appropriate_body) { nil }
+    let!(:eligibility) { create(:seed_ecf_participant_eligibility, :no_induction, participant_profile:) }
     let!(:induction_record) { create(:seed_induction_record, :valid, participant_profile:, induction_programme:, appropriate_body: ect_appropriate_body) }
 
     before do
@@ -155,6 +171,20 @@ RSpec.describe BulkMailers::SchoolReminderComms, type: :mailer do
 
         it "returns the count of emails that would have been sent" do
           expect(service.contact_sits_that_need_to_appoint_an_ab_for_unregistered_ects).to eq 1
+        end
+      end
+
+      context "when there are no eligible participants without a registered induction" do
+        let!(:eligibility) { create(:seed_ecf_participant_eligibility, :no_induction, :no_qts, participant_profile:) }
+
+        it "does not mail the induction coordinator" do
+          expect {
+            service.contact_sits_that_need_to_chase_their_ab_to_register_ects
+          }.not_to have_enqueued_mail(SchoolMailer, :remind_sit_that_ab_has_not_registered_ect)
+        end
+
+        it "returns the count of emails sent" do
+          expect(service.contact_sits_that_need_to_chase_their_ab_to_register_ects).to eq 0
         end
       end
     end


### PR DESCRIPTION
### Context

In a recent chaser email to schools it was noticed in support that some participants did not have QTS. This fixes the queries so that they do not include participants that have other eligibility issues.

### Changes proposed in this pull request
Check the `ECFParticipantEligibility` record for other flags and only include those that have no induction

### Guidance to review

