### PR TITLE
Change concurrency group to head_ref then run_id

### DIFF
--- a/.github/workflows/aks_deploy.yml
+++ b/.github/workflows/aks_deploy.yml
@@ -1,7 +1,7 @@
 name: "Deploy"
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 on:


### PR DESCRIPTION
The concurrency setting in GitHub workflows will cancel a run when another run in the same group occurs. The group was set to `github.ref` but this appears to cancel the deployment on main before it finishes when queues are enabled.

This is because while the first branch is being deployed, the second branch's tests are running and then when they complete *it* is deployed. But, because the second branch's build is shorter (it runs the tests/lint but doesn't deploy anything) - it's merged _before_ the first branch has reached `production`/`migration`/`sandbox` and cancels their deploy 🤦🏽‍♂️  

Instead if we use `github.head_ref || github.run_id` the cancellation [should only happen within the context of pull requests or retries](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context).
