### PR TITLE
[CPDLP-2836] Surface mentor completed field in ECF participants API v3 endpoint

### DIFF
--- a/app/serializers/api/v3/ecf/participant_serializer.rb
+++ b/app/serializers/api/v3/ecf/participant_serializer.rb
@@ -139,7 +139,9 @@ module Api
               deferral: deferral(profile:, cpd_lead_provider: params[:cpd_lead_provider], latest_induction_record:),
               created_at: profile.created_at.rfc3339,
               induction_end_date: profile.induction_completion_date&.strftime("%Y-%m-%d"),
-            }
+            }.tap do |hash|
+              hash.merge!(mentor_funding_end_date: profile.mentor_completion_date&.strftime("%Y-%m-%d")) unless Rails.env.production?
+            end
           }.compact
         end
 

--- a/docs/source/ecf/guidance.html.md
+++ b/docs/source/ecf/guidance.html.md
@@ -428,7 +428,8 @@ For more detailed information see the specifications for this [view multiple ECF
             "withdrawal": null,
             "deferral": null,
             "created_at": "2021-05-31T02:22:32.000Z",
-            "induction_end_date": "2022-01-12"
+            "induction_end_date": "2022-01-12",
+            "mentor_funding_end_date": "2021-04-19"
           }
         ],
         "participant_id_changes": [
@@ -489,7 +490,8 @@ For more detailed information see the specifications for this [view a single ECF
           "withdrawal": null,
           "deferral": null,
           "created_at": "2021-05-31T02:22:32.000Z",
-          "induction_end_date": "2022-01-12"
+          "induction_end_date": "2022-01-12",
+          "mentor_funding_end_date": "2021-04-19"
         }
       ],
       "participant_id_changes": [

--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -7,15 +7,13 @@ weight: 8
 
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
 
-## [PLACEHOLDER] 26 February 2024
+## 4 March 2024
 
-Lead providers integrated with v3 of the API can now view details of when a mentor training was completed.
+We're trialing new functionality in the API v3 sandbox which surfaces the `mentor_funding_end_date` field in the [ ECF participant endpoint](/api-reference/reference-v3.html#api-v3-participants-ecf-get).
 
-We've added a new field, `mentor_funding_end_date`, to [ECFEnrolment](/api-reference/reference-v3.html#schema-ecfenrolment).
+When a declaration is submitted for a mentor the completed date will equal the declaration date. When a declaration is voided the completed date will be cleared. Completed dates for early roll-out mentors will be set to 19 April 2021 regardless of any completed declarations.
 
-A mentor training is deemed complete if as mentor has completed their mentor training OR has completed training on Early Roll Out (ERO) on the ECF.
-
-The declaration date of a "completed" declaration will be used as the completion date for a mentor's training.
+We'd welcome feedback on this sandbox update before it goes into production.
 
 ## 16 February 2024
 

--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -7,6 +7,16 @@ weight: 8
 
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
 
+## [PLACEHOLDER] 26 February 2024
+
+Lead providers integrated with v3 of the API can now view details of when a mentor training was completed.
+
+We've added a new field, `mentor_funding_end_date`, to [ECFEnrolment](/api-reference/reference-v3.html#schema-ecfenrolment).
+
+A mentor training is deemed complete if as mentor has completed their mentor training OR has completed training on Early Roll Out (ERO) on the ECF.
+
+The declaration date of a "completed" declaration will be used as the completion date for a mentor's training.
+
 ## 16 February 2024
 
 We’ve found and fixed a bug that meant for a small number of NPQ applications the value in the `itt_provider` field was incorrectly set, so was not showing the name of the provider.
@@ -15,9 +25,9 @@ The full legal name of the initial teacher training provider can now be seen on 
 
 ## 6 February 2024
 
-We’ve done an update to ensure that early career teacher (ECT) participant records only ever appear in one cohort. 
+We’ve done an update to ensure that early career teacher (ECT) participant records only ever appear in one cohort.
 
-Some providers had found it confusing because participants who’d moved cohort were appearing multiple times when they filtered by cohort in the ‘GET participants’ endpoint. 
+Some providers had found it confusing because participants who’d moved cohort were appearing multiple times when they filtered by cohort in the ‘GET participants’ endpoint.
 
 Training providers will now only see the ECT in the latest cohort they’ve been assigned to.
 

--- a/spec/docs/v3/ecf_participants_spec.rb
+++ b/spec/docs/v3/ecf_participants_spec.rb
@@ -196,6 +196,7 @@ describe "API", type: :request, swagger_doc: "v3/api_spec.json" do
                             },
                             created_at: "2022-11-09T16:07:38Z",
                             induction_end_date: "2022-01-12",
