### PR TITLE
Configure merge queues

### DIFF
--- a/.github/workflows/aks_deploy.yml
+++ b/.github/workflows/aks_deploy.yml
@@ -45,7 +45,7 @@ jobs:
   docker:
     name: Build and push Docker image
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]'
+    if: github.actor != 'dependabot[bot]' && github.event_name != 'merge_group'
     outputs:
       docker-image: ${{ steps.build-docker-image.outputs.image }}
     steps:

--- a/.github/workflows/aks_deploy.yml
+++ b/.github/workflows/aks_deploy.yml
@@ -17,10 +17,10 @@ on:
   push:
     branches:
       - main
-
   pull_request:
     branches:
       - main
+  merge_group:
 
 jobs:
   lint:


### PR DESCRIPTION
Queuing PRs should help keep the log linear, tidy and prevent statefile locking issues in deploys.
