### PR TITLE
[Archiving] Use no_touching for the bulk of the destruction

### DIFF
--- a/app/services/archive/destroy_ecf_profile_data.rb
+++ b/app/services/archive/destroy_ecf_profile_data.rb
@@ -35,17 +35,17 @@ module Archive
     def destroy_profile!
       ActiveRecord::Base.transaction do
         ActiveRecord::Base.no_touching do
-          participant_profile.ecf_participant_validation_data&.delete
-          participant_profile.ecf_participant_eligibility&.delete
+          participant_profile.ecf_participant_validation_data&.destroy!
+          participant_profile.ecf_participant_eligibility&.destroy!
 
-          participant_profile.participant_profile_states.delete_all(:delete_all)
-          participant_profile.participant_profile_schedules.delete_all(:delete_all)
-          participant_profile.participant_declarations.delete_all(:delete_all)
-          participant_profile.induction_records.delete_all(:delete_all)
-          participant_profile.validation_decisions.delete_all(:delete_all)
-          participant_profile.deleted_duplicates.delete_all(:delete_all)
+          participant_profile.participant_profile_states.destroy_all
+          participant_profile.participant_profile_schedules.destroy_all
+          participant_profile.participant_declarations.destroy_all
+          participant_profile.induction_records.destroy_all
+          participant_profile.validation_decisions.destroy_all
+          participant_profile.deleted_duplicates.destroy_all
 
-          participant_profile.school_mentors.delete_all(:delete_all) if participant_profile.mentor?
+          participant_profile.school_mentors.destroy_all if participant_profile.mentor?
         end
 
         # allow callbacks and touching for this bit so we get analytics

--- a/app/services/archive/destroy_ecf_profile_data.rb
+++ b/app/services/archive/destroy_ecf_profile_data.rb
@@ -34,19 +34,21 @@ module Archive
 
     def destroy_profile!
       ActiveRecord::Base.transaction do
-        participant_profile.ecf_participant_validation_data&.destroy!
-        participant_profile.ecf_participant_eligibility&.destroy!
-        # for some reason .destroy_all doesn't always seems to destroy the objects and
-        # doesn't fail loudly. Don't want to use .delete_all either as we want callbacks
-        # to trigger for analytics at least
-        participant_profile.participant_profile_states.each(&:destroy!)
-        participant_profile.participant_profile_schedules.each(&:destroy!)
-        participant_profile.participant_declarations.each(&:destroy!)
-        participant_profile.induction_records.each(&:destroy!)
-        participant_profile.validation_decisions.each(&:destroy!)
-        participant_profile.deleted_duplicates.each(&:destroy!)
+        ActiveRecord::Base.no_touching do
+          participant_profile.ecf_participant_validation_data&.delete
+          participant_profile.ecf_participant_eligibility&.delete
 
-        participant_profile.school_mentors.each(&:destroy!) if participant_profile.mentor?
+          participant_profile.participant_profile_states.delete_all(:delete_all)
+          participant_profile.participant_profile_schedules.delete_all(:delete_all)
+          participant_profile.participant_declarations.delete_all(:delete_all)
+          participant_profile.induction_records.delete_all(:delete_all)
+          participant_profile.validation_decisions.delete_all(:delete_all)
+          participant_profile.deleted_duplicates.delete_all(:delete_all)
+
+          participant_profile.school_mentors.delete_all(:delete_all) if participant_profile.mentor?
+        end
+
+        # allow callbacks and touching for this bit so we get analytics
         participant_profile.destroy!
       end
     end


### PR DESCRIPTION
### Context

Still trying to fix issues deleting child records of participant profile during archiving. Attempting to wrap those in a `no_touching` block to prevent callbacks or analytics being triggered as these may be the issue. 

### Changes proposed in this pull request
Prevent analytics and callbacks to try and avoid fkey errors when deleting the user record.

### Guidance to review