+                            mentor_funding_end_date: "2021-04-19",
                           },
                         ],
                         participant_id_changes: [
@@ -358,6 +359,7 @@ describe "API", type: :request, swagger_doc: "v3/api_spec.json" do
                             deferral: nil,
                             created_at: "2022-11-09T16:07:38Z",
                             induction_end_date: "2022-01-12",
+                            mentor_funding_end_date: "2021-04-19",
                           },
                         ],
                         participant_id_changes: [

--- a/spec/requests/api/v3/ecf/participants_spec.rb
+++ b/spec/requests/api/v3/ecf/participants_spec.rb
@@ -333,6 +333,7 @@ RSpec.describe "API ECF Participants", type: :request do
                 "deferral": nil,
                 "created_at": early_career_teacher_profile.created_at.rfc3339,
                 "induction_end_date": "2022-01-12",
+                "mentor_funding_end_date": nil,
               }],
               "participant_id_changes": [],
             },

--- a/spec/serializers/api/v3/ecf/participant_serializer_spec.rb
+++ b/spec/serializers/api/v3/ecf/participant_serializer_spec.rb
@@ -77,30 +77,64 @@ module Api
             context "when there are multiple profiles involved" do
               let!(:mentor_profile) { create(:mentor, school_cohort:, user: participant) }
 
-              before { mentor_profile.update!(mentor_completion_date: Date.new(2021, 4, 19)) }
+              before do
+                mentor_profile.update!(mentor_completion_date: Date.new(2021, 4, 19))
+                allow(Rails).to receive(:env).and_return ActiveSupport::EnvironmentInquirer.new(environment.to_s)
+              end
 
-              it "includes the second profile data" do
-                expect(result[:data][0][:attributes][:ecf_enrolments].find { |efce| efce[:participant_type] == :mentor }).to eq({
-                  training_record_id: mentor_profile.id,
-                  email: participant.email,
-                  mentor_id: nil,
-                  school_urn: school.urn,
-                  participant_type: :mentor,
-                  cohort: school_cohort.cohort.start_year&.to_s,
-                  training_status: "active",
-                  participant_status: "active",
-                  teacher_reference_number_validated: false,
-                  eligible_for_funding: nil,
-                  pupil_premium_uplift: mentor_profile.pupil_premium_uplift,
-                  sparsity_uplift: mentor_profile.sparsity_uplift,
-                  schedule_identifier: mentor_profile.schedule&.schedule_identifier,
-                  delivery_partner_id: delivery_partner.id,
-                  withdrawal: nil,
-                  deferral: nil,
-                  created_at: mentor_profile.created_at.rfc3339,
-                  induction_end_date: nil,
-                  mentor_funding_end_date: Date.new(2021, 4, 19).to_s,
-                })
+              context "in non-production environment" do
+                let(:environment) { :sandbox }
+
+                it "includes the second profile data" do
+                  expect(result[:data][0][:attributes][:ecf_enrolments].find { |efce| efce[:participant_type] == :mentor }).to eq({
+                    training_record_id: mentor_profile.id,
+                    email: participant.email,
+                    mentor_id: nil,
+                    school_urn: school.urn,
+                    participant_type: :mentor,
+                    cohort: school_cohort.cohort.start_year&.to_s,
+                    training_status: "active",
+                    participant_status: "active",
+                    teacher_reference_number_validated: false,
+                    eligible_for_funding: nil,
+                    pupil_premium_uplift: mentor_profile.pupil_premium_uplift,
+                    sparsity_uplift: mentor_profile.sparsity_uplift,
+                    schedule_identifier: mentor_profile.schedule&.schedule_identifier,
+                    delivery_partner_id: delivery_partner.id,
+                    withdrawal: nil,
+                    deferral: nil,
+                    created_at: mentor_profile.created_at.rfc3339,
+                    induction_end_date: nil,
+                    mentor_funding_end_date: "2021-04-19",
+                  })
+                end
+              end
+
+              context "in production environment" do
+                let(:environment) { :production }
+
+                it "includes the second profile data" do
+                  expect(result[:data][0][:attributes][:ecf_enrolments].find { |efce| efce[:participant_type] == :mentor }).to eq({
+                    training_record_id: mentor_profile.id,
+                    email: participant.email,
+                    mentor_id: nil,
+                    school_urn: school.urn,
+                    participant_type: :mentor,
+                    cohort: school_cohort.cohort.start_year&.to_s,
+                    training_status: "active",
+                    participant_status: "active",
+                    teacher_reference_number_validated: false,
+                    eligible_for_funding: nil,
+                    pupil_premium_uplift: mentor_profile.pupil_premium_uplift,
+                    sparsity_uplift: mentor_profile.sparsity_uplift,
+                    schedule_identifier: mentor_profile.schedule&.schedule_identifier,
+                    delivery_partner_id: delivery_partner.id,
+                    withdrawal: nil,
+                    deferral: nil,
+                    created_at: mentor_profile.created_at.rfc3339,
+                    induction_end_date: nil,
+                  })
+                end
               end
             end
 

