### PR TITLE
CST-2510: use the latest induction record of a pp to get the status t…

### DIFF
--- a/app/components/admin/participants/table_row.html.erb
+++ b/app/components/admin/participants/table_row.html.erb
@@ -27,6 +27,7 @@
   </td>
   <td class="govuk-table__cell nhsuk-table__cell">
     <span class="nhsuk-table-responsive__heading">Training record state</span>
-    <%= render StatusTags::AdminParticipantStatusTag.new(participant_profile: profile) %>
+    <%= render StatusTags::AdminParticipantStatusTag.new(participant_profile: profile,
+                                                         induction_record: profile.latest_current_induction_record) %>
   </td>
 </tr>


### PR DESCRIPTION
…o display in the list of participants of a school (admin)

### Context

- [School participants list statuses don't match that of the Details tab on admin console](https://dfedigital.atlassian.net/browse/CST-2510): 

### Changes proposed in this pull request

### Guidance to review

