### PR TITLE
[CST-2360] Enhance AB selection based on School Type Codes

### DIFF
--- a/app/forms/admin/schools/cohorts/appropriate_bodies/update_form.rb
+++ b/app/forms/admin/schools/cohorts/appropriate_bodies/update_form.rb
@@ -23,7 +23,7 @@ module Admin
 
           def radio_options
             @radio_options ||= [
-              appropriate_bodies.where(listed: true),
+              listed_appropriate_bodies,
               OpenStruct.new(id: TEACHING_SCHOOL_HUB_ID, name: "A teaching school hub"),
             ].flatten.compact
           end
@@ -51,6 +51,10 @@ module Admin
 
           def appropriate_bodies
             AppropriateBody.active_in_year(cohort_start_year)
+          end
+
+          def listed_appropriate_bodies
+            appropriate_bodies.where(listed: true).where("listed_for_school_type_codes @> '{?}'", school_cohort.school.school_type_code)
           end
 
           def cohort_start_year

--- a/app/models/concerns/gias_types.rb
+++ b/app/models/concerns/gias_types.rb
@@ -7,12 +7,24 @@ module GiasTypes
   ELIGIBLE_STATUS_CODES = [1, 3].freeze
   CIP_ONLY_TYPE_CODES = [10, 11, 30, 37].freeze
   CIP_ONLY_EXCEPT_WELSH_CODES = [10, 11, 37].freeze
+  INDEPENDENT_SCHOOLS_TYPE_CODES = [10, 11].freeze
 
   # Types that *are* eligible but we would prefer not to send communications to.
   NO_INVITATIONS_TYPE_CODES = [47, 48].freeze
 
   OPEN_STATUS_CODES = ELIGIBLE_STATUS_CODES
   CLOSED_STATUS_CODES = [2, 4].freeze
+
+  ALL_TYPE_CODES = (
+    ELIGIBLE_TYPE_CODES +
+    ELIGIBLE_STATUS_CODES +
+    CIP_ONLY_TYPE_CODES +
+    CIP_ONLY_EXCEPT_WELSH_CODES +
+    INDEPENDENT_SCHOOLS_TYPE_CODES +
+    NO_INVITATIONS_TYPE_CODES +
+    OPEN_STATUS_CODES +
+    CLOSED_STATUS_CODES
+  ).uniq.sort.freeze
 
   MAJOR_CHANGE_ATTRIBUTES = %w[
     school_status_code

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -154,6 +154,7 @@
   - updated_at
   - disable_from_year
   - listed
+  - listed_for_school_type_codes
   :participant_profiles:
   - id
   - school_id

--- a/db/migrate/20240226135601_add_listed_for_school_type_codes_to_appropriate_bodies.rb
+++ b/db/migrate/20240226135601_add_listed_for_school_type_codes_to_appropriate_bodies.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddListedForSchoolTypeCodesToAppropriateBodies < ActiveRecord::Migration[7.0]
+  def change
+    add_column :appropriate_bodies, :listed_for_school_type_codes, :integer, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_06_170145) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_26_135601) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -207,6 +207,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_06_170145) do
     t.datetime "updated_at", null: false
     t.integer "disable_from_year"
     t.boolean "listed", default: false, null: false
+    t.integer "listed_for_school_type_codes", default: [], array: true
     t.index ["body_type", "name"], name: "index_appropriate_bodies_on_body_type_and_name", unique: true
   end
 

--- a/spec/factories/appropriate_bodies.rb
+++ b/spec/factories/appropriate_bodies.rb
@@ -22,5 +22,13 @@ FactoryBot.define do
       end
       body_type { "national" }
     end
+
+    trait :supports_independent_schools_only do
+      listed_for_school_type_codes { GiasTypes::INDEPENDENT_SCHOOLS_TYPE_CODES }
+    end
+
+    trait :supports_all_schools do
+      listed_for_school_type_codes { GiasTypes::ALL_TYPE_CODES }
+    end
   end
 end