--- a/spec/serializers/api/v3/ecf/participant_serializer_spec.rb
+++ b/spec/serializers/api/v3/ecf/participant_serializer_spec.rb
@@ -56,6 +56,7 @@ module Api
                       deferral: nil,
                       created_at: ect_profile.created_at.rfc3339,
                       induction_end_date: "2022-01-12",
+                      mentor_funding_end_date: nil,
                     },
                   ],
                 participant_id_changes: [],
@@ -75,6 +76,8 @@ module Api
 
             context "when there are multiple profiles involved" do
               let!(:mentor_profile) { create(:mentor, school_cohort:, user: participant) }
+
+              before { mentor_profile.update!(mentor_completion_date: Date.new(2021, 4, 19)) }
 
               it "includes the second profile data" do
                 expect(result[:data][0][:attributes][:ecf_enrolments].find { |efce| efce[:participant_type] == :mentor }).to eq({
@@ -96,6 +99,7 @@ module Api
                   deferral: nil,
                   created_at: mentor_profile.created_at.rfc3339,
                   induction_end_date: nil,
+                  mentor_funding_end_date: Date.new(2021, 4, 19).to_s,
                 })
               end
             end

--- a/swagger/v3/api_spec.json
+++ b/swagger/v3/api_spec.json
@@ -2446,7 +2446,8 @@
                                 "date": "2021-06-31T02:22:32.000Z"
                               },
                               "created_at": "2021-05-31T02:22:32.000Z",
-                              "induction_end_date": "2022-01-12"
+                              "induction_end_date": "2022-01-12",
+                              "mentor_funding_end_date": "2021-04-19"
                             }
                           ],
                           "participant_id_changes": [
@@ -2591,7 +2592,8 @@
                                 "date": "2021-06-31T02:22:32.000Z"
                               },
                               "created_at": "2021-05-31T02:22:32.000Z",
-                              "induction_end_date": "2022-01-12"
+                              "induction_end_date": "2022-01-12",
+                              "mentor_funding_end_date": "2021-04-19"
                             }
                           ],
                           "participant_id_changes": [
@@ -3288,6 +3290,13 @@
             "nullable": true,
             "format": "date",
             "example": "2022-01-12"
+          },
+          "mentor_funding_end_date": {
+            "description": "The ECF participant mentor training completion date",
+            "type": "string",
+            "nullable": true,
+            "format": "date",
+            "example": "2021-04-19"
           }
         }
       },

--- a/swagger/v3/component_schemas/ECFEnrolment.yml
+++ b/swagger/v3/component_schemas/ECFEnrolment.yml
@@ -122,3 +122,9 @@ properties:
     format: date
     nullable: true
     example: "2022-01-12"
+  mentor_funding_end_date:
+    description: The ECF participant mentor training completion date
+    type: string
+    format: date
+    nullable: true
+    example: "2021-04-19"


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-2836

We would like to start capturing completion of mentor training, and surfacing this data in the API for providers.

### Changes proposed in this pull request

Add new field called `mentor_funding_end_date` in the participant ECF endpoint in API v3 only.