### PR TITLE
[CST-2366] Add pre-term reminder comms

### DIFF
--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -27,6 +27,7 @@ class SchoolMailer < ApplicationMailer
   NOTIFY_SIT_WE_HAVE_ARCHIVED_PARTICIPANT = "558eafd2-7f8f-407d-a3a8-60649fb26ea8"
   REMIND_SIT_THAT_AB_HAS_NOT_REGISTERED_ECT = "a9dbd93e-4358-414d-832c-b0aea585a72b"
   REMIND_SIT_TO_APPOINT_AB_FOR_UNREGISTERED_ECT = "e697e076-a0f6-4738-a421-ae507d804499"
+  SIT_PRE_TERM_REMINDER_TO_REPORT_ANY_CHANGES = "59983db6-678f-4a7d-9a3b-80bed4f6ef17"
 
   def remind_sit_that_ab_has_not_registered_ect
     school = params[:school]
@@ -511,5 +512,22 @@ class SchoolMailer < ApplicationMailer
         local_authority_name:,
       },
     ).tag(:finance_errors_with_nqt_plus_one_and_ecf_year_2_local_authority_version)
+  end
+
+  def sit_pre_term_reminder_to_report_any_changes
+    induction_coordinator = params[:induction_coordinator]
+    sit_name = induction_coordinator.user.full_name
+    email_address = induction_coordinator.user.email
+
+    template_mail(
+      SIT_PRE_TERM_REMINDER_TO_REPORT_ANY_CHANGES,
+      to: email_address,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        name: sit_name,
+        email_address:,
+      },
+    ).tag(:sit_pre_term_reminder_to_report_any_changes).associate_with(induction_coordinator, as: :induction_coordinator_profile)
   end
 end

--- a/app/queries/schools/pre_term_reminder_to_report_any_changes_query.rb
+++ b/app/queries/schools/pre_term_reminder_to_report_any_changes_query.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Schools
+  class PreTermReminderToReportAnyChangesQuery < BaseService
+    def call
+      schools_to_include.where(id: opted_in_schools_that_ran_fip_or_cip.select(:school_id))
+    end
+
+    attr_reader :cohort, :school_type_codes
+
+    def initialize(cohort:, school_type_codes: [])
+      @cohort = cohort
+      @school_type_codes = school_type_codes
+    end
+
+    def schools_to_include
+      scope = School.currently_open.in_england
+      return scope if school_type_codes.blank?
+
+      scope.where(school_type_code: school_type_codes)
+    end
+
+    def opted_in_schools_that_ran_fip_or_cip
+      School
+        .joins(:school_cohorts)
+        .merge(SchoolCohort.where(cohort:, induction_programme_choice: %w[full_induction_programme core_induction_programme], opt_out_of_updates: false))
+    end
+  end
+end

--- a/spec/mailers/school_mailer_spec.rb
+++ b/spec/mailers/school_mailer_spec.rb
@@ -498,4 +498,24 @@ RSpec.describe SchoolMailer, type: :mailer do
       expect(SchoolMailer::FINANCE_ERRORS_WITH_NQT_PLUS_ONE_AND_ECF_YEAR_2_LOCAL_AUTHORITY_VERSION).to eq("9953ed6b-4853-4be2-9ac2-692f07906166")
     end
   end
+
+  describe "#sit_pre_term_reminder_to_report_any_changes" do
+    let(:induction_coordinator) { create(:seed_induction_coordinator_profile, :with_user) }
+    let(:email_address) { induction_coordinator.user.email }
+
+    let(:sit_pre_term_reminder_to_report_any_changes) do
+      SchoolMailer.with(
+        induction_coordinator:,
+      ).sit_pre_term_reminder_to_report_any_changes.deliver_now
+    end
+
+    it "renders the right headers" do
+      expect(sit_pre_term_reminder_to_report_any_changes.to).to eq([email_address])
+      expect(sit_pre_term_reminder_to_report_any_changes.from).to eq(["mail@example.com"])
+    end
+
+    it "uses the correct Notify template" do
+      expect(SchoolMailer::SIT_PRE_TERM_REMINDER_TO_REPORT_ANY_CHANGES).to eq("59983db6-678f-4a7d-9a3b-80bed4f6ef17")
+    end
+  end
 end

