### PR TITLE
CST-2439: adding an ECT to a withdrawn mentor is not allowed to SITs

### DIFF
--- a/app/views/schools/mentors/_mentoring.html.erb
+++ b/app/views/schools/mentors/_mentoring.html.erb
@@ -51,7 +51,7 @@
       <% else %>
         <p class="govuk-body govuk-!-margin-bottom-4">Not currently mentoring</p>
 
-        <% if possible_ects.present? %>
+        <% if profile.active_record? && possible_ects.present? %>
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
               <div>


### PR DESCRIPTION
### Context

- [Ticket](https://dfedigital.atlassian.net/browse/CST-2439): 

### Changes proposed in this pull request
Mentor profile page: check if the mentor is induction-withdrawn and if so, do not show the link to add them ECTs.

### Guidance to review

