### PR TITLE
Revert "Bump dfe-analytics from v1.11.7 to v1.12.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -116,7 +116,7 @@ gem "rouge"
 
 gem "auto_strip_attributes", "~> 2.6"
 
-gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.12.0"
+gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.11.7"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/DFE-Digital/dfe-analytics.git
-  revision: 7f0bcd0a3e19910e6c1ff34c80fd61877f3a6389
-  tag: v1.12.0
+  revision: 6c992b64df6909a4e5e82dc27e2237c8db915865
+  tag: v1.11.7
   specs:
-    dfe-analytics (1.12.0)
+    dfe-analytics (1.11.7)
       google-cloud-bigquery (~> 1.38)
       request_store_rails (~> 2)
 
@@ -211,8 +211,8 @@ GEM
       raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    google-apis-bigquery_v2 (0.65.0)
-      google-apis-core (>= 0.14.0, < 2.a)
+    google-apis-bigquery_v2 (0.64.0)
+      google-apis-core (>= 0.12.0, < 2.a)
     google-apis-core (0.14.0)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (~> 1.9)
@@ -281,7 +281,7 @@ GEM
       rspec-expectations
     jsonapi-serializer (2.2.0)
       activesupport (>= 4.2)
-    jwt (2.8.1)
+    jwt (2.8.0)
       base64
     kramdown (2.4.0)
       rexml


### PR DESCRIPTION
This reverts commit 61a3faa5a7fa658fd834c53ed93fdcef950e1dc2.

### Context

The dfe-analytics started failing after upgrading to the latest version. 

I'm reverting it back to the prev version until we figure out the issue.

