### PR TITLE
Bump strong_migrations from 1.7.0 to 1.8.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,7 @@ gem "rubyzip", "~> 2.3", ">= 2.3.0"
 gem "savon", "~> 2.15"
 
 # Strong migration checker for database migrations
-gem "strong_migrations", "~> 1.7"
+gem "strong_migrations", "~> 1.8"
 
 # Pagination
 gem "pagy", "~> 6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,7 +265,7 @@ GEM
       mutex_m
       nkf
       rack (>= 2.0, < 3.1)
-    i18n (1.14.1)
+    i18n (1.14.4)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     inflection (1.0.0)
@@ -590,7 +590,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     stackprof (0.2.26)
-    strong_migrations (1.7.0)
+    strong_migrations (1.8.0)
       activerecord (>= 5.2)
     thor (1.3.0)
     thread_safe (0.3.6)
@@ -734,7 +734,7 @@ DEPENDENCIES
   sprockets (~> 4.2.1)
   sprockets-rails
   stackprof
-  strong_migrations (~> 1.7)
+  strong_migrations (~> 1.8)
   timecop
   tzinfo-data
   view_component

--- a/db/migrate/20230919093921_add_primary_key_to_cohorts_lead_providers.rb
+++ b/db/migrate/20230919093921_add_primary_key_to_cohorts_lead_providers.rb
@@ -2,6 +2,8 @@
 
 class AddPrimaryKeyToCohortsLeadProviders < ActiveRecord::Migration[7.0]
   def change
+    StrongMigrations.disable_check(:add_column_auto_incrementing)
     add_column :cohorts_lead_providers, :id, :primary_key
+    StrongMigrations.enable_check(:add_column_auto_incrementing)
   end
 end


### PR DESCRIPTION
Reverts DFE-Digital/early-careers-framework#4624
Disables new [strong migration check](https://github.com/ankane/strong_migrations/tree/537c5543feb5c7ecbf57075167a90e7992a1def9?tab=readme-ov-file#adding-an-auto-incrementing-column) for old migrations introducing a primary key to an existing table.