### PR TITLE
Use new namespace option when connecting to konduit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,10 +218,10 @@ endef
 
 # Creates a konduit to the DB and points development to it. The konduit URL is removed when the konduit is closed.
 konduit: get-cluster-credentials
-	$(KONDUIT_CONNECT) ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-pg -k ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-app-kv cpd-ecf-${CONFIG_LONG}-web -- psql > "$$tmp_file"
+	$(KONDUIT_CONNECT) ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-pg -n ${NAMESPACE} -k ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-app-kv cpd-ecf-${CONFIG_LONG}-web -- psql > "$$tmp_file"
 	exit 0
 
 # Creates a konduit to the snapshot DB and points development to it. The konduit URL is removed when the konduit is closed.
 konduit-snapshot: get-cluster-credentials
-	$(KONDUIT_CONNECT) ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-pg-snapshot -k ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-app-kv cpd-ecf-${CONFIG_LONG}-web -- psql > "$$tmp_file"
+	$(KONDUIT_CONNECT) ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-pg-snapshot -n ${NAMESPACE} -k ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-app-kv cpd-ecf-${CONFIG_LONG}-web -- psql > "$$tmp_file"
 	exit 0


### PR DESCRIPTION
### Context

- Ticket: N/A

### Changes proposed in this pull request

Use new namespace option when connecting to konduit

### Guidance to review

- Request PIM for group `s189 CPD production PIM`
- Run: `rm -f bin/konduit.sh && make install-konduit`
- Edit `bin/konduit.sh` and add back `echo "$DB_URL"` into `run_psql()` function as per below:
```
run_psql() {
  if [ "$Inputfile" = "" ]; then
   echo "$DB_URL"
   psql -d "$DB_URL" --no-password "${OTHERARGS}"
  elif [ "$CompressedInput" = "" ]; then
   echo "$DB_URL"
   psql -d "$DB_URL" --no-password <"$Inputfile"
  else
   echo "$DB_URL"
   gzip -d --to-stdout "${Inputfile}" | psql -d "$DB_URL" --no-password
  fi
}
```
- Connect as usual to snapshot db `make ci production konduit-snapshot`
- Spin up `rails s`