### PR TITLE
CST-2451: get training status from the latest induction record in the…

### DIFF
--- a/app/views/admin/participants/details/_show_ecf.html.erb
+++ b/app/views/admin/participants/details/_show_ecf.html.erb
@@ -61,7 +61,9 @@
 
   sl.with_row do |row|
     row.with_key(text: "Training record state")
-    row.with_value(text: render(StatusTags::AdminParticipantStatusTag.new(participant_profile: @participant_profile, school: @participant_presenter.school)))
+    row.with_value(text: render(StatusTags::AdminParticipantStatusTag.new(participant_profile: @participant_profile,
+                                                                          induction_record: @participant_presenter.all_induction_records[0],
+                                                                          school: @participant_presenter.school)))
   end
 
   if @participant_presenter.teacher_profile


### PR DESCRIPTION
… Details tab of a participant in admin console

### Context

The status displayed in the Details tab of a participant (admin console) sometimes doesn't match that of the Current Induction Record in the Training tab. 

- [Ticket](https://dfedigital.atlassian.net/browse/CST-2451)

### Changes proposed in this pull request
Use the latest induction record of the participant to determine the training status displayed in the Details tab.

### Guidance to review

