### PR TITLE
Upgrade to govuk-frontend 5.3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,8 +58,8 @@ gem "mail-notify", "~> 1.2"
 # do not rely on host's timezone data, which can be inconsistent
 gem "tzinfo-data"
 
-gem "govuk-components", "~> 5.3.1"
-gem "govuk_design_system_formbuilder", "~> 5.3.2"
+gem "govuk-components", "~> 5.3.2"
+gem "govuk_design_system_formbuilder", "~> 5.3.3"
 gem "view_component", require: "view_component/engine"
 
 # Fetching from APIs

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,11 +253,11 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
-    govuk-components (5.3.1)
+    govuk-components (5.3.2)
       html-attributes-utils (~> 1.0.0, >= 1.0.0)
       pagy (>= 6, < 8)
       view_component (>= 3.9, < 3.12)
-    govuk_design_system_formbuilder (5.3.2)
+    govuk_design_system_formbuilder (5.3.3)
       actionview (>= 6.1)
       activemodel (>= 6.1)
       activesupport (>= 6.1)
@@ -720,8 +720,8 @@ DEPENDENCIES
   google-apis-drive_v3
   google-cloud-bigquery
   googleauth
-  govuk-components (~> 5.3.1)
-  govuk_design_system_formbuilder (~> 5.3.2)
+  govuk-components (~> 5.3.2)
+  govuk_design_system_formbuilder (~> 5.3.3)
   httpclient (~> 2.8, >= 2.8.3)
   jsbundling-rails
   json-diff (~> 0.4.1)

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "compression-webpack-plugin": "^9.2.0",
     "es6-promise": "^4.2.8",
     "file-loader": "^6.2.0",
-    "govuk-frontend": "^5.3.0",
+    "govuk-frontend": "^5.3.1",
     "nunjucks": "^3.2.4",
     "sass": "^1.75.0",
     "terser-webpack-plugin": "^5.3.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5671,7 +5671,7 @@ __metadata:
     eslint-plugin-import: "npm:^2.29.1"
     eslint-plugin-no-only-tests: "npm:^2.6.0"
     file-loader: "npm:^6.2.0"
-    govuk-frontend: "npm:^5.3.0"
+    govuk-frontend: "npm:^5.3.1"
     nunjucks: "npm:^3.2.4"
     prettier: "npm:^2.8.8"
     sass: "npm:^1.75.0"
@@ -6984,10 +6984,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"govuk-frontend@npm:^5.3.0":
-  version: 5.3.0
-  resolution: "govuk-frontend@npm:5.3.0"
-  checksum: 3195fa74b16a0053680979b0813e9b155f9db0c84f276e26b86ddb1144e9da67c766dba911e9bf51867b58a0004cb234bfc92a26feaa092084973d80edbf20e4
+"govuk-frontend@npm:^5.3.1":
+  version: 5.3.1
+  resolution: "govuk-frontend@npm:5.3.1"
+  checksum: 15e36df6155b609b4f48e2e90c3c0bb837d4a1a0206420588eff5f97f1171439dfd45e0caa4e25e1d27093216ab44d3ff66949a8216c34d04fd03e0722c38163
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

### Context

Upgrade to [latest version of govuk-frontend](https://github.com/alphagov/govuk-frontend/releases/tag/v5.3.1) and bump components and form builder gems.

Fixes #4725, #4729, #4730

### Changes proposed in this pull request

- **Upgrade to govuk-frontend 5.3.1**
- **Upgrade to latest form builder and components**

### Guidance to review

