### PR TITLE
[CST-2383] Add rake task to reactivate a participant profile

### DIFF
--- a/app/services/support/base_service.rb
+++ b/app/services/support/base_service.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Support
+  class BaseService
+  private
+
+    def log_message(message)
+      logger.info(message)
+    end
+
+    def log_error(message)
+      logger.error(message)
+    end
+
+    def logger
+      @logger = Logger.new($stdout)
+    end
+  end
+end

--- a/app/services/support/participants/reactivate.rb
+++ b/app/services/support/participants/reactivate.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module Support
+  module Participants
+    class Reactivate < Support::BaseService
+      class << self
+        def call(participant_profile_id:)
+          new(participant_profile_id:).call
+        end
+      end
+
+      attr_reader :participant_profile
+      attr_writer :logger # allow logging to be disabled for specs
+
+      def initialize(participant_profile_id:)
+        @participant_profile = ParticipantProfile::ECF.find_by!(id: participant_profile_id)
+      end
+
+      def call
+        ActiveRecord::Base.transaction do
+          log_message("Updating training_status and induction_status for ParticipantProfile##{participant_profile.id} to active")
+
+          participant_profile.update!(status: :active, training_status: :active)
+
+          status_change_form = Finance::ECF::ChangeTrainingStatusForm.new(
+            participant_profile:,
+            training_status: "active",
+            reason: "other",
+            induction_record: participant_profile.latest_induction_record,
+          )
+
+          unless status_change_form.save
+            raise "Error in Finance::ECF::ChangeTrainingStatusForm: #{status_change_form.errors.full_messages}"
+          end
+
+          Induction::ChangeInductionRecord.call(
+            induction_record: participant_profile.latest_induction_record,
+            changes: { induction_status: :active },
+          )
+
+          log_current_state
+        end
+      rescue StandardError => e
+        log_error("Rolling back transaction")
+        log_error(e.message)
+      end
+
+      def dry_run
+        ActiveRecord::Base.transaction do
+          call
+
+          log_message("Dry run complete")
+          log_message("Rolling back changes")
+
+          raise ActiveRecord::Rollback
+        end
+      end
+
+    private
+
+      def log_current_state
+        log_message("Induction Record - training_status: #{participant_profile.latest_induction_record.training_status}")
+        log_message("Induction Record - induction_status: #{participant_profile.latest_induction_record.induction_status}")
+
+        log_message("Participant Profile - status: #{participant_profile.status}")
+        log_message("Participant Profile - training_status: #{participant_profile.training_status}")
+      end
+    end
+  end
+end

--- a/lib/tasks/support/participants.rake
+++ b/lib/tasks/support/participants.rake
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rake"
+
+namespace :support do
+  namespace :participants do
+    namespace :reactivate do
+      desc "Reactivates a participant, moving their training and induction statuses to active"
+      task :run, %i[participant_profile_id] => :environment do |_task, args|
+        participant_profile_id = args.participant_profile_id
+
+        Support::Participants::Reactivate.call(participant_profile_id:)
+      end
+
+      desc "DRY RUN (rolls back on completion): Reactivates a participant, moving their training and induction statuses to active"
+      task :dry_run, %i[participant_profile_id] => :environment do |_task, args|
+        participant_profile_id = args.participant_profile_id
+
+        Support::Participants::Reactivate.new(participant_profile_id:).dry_run
+      end
+    end
+  end
+end

--- a/spec/services/support/participants/reactivate_spec.rb
+++ b/spec/services/support/participants/reactivate_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Support::Participants::Reactivate do
+  subject(:reactivate) { described_class.new(participant_profile_id: participant_profile.id) }
+
+  let(:school_cohort) { create(:school_cohort, :fip) }
+  let(:partnership) { create :partnership, school: school_cohort.school, cohort: school_cohort.cohort }
+  let(:programme) { create(:induction_programme, :fip, school_cohort:, partnership:) }
+  let(:participant_profile) { create(:ect_participant_profile, :ecf_participant_eligibility, school_cohort:) }
+
+  before do
+    Induction::Enrol.call(participant_profile:, induction_programme: programme)
+    participant_profile.update!(status: :withdrawn, training_status: :withdrawn)
+    participant_profile.latest_induction_record.withdrawing!
+    Induction::ChangeInductionRecord.call(induction_record: participant_profile.latest_induction_record, changes: { training_status: "withdrawn" })
+
+    # disable logging
+    reactivate.logger = Logger.new("/dev/null")
+  end
+
+  describe "#call" do
+    it "reactivates the participant" do
+      expect { reactivate.call }.to change {
+        [
+          participant_profile.reload.status,
+          participant_profile.reload.training_status,
+          participant_profile.reload.latest_induction_record.induction_status,
+          participant_profile.reload.latest_induction_record.training_status,
+        ]
+      }.from(%w[withdrawn withdrawn withdrawn withdrawn])
+       .to(%w[active active active active])
+    end
+
+    describe "failures to update participant profile" do
+      before do
+        allow_any_instance_of(ParticipantProfile).to receive(:update!).and_raise(ActiveRecord::RecordInvalid)
+      end
+
+      it "rolls back the transaction" do
+        expect { reactivate.call }.not_to change {
+          [
+            participant_profile.reload.status,
+            participant_profile.reload.training_status,
+            participant_profile.reload.latest_induction_record.induction_status,
+            participant_profile.reload.latest_induction_record.training_status,
+          ]
+        }
+      end
+    end
+
+    describe "validation failures" do
+      before do
+        allow_any_instance_of(Finance::ECF::ChangeTrainingStatusForm).to receive(:valid?).and_return(false)
+      end
+
+      it "rolls back the transaction" do
+        expect { reactivate.call }.not_to change {
+          [
+            participant_profile.reload.status,
+            participant_profile.reload.training_status,
+            participant_profile.reload.latest_induction_record.induction_status,
+            participant_profile.reload.latest_induction_record.training_status,
+          ]
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CST-2383

### Changes proposed in this pull request

- Adds rake task for reactivating profiles

### Sample output on seeded data

```
rails "support:participants:reactivate:run[12345]"
I, []  INFO -- : Updating training_status and induction_status for ParticipantProfile#12345 to active
I, []  INFO -- : Induction Record - training_status: active
I, []  INFO -- : Induction Record - induction_status: active
I, []  INFO -- : Participant Profile - status: active
I, []  INFO -- : Participant Profile - training_status: active
```