### PR TITLE
CST-2300: re-schedule jobs to update induction completion dates

### DIFF
--- a/app/jobs/set_participant_completion_date_job.rb
+++ b/app/jobs/set_participant_completion_date_job.rb
@@ -9,11 +9,17 @@ class SetParticipantCompletionDateJob < ApplicationJob
   MAX_CANDIDATES = 200
 
   def perform
-    CompletionCandidate.limit(MAX_CANDIDATES).each do |candidate|
+    candidates.each do |candidate|
       Participants::CheckAndSetCompletionDate.call(participant_profile: candidate.participant_profile)
       candidate.destroy!
     end
   rescue StandardError => e
     Rails.logger.error("SetParticipantCompletionDateJob: #{e.message}")
+  end
+
+private
+
+  def candidates
+    @candidates ||= CompletionCandidate.includes(participant_profile: :teacher_profile).limit(MAX_CANDIDATES)
   end
 end

--- a/app/services/participants/build_completion_candidate_list.rb
+++ b/app/services/participants/build_completion_candidate_list.rb
@@ -27,20 +27,12 @@ module Participants
           SELECT pp.id
           FROM participant_profiles pp
           JOIN teacher_profiles tp ON tp.id = pp.teacher_profile_id
-          JOIN schedules s ON s.id = pp.schedule_id
-          JOIN cohorts c ON c.id = s.cohort_id
           WHERE pp.type = 'ParticipantProfile::ECT'
-          AND c.start_year IN (2020,2021,2022)
           AND pp.induction_start_date IS NOT NULL
           AND pp.induction_completion_date IS NULL
-          AND pp.created_at < '#{registration_start_date}'
           AND tp.trn IS NOT NULL;
         SQL
       )
-    end
-
-    def registration_start_date
-      Cohort.find_by(start_year: 2023).registration_start_date.to_date.to_s
     end
   end
 end

--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -38,7 +38,7 @@ send_outcomes_to_qualified_teachers_api:
   class: "ParticipantOutcomes::BatchSendLatestOutcomesJob"
   queue: participant_outcomes
 build_completion_candidates_list_job:
-  cron: "15 23 * * *"
+  cron: "15 23 * * 1,4"
   class: "BuildCompletionCandidatesListJob"
   queue: default
 set_participant_completion_date_job:

--- a/spec/services/participants/build_completion_candidate_list_spec.rb
+++ b/spec/services/participants/build_completion_candidate_list_spec.rb
@@ -14,13 +14,8 @@ RSpec.describe Participants::BuildCompletionCandidateList do
   subject(:service_call) { described_class.call }
 
   describe "#call" do
-    it "adds eligible ECTs from 2021 and 2022 to the list" do
-      expect { service_call }.to change { CompletionCandidate.count }.by(2)
-    end
-
-    it "does not add ECTs from 2023" do
-      service_call
-      expect(CompletionCandidate.all).not_to include ect_23
+    it "adds eligible ECTs from to the list" do
+      expect { service_call }.to change { CompletionCandidate.count }.by(3)
     end
 
     context "when an ECT does not have an induction start date" do
@@ -30,7 +25,7 @@ RSpec.describe Participants::BuildCompletionCandidateList do
 
       it "does not add them to the list" do
         service_call
-        expect(CompletionCandidate.all).not_to include ect_22
+        expect(CompletionCandidate.exists?(participant_profile_id: ect_22.id)).to be_falsey
       end
     end
 
@@ -41,7 +36,7 @@ RSpec.describe Participants::BuildCompletionCandidateList do
 
       it "does not add them to the list" do
         service_call
-        expect(CompletionCandidate.all).not_to include ect_22
+        expect(CompletionCandidate.exists?(participant_profile_id: ect_22.id)).to be_falsey
       end
     end
   end


### PR DESCRIPTION
### Context

We currently have a job that runs daily overnight to check DQT for new ECT completion dates. This checks all ECTs registered before 2023 who don't already have a completion date (c. 36,000 ECTs).

There is a limit on the DQT API, which means it has to be run several times throughout the night, and with such a long list of people to check, there is a risk that we aren't getting through everyone each time. We also need to add in 2023 ppts which will increase the list further (c. 60,000).

For checking new induction starts, we currently have a weekly job that runs on a Monday morning.

We wanted to consider ways to improve the approach to checking for ECT completions, to ensure the full list is checked and up to date without risking the job being shut down for taking too long.

We considered whether the list of candidates to check could be narrowed down to a targeted group of only those with a completed declaration, but we have confirmed with Nathan that all records do need to be checked regularly. This is because ppts on reduced inductions don't always have a completed declaration and providers are not always aware of them until DfE flags that they are complete, and we do not have another way of identifying those reduced induction records. Nathan has suggested that we would be happy with a less frequent cadence of checks if we can be confident that records are up to date on a Monday morning.

We would like to extend the schedule to only run twice a week for the job that populates the list of people to check - the list would then be checked all the way through (possibly over several nights) and stop until a new list is populated to check. If we schedule the job to start on Wednesday night and Saturday night each week, any record would be at most 3.5 days out of date. On a Monday morning, all records updated before Saturday night will be up to date.

[Ticket](https://dfedigital.atlassian.net/browse/CST-2300)

### Changes proposed in this pull request
- The 'Build completion candidates list' job updated to include all ECTs who do not yet have a completion date, including participants registered in 2023

- The existing schedule for the 'Build completion candidates list' job that populates the list of ECTs to check for a completion date extended to run twice a week, starting on Monday and Thursday nights each week.

- The existing daily job to process the list and set completion dates keeps running every single night of the week from 0-8 every 2 minutes.

There are around 54K ECTs with incomplete induction. 
Every Monday night the list of ECTs to check will be rebuilt.
On Monday, Tuesday and Wednesday nights, the job to check and set completion dates will be running during 9 hours, 30 times per hour picking 200 ECTs per run = 54K ECTs per day.
That means that during those 3 next nights when the list has been rebuilt, we might be checking at most 162K ECTs.

This cycle repeats again starting on Thursday night during 4 nights so checking a maximum of 216K ECTs.


