### PR TITLE
[CPDLP-2849] Fix bug when accepting a NPQ application where another for the same course has already been accepted

### DIFF
--- a/app/services/npq/application/accept.rb
+++ b/app/services/npq/application/accept.rb
@@ -106,8 +106,14 @@ module NPQ
         @participant_profile ||= ParticipantProfile.find(npq_application.id)
       end
 
+      def trn
+        @trn ||= npq_application.teacher_reference_number_verified? ? npq_application.teacher_reference_number : user.teacher_profile&.trn
+      end
+
+      # Make sure existing or the new teacher profile has a valid TRN so we fetch same_trn_user & other_accepted_applications_with_same_course correctly
       def teacher_profile
-        @teacher_profile ||= user.teacher_profile || user.build_teacher_profile
+        @teacher_profile ||= (user.teacher_profile&.assign_attributes(trn:)
+                              user.teacher_profile) || user.build_teacher_profile(trn:)
       end
 
       def user

--- a/app/services/npq/application/accept.rb
+++ b/app/services/npq/application/accept.rb
@@ -107,13 +107,11 @@ module NPQ
       end
 
       def trn
-        @trn ||= npq_application.teacher_reference_number_verified? ? npq_application.teacher_reference_number : user.teacher_profile&.trn
+        @trn ||= npq_application.teacher_reference_number_verified? ? npq_application.teacher_reference_number : teacher_profile&.trn
       end
 
-      # Make sure existing or the new teacher profile has a valid TRN so we fetch same_trn_user & other_accepted_applications_with_same_course correctly
       def teacher_profile
-        @teacher_profile ||= (user.teacher_profile&.assign_attributes(trn:)
-                              user.teacher_profile) || user.build_teacher_profile(trn:)
+        @teacher_profile ||= user.teacher_profile || user.build_teacher_profile
       end
 
       def user
@@ -121,11 +119,11 @@ module NPQ
       end
 
       def same_trn_user
-        return if teacher_profile&.trn.blank?
+        return if trn.blank?
 
         @same_trn_user ||= TeacherProfile
                            .oldest_first
-                           .where(trn: teacher_profile.trn)
+                           .where(trn:)
                            .where.not(id: teacher_profile.id)
                            .first
                            &.user


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-2849](https://dfedigital.atlassian.net/browse/CPDLP-2849)

TDT have flagged that they were not able to submit a start declaration for this participant. The user has two accepted applications for the same course with different lead providers. Our service should not allow this to happen.

### Changes proposed in this pull request

Fix bug when accepting a NPQ application where another for the same course has already been accepted.

[CPDLP-2849]: https://dfedigital.atlassian.net/browse/CPDLP-2849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