### PR TITLE
Don't seed the test database

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -23,6 +23,8 @@ if ENV["LEGACY_SEEDS"] == "true"
   end
 elsif Rails.env.performance?
   load(Rails.root.join(*%w[db new_seeds performance.rb]).to_s)
+elsif Rails.env.test?
+  Rails.logger.warn("skipping seeding the test database")
 else
   load(Rails.root.join(*%w[db new_seeds run.rb]).to_s)
 end


### PR DESCRIPTION
We appear to be needlessly seeding the test database and then ignoring and generating new data when we run the tests. This came to light when we noticed tests failing when the test database had been populated via `rails db:setup` but passing when it'd just been created with `rails db:create`.

This change just skips seeding when the Rails environment is `test`.
