### PR TITLE
CST-2430: clear session data earlier to prevent programme change happ…

### DIFF
--- a/app/controllers/admin/participants/school_transfer_controller.rb
+++ b/app/controllers/admin/participants/school_transfer_controller.rb
@@ -28,8 +28,8 @@ module Admin::Participants
     def email; end
 
     def check_answers
-      @school_transfer_form.perform_transfer!
       clear_session_data
+      @school_transfer_form.perform_transfer!
 
       set_success_message content: "#{@school_transfer_form.participant_name} has been successfully transferred"
       redirect_to admin_participant_path(@participant_profile)


### PR DESCRIPTION
…ening but email notifications throwing an error

### Context

When an admin transfers a participant to a new school, the final step (check-answers) do this:
  - move the participant to the new school programme
  - send email notifications to agents involved (lead providers, sit...)
  - clear session data
  
If the notifications step fails for some reason, the participant has already been moved to the new school but the user might click the Back button of the browser, choose a different programme to add the participant to in the new school and confirm the answers again. 
That will create 2 active induction records!


- [Ticket](https://dfedigital.atlassian.net/browse/CST-2430) 

### Changes proposed in this pull request

Clear session data earlier 
### Guidance to review

