### PR TITLE
CST-2450: pick the latest induction records to display the dashboard

### DIFF
--- a/app/models/induction_record.rb
+++ b/app/models/induction_record.rb
@@ -75,26 +75,17 @@ class InductionRecord < ApplicationRecord
   # sorting
   scope :completed_first, -> { order(Arel.sql("CASE WHEN induction_records.induction_status = 'completed' THEN 0 ELSE 1 END")) }
 
-  scope :no_end_date_first, -> { order(Arel.sql("CASE WHEN induction_records.end_date IS NULL THEN 0 ELSE 1 END")) }
+  scope :with_no_end_date_first, -> { order(Arel.sql("CASE WHEN induction_records.end_date IS NULL THEN 0 ELSE 1 END")) }
   scope :with_end_date_first, -> { order(Arel.sql("CASE WHEN induction_records.end_date IS NULL THEN 1 ELSE 0 END")) }
 
-  scope :less_recent_start_date_first, -> { order(start_date: :asc) }
-  scope :most_recent_start_date_first, -> { order(start_date: :desc) }
+  scope :oldest_start_date_first, -> { order(start_date: :asc) }
+  scope :newest_start_date_first, -> { order(start_date: :desc) }
 
-  scope :less_recent_end_date_first, -> { order(end_date: :asc) }
-  scope :most_recent_end_date_first, -> { order(end_date: :desc) }
+  scope :oldest_end_date_first, -> { order(end_date: :asc) }
+  scope :newest_end_date_first, -> { order(end_date: :desc) }
 
-  scope :less_recent_first, -> { order(created_at: :asc) }
-  scope :most_recent_first, -> { order(created_at: :desc) }
-
-  scope :oldest_first, -> { with_end_date_first
-                              .less_recent_start_date_first
-                              .less_recent_end_date_first
-                              .less_recent_first }
-  scope :newest_first, -> { no_end_date_first
-                              .most_recent_start_date_first
-                              .most_recent_end_date_first
-                              .most_recent_first }
+  scope :oldest_created_first, -> { order(created_at: :asc) }
+  scope :newest_created_first, -> { order(created_at: :desc) }
 
   scope :oldest, -> { oldest_first.first }
 
@@ -104,6 +95,28 @@ class InductionRecord < ApplicationRecord
   # Class Methods
   def self.latest
     newest_first.first
+  end
+
+  def self.newest_first
+    with_no_end_date_first
+      .newest_start_date_first
+      .newest_end_date_first
+      .newest_created_first
+  end
+
+  def self.oldest_first
+    with_end_date_first
+      .oldest_start_date_first
+      .oldest_end_date_first
+      .oldest_created_first
+  end
+
+  def self.inverse_induction_order
+    with_no_end_date_first
+      .completed_first
+      .newest_start_date_first
+      .newest_end_date_first
+      .newest_created_first
   end
 
   def self.ransackable_attributes(_auth_object = nil)

--- a/app/models/induction_record.rb
+++ b/app/models/induction_record.rb
@@ -72,8 +72,29 @@ class InductionRecord < ApplicationRecord
 
   scope :for_school, ->(school) { joins(:school).where(school: { id: school.id }) }
 
-  scope :oldest_first, -> { order(Arel.sql("CASE WHEN induction_records.end_date IS NULL THEN 1 ELSE 0 END"), start_date: :asc, end_date: :asc, created_at: :asc) }
-  scope :newest_first, -> { order(Arel.sql("CASE WHEN induction_records.end_date IS NULL THEN 0 ELSE 1 END"), start_date: :desc, end_date: :desc, created_at: :desc) }
+  # sorting
+  scope :completed_first, -> { order(Arel.sql("CASE WHEN induction_records.induction_status = 'completed' THEN 0 ELSE 1 END")) }
+
+  scope :no_end_date_first, -> { order(Arel.sql("CASE WHEN induction_records.end_date IS NULL THEN 0 ELSE 1 END")) }
+  scope :with_end_date_first, -> { order(Arel.sql("CASE WHEN induction_records.end_date IS NULL THEN 1 ELSE 0 END")) }
+
+  scope :less_recent_start_date_first, -> { order(start_date: :asc) }
+  scope :most_recent_start_date_first, -> { order(start_date: :desc) }
+
+  scope :less_recent_end_date_first, -> { order(end_date: :asc) }
+  scope :most_recent_end_date_first, -> { order(end_date: :desc) }
+
+  scope :less_recent_first, -> { order(created_at: :asc) }
+  scope :most_recent_first, -> { order(created_at: :desc) }
+
+  scope :oldest_first, -> { with_end_date_first
+                              .less_recent_start_date_first
+                              .less_recent_end_date_first
+                              .less_recent_first }
+  scope :newest_first, -> { no_end_date_first
+                              .most_recent_start_date_first
+                              .most_recent_end_date_first
+                              .most_recent_first }
 
   scope :oldest, -> { oldest_first.first }
 

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -35,6 +35,7 @@ class School < ApplicationRecord
   has_many :pupil_premiums
   has_many :nomination_emails, -> { order(created_at: :desc) }
 
