### PR TITLE
[CPDLP-3013] Remove `accept_npq_application_can_change_schedule` feature flag

### DIFF
--- a/app/controllers/api/v3/npq_applications_controller.rb
+++ b/app/controllers/api/v3/npq_applications_controller.rb
@@ -47,8 +47,6 @@ module Api
       end
 
       def accept_npq_application_params
-        return {} unless FeatureFlag.active?(:accept_npq_application_can_change_schedule)
-
         parameters = params
           .fetch(:data)
           .permit(:type, attributes: %i[schedule_identifier])

--- a/app/serializers/api/v3/npq_application_serializer.rb
+++ b/app/serializers/api/v3/npq_application_serializer.rb
@@ -3,7 +3,7 @@
 module Api
   module V3
     class NPQApplicationSerializer < V1::NPQApplicationSerializer
-      attribute(:schedule_identifier, if: -> { FeatureFlag.active?(:accept_npq_application_can_change_schedule) }) do |object|
+      attribute(:schedule_identifier) do |object|
         object.profile&.schedule&.schedule_identifier
       end
     end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -23,7 +23,6 @@ class FeatureFlag
     eligibility_notifications
     prevent_2023_ect_registrations
     school_participant_status_language
-    accept_npq_application_can_change_schedule
     npq_capping
   ].freeze
 

--- a/spec/requests/api/v3/npq_applications_spec.rb
+++ b/spec/requests/api/v3/npq_applications_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "NPQ Applications API", type: :request, with_feature_flags: { accept_npq_application_can_change_schedule: "active" } do
+RSpec.describe "NPQ Applications API", type: :request do
   let(:npq_lead_provider) { create(:npq_lead_provider) }
   let(:cpd_lead_provider) { create(:cpd_lead_provider, npq_lead_provider:) }
   let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider:) }
@@ -351,7 +351,7 @@ RSpec.describe "NPQ Applications API", type: :request, with_feature_flags: { acc
       end
     end
 
-    context "when schedule identifier is in the params", with_feature_flags: { accept_npq_application_can_change_schedule: "active" } do
+    context "when schedule identifier is in the params" do
       let(:params) do
         { data: { attributes: { schedule_identifier: "npq-leadership-spring" } } }
       end

--- a/spec/serializers/api/v3/npq_application_serializer_spec.rb
+++ b/spec/serializers/api/v3/npq_application_serializer_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 module Api
   module V3
-    RSpec.describe NPQApplicationSerializer, with_feature_flags: { accept_npq_application_can_change_schedule: "active" } do
+    RSpec.describe NPQApplicationSerializer do
       subject(:result) { described_class.new(npq_application).serializable_hash }
 
       describe "serialization" do

--- a/spec/services/npq/application/accept_spec.rb
+++ b/spec/services/npq/application/accept_spec.rb
@@ -328,7 +328,7 @@ RSpec.describe NPQ::Application::Accept do
         end
       end
 
-      context "when the schedule identifier is present in the params", with_feature_flags: { accept_npq_application_can_change_schedule: "active" } do
+      context "when the schedule identifier is present in the params" do
         let(:params) do
           {
             npq_application:,


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-3013

We added a feature flag accept_npq_application_can_change_schedule to allow providers to change schedule when accepting applications. This feature is/will be permanently turned on now. So there's no need for the feature flag.

### Changes proposed in this pull request

- Remove `accept_npq_application_can_change_schedule` feature flag
- Remove feature flag from serializer
- Remove feature flag from specs

Note:

- Run `Feature.find_by_name(:accept_npq_application_can_change_schedule).destroy` in every env after this is merged/deployed.