### PR TITLE
CPDNPQ-1735 Permit fields in the ecf app

### DIFF
--- a/app/controllers/api/v1/npq_profiles_controller.rb
+++ b/app/controllers/api/v1/npq_profiles_controller.rb
@@ -117,6 +117,9 @@ module Api
             funding_eligiblity_status_code
             teacher_catchment
             teacher_catchment_country
+            primary_establishment
+            number_of_pupils
+            tsf_primary_plus_eligibility
           ])
       end
     end


### PR DESCRIPTION
### Context
Permit the following fields in the ecf app

- primary_establishment
- number_of_pupils
- tsf_primary_plus_eligibility
### Ticket 
https://dfedigital.atlassian.net/browse/CPDNPQ-1735
### Changes proposed in this pull request
By allowing to update these fields, we will be able to populate additional info. Also, we would need to backfill data for historic records and there will be a job to carry out that part.