+  has_many :induction_records, through: :school_cohorts
   has_many :induction_coordinator_profiles_schools, dependent: :destroy
   has_many :induction_coordinator_profiles, through: :induction_coordinator_profiles_schools
   has_many :induction_coordinators, through: :induction_coordinator_profiles, source: :user

--- a/app/presenters/admin/participant_presenter.rb
+++ b/app/presenters/admin/participant_presenter.rb
@@ -158,7 +158,7 @@ private
         },
         mentor_profile: :user,
       )
-      .order(start_date: :desc, created_at: :desc)
+      .inverse_induction_order
   end
 
   def school_latest_induction_records

--- a/app/services/dashboard/participants.rb
+++ b/app/services/dashboard/participants.rb
@@ -91,15 +91,23 @@ module Dashboard
                                     school
                                       .induction_records
                                       .school_dashboard_relevant
-                                      .eager_load(induction_programme: %i[school core_induction_programme lead_provider delivery_partner],
-                                                  participant_profile: %i[user ecf_participant_eligibility ecf_participant_validation_data])
-                                      .where(induction_programmes: { school_cohort_id: dashboard_school_cohorts.map(&:id) }))
+                                      .eager_load(induction_programme: %i[school
+                                                                          core_induction_programme
+                                                                          lead_provider
+                                                                          delivery_partner],
+                                                  participant_profile: %i[user
+                                                                          ecf_participant_eligibility
+                                                                          ecf_participant_validation_data])
+                                      .where(induction_programmes: {
+                                        school_cohort_id: dashboard_school_cohorts.map(&:id),
+                                      }))
                                .resolve
-                               .order("users.full_name",
-                                      Arel.sql("CASE WHEN induction_records.end_date IS NULL THEN 0 ELSE 1 END"),
-                                      Arel.sql("CASE WHEN induction_records.induction_status = 'completed' THEN 0 ELSE 1 END"),
-                                      start_date: :desc,
-                                      created_at: :desc)
+                               .order("users.full_name")
+                               .no_end_date_first
+                               .completed_first
+                               .most_recent_start_date_first
+                               .most_recent_end_date_first
+                               .most_recent_first
                                .uniq(&:participant_profile_id)
     end
 

--- a/app/services/dashboard/participants.rb
+++ b/app/services/dashboard/participants.rb
@@ -86,18 +86,21 @@ module Dashboard
     # List of relevant (current or transferring_in or transferred) induction record of each of the participant of
     # the school in the cohorts displayed by the dashboard
     def induction_records
