### PR TITLE
Update mentor completion reason values

### DIFF
--- a/app/models/participant_profile/mentor.rb
+++ b/app/models/participant_profile/mentor.rb
@@ -17,8 +17,7 @@ class ParticipantProfile::Mentor < ParticipantProfile::ECF
   enum mentor_completion_reason: {
     completed_declaration_received: "completed_declaration_received",
     completed_during_early_roll_out: "completed_during_early_roll_out",
-    two_years_without_completed_declaration: "two_years_without_completed_declaration",
-    two_years_association_but_not_yet_started: "two_years_association_but_not_yet_started",
+    started_not_completed: "started_not_completed",
   }
 
   def complete_training!(completion_date:, completion_reason:)


### PR DESCRIPTION
### Context

When discussion feasibility of implementing rule 3 for completed mentors, Nathan requested that we amend the reason name to "started not completed" for rule 3 and removed rule 4 as it was not going to be implemented.

### Changes proposed in this pull request
Update the `mentor_completion_reason` enum to reflect the requested changes.

### Guidance to review

