### PR TITLE
Add `funded_place` to NPQApplications

### DIFF
--- a/app/models/npq_application.rb
+++ b/app/models/npq_application.rb
@@ -16,7 +16,7 @@ class NPQApplication < ApplicationRecord
     marked_ineligible_by_policy
   ].freeze
 
-  has_paper_trail only: %i[eligible_for_funding funding_eligiblity_status_code user_id npq_lead_provider_id npq_course_id created_at updated_at lead_provider_approval_status]
+  has_paper_trail only: %i[eligible_for_funding funded_place funding_eligiblity_status_code user_id npq_lead_provider_id npq_course_id created_at updated_at lead_provider_approval_status]
 
   self.ignored_columns = %w[user_id]
 

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -131,6 +131,7 @@
   - tsf_primary_plus_eligibility
   - eligible_for_funding_updated_by_id
   - eligible_for_funding_updated_at
+  - funded_place
   :induction_records:
   - id
   - induction_programme_id

--- a/db/migrate/20240405082911_add_funded_place_to_npq_applications.rb
+++ b/db/migrate/20240405082911_add_funded_place_to_npq_applications.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddFundedPlaceToNPQApplications < ActiveRecord::Migration[7.0]
+  def change
+    add_column :npq_applications, :funded_place, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -742,6 +742,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_09_131835) do
     t.boolean "tsf_primary_plus_eligibility", default: false
     t.uuid "eligible_for_funding_updated_by_id"
     t.datetime "eligible_for_funding_updated_at"
+    t.boolean "funded_place"
     t.index ["cohort_id"], name: "index_npq_applications_on_cohort_id"
     t.index ["npq_course_id"], name: "index_npq_applications_on_npq_course_id"
     t.index ["npq_lead_provider_id"], name: "index_npq_applications_on_npq_lead_provider_id"

--- a/spec/requests/api/v1/npq_profiles_spec.rb
+++ b/spec/requests/api/v1/npq_profiles_spec.rb
@@ -210,6 +210,7 @@ RSpec.describe "NPQ profiles api endpoint", type: :request do
             updated_at
             participant_identity_id
             targeted_support_funding_eligibility
+            funded_place
           ])
 
           expect(application_as_json).to match({


### PR DESCRIPTION
### Ticket

https://dfedigital.atlassian.net/browse/CPDLP-2935

### Description

We need to capture if a participant has been allocated a funding place by providers. This field will be updated via the API in cohorts 2024 to true and false. Other cohorts will default to nil

