### PR TITLE
[Archiving] Check for presence of declarations where user is mentor_user

### DIFF
--- a/app/services/archive/destroy_ecf_profile_data.rb
+++ b/app/services/archive/destroy_ecf_profile_data.rb
@@ -40,7 +40,12 @@ module Archive
 
           participant_profile.participant_profile_states.destroy_all
           participant_profile.participant_profile_schedules.destroy_all
-          participant_profile.participant_declarations.destroy_all
+          participant_profile.participant_declarations.each do |declaration|
+            declaration.participant_declaration_attempts.destroy_all
+            declaration.declaration_states.destroy_all
+            declaration.statement_line_items.destroy_all
+            declaration.destroy!
+          end
           participant_profile.induction_records.destroy_all
           participant_profile.validation_decisions.destroy_all
           participant_profile.deleted_duplicates.destroy_all

--- a/app/services/archive/unvalidated_user.rb
+++ b/app/services/archive/unvalidated_user.rb
@@ -45,6 +45,8 @@ module Archive
         raise ArchiveError, "User #{user.id} has transfer records"
       elsif user_has_gai_id?
         raise ArchiveError, "User #{user.id} has a Get an Identity ID"
+      elsif user_is_mentor_on_declarations?
+        raise ArchiveError, "User #{user.id} is mentor on declarations"
       end
     end
 
@@ -78,6 +80,10 @@ module Archive
 
     def user_has_gai_id?
       user.get_an_identity_id.present?
+    end
+
+    def user_is_mentor_on_declarations?
+      ParticipantDeclaration.where(mentor_user_id: user.id).any?
     end
 
     def destroy_user!

--- a/spec/services/archive/unvalidated_user_spec.rb
+++ b/spec/services/archive/unvalidated_user_spec.rb
@@ -216,4 +216,15 @@ RSpec.describe Archive::UnvalidatedUser do
       }.to raise_error Archive::ArchiveError
     end
   end
+
+  context "when the user is a mentor user on a participants declaration" do
+    let(:participant_profile) { create(:mentor_participant_profile) }
+    let!(:declaration) { create(:seed_ecf_participant_declaration, :valid, mentor_user_id: user.id) }
+
+    it "raises an ArchiveError" do
+      expect {
+        service_call
+      }.to raise_error Archive::ArchiveError
+    end
+  end
 end


### PR DESCRIPTION
### Context

Got to the bottom of the issues with deleting users during the archival. When the user has a mentor profile it is possible that that may be associated with declarations belonging to ECTs.  This PR adds a check for this in the `Archive::UnvalidatedUser` service and also destroys the child records of declarations explicitly.

