### PR TITLE
CPDNPQ-1688 Reduce Number of Sentry Issues from Unsynced Applications

### DIFF
--- a/app/controllers/api/v1/npq_profiles_controller.rb
+++ b/app/controllers/api/v1/npq_profiles_controller.rb
@@ -13,12 +13,16 @@ module Api
       def create
         @npq_application = build_npq_application
 
-        if @npq_application.save_and_dedupe_participant
-          render status: :created,
-                 content_type: "application/vnd.api+json",
-                 json: NPQValidationDataSerializer.new(@npq_application).serializable_hash
-        else
-          render json: { errors: Api::ErrorFactory.new(model: @npq_application).call }, status: :bad_request
+        begin
+          if @npq_application.save_and_dedupe_participant
+            render status: :created,
+                   content_type: "application/vnd.api+json",
+                   json: NPQValidationDataSerializer.new(@npq_application).serializable_hash
+          else
+            render json: { errors: Api::ErrorFactory.new(model: @npq_application).call }, status: :bad_request
+          end
+        rescue StandardError
+          render json: { error: "Identity ids present on both User records" }, status: :internal_server_error
         end
       end
 


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-1688

This is done when the persistent errors which are being caused by the GAI ID/transfer identity onion are reduced.
We know who the affected users and applications are via the NPQ admin console unsynced applications tab
