### PR TITLE
Make the user is admin validation more robust

### DIFF
--- a/app/models/npq_applications/eligibility_import.rb
+++ b/app/models/npq_applications/eligibility_import.rb
@@ -47,6 +47,8 @@ module NPQApplications
   private
 
     def validate_user_is_admin
+      return if user.blank?
+
       errors.add(:user, :not_admin) unless user.admin?
     end
   end


### PR DESCRIPTION
We're already checking for the presence of users elsewhere and this validation crashes when the user is `nil`.
