### PR TITLE
Add authorised for payment date in local timezone

### DIFF
--- a/spec/features/finance/npq/statement_spec.rb
+++ b/spec/features/finance/npq/statement_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "Show NPQ statement", :js do
 
       when_i_visit_the_npq_financial_statements_page
 
-      then_i_do_not_see("Authorised for payment at #{statement.marked_as_paid_at.strftime('%-I:%M%P on %-e %b %Y')}")
+      then_i_do_not_see("Authorised for payment at #{statement.marked_as_paid_at.in_time_zone('London').strftime('%-I:%M%P on %-e %b %Y')}")
     end
 
     scenario "successfully authorised", perform_jobs: true do
@@ -63,7 +63,7 @@ RSpec.describe "Show NPQ statement", :js do
 
       when_i_visit_the_npq_financial_statements_page
 
-      then_i_see("Authorised for payment at #{Finance::Statement.find(statement.id).marked_as_paid_at.strftime('%-I:%M%P on %-e %b %Y')}")
+      then_i_see("Authorised for payment at #{Finance::Statement.find(statement.id).marked_as_paid_at.in_time_zone('London').strftime('%-I:%M%P on %-e %b %Y')}")
     end
 
     scenario "missing doing assurance checks" do


### PR DESCRIPTION
### Context

Clocks going forward have caused this test to fail, add localtime zone to avoid this tripping up again
Fix introduced [here](https://github.com/DFE-Digital/early-careers-framework/pull/4221) for other tests
- Ticket: n/a

### Changes proposed in this pull request
Add local timezone to test to avoid failure when clocks change

### Guidance to review
Timezone fun
