### PR TITLE
Changing an ECT mentor: do not add induction record when the mentor profile remains the same

### DIFF
--- a/app/controllers/schools/participants_controller.rb
+++ b/app/controllers/schools/participants_controller.rb
@@ -91,8 +91,12 @@ class Schools::ParticipantsController < Schools::BaseController
     if @mentor_form.valid?
       induction_record = @profile.induction_records.for_school(@school).latest
       new_mentor_profile = @mentor_form.mentor&.mentor_profile
-      Induction::ChangeMentor.call(induction_record:, mentor_profile: new_mentor_profile)
-      @message = "#{new_mentor_profile.full_name} has been assigned to #{@profile.full_name}"
+      if new_mentor_profile.id == induction_record.mentor_profile_id
+        @message = "#{new_mentor_profile.full_name} still assigned to #{@profile.full_name}"
+      else
+        Induction::ChangeMentor.call(induction_record:, mentor_profile: new_mentor_profile)
+        @message = "#{new_mentor_profile.full_name} has been assigned to #{@profile.full_name}"
+      end
 
       redirect_to path_to_participant(@profile, @school)
     else


### PR DESCRIPTION
### Context

The feature to change the mentor of an ECT is creating useless induction records similar to the previous one when the SIT decides to assign the same mentor again.

- Ticket: 

### Changes proposed in this pull request

### Guidance to review

