### PR TITLE
[CPDLP-3000] Create magic dates to create validated ECTs and mentors in the 2024 cohort

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ exactly what and how their test data is configured. These magic values are only 
 | 21/1/1900 | Participant matched and has a 2021 cohort induction start date |
 | 22/1/1900 | Participant matched and has a 2022 cohort induction start date |
 | 23/1/1900 | Participant matched and has a 2023 cohort induction start date |
+| 24/1/1900 | Participant matched and has a 2024 cohort induction start date |
 
 ## Deployment infrastructure
 

--- a/app/services/dqt_record_check.rb
+++ b/app/services/dqt_record_check.rb
@@ -134,11 +134,8 @@ private
       # all matches 23 cohort start date - use 23/1/1900
       23 => CheckResult.new(magic_dqt_record(induction_start_date: Date.new(2023, 9, 1)), true, true, true, true, 4),
 
-      # all matches 23 cohort start date - use 24/1/1900
+      # all matches 24 cohort start date - use 24/1/1900
       24 => CheckResult.new(magic_dqt_record(induction_start_date: Date.new(2024, 9, 1)), true, true, true, true, 4),
-
-      # all matches 25 cohort start date - use 25/1/1900
-      25 => CheckResult.new(magic_dqt_record(induction_start_date: Date.new(2025, 9, 1)), true, true, true, true, 4),
     }
   end
 

--- a/app/services/dqt_record_check.rb
+++ b/app/services/dqt_record_check.rb
@@ -133,6 +133,12 @@ private
 
       # all matches 23 cohort start date - use 23/1/1900
       23 => CheckResult.new(magic_dqt_record(induction_start_date: Date.new(2023, 9, 1)), true, true, true, true, 4),
+
+      # all matches 23 cohort start date - use 24/1/1900
+      24 => CheckResult.new(magic_dqt_record(induction_start_date: Date.new(2024, 9, 1)), true, true, true, true, 4),
+
+      # all matches 25 cohort start date - use 25/1/1900
+      25 => CheckResult.new(magic_dqt_record(induction_start_date: Date.new(2025, 9, 1)), true, true, true, true, 4),
     }
   end
 


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-3000](https://dfedigital.atlassian.net/browse/CPDLP-3000)

We'd like to create a magic date that providers and DfE users can create validated, eligible for funding mentors and ECT’s in the 2024 cohort.

### Changes proposed in this pull request

Create magic dates to create validated ECT's and mentors in the 2024 cohort.


[CPDLP-3000]: https://dfedigital.atlassian.net/browse/CPDLP-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