--- a/spec/queries/schools/pre_term_reminder_to_report_any_changes_query_spec.rb
+++ b/spec/queries/schools/pre_term_reminder_to_report_any_changes_query_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Schools::PreTermReminderToReportAnyChangesQuery do
+  let(:cohort) { create(:seed_cohort) }
+  let(:query_cohort) { cohort }
+  let(:school_type_codes) { [] }
+
+  let(:fip_school_cohort) { create(:seed_school_cohort, :fip, :with_school, cohort:) }
+  let(:induction_programme) { create(:seed_induction_programme, :fip, school_cohort: fip_school_cohort) }
+  let(:fip_school) { fip_school_cohort.school }
+
+  let(:cip_school_cohort) { create(:seed_school_cohort, :cip, :with_school, cohort:) }
+  let(:induction_programme) { create(:seed_induction_programme, :cip, school_cohort: cip_school_cohort) }
+  let(:cip_school) { cip_school_cohort.school }
+
+  let(:diy_school_cohort) { create(:seed_school_cohort, :design_our_own, :with_school, cohort:) }
+  let(:induction_programme) { create(:seed_induction_programme, :design_our_own, school_cohort: diy_school_cohort) }
+  let(:diy_school) { diy_school_cohort.school }
+
+  let(:opted_out_school_cohort) { create(:seed_school_cohort, :fip, :with_school, cohort:, opt_out_of_updates: true) }
+  let(:opted_out_school) { opted_out_school_cohort.school }
+
+  let(:school_funded_fip_school_cohort) { create(:seed_school_cohort, :school_funded_fip, :with_school, cohort:) }
+  let(:induction_programme) { create(:seed_induction_programme, :school_funded_fip, partnership:, school_cohort: school_funded_fip_school_cohort) }
+  let(:school_funded_fip_school) { school_funded_fip_school_cohort.school }
+
+  subject(:query_result) { described_class.call(cohort: query_cohort, school_type_codes:) }
+
+  describe "#call" do
+    it "does not return schools that have opted out of updates" do
+      expect(query_result).not_to include(opted_out_school)
+    end
+
+    it "does not return schools that run DIY programmes" do
+      expect(query_result).not_to include(diy_school)
+    end
+
+    it "does not return schools that run School Funded FIP" do
+      expect(query_result).not_to include(school_funded_fip_school)
+    end
+
+    it "returns schools running FIP" do
+      expect(query_result).to include(fip_school)
+    end
+
+    it "returns schools running CIP" do
+      expect(query_result).to include(cip_school)
+    end
+
+    context "when school type codes are supplied" do
+      let(:school_type_codes) { [1, 2, 3] }
+
+      context "and the school does not match one of the school types" do
+        before do
+          fip_school.update!(school_type_code: 5)
+        end
+
+        it "does not return the school" do
+          expect(query_result).not_to include(fip_school)
+        end
+      end
+    end
+
+    context "and the school matches one of the school types" do
+      before do
+        fip_school.update!(school_type_code: 2)
+      end
+
+      it "includes the school" do
+        expect(query_result).to include(fip_school)
+      end
+    end
+  end
+end

--- a/spec/services/bulk_mailers/school_reminder_comms_spec.rb
+++ b/spec/services/bulk_mailers/school_reminder_comms_spec.rb
@@ -377,4 +377,29 @@ RSpec.describe BulkMailers::SchoolReminderComms, type: :mailer do
       end
     end
   end
+
+  describe "#contact_sits_pre_term_to_report_any_changes" do
+    context "when a school rans FIP or CIP and has not opted out of updates" do
+      it "mails the induction coordinator" do
+        expect {
+          service.contact_sits_pre_term_to_report_any_changes
+        }.to have_enqueued_mail(SchoolMailer, :sit_pre_term_reminder_to_report_any_changes)
+          .with(params: { induction_coordinator: sit_profile }, args: [])
+      end
+    end
+
+    context "when the dry_run flag is set" do
+      let(:dry_run) { true }
+
+      it "does not mail the induction coordinator" do
+        expect {
+          service.contact_sits_pre_term_to_report_any_changes
+        }.not_to have_enqueued_mail
+      end
+
+      it "returns the count of emails that would be sent" do
+        expect(service.contact_sits_pre_term_to_report_any_changes).to eq 1
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

- Ticket: CST-2366

We want to send pre-term comms to SITs in eligible schools that are running FIP or CIP programmes in 2023/24 cohort, to remind them to report any changes.

### Changes proposed in this pull request
- Add the mailer for the Notify template that will be sent
- Add a query class to return all the schools that need to be contacted
- Add a bulk mailer to trigger the emails

### Guidance to review
