### PR TITLE
Avoid creating papertrail records on touch

### DIFF
--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -3,3 +3,8 @@
 PaperTrail.config.enabled = true
 PaperTrail.config.version_limit = nil
 PaperTrail.serializer = PaperTrail::Serializers::JSON
+
+# Exclude :touch events to avoid creating unnecessary versions
+PaperTrail.config.has_paper_trail_defaults = {
+  on: %i[create update destroy],
+}


### PR DESCRIPTION
### Context

- Ticket: N/A

We are currently generating numerous unnecessary version records with `object_changes: nil`, which do not provide any real value. 

By excluding records on `:touch` events, we will enhance the visibility of significant changes and reduce the overall number of version records.

### Changes proposed in this pull request
- Add global config in the PaperTrail initializer to exclude :touch events

### Guidance to review

