### PR TITLE
Specify more as the PAGER

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,7 +101,7 @@ COPY --from=middleman /public/ /app/public/
 RUN echo export PATH=/usr/local/bin:\$PATH > /root/.ashrc
 ENV ENV="/root/.ashrc"
 
-RUN echo "cd /app && bundle exec rails c" > /root/.ash_history
+RUN echo "cd /app && PAGER=more bundle exec rails c" > /root/.ash_history
 RUN echo "IRB.conf[:USE_AUTOCOMPLETE] = false" > /root/.irbrc
 
 WORKDIR /app


### PR DESCRIPTION
### Context

Recent changes (maybe Rails 7.1) have resulted in issues with paging in the rails console. The output is paged but not syntax coloured and multi-page output history is lost once the pager is exited.
If we specify `more` as the pager, sanity is restored.

### Changes proposed in this pull request
Set the shell history "helper" with the environment var `PAGER=more` before invoking the rails console

### Guidance to review