--- a/spec/factories/school.rb
+++ b/spec/factories/school.rb
@@ -60,6 +60,10 @@ FactoryBot.define do
       school_type_code { GiasTypes::CIP_ONLY_TYPE_CODES.sample }
     end
 
+    trait :independent_school do
+      school_type_code   { GiasTypes::INDEPENDENT_SCHOOLS_TYPE_CODES.sample }
+    end
+
     factory :school_with_consecutive_cohorts do
       transient do
         school_cohorts_count { 5 }

--- a/spec/features/admin/schools/changing_appropriate_bodies_spec.rb
+++ b/spec/features/admin/schools/changing_appropriate_bodies_spec.rb
@@ -9,6 +9,18 @@ RSpec.feature "Admin managing appropriate bodies", js: true, rutabaga: false do
     and_there_should_be_a_radio_button_for @listed_ab.name
     and_there_should_be_a_radio_button_for @listed_ab_2023_disabled.name
     and_there_should_be_a_radio_button_for "A teaching school hub"
+    and_there_should_not_be_a_radio_button_for @listed_independent_schools_ab.name
+
+    and_i_should_be_able_to_update_the_appropriate_body(@listed_ab.name, 2021)
+  end
+
+  scenario "Admin changes appropriate body of an independent school to IStip" do
+    given_there_is_an_independent_cip_school_in(2021)
+    i_should_be_able_to_navigate_to_the_edit_page(2021)
+    and_there_should_be_a_radio_button_for @listed_ab.name
+    and_there_should_be_a_radio_button_for @listed_ab_2023_disabled.name
+    and_there_should_be_a_radio_button_for "A teaching school hub"
+    and_there_should_be_a_radio_button_for @listed_independent_schools_ab.name
 
     and_i_should_be_able_to_update_the_appropriate_body(@listed_ab.name, 2021)
   end
@@ -55,8 +67,12 @@ RSpec.feature "Admin managing appropriate bodies", js: true, rutabaga: false do
 
 private
 
-  def given_there_is_a_cip_school_in(year, induction_programme_choice: "core_induction_programme")
-    @school = create(:school, name: "Test school")
+  def given_there_is_a_cip_school_in(year, induction_programme_choice: "core_induction_programme", independent_school: false)
+    @school = if independent_school
+                create(:school, :independent_school, name: "Test school")
+              else
+                create(:school, name: "Test school")
+              end
     cohort = Cohort.find_by(start_year: year) || create(:cohort, start_year: year)
     create(:seed_partnership, :with_lead_provider, :valid, cohort:, school: @school)
 
@@ -71,9 +87,14 @@ private
                             core_induction_programme: chosen_cip)
   end
 
+  def given_there_is_an_independent_cip_school_in(year)
+    given_there_is_a_cip_school_in(year, induction_programme_choice: "core_induction_programme", independent_school: true)
+  end
+
   def and_there_are_the_required_appropriate_bodies
-    @listed_ab = create(:appropriate_body_national_organisation, listed: true)
-    @listed_ab_2023_disabled = create(:appropriate_body_national_organisation, listed: true, disable_from_year: 2023)
+    @listed_ab = create(:appropriate_body_national_organisation, :supports_all_schools, listed: true)
+    @listed_ab_2023_disabled = create(:appropriate_body_national_organisation, :supports_all_schools, listed: true, disable_from_year: 2023)
+    @listed_independent_schools_ab = create(:appropriate_body_national_organisation, :supports_independent_schools_only, listed: true, name: "independent schools only")
     create(:appropriate_body_teaching_school_hub, name: "Example teaching school hub")
   end
 


### PR DESCRIPTION
### Context

- Ticket: CST-2360

Given that not every Appropriate Body (AB) supports all school type codes, it's essential to tailor the AB options displayed to School Induction Tutors (SITs) or Admins during the AB selection process for a school's induction programme.

IStip is an example that only supports independent schools.

### Changes proposed in this pull request
- Introduce a new attribute in the Appropriate Body model to specify the supported school type codes, with a default setting of an empty array.
- Ensure only ABs compatible with a school's type code are shown as options when an SIT or Admin selects an AB for an induction programme.

### Guidance to review

