### PR TITLE
[Bug-fix] Look up from_mentor object to pass to helper not the id

### DIFF
--- a/app/views/schools/participants/edit_mentor.html.erb
+++ b/app/views/schools/participants/edit_mentor.html.erb
@@ -1,8 +1,9 @@
 <% content_for :title, "Change mentor" %>
+<% from_mentor = params[:from_mentor].present? ? ParticipantProfile.find(params[:from_mentor]) : nil %>
 
 <% content_for :before_content,
                govuk_back_link(text: "Back",
-                               href: path_to_participant(params[:from_mentor].presence || @profile, @school)) %>
+                               href: path_to_participant(from_mentor || @profile, @school)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
### Context

Fix a recurring sentry error, looks like this was introduced recently during the split into ECT and Mentor "tabs"

### Changes proposed in this pull request
Look up the `ParticipantProfile` to pass in to the helper instead of passing the `id`