-      @induction_records ||= dashboard_school_cohorts.flat_map { |school_cohort|
-        InductionRecordPolicy::Scope
-          .new(user,
-               school_cohort
-                 .induction_records
-                 .school_dashboard_relevant
-                 .eager_load(induction_programme: %i[school core_induction_programme lead_provider delivery_partner],
-                             participant_profile: %i[user ecf_participant_eligibility ecf_participant_validation_data])
-                 .order("users.full_name"))
-          .resolve
-          .order(start_date: :desc, created_at: :desc)
-      }.uniq(&:participant_profile_id)
+      @induction_records ||= InductionRecordPolicy::Scope
+                               .new(user,
+                                    school
+                                      .induction_records
+                                      .school_dashboard_relevant
+                                      .eager_load(induction_programme: %i[school core_induction_programme lead_provider delivery_partner],
+                                                  participant_profile: %i[user ecf_participant_eligibility ecf_participant_validation_data])
+                                      .where(induction_programmes: { school_cohort_id: dashboard_school_cohorts.map(&:id) }))
+                               .resolve
+                               .order("users.full_name",
+                                      Arel.sql("CASE WHEN induction_records.end_date IS NULL THEN 0 ELSE 1 END"),
+                                      Arel.sql("CASE WHEN induction_records.induction_status = 'completed' THEN 0 ELSE 1 END"),
+                                      start_date: :desc,
+                                      created_at: :desc)
+                               .uniq(&:participant_profile_id)
     end
 
     def no_qts?(induction_record)
@@ -135,14 +138,14 @@ module Dashboard
 
     def process_ects
       induction_records
-        .select(&:ect?)
-        .each do |induction_record|
-          next completed_induction_ect(induction_record) if induction_record.completed_induction_status?
-          next no_longer_training_ect(induction_record) if induction_record.deferred_or_transferred_or_withdrawn?
-          next orphan_ect(induction_record) if induction_record.mentor_profile_id.blank?
+      .select(&:ect?)
+      .each do |induction_record|
+        next completed_induction_ect(induction_record) if induction_record.completed_induction_status?
+        next no_longer_training_ect(induction_record) if induction_record.deferred_or_transferred_or_withdrawn?
+        next orphan_ect(induction_record) if induction_record.mentor_profile_id.blank?
 
-          currently_training_ect(induction_record)
-        end
+        currently_training_ect(induction_record)
+      end
     end
 
     # Discover all the relevant mentors of the school, including:
@@ -151,12 +154,12 @@ module Dashboard
     # - mentors linked to the school's ects, but not in the school's mentor pool
     def process_mentors
       induction_records
-        .reject(&:ect?)
-        .each do |induction_record|
-          next if induction_record.deferred_or_transferred_or_withdrawn?
+      .reject(&:ect?)
+      .each do |induction_record|
+        next if induction_record.deferred_or_transferred_or_withdrawn?
 
-          @active_mentors << dashboard_participant(induction_record.participant_profile_id, induction_record:)
-        end
+        @active_mentors << dashboard_participant(induction_record.participant_profile_id, induction_record:)
+      end
 
       # Create a hash with the format below, to display the mentors in the "Currently training" filter
       # { mentor_dashboard_participant => [ect_dashboard_participant_1, ect_dashboard_participant_2] }
@@ -171,13 +174,13 @@ module Dashboard
       end
 
       induction_records
-        .select(&:mentor?)
-        .each do |induction_record|
-          mentees = ects_mentored_by(induction_record.participant_profile)
-          next currently_mentoring_mentor(induction_record) if mentees.present?
+      .select(&:mentor?)
+      .each do |induction_record|
+        mentees = ects_mentored_by(induction_record.participant_profile)
+        next currently_mentoring_mentor(induction_record) if mentees.present?
 
-          not_mentoring_mentor(induction_record)
-        end
+        not_mentoring_mentor(induction_record)
+      end
     end
 
     def currently_mentoring_mentor(induction_record)

--- a/app/services/dashboard/participants.rb
+++ b/app/services/dashboard/participants.rb
@@ -103,11 +103,7 @@ module Dashboard
                                       }))
                                .resolve
                                .order("users.full_name")
-                               .no_end_date_first
-                               .completed_first
-                               .most_recent_start_date_first
-                               .most_recent_end_date_first
-                               .most_recent_first
+                               .inverse_induction_order
                                .uniq(&:participant_profile_id)
     end
 


### PR DESCRIPTION
### Context

The current participants dashboard is not listing properly all the participants.
For instance, when a participant has been moved from one provider to another in the same school and the first provider training-withdraw that participant, the dashboard is displaying it as no longer training when actually the participant is actively training with the new provider.

- [Ticket](https://dfedigital.atlassian.net/browse/CST-2450)

### Changes proposed in this pull request

Fix the query that retrieves the latest induction record of the school participants.

### Guidance to review

