### PR TITLE
Update import scripts for cohort/npq contract

### DIFF
--- a/app/services/importers/create_cohort.rb
+++ b/app/services/importers/create_cohort.rb
@@ -31,12 +31,15 @@ module Importers
       start_year = row["start-year"].to_i
       logger.info "CreateCohort: Creating cohort for starting year #{start_year}"
 
+      default_automatic_assignment_period_end_date = Date.new(start_year + 1, 3, 31)
+
       Cohort.upsert(
         {
           start_year:,
           registration_start_date: safe_parse(row["registration-start-date"]),
           academic_year_start_date: safe_parse(row["academic-year-start-date"]),
           npq_registration_start_date: safe_parse(row["npq-registration-start-date"]),
+          automatic_assignment_period_end_date: safe_parse(row["automatic-assignment-period-end-date"]) || default_automatic_assignment_period_end_date,
           created_at: Time.zone.now,
           updated_at: Time.zone.now,
         },
@@ -56,7 +59,7 @@ module Importers
     end
 
     def check_headers!
-      unless %w[start-year registration-start-date academic-year-start-date npq-registration-start-date].all? { |header| rows.headers.include?(header) }
+      unless %w[start-year registration-start-date academic-year-start-date npq-registration-start-date automatic-assignment-period-end-date].all? { |header| rows.headers.include?(header) }
         raise NameError, "Invalid headers"
       end
     end

--- a/app/services/importers/create_npq_contract.rb
+++ b/app/services/importers/create_npq_contract.rb
@@ -4,6 +4,17 @@ require "csv"
 
 module Importers
   class CreateNPQContract
+    AVAILABLE_HEADERS = %w[
+      provider_name
+      cohort_year
+      course_identifier
+      recruitment_target
+      per_participant
+      service_fee_installments
+      special_course
+      monthly_service_fee
+    ].freeze
+
     attr_reader :path_to_csv, :set_to_latest_version
 
     def initialize(path_to_csv:, set_to_latest_version: false)
@@ -32,7 +43,7 @@ module Importers
           )
 
           contract.update!(
-            monthly_service_fee: 0.0,
+            monthly_service_fee: row["monthly_service_fee"] || 0.0,
             recruitment_target: row["recruitment_target"].to_i,
             per_participant: row["per_participant"],
             service_fee_installments: row["service_fee_installments"].to_i,
@@ -85,7 +96,7 @@ module Importers
     end
 
     def check_headers
-      unless rows.headers == %w[provider_name cohort_year course_identifier recruitment_target per_participant service_fee_installments special_course]
+      unless rows.headers.all? { |h| h.in?(AVAILABLE_HEADERS) }
         raise NameError, "Invalid headers"
       end
     end

--- a/db/data/npq_contracts/fake-2021.csv
+++ b/db/data/npq_contracts/fake-2021.csv
@@ -1,78 +1,78 @@
-provider_name,cohort_year,course_identifier,recruitment_target,per_participant,service_fee_installments,special_course
-Ambition Institute,2021,npq-leading-teaching,1000,900,12,FALSE
-Ambition Institute,2021,npq-leading-behaviour-culture,1001,901,13,FALSE
-Ambition Institute,2021,npq-leading-teaching-development,1002,902,14,FALSE
-Ambition Institute,2021,npq-senior-leadership,1003,903,15,FALSE
-Ambition Institute,2021,npq-headship,1004,904,16,FALSE
-Ambition Institute,2021,npq-executive-leadership,1005,905,17,FALSE
-Ambition Institute,2021,npq-leading-literacy,1006,906,18,FALSE
-Ambition Institute,2021,npq-early-years-leadership,1007,907,19,FALSE
-Best Practice Network,2021,npq-leading-teaching,1008,908,20,FALSE
-Best Practice Network,2021,npq-leading-behaviour-culture,1009,909,21,FALSE
-Best Practice Network,2021,npq-leading-teaching-development,1010,910,22,FALSE
-Best Practice Network,2021,npq-senior-leadership,1011,911,23,FALSE
-Best Practice Network,2021,npq-headship,1012,912,24,FALSE
-Best Practice Network,2021,npq-executive-leadership,1013,913,25,FALSE
-Church of England,2021,npq-leading-teaching,1014,914,26,FALSE
-Church of England,2021,npq-leading-behaviour-culture,1015,915,27,FALSE
-Church of England,2021,npq-leading-teaching-development,1016,916,28,FALSE
-Church of England,2021,npq-senior-leadership,1017,917,29,FALSE
-Church of England,2021,npq-headship,1018,918,30,FALSE
-Church of England,2021,npq-executive-leadership,1019,919,31,FALSE
-Education Development Trust,2021,npq-leading-teaching,1020,920,32,FALSE
-Education Development Trust,2021,npq-leading-behaviour-culture,1021,921,33,FALSE
-Education Development Trust,2021,npq-leading-teaching-development,1022,922,34,FALSE
-Education Development Trust,2021,npq-senior-leadership,1023,923,35,FALSE
-Education Development Trust,2021,npq-headship,1024,924,36,FALSE
-Education Development Trust,2021,npq-executive-leadership,1025,925,37,FALSE
-Education Development Trust,2021,npq-leading-literacy,1026,926,38,FALSE
-Education Development Trust,2021,npq-early-years-leadership,1027,927,39,FALSE
-School-Led Network,2021,npq-leading-teaching,1028,928,40,FALSE
-School-Led Network,2021,npq-leading-behaviour-culture,1029,929,41,FALSE
-School-Led Network,2021,npq-leading-teaching-development,1030,930,42,FALSE
-School-Led Network,2021,npq-senior-leadership,1031,931,43,FALSE
-School-Led Network,2021,npq-headship,1032,932,44,FALSE
-School-Led Network,2021,npq-executive-leadership,1033,933,45,FALSE
-School-Led Network,2021,npq-leading-literacy,1034,934,46,FALSE
-School-Led Network,2021,npq-early-years-leadership,1035,935,47,FALSE
-LLSE,2021,npq-leading-teaching,1036,936,48,FALSE
-LLSE,2021,npq-leading-behaviour-culture,1037,937,49,FALSE
-LLSE,2021,npq-leading-teaching-development,1038,938,50,FALSE
-LLSE,2021,npq-senior-leadership,1039,939,51,FALSE
-LLSE,2021,npq-headship,1040,940,52,FALSE
-LLSE,2021,npq-executive-leadership,1041,941,53,FALSE
-LLSE,2021,npq-leading-literacy,1042,942,54,FALSE
-LLSE,2021,npq-early-years-leadership,1043,943,55,FALSE
-Teach First,2021,npq-leading-teaching,1044,944,56,FALSE
-Teach First,2021,npq-leading-behaviour-culture,1045,945,57,FALSE
-Teach First,2021,npq-leading-teaching-development,1046,946,58,FALSE
-Teach First,2021,npq-senior-leadership,1047,947,59,FALSE
-Teach First,2021,npq-headship,1048,948,60,FALSE
-Teach First,2021,npq-executive-leadership,1049,949,61,FALSE
-Teach First,2021,npq-leading-literacy,1050,950,62,FALSE
-Teach First,2021,npq-early-years-leadership,1051,951,63,FALSE
-Teacher Development Trust,2021,npq-leading-teaching,1052,952,64,FALSE
-Teacher Development Trust,2021,npq-leading-behaviour-culture,1053,953,65,FALSE
-Teacher Development Trust,2021,npq-leading-teaching-development,1054,954,66,FALSE
-Teacher Development Trust,2021,npq-senior-leadership,1055,955,67,FALSE
-Teacher Development Trust,2021,npq-headship,1056,956,68,FALSE
-Teacher Development Trust,2021,npq-executive-leadership,1057,957,69,FALSE
-Teacher Development Trust,2021,npq-leading-literacy,1058,958,70,FALSE
-Teacher Development Trust,2021,npq-early-years-leadership,1059,959,71,FALSE
-UCL Institute of Education,2021,npq-leading-teaching,1060,960,72,FALSE
-UCL Institute of Education,2021,npq-leading-behaviour-culture,1061,961,73,FALSE
-UCL Institute of Education,2021,npq-leading-teaching-development,1062,962,74,FALSE
-UCL Institute of Education,2021,npq-senior-leadership,1063,963,75,FALSE
-UCL Institute of Education,2021,npq-headship,1064,964,76,FALSE
-UCL Institute of Education,2021,npq-executive-leadership,1065,965,77,FALSE
-UCL Institute of Education,2021,npq-leading-literacy,1066,966,78,FALSE
-UCL Institute of Education,2021,npq-early-years-leadership,1067,967,79,FALSE
-Ambition Institute,2021,npq-early-headship-coaching-offer,300,800,0,FALSE
-Best Practice Network,2021,npq-early-headship-coaching-offer,300,800,0,FALSE
-Church of England,2021,npq-early-headship-coaching-offer,300,800,0,FALSE
-Education Development Trust,2021,npq-early-headship-coaching-offer,300,800,0,FALSE
-School-Led Network,2021,npq-early-headship-coaching-offer,300,800,0,FALSE
-LLSE,2021,npq-early-headship-coaching-offer,300,800,0,FALSE
-Teach First,2021,npq-early-headship-coaching-offer,300,800,0,FALSE
-Teacher Development Trust,2021,npq-early-headship-coaching-offer,300,800,0,FALSE
-UCL Institute of Education,2021,npq-early-headship-coaching-offer,300,800,0,FALSE
+provider_name,cohort_year,course_identifier,recruitment_target,per_participant,service_fee_installments,special_course,monthly_service_fee
+Ambition Institute,2021,npq-leading-teaching,1000,900,12,FALSE,0.0
+Ambition Institute,2021,npq-leading-behaviour-culture,1001,901,13,FALSE,0.0
+Ambition Institute,2021,npq-leading-teaching-development,1002,902,14,FALSE,0.0
+Ambition Institute,2021,npq-senior-leadership,1003,903,15,FALSE,0.0
+Ambition Institute,2021,npq-headship,1004,904,16,FALSE,0.0
+Ambition Institute,2021,npq-executive-leadership,1005,905,17,FALSE,0.0
+Ambition Institute,2021,npq-leading-literacy,1006,906,18,FALSE,0.0
+Ambition Institute,2021,npq-early-years-leadership,1007,907,19,FALSE,0.0
+Best Practice Network,2021,npq-leading-teaching,1008,908,20,FALSE,0.0
+Best Practice Network,2021,npq-leading-behaviour-culture,1009,909,21,FALSE,0.0
+Best Practice Network,2021,npq-leading-teaching-development,1010,910,22,FALSE,0.0
+Best Practice Network,2021,npq-senior-leadership,1011,911,23,FALSE,0.0
+Best Practice Network,2021,npq-headship,1012,912,24,FALSE,0.0
+Best Practice Network,2021,npq-executive-leadership,1013,913,25,FALSE,0.0
+Church of England,2021,npq-leading-teaching,1014,914,26,FALSE,0.0
+Church of England,2021,npq-leading-behaviour-culture,1015,915,27,FALSE,0.0
+Church of England,2021,npq-leading-teaching-development,1016,916,28,FALSE,0.0
+Church of England,2021,npq-senior-leadership,1017,917,29,FALSE,0.0
+Church of England,2021,npq-headship,1018,918,30,FALSE,0.0
+Church of England,2021,npq-executive-leadership,1019,919,31,FALSE,0.0
+Education Development Trust,2021,npq-leading-teaching,1020,920,32,FALSE,0.0
+Education Development Trust,2021,npq-leading-behaviour-culture,1021,921,33,FALSE,0.0
+Education Development Trust,2021,npq-leading-teaching-development,1022,922,34,FALSE,0.0
+Education Development Trust,2021,npq-senior-leadership,1023,923,35,FALSE,0.0
+Education Development Trust,2021,npq-headship,1024,924,36,FALSE,0.0
+Education Development Trust,2021,npq-executive-leadership,1025,925,37,FALSE,0.0
+Education Development Trust,2021,npq-leading-literacy,1026,926,38,FALSE,0.0
+Education Development Trust,2021,npq-early-years-leadership,1027,927,39,FALSE,0.0
+School-Led Network,2021,npq-leading-teaching,1028,928,40,FALSE,0.0
+School-Led Network,2021,npq-leading-behaviour-culture,1029,929,41,FALSE,0.0
+School-Led Network,2021,npq-leading-teaching-development,1030,930,42,FALSE,0.0
+School-Led Network,2021,npq-senior-leadership,1031,931,43,FALSE,0.0
+School-Led Network,2021,npq-headship,1032,932,44,FALSE,0.0
+School-Led Network,2021,npq-executive-leadership,1033,933,45,FALSE,0.0
+School-Led Network,2021,npq-leading-literacy,1034,934,46,FALSE,0.0
+School-Led Network,2021,npq-early-years-leadership,1035,935,47,FALSE,0.0
+LLSE,2021,npq-leading-teaching,1036,936,48,FALSE,0.0
+LLSE,2021,npq-leading-behaviour-culture,1037,937,49,FALSE,0.0
+LLSE,2021,npq-leading-teaching-development,1038,938,50,FALSE,0.0
+LLSE,2021,npq-senior-leadership,1039,939,51,FALSE,0.0
+LLSE,2021,npq-headship,1040,940,52,FALSE,0.0
+LLSE,2021,npq-executive-leadership,1041,941,53,FALSE,0.0
+LLSE,2021,npq-leading-literacy,1042,942,54,FALSE,0.0
+LLSE,2021,npq-early-years-leadership,1043,943,55,FALSE,0.0
+Teach First,2021,npq-leading-teaching,1044,944,56,FALSE,0.0
+Teach First,2021,npq-leading-behaviour-culture,1045,945,57,FALSE,0.0
+Teach First,2021,npq-leading-teaching-development,1046,946,58,FALSE,0.0
+Teach First,2021,npq-senior-leadership,1047,947,59,FALSE,0.0
+Teach First,2021,npq-headship,1048,948,60,FALSE,0.0
+Teach First,2021,npq-executive-leadership,1049,949,61,FALSE,0.0
+Teach First,2021,npq-leading-literacy,1050,950,62,FALSE,0.0
+Teach First,2021,npq-early-years-leadership,1051,951,63,FALSE,0.0
+Teacher Development Trust,2021,npq-leading-teaching,1052,952,64,FALSE,0.0
+Teacher Development Trust,2021,npq-leading-behaviour-culture,1053,953,65,FALSE,0.0
+Teacher Development Trust,2021,npq-leading-teaching-development,1054,954,66,FALSE,0.0
+Teacher Development Trust,2021,npq-senior-leadership,1055,955,67,FALSE,0.0
+Teacher Development Trust,2021,npq-headship,1056,956,68,FALSE,0.0
+Teacher Development Trust,2021,npq-executive-leadership,1057,957,69,FALSE,0.0
+Teacher Development Trust,2021,npq-leading-literacy,1058,958,70,FALSE,0.0
+Teacher Development Trust,2021,npq-early-years-leadership,1059,959,71,FALSE,0.0
+UCL Institute of Education,2021,npq-leading-teaching,1060,960,72,FALSE,0.0
+UCL Institute of Education,2021,npq-leading-behaviour-culture,1061,961,73,FALSE,0.0
+UCL Institute of Education,2021,npq-leading-teaching-development,1062,962,74,FALSE,0.0
+UCL Institute of Education,2021,npq-senior-leadership,1063,963,75,FALSE,0.0
+UCL Institute of Education,2021,npq-headship,1064,964,76,FALSE,0.0
+UCL Institute of Education,2021,npq-executive-leadership,1065,965,77,FALSE,0.0
+UCL Institute of Education,2021,npq-leading-literacy,1066,966,78,FALSE,0.0
+UCL Institute of Education,2021,npq-early-years-leadership,1067,967,79,FALSE,0.0
+Ambition Institute,2021,npq-early-headship-coaching-offer,300,800,0,FALSE,0.0
+Best Practice Network,2021,npq-early-headship-coaching-offer,300,800,0,FALSE,0.0
+Church of England,2021,npq-early-headship-coaching-offer,300,800,0,FALSE,0.0
+Education Development Trust,2021,npq-early-headship-coaching-offer,300,800,0,FALSE,0.0
+School-Led Network,2021,npq-early-headship-coaching-offer,300,800,0,FALSE,0.0
+LLSE,2021,npq-early-headship-coaching-offer,300,800,0,FALSE,0.0
+Teach First,2021,npq-early-headship-coaching-offer,300,800,0,FALSE,0.0
+Teacher Development Trust,2021,npq-early-headship-coaching-offer,300,800,0,FALSE,0.0
+UCL Institute of Education,2021,npq-early-headship-coaching-offer,300,800,0,FALSE,0.0

--- a/db/data/npq_contracts/fake-2022.csv
+++ b/db/data/npq_contracts/fake-2022.csv
@@ -1,87 +1,87 @@
-provider_name,cohort_year,course_identifier,recruitment_target,per_participant,service_fee_installments,special_course
-Ambition Institute,2022,npq-leading-teaching,1000,100,12,FALSE
-Ambition Institute,2022,npq-leading-behaviour-culture,1001,101,13,FALSE
-Ambition Institute,2022,npq-leading-teaching-development,1002,102,14,FALSE
-Ambition Institute,2022,npq-senior-leadership,1003,103,15,FALSE
-Ambition Institute,2022,npq-headship,1004,104,16,FALSE
-Ambition Institute,2022,npq-executive-leadership,1005,105,17,FALSE
-Ambition Institute,2022,npq-leading-literacy,1006,106,18,FALSE
-Ambition Institute,2022,npq-early-years-leadership,1007,107,19,FALSE
-Best Practice Network,2022,npq-leading-teaching,1008,108,20,FALSE
-Best Practice Network,2022,npq-leading-behaviour-culture,1009,109,21,FALSE
-Best Practice Network,2022,npq-leading-teaching-development,1010,110,22,FALSE
-Best Practice Network,2022,npq-senior-leadership,1011,111,23,FALSE
-Best Practice Network,2022,npq-headship,1012,112,24,FALSE
-Best Practice Network,2022,npq-executive-leadership,1013,113,25,FALSE
-Church of England,2022,npq-leading-teaching,1014,114,26,FALSE
-Church of England,2022,npq-leading-behaviour-culture,1015,115,27,FALSE
-Church of England,2022,npq-leading-teaching-development,1016,116,28,FALSE
-Church of England,2022,npq-senior-leadership,1017,117,29,FALSE
-Church of England,2022,npq-headship,1018,118,30,FALSE
-Church of England,2022,npq-executive-leadership,1019,119,31,FALSE
-Education Development Trust,2022,npq-leading-teaching,1020,120,32,FALSE
-Education Development Trust,2022,npq-leading-behaviour-culture,1021,121,33,FALSE
-Education Development Trust,2022,npq-leading-teaching-development,1022,122,34,FALSE
-Education Development Trust,2022,npq-senior-leadership,1023,123,35,FALSE
-Education Development Trust,2022,npq-headship,1024,124,36,FALSE
-Education Development Trust,2022,npq-executive-leadership,1025,125,37,FALSE
-Education Development Trust,2022,npq-leading-literacy,1026,126,38,FALSE
-Education Development Trust,2022,npq-early-years-leadership,1027,127,39,FALSE
-School-Led Network,2022,npq-leading-teaching,1028,128,40,FALSE
-School-Led Network,2022,npq-leading-behaviour-culture,1029,129,41,FALSE
-School-Led Network,2022,npq-leading-teaching-development,1030,130,42,FALSE
-School-Led Network,2022,npq-senior-leadership,1031,131,43,FALSE
-School-Led Network,2022,npq-headship,1032,132,44,FALSE
-School-Led Network,2022,npq-executive-leadership,1033,133,45,FALSE
-School-Led Network,2022,npq-leading-literacy,1034,134,46,FALSE
-School-Led Network,2022,npq-early-years-leadership,1035,135,47,FALSE
-LLSE,2022,npq-leading-teaching,1036,136,48,FALSE
-LLSE,2022,npq-leading-behaviour-culture,1037,137,49,FALSE
-LLSE,2022,npq-leading-teaching-development,1038,138,50,FALSE
-LLSE,2022,npq-senior-leadership,1039,139,51,FALSE
-LLSE,2022,npq-headship,1040,140,52,FALSE
-LLSE,2022,npq-executive-leadership,1041,141,53,FALSE
-LLSE,2022,npq-leading-literacy,1042,142,54,FALSE
-LLSE,2022,npq-early-years-leadership,1043,143,55,FALSE
-Teach First,2022,npq-leading-teaching,1044,144,56,FALSE
-Teach First,2022,npq-leading-behaviour-culture,1045,145,57,FALSE
-Teach First,2022,npq-leading-teaching-development,1046,146,58,FALSE
-Teach First,2022,npq-senior-leadership,1047,147,59,FALSE
-Teach First,2022,npq-headship,1048,148,60,FALSE
-Teach First,2022,npq-executive-leadership,1049,149,61,FALSE
-Teach First,2022,npq-leading-literacy,1050,150,62,FALSE
-Teach First,2022,npq-early-years-leadership,1051,151,63,FALSE
-Teacher Development Trust,2022,npq-leading-teaching,1052,152,64,FALSE
-Teacher Development Trust,2022,npq-leading-behaviour-culture,1053,153,65,FALSE
-Teacher Development Trust,2022,npq-leading-teaching-development,1054,154,66,FALSE
-Teacher Development Trust,2022,npq-senior-leadership,1055,155,67,FALSE
-Teacher Development Trust,2022,npq-headship,1056,156,68,FALSE
-Teacher Development Trust,2022,npq-executive-leadership,1057,157,69,FALSE
-Teacher Development Trust,2022,npq-leading-literacy,1058,158,70,FALSE
-Teacher Development Trust,2022,npq-early-years-leadership,1059,159,71,FALSE
-UCL Institute of Education,2022,npq-leading-teaching,1060,160,72,FALSE
-UCL Institute of Education,2022,npq-leading-behaviour-culture,1061,161,73,FALSE
-UCL Institute of Education,2022,npq-leading-teaching-development,1062,162,74,FALSE
-UCL Institute of Education,2022,npq-senior-leadership,1063,163,75,FALSE
-UCL Institute of Education,2022,npq-headship,1064,164,76,FALSE
-UCL Institute of Education,2022,npq-executive-leadership,1065,165,77,FALSE
-UCL Institute of Education,2022,npq-leading-literacy,1066,166,78,FALSE
-UCL Institute of Education,2022,npq-early-years-leadership,1067,167,79,FALSE
-Ambition Institute,2022,npq-early-headship-coaching-offer,1068,168,0,FALSE
-Best Practice Network,2022,npq-early-headship-coaching-offer,1069,169,0,FALSE
-Church of England,2022,npq-early-headship-coaching-offer,1070,170,0,FALSE
-Education Development Trust,2022,npq-early-headship-coaching-offer,1071,171,0,FALSE
-School-Led Network,2022,npq-early-headship-coaching-offer,1072,172,0,FALSE
-LLSE,2022,npq-early-headship-coaching-offer,1073,173,0,FALSE
-Teach First,2022,npq-early-headship-coaching-offer,1074,174,0,FALSE
-Teacher Development Trust,2022,npq-early-headship-coaching-offer,1075,175,0,FALSE
-UCL Institute of Education,2022,npq-early-headship-coaching-offer,1076,176,0,FALSE
-National Institute of Teaching,2022,npq-leading-teaching,100,800,24,FALSE
-National Institute of Teaching,2022,npq-leading-behaviour-culture,101,801,24,FALSE
-National Institute of Teaching,2022,npq-leading-teaching-development,102,802,24,FALSE
-National Institute of Teaching,2022,npq-senior-leadership,103,803,24,FALSE
-National Institute of Teaching,2022,npq-headship,104,804,24,FALSE
-National Institute of Teaching,2022,npq-executive-leadership,105,805,24,FALSE
-National Institute of Teaching,2022,npq-leading-literacy,106,806,24,FALSE
-National Institute of Teaching,2022,npq-early-years-leadership,107,807,24,FALSE
-National Institute of Teaching,2022,npq-early-headship-coaching-offer,1000,800,0,FALSE
+provider_name,cohort_year,course_identifier,recruitment_target,per_participant,service_fee_installments,special_course,monthly_service_fee
+Ambition Institute,2022,npq-leading-teaching,1000,100,12,FALSE,0.0
+Ambition Institute,2022,npq-leading-behaviour-culture,1001,101,13,FALSE,0.0
+Ambition Institute,2022,npq-leading-teaching-development,1002,102,14,FALSE,0.0
+Ambition Institute,2022,npq-senior-leadership,1003,103,15,FALSE,0.0
+Ambition Institute,2022,npq-headship,1004,104,16,FALSE,0.0
+Ambition Institute,2022,npq-executive-leadership,1005,105,17,FALSE,0.0
+Ambition Institute,2022,npq-leading-literacy,1006,106,18,FALSE,0.0
+Ambition Institute,2022,npq-early-years-leadership,1007,107,19,FALSE,0.0
+Best Practice Network,2022,npq-leading-teaching,1008,108,20,FALSE,0.0
+Best Practice Network,2022,npq-leading-behaviour-culture,1009,109,21,FALSE,0.0
+Best Practice Network,2022,npq-leading-teaching-development,1010,110,22,FALSE,0.0
+Best Practice Network,2022,npq-senior-leadership,1011,111,23,FALSE,0.0
+Best Practice Network,2022,npq-headship,1012,112,24,FALSE,0.0
+Best Practice Network,2022,npq-executive-leadership,1013,113,25,FALSE,0.0
+Church of England,2022,npq-leading-teaching,1014,114,26,FALSE,0.0
+Church of England,2022,npq-leading-behaviour-culture,1015,115,27,FALSE,0.0
+Church of England,2022,npq-leading-teaching-development,1016,116,28,FALSE,0.0
+Church of England,2022,npq-senior-leadership,1017,117,29,FALSE,0.0
+Church of England,2022,npq-headship,1018,118,30,FALSE,0.0
+Church of England,2022,npq-executive-leadership,1019,119,31,FALSE,0.0
+Education Development Trust,2022,npq-leading-teaching,1020,120,32,FALSE,0.0
+Education Development Trust,2022,npq-leading-behaviour-culture,1021,121,33,FALSE,0.0
+Education Development Trust,2022,npq-leading-teaching-development,1022,122,34,FALSE,0.0
+Education Development Trust,2022,npq-senior-leadership,1023,123,35,FALSE,0.0
+Education Development Trust,2022,npq-headship,1024,124,36,FALSE,0.0
+Education Development Trust,2022,npq-executive-leadership,1025,125,37,FALSE,0.0
+Education Development Trust,2022,npq-leading-literacy,1026,126,38,FALSE,0.0
+Education Development Trust,2022,npq-early-years-leadership,1027,127,39,FALSE,0.0
+School-Led Network,2022,npq-leading-teaching,1028,128,40,FALSE,0.0
+School-Led Network,2022,npq-leading-behaviour-culture,1029,129,41,FALSE,0.0
+School-Led Network,2022,npq-leading-teaching-development,1030,130,42,FALSE,0.0
+School-Led Network,2022,npq-senior-leadership,1031,131,43,FALSE,0.0
+School-Led Network,2022,npq-headship,1032,132,44,FALSE,0.0
+School-Led Network,2022,npq-executive-leadership,1033,133,45,FALSE,0.0
+School-Led Network,2022,npq-leading-literacy,1034,134,46,FALSE,0.0
+School-Led Network,2022,npq-early-years-leadership,1035,135,47,FALSE,0.0
+LLSE,2022,npq-leading-teaching,1036,136,48,FALSE,0.0
+LLSE,2022,npq-leading-behaviour-culture,1037,137,49,FALSE,0.0
+LLSE,2022,npq-leading-teaching-development,1038,138,50,FALSE,0.0
+LLSE,2022,npq-senior-leadership,1039,139,51,FALSE,0.0
+LLSE,2022,npq-headship,1040,140,52,FALSE,0.0
+LLSE,2022,npq-executive-leadership,1041,141,53,FALSE,0.0
+LLSE,2022,npq-leading-literacy,1042,142,54,FALSE,0.0
+LLSE,2022,npq-early-years-leadership,1043,143,55,FALSE,0.0
+Teach First,2022,npq-leading-teaching,1044,144,56,FALSE,0.0
+Teach First,2022,npq-leading-behaviour-culture,1045,145,57,FALSE,0.0
+Teach First,2022,npq-leading-teaching-development,1046,146,58,FALSE,0.0
+Teach First,2022,npq-senior-leadership,1047,147,59,FALSE,0.0
+Teach First,2022,npq-headship,1048,148,60,FALSE,0.0
+Teach First,2022,npq-executive-leadership,1049,149,61,FALSE,0.0
+Teach First,2022,npq-leading-literacy,1050,150,62,FALSE,0.0
+Teach First,2022,npq-early-years-leadership,1051,151,63,FALSE,0.0
+Teacher Development Trust,2022,npq-leading-teaching,1052,152,64,FALSE,0.0
+Teacher Development Trust,2022,npq-leading-behaviour-culture,1053,153,65,FALSE,0.0
+Teacher Development Trust,2022,npq-leading-teaching-development,1054,154,66,FALSE,0.0
+Teacher Development Trust,2022,npq-senior-leadership,1055,155,67,FALSE,0.0
+Teacher Development Trust,2022,npq-headship,1056,156,68,FALSE,0.0
+Teacher Development Trust,2022,npq-executive-leadership,1057,157,69,FALSE,0.0
+Teacher Development Trust,2022,npq-leading-literacy,1058,158,70,FALSE,0.0
+Teacher Development Trust,2022,npq-early-years-leadership,1059,159,71,FALSE,0.0
+UCL Institute of Education,2022,npq-leading-teaching,1060,160,72,FALSE,0.0
+UCL Institute of Education,2022,npq-leading-behaviour-culture,1061,161,73,FALSE,0.0
+UCL Institute of Education,2022,npq-leading-teaching-development,1062,162,74,FALSE,0.0
+UCL Institute of Education,2022,npq-senior-leadership,1063,163,75,FALSE,0.0
+UCL Institute of Education,2022,npq-headship,1064,164,76,FALSE,0.0
+UCL Institute of Education,2022,npq-executive-leadership,1065,165,77,FALSE,0.0
+UCL Institute of Education,2022,npq-leading-literacy,1066,166,78,FALSE,0.0
+UCL Institute of Education,2022,npq-early-years-leadership,1067,167,79,FALSE,0.0
+Ambition Institute,2022,npq-early-headship-coaching-offer,1068,168,0,FALSE,0.0
+Best Practice Network,2022,npq-early-headship-coaching-offer,1069,169,0,FALSE,0.0
+Church of England,2022,npq-early-headship-coaching-offer,1070,170,0,FALSE,0.0
+Education Development Trust,2022,npq-early-headship-coaching-offer,1071,171,0,FALSE,0.0
+School-Led Network,2022,npq-early-headship-coaching-offer,1072,172,0,FALSE,0.0
+LLSE,2022,npq-early-headship-coaching-offer,1073,173,0,FALSE,0.0
+Teach First,2022,npq-early-headship-coaching-offer,1074,174,0,FALSE,0.0
+Teacher Development Trust,2022,npq-early-headship-coaching-offer,1075,175,0,FALSE,0.0
+UCL Institute of Education,2022,npq-early-headship-coaching-offer,1076,176,0,FALSE,0.0
+National Institute of Teaching,2022,npq-leading-teaching,100,800,24,FALSE,0.0
+National Institute of Teaching,2022,npq-leading-behaviour-culture,101,801,24,FALSE,0.0
+National Institute of Teaching,2022,npq-leading-teaching-development,102,802,24,FALSE,0.0
+National Institute of Teaching,2022,npq-senior-leadership,103,803,24,FALSE,0.0
+National Institute of Teaching,2022,npq-headship,104,804,24,FALSE,0.0
+National Institute of Teaching,2022,npq-executive-leadership,105,805,24,FALSE,0.0
+National Institute of Teaching,2022,npq-leading-literacy,106,806,24,FALSE,0.0
+National Institute of Teaching,2022,npq-early-years-leadership,107,807,24,FALSE,0.0
+National Institute of Teaching,2022,npq-early-headship-coaching-offer,1000,800,0,FALSE,0.0

--- a/db/data/npq_contracts/fake-2023.csv
+++ b/db/data/npq_contracts/fake-2023.csv
@@ -1,90 +1,90 @@
-provider_name,cohort_year,course_identifier,recruitment_target,per_participant,service_fee_installments,special_course
-Ambition Institute,2023,npq-leading-teaching,1000,100,12,FALSE
-Ambition Institute,2023,npq-leading-behaviour-culture,1001,101,13,FALSE
-Ambition Institute,2023,npq-leading-teaching-development,1002,102,14,FALSE
-Ambition Institute,2023,npq-senior-leadership,1003,103,15,FALSE
-Ambition Institute,2023,npq-headship,1004,104,16,FALSE
-Ambition Institute,2023,npq-executive-leadership,1005,105,17,FALSE
-Ambition Institute,2023,npq-leading-literacy,1006,106,18,FALSE
-Ambition Institute,2023,npq-early-years-leadership,1007,107,19,FALSE
-Best Practice Network,2023,npq-leading-teaching,1008,108,20,FALSE
-Best Practice Network,2023,npq-leading-behaviour-culture,1009,109,21,FALSE
-Best Practice Network,2023,npq-leading-teaching-development,1010,110,22,FALSE
-Best Practice Network,2023,npq-senior-leadership,1011,111,23,FALSE
-Best Practice Network,2023,npq-headship,1012,112,24,FALSE
-Best Practice Network,2023,npq-executive-leadership,1013,113,25,FALSE
-Church of England,2023,npq-leading-teaching,1014,114,26,FALSE
-Church of England,2023,npq-leading-behaviour-culture,1015,115,27,FALSE
-Church of England,2023,npq-leading-teaching-development,1016,116,28,FALSE
-Church of England,2023,npq-senior-leadership,1017,117,29,FALSE
-Church of England,2023,npq-headship,1018,118,30,FALSE
-Church of England,2023,npq-executive-leadership,1019,119,31,FALSE
-Education Development Trust,2023,npq-leading-teaching,1020,120,32,FALSE
-Education Development Trust,2023,npq-leading-behaviour-culture,1021,121,33,FALSE
-Education Development Trust,2023,npq-leading-teaching-development,1022,122,34,FALSE
-Education Development Trust,2023,npq-senior-leadership,1023,123,35,FALSE
-Education Development Trust,2023,npq-headship,1024,124,36,FALSE
-Education Development Trust,2023,npq-executive-leadership,1025,125,37,FALSE
-Education Development Trust,2023,npq-leading-literacy,1026,126,38,FALSE
-Education Development Trust,2023,npq-early-years-leadership,1027,127,39,FALSE
-School-Led Network,2023,npq-leading-teaching,1028,128,40,FALSE
-School-Led Network,2023,npq-leading-behaviour-culture,1029,129,41,FALSE
-School-Led Network,2023,npq-leading-teaching-development,1030,130,42,FALSE
-School-Led Network,2023,npq-senior-leadership,1031,131,43,FALSE
-School-Led Network,2023,npq-headship,1032,132,44,FALSE
-School-Led Network,2023,npq-executive-leadership,1033,133,45,FALSE
-School-Led Network,2023,npq-leading-literacy,1034,134,46,FALSE
-School-Led Network,2023,npq-early-years-leadership,1035,135,47,FALSE
-LLSE,2023,npq-leading-teaching,1036,136,48,FALSE
-LLSE,2023,npq-leading-behaviour-culture,1037,137,49,FALSE
-LLSE,2023,npq-leading-teaching-development,1038,138,50,FALSE
-LLSE,2023,npq-senior-leadership,1039,139,51,FALSE
-LLSE,2023,npq-headship,1040,140,52,FALSE
-LLSE,2023,npq-executive-leadership,1041,141,53,FALSE
-LLSE,2023,npq-leading-literacy,1042,142,54,FALSE
-LLSE,2023,npq-early-years-leadership,1043,143,55,FALSE
-Teach First,2023,npq-leading-teaching,1044,144,56,FALSE
-Teach First,2023,npq-leading-behaviour-culture,1045,145,57,FALSE
-Teach First,2023,npq-leading-teaching-development,1046,146,58,FALSE
-Teach First,2023,npq-senior-leadership,1047,147,59,FALSE
-Teach First,2023,npq-headship,1048,148,60,FALSE
-Teach First,2023,npq-executive-leadership,1049,149,61,FALSE
-Teach First,2023,npq-leading-literacy,1050,150,62,FALSE
-Teach First,2023,npq-early-years-leadership,1051,151,63,FALSE
-Teacher Development Trust,2023,npq-leading-teaching,1052,152,64,FALSE
-Teacher Development Trust,2023,npq-leading-behaviour-culture,1053,153,65,FALSE
-Teacher Development Trust,2023,npq-leading-teaching-development,1054,154,66,FALSE
-Teacher Development Trust,2023,npq-senior-leadership,1055,155,67,FALSE
-Teacher Development Trust,2023,npq-headship,1056,156,68,FALSE
-Teacher Development Trust,2023,npq-executive-leadership,1057,157,69,FALSE
-Teacher Development Trust,2023,npq-leading-literacy,1058,158,70,FALSE
-Teacher Development Trust,2023,npq-early-years-leadership,1059,159,71,FALSE
-UCL Institute of Education,2023,npq-leading-teaching,1060,160,72,FALSE
-UCL Institute of Education,2023,npq-leading-behaviour-culture,1061,161,73,FALSE
-UCL Institute of Education,2023,npq-leading-teaching-development,1062,162,74,FALSE
-UCL Institute of Education,2023,npq-senior-leadership,1063,163,75,FALSE
-UCL Institute of Education,2023,npq-headship,1064,164,76,FALSE
-UCL Institute of Education,2023,npq-executive-leadership,1065,165,77,FALSE
-UCL Institute of Education,2023,npq-leading-literacy,1066,166,78,FALSE
-UCL Institute of Education,2023,npq-early-years-leadership,1067,167,79,FALSE
-Ambition Institute,2023,npq-early-headship-coaching-offer,1068,168,0,FALSE
-Best Practice Network,2023,npq-early-headship-coaching-offer,1069,169,0,FALSE
-Church of England,2023,npq-early-headship-coaching-offer,1070,170,0,FALSE
-Education Development Trust,2023,npq-early-headship-coaching-offer,1071,171,0,FALSE
-School-Led Network,2023,npq-early-headship-coaching-offer,1072,172,0,FALSE
-LLSE,2023,npq-early-headship-coaching-offer,1073,173,0,FALSE
-Teach First,2023,npq-early-headship-coaching-offer,1074,174,0,FALSE
-Teacher Development Trust,2023,npq-early-headship-coaching-offer,1075,175,0,FALSE
-UCL Institute of Education,2023,npq-early-headship-coaching-offer,1076,176,0,FALSE
-National Institute of Teaching,2023,npq-leading-teaching,100,800,24,FALSE
-National Institute of Teaching,2023,npq-leading-behaviour-culture,101,801,24,FALSE
-National Institute of Teaching,2023,npq-leading-teaching-development,102,802,24,FALSE
-National Institute of Teaching,2023,npq-senior-leadership,103,803,24,FALSE
-National Institute of Teaching,2023,npq-headship,104,804,24,FALSE
-National Institute of Teaching,2023,npq-executive-leadership,105,805,24,FALSE
-National Institute of Teaching,2023,npq-leading-literacy,106,806,24,FALSE
-National Institute of Teaching,2023,npq-early-years-leadership,107,807,24,FALSE
-National Institute of Teaching,2023,npq-early-headship-coaching-offer,1000,800,0,FALSE
+provider_name,cohort_year,course_identifier,recruitment_target,per_participant,service_fee_installments,special_course,monthly_service_fee
+Ambition Institute,2023,npq-leading-teaching,1000,100,12,FALSE,0.0
+Ambition Institute,2023,npq-leading-behaviour-culture,1001,101,13,FALSE,0.0
+Ambition Institute,2023,npq-leading-teaching-development,1002,102,14,FALSE,0.0
+Ambition Institute,2023,npq-senior-leadership,1003,103,15,FALSE,0.0
+Ambition Institute,2023,npq-headship,1004,104,16,FALSE,0.0
+Ambition Institute,2023,npq-executive-leadership,1005,105,17,FALSE,0.0
+Ambition Institute,2023,npq-leading-literacy,1006,106,18,FALSE,0.0
+Ambition Institute,2023,npq-early-years-leadership,1007,107,19,FALSE,0.0
+Best Practice Network,2023,npq-leading-teaching,1008,108,20,FALSE,0.0
+Best Practice Network,2023,npq-leading-behaviour-culture,1009,109,21,FALSE,0.0
+Best Practice Network,2023,npq-leading-teaching-development,1010,110,22,FALSE,0.0
+Best Practice Network,2023,npq-senior-leadership,1011,111,23,FALSE,0.0
+Best Practice Network,2023,npq-headship,1012,112,24,FALSE,0.0
+Best Practice Network,2023,npq-executive-leadership,1013,113,25,FALSE,0.0
+Church of England,2023,npq-leading-teaching,1014,114,26,FALSE,0.0
+Church of England,2023,npq-leading-behaviour-culture,1015,115,27,FALSE,0.0
+Church of England,2023,npq-leading-teaching-development,1016,116,28,FALSE,0.0
+Church of England,2023,npq-senior-leadership,1017,117,29,FALSE,0.0
+Church of England,2023,npq-headship,1018,118,30,FALSE,0.0
+Church of England,2023,npq-executive-leadership,1019,119,31,FALSE,0.0
+Education Development Trust,2023,npq-leading-teaching,1020,120,32,FALSE,0.0
+Education Development Trust,2023,npq-leading-behaviour-culture,1021,121,33,FALSE,0.0
+Education Development Trust,2023,npq-leading-teaching-development,1022,122,34,FALSE,0.0
+Education Development Trust,2023,npq-senior-leadership,1023,123,35,FALSE,0.0
+Education Development Trust,2023,npq-headship,1024,124,36,FALSE,0.0
+Education Development Trust,2023,npq-executive-leadership,1025,125,37,FALSE,0.0
+Education Development Trust,2023,npq-leading-literacy,1026,126,38,FALSE,0.0
+Education Development Trust,2023,npq-early-years-leadership,1027,127,39,FALSE,0.0
+School-Led Network,2023,npq-leading-teaching,1028,128,40,FALSE,0.0
+School-Led Network,2023,npq-leading-behaviour-culture,1029,129,41,FALSE,0.0
+School-Led Network,2023,npq-leading-teaching-development,1030,130,42,FALSE,0.0
+School-Led Network,2023,npq-senior-leadership,1031,131,43,FALSE,0.0
+School-Led Network,2023,npq-headship,1032,132,44,FALSE,0.0
+School-Led Network,2023,npq-executive-leadership,1033,133,45,FALSE,0.0
+School-Led Network,2023,npq-leading-literacy,1034,134,46,FALSE,0.0
+School-Led Network,2023,npq-early-years-leadership,1035,135,47,FALSE,0.0
+LLSE,2023,npq-leading-teaching,1036,136,48,FALSE,0.0
+LLSE,2023,npq-leading-behaviour-culture,1037,137,49,FALSE,0.0
+LLSE,2023,npq-leading-teaching-development,1038,138,50,FALSE,0.0
+LLSE,2023,npq-senior-leadership,1039,139,51,FALSE,0.0
+LLSE,2023,npq-headship,1040,140,52,FALSE,0.0
+LLSE,2023,npq-executive-leadership,1041,141,53,FALSE,0.0
+LLSE,2023,npq-leading-literacy,1042,142,54,FALSE,0.0
+LLSE,2023,npq-early-years-leadership,1043,143,55,FALSE,0.0
+Teach First,2023,npq-leading-teaching,1044,144,56,FALSE,0.0
+Teach First,2023,npq-leading-behaviour-culture,1045,145,57,FALSE,0.0
+Teach First,2023,npq-leading-teaching-development,1046,146,58,FALSE,0.0
+Teach First,2023,npq-senior-leadership,1047,147,59,FALSE,0.0
+Teach First,2023,npq-headship,1048,148,60,FALSE,0.0
+Teach First,2023,npq-executive-leadership,1049,149,61,FALSE,0.0
+Teach First,2023,npq-leading-literacy,1050,150,62,FALSE,0.0
+Teach First,2023,npq-early-years-leadership,1051,151,63,FALSE,0.0
+Teacher Development Trust,2023,npq-leading-teaching,1052,152,64,FALSE,0.0
+Teacher Development Trust,2023,npq-leading-behaviour-culture,1053,153,65,FALSE,0.0
+Teacher Development Trust,2023,npq-leading-teaching-development,1054,154,66,FALSE,0.0
+Teacher Development Trust,2023,npq-senior-leadership,1055,155,67,FALSE,0.0
+Teacher Development Trust,2023,npq-headship,1056,156,68,FALSE,0.0
+Teacher Development Trust,2023,npq-executive-leadership,1057,157,69,FALSE,0.0
+Teacher Development Trust,2023,npq-leading-literacy,1058,158,70,FALSE,0.0
+Teacher Development Trust,2023,npq-early-years-leadership,1059,159,71,FALSE,0.0
+UCL Institute of Education,2023,npq-leading-teaching,1060,160,72,FALSE,0.0
+UCL Institute of Education,2023,npq-leading-behaviour-culture,1061,161,73,FALSE,0.0
+UCL Institute of Education,2023,npq-leading-teaching-development,1062,162,74,FALSE,0.0
+UCL Institute of Education,2023,npq-senior-leadership,1063,163,75,FALSE,0.0
+UCL Institute of Education,2023,npq-headship,1064,164,76,FALSE,0.0
+UCL Institute of Education,2023,npq-executive-leadership,1065,165,77,FALSE,0.0
+UCL Institute of Education,2023,npq-leading-literacy,1066,166,78,FALSE,0.0
+UCL Institute of Education,2023,npq-early-years-leadership,1067,167,79,FALSE,0.0
+Ambition Institute,2023,npq-early-headship-coaching-offer,1068,168,0,FALSE,0.0
+Best Practice Network,2023,npq-early-headship-coaching-offer,1069,169,0,FALSE,0.0
+Church of England,2023,npq-early-headship-coaching-offer,1070,170,0,FALSE,0.0
+Education Development Trust,2023,npq-early-headship-coaching-offer,1071,171,0,FALSE,0.0
+School-Led Network,2023,npq-early-headship-coaching-offer,1072,172,0,FALSE,0.0
+LLSE,2023,npq-early-headship-coaching-offer,1073,173,0,FALSE,0.0
+Teach First,2023,npq-early-headship-coaching-offer,1074,174,0,FALSE,0.0
+Teacher Development Trust,2023,npq-early-headship-coaching-offer,1075,175,0,FALSE,0.0
+UCL Institute of Education,2023,npq-early-headship-coaching-offer,1076,176,0,FALSE,0.0
+National Institute of Teaching,2023,npq-leading-teaching,100,800,24,FALSE,0.0
+National Institute of Teaching,2023,npq-leading-behaviour-culture,101,801,24,FALSE,0.0
+National Institute of Teaching,2023,npq-leading-teaching-development,102,802,24,FALSE,0.0
+National Institute of Teaching,2023,npq-senior-leadership,103,803,24,FALSE,0.0
+National Institute of Teaching,2023,npq-headship,104,804,24,FALSE,0.0
+National Institute of Teaching,2023,npq-executive-leadership,105,805,24,FALSE,0.0
+National Institute of Teaching,2023,npq-leading-literacy,106,806,24,FALSE,0.0
+National Institute of Teaching,2023,npq-early-years-leadership,107,807,24,FALSE,0.0
+National Institute of Teaching,2023,npq-early-headship-coaching-offer,1000,800,0,FALSE,0.0
 Ambition Institute,2023,npq-leading-primary-mathematics,1007,107,19,TRUE
 Best Practice Network,2023,npq-leading-primary-mathematics,1013,113,25,TRUE
 Church of England,2023,npq-leading-primary-mathematics,1019,119,31,TRUE

--- a/spec/fixtures/files/importers/cohort_csv_data.csv
+++ b/spec/fixtures/files/importers/cohort_csv_data.csv
@@ -1,2 +1,2 @@
-start-year,registration-start-date,academic-year-start-date,npq-registration-start-date
-2025,2025/05/10,2025/09/01
+start-year,registration-start-date,academic-year-start-date,npq-registration-start-date,automatic-assignment-period-end-date
+2025,2025/05/10,2025/09/01,2026/03/31

--- a/spec/services/importers/create_cohort_spec.rb
+++ b/spec/services/importers/create_cohort_spec.rb
@@ -11,15 +11,15 @@ RSpec.describe Importers::CreateCohort do
   describe "#call" do
     context "with new cohorts" do
       before do
-        csv.write "start-year,registration-start-date,academic-year-start-date,npq-registration-start-date"
+        csv.write "start-year,registration-start-date,academic-year-start-date,npq-registration-start-date,automatic-assignment-period-end-date"
         csv.write "\n"
-        csv.write "3030,3030/05/10,3030/09/01,"
+        csv.write "3030,3030/05/10,3030/09/01,3031/03/31,"
         csv.write "\n"
-        csv.write "3031,3031/05/10,3031/09/01,"
+        csv.write "3031,3031/05/10,3031/09/01,3032/03/31,"
         csv.write "\n"
-        csv.write "3032,3032/05/10,3032/09/01,"
+        csv.write "3032,3032/05/10,3032/09/01,,"
         csv.write "\n"
-        csv.write "3033,3033/05/10,3033/09/01,"
+        csv.write "3033,3033/05/10,3033/09/01,3034/03/31,"
         csv.write "\n"
         csv.close
       end
@@ -41,6 +41,20 @@ RSpec.describe Importers::CreateCohort do
         expect(cohort_3031.registration_start_date).to eq Date.new(3031, 5, 10)
       end
 
+      it "sets the correct automatic assignment period end date on the record" do
+        importer.call
+
+        cohort_3031 = Cohort.find_by(start_year: 3031)
+        expect(cohort_3031.automatic_assignment_period_end_date).to eq Date.new(3032, 3, 31)
+      end
+
+      it "defaults the automatic assignment period to 31st March of the following year" do
+        importer.call
+
+        cohort_3032 = Cohort.find_by(start_year: 3032)
+        expect(cohort_3032.automatic_assignment_period_end_date).to eq(Date.new(3033, 3, 31))
+      end
+
       it "only creates one cohort record per year" do
         original_cohort_count = Cohort.count
         importer.call
@@ -58,9 +72,9 @@ RSpec.describe Importers::CreateCohort do
       end
 
       before do
-        csv.write "start-year,registration-start-date,academic-year-start-date,npq-registration-start-date"
+        csv.write "start-year,registration-start-date,academic-year-start-date,npq-registration-start-date,automatic-assignment-period-end-date"
         csv.write "\n"
-        csv.write "4041,4041/05/10,4041/09/01,4041/04/01"
+        csv.write "4041,4041/05/10,4041/09/01,4041/04/01,4042/03/31"
         csv.write "\n"
         csv.close
       end

--- a/spec/services/importers/create_new_npq_cohort_spec.rb
+++ b/spec/services/importers/create_new_npq_cohort_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe Importers::CreateNewNPQCohort do
 
     let(:cohort_csv) do
       csv = Tempfile.new("cohort_csv_data.csv")
-      csv.write "start-year,registration-start-date,academic-year-start-date,npq-registration-start-date"
+      csv.write "start-year,registration-start-date,academic-year-start-date,npq-registration-start-date,automatic-assignment-period-end-date"
       csv.write "\n"
       4.times.each do |n|
-        csv.write "#{start_year + n},#{start_year + n}/05/10,#{start_year}/09/01,"
+        csv.write "#{start_year + n},#{start_year + n}/05/10,#{start_year}/09/01,#{start_year + 1}/03/31,"
         csv.write "\n"
       end
       csv.close

--- a/spec/services/importers/create_npq_contract_spec.rb
+++ b/spec/services/importers/create_npq_contract_spec.rb
@@ -30,10 +30,12 @@ RSpec.describe Importers::CreateNPQContract do
     end
 
     context "when new contract" do
+      let(:monthly_service_fee) { 12.34 }
+
       before do
-        csv.write "provider_name,cohort_year,course_identifier,recruitment_target,per_participant,service_fee_installments,special_course"
+        csv.write "provider_name,cohort_year,course_identifier,recruitment_target,per_participant,service_fee_installments,special_course,monthly_service_fee"
         csv.write "\n"
-        csv.write "Ambition Institute,#{cohort.start_year},npq-leading-teaching,123,456.78,13,TRUE"
+        csv.write "Ambition Institute,#{cohort.start_year},npq-leading-teaching,123,456.78,13,TRUE,#{monthly_service_fee}"
         csv.write "\n"
         csv.close
       end
@@ -53,8 +55,20 @@ RSpec.describe Importers::CreateNPQContract do
         expect(contract.number_of_payment_periods).to eql(3)
         expect(contract.cohort).to eql(cohort)
         expect(contract.version).to eql("0.0.1")
-        expect(contract.monthly_service_fee).to eql(0.0)
+        expect(contract.monthly_service_fee).to eql(12.34)
         expect(contract.special_course).to eql(true)
+      end
+
+      context "when the monthly_service_fee is not specified" do
+        let(:monthly_service_fee) { nil }
+
+        it "defaults it to 0.0" do
+          expect { subject.call }.to change { NPQContract.count }.by(1)
+
+          contract = NPQContract.last
+
+          expect(contract.monthly_service_fee).to be_zero
+        end
       end
     end
 


### PR DESCRIPTION
### Context

We have a new field `automatic_assignment_period_end_date` on Cohort that we want to allow in the CSV and default to the 31st March of the following year (relative to the `start_year` of the Cohort).

The NPQ Contract also has a new `monthly_service_fee` field; this was already defaulting to `0.0` in the import script, but this will also allow it to be added as part of the CSV.

### Changes proposed in this pull request

- Update import scripts for cohort/npq contract

### Guidance to review

