### PR TITLE
CST-2467: add gias contact params to mailer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -682,6 +682,7 @@ GEM
       multipart-post (~> 2.0)
 
 PLATFORMS
+  arm64-darwin-21
   arm64-darwin-22
   x86_64-darwin-22
   x86_64-linux

--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -121,8 +121,8 @@ class SchoolMailer < ApplicationMailer
     start_page_url = params[:start_page_url]
     nomination_url = params[:nomination_link]
     induction_coordinator = params[:induction_coordinator]
-
-    email_address = school.primary_contact_email || school.secondary_contact_email
+    email_address = params[:primary_contact_email] || params[:secondary_contact_email]
+    email_address ||= school.primary_contact_email || school.secondary_contact_email
 
     template_mail(
       LAUNCH_ASK_GIAS_CONTACT_TO_VALIDATE_SIT_DETAILS_TEMPLATE,


### PR DESCRIPTION
### Context

Minor change to be able to pass gias contacts to the mailer.

- Ticket: [Send comms to GIAS contacts for schools we failed to contact in March](https://dfedigital.atlassian.net/browse/CST-2467)

### Changes proposed in this pull request

### Guidance to review

