### PR TITLE
CST-2540: get induction start date from DQT induction periods

### DIFF
--- a/app/presenters/dqt_record_presenter.rb
+++ b/app/presenters/dqt_record_presenter.rb
@@ -35,7 +35,9 @@ class DQTRecordPresenter < SimpleDelegator
   # The "induction", "start_date" coming in DQT::V1 is not the more accurate one so,
   # either we get it from the "induction" "periods" coming V1 or V3
   def induction_start_date
-    @induction_start_date ||= (
+    return @induction_start_date if instance_variable_defined?(:@induction_start_date)
+
+    @induction_start_date = (
       dqt_record.dig("induction", "periods") ||
         FullDQT::V3::Client.new.get_record(trn:)&.dig("induction", "periods")
     ).to_a

--- a/app/presenters/dqt_record_presenter.rb
+++ b/app/presenters/dqt_record_presenter.rb
@@ -31,8 +31,17 @@ class DQTRecordPresenter < SimpleDelegator
     dqt_record.dig("qualified_teacher_status", "qts_date")
   end
 
+  # This is a patch until we migrate this presenter from DQT::V1 to DQT::V3
+  # The "induction", "start_date" coming in DQT::V1 is not the more accurate one so,
+  # either we get it from the "induction" "periods" coming V1 or V3
   def induction_start_date
-    dqt_record.dig("induction", "start_date")
+    @induction_start_date ||= (
+      dqt_record.dig("induction", "periods") ||
+        FullDQT::V3::Client.new.get_record(trn:)&.dig("induction", "periods")
+    ).to_a
+     .map { |period| period["startDate"] }
+     .compact
+     .min
   end
 
   def induction_completion_date

--- a/app/services/dqt_record_check.rb
+++ b/app/services/dqt_record_check.rb
@@ -151,7 +151,9 @@ private
 
     if with_induction
       record.merge!("induction" => {
-        "start_date" => induction_start_date,
+        "periods" => [
+          { "start_date" => induction_start_date },
+        ],
         "status" => "In Progress",
       })
     end

--- a/app/services/participants/check_and_set_completion_date.rb
+++ b/app/services/participants/check_and_set_completion_date.rb
@@ -21,16 +21,16 @@ module Participants
       induction&.fetch("endDate", nil)
     end
 
-    def start_date
-      induction&.fetch("startDate", nil)
+    def induction
+      @induction ||= DQT::GetInductionRecord.call(trn: participant_profile.teacher_profile.trn)
+    end
+
+    def induction_periods
+      Array(induction&.dig("periods"))
     end
 
     def participant_start_date
       participant_profile.induction_start_date
-    end
-
-    def induction
-      @induction ||= DQT::GetInductionRecord.call(trn: participant_profile.teacher_profile.trn)
     end
 
     def record_start_date_inconsistency
@@ -41,6 +41,11 @@ module Participants
           participant_value: participant_start_date,
         },
       )
+    end
+
+    # returns the minimum start date of all the induction periods
+    def start_date
+      @start_date ||= induction_periods.map { |period| period["startDate"] }.compact.min
     end
   end
 end

--- a/app/services/participants/check_and_set_completion_date.rb
+++ b/app/services/participants/check_and_set_completion_date.rb
@@ -40,6 +40,7 @@ module Participants
           dqt_value: start_date,
           participant_value: participant_start_date,
         },
+        unique_by: :participant_profile_id,
       )
     end
 

--- a/db/migrate/20240502102913_add_unique_index_to_participant_profile_start_date_inconsistencies.rb
+++ b/db/migrate/20240502102913_add_unique_index_to_participant_profile_start_date_inconsistencies.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexToParticipantProfileStartDateInconsistencies < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    remove_index :participant_profile_start_date_inconsistencies, :participant_profile_id
+    add_index :participant_profile_start_date_inconsistencies, :participant_profile_id, unique: true, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_11_160127) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_02_102913) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -904,7 +904,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_11_160127) do
     t.date "participant_value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["participant_profile_id"], name: "idx_on_participant_profile_id_77e3f2fe02"
+    t.index ["participant_profile_id"], name: "idx_on_participant_profile_id_77e3f2fe02", unique: true
   end
 
   create_table "participant_profile_states", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/features/schools/participants/add_participants/add_ect_with_appropriate_body_spec.rb
+++ b/spec/features/schools/participants/add_participants/add_ect_with_appropriate_body_spec.rb
@@ -160,7 +160,7 @@ private
       "qualified_teacher_status" => { "qts_date" => 1.year.ago },
       "induction_start_date" => Date.new(2022, 9, 1),
       "induction" => {
-        "start_date" => 1.month.ago,
+        "periods" => [{ "startDate" => 1.month.ago }],
         "status" => "Active",
       },
     })

--- a/spec/features/schools/participants/add_participants/add_previously_withdrawn_ect_spec.rb
+++ b/spec/features/schools/participants/add_participants/add_previously_withdrawn_ect_spec.rb
@@ -259,7 +259,7 @@ private
       "qualified_teacher_status" => { "qts_date" => 1.year.ago },
       "induction_start_date" => induction_start_date.to_date,
       "induction" => {
-        "start_date" => induction_start_date,
+        "periods" => [{ "startDate" => induction_start_date }],
         "status" => "Active",
       },
     )

--- a/spec/features/schools/participants/add_participants/add_previously_withdrawn_mentor_spec.rb
+++ b/spec/features/schools/participants/add_participants/add_previously_withdrawn_mentor_spec.rb
@@ -300,7 +300,7 @@ private
       "qualified_teacher_status" => { "qts_date" => 1.year.ago },
       "induction_start_date" => induction_start_date.to_date,
       "induction" => {
-        "start_date" => induction_start_date,
+        "periods" => [{ "startDate" => induction_start_date }],
         "status" => "Active",
       },
     })

--- a/spec/features/schools/participants/add_participants/reporting_participants_with_trn_spec.rb
+++ b/spec/features/schools/participants/add_participants/reporting_participants_with_trn_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe "Reporting participants with a known TRN", type: :feature, js: tr
       "dob" => participant_data[:date_of_birth],
       "qualified_teacher_status" => { "qts_date" => 1.year.ago },
       "induction" => {
-        "start_date" => 1.month.ago,
+        "periods" => [{ "startDate" => 1.month.ago }],
         "status" => "Active",
       },
     })

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/allow_withdrawn_participant_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/allow_withdrawn_participant_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe "transferring a withdrawn participant", type: :feature, js: true 
       "dob" => participant_data[:date_of_birth],
       "qualified_teacher_status" => { "qts_date" => 1.year.ago },
       "induction" => {
-        "start_date" => 1.month.ago,
+        "periods" => [{ "startDate" => 1.month.ago }],
         "status" => "Active",
       },
     })

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_different_partner_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_different_partner_spec.rb
@@ -383,7 +383,7 @@ RSpec.describe "Transferring ECT is with a different lead provider", type: :feat
       "dob" => participant_data[:date_of_birth],
       "qualified_teacher_status" => { "qts_date" => 1.year.ago },
       "induction" => {
-        "start_date" => 1.month.ago,
+        "periods" => [{ "startDate" => 1.month.ago }],
         "status" => "Active",
       },
     })

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_no_change_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_no_change_spec.rb
@@ -398,7 +398,7 @@ RSpec.describe "ECT has matching lead provider and delivery partner", type: :fea
       "dob" => participant_data[:date_of_birth],
       "qualified_teacher_status" => { "qts_date" => 1.year.ago },
       "induction" => {
-        "start_date" => 1.month.ago,
+        "periods" => [{ "startDate" => 1.month.ago }],
         "status" => "Active",
       },
     })

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_different_partner_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_different_partner_spec.rb
@@ -359,7 +359,7 @@ RSpec.describe "Transferring a mentor with a different provider", type: :feature
       "dob" => participant_data[:date_of_birth],
       "qualified_teacher_status" => { "qts_date" => 1.year.ago },
       "induction" => {
-        "start_date" => 1.month.ago,
+        "periods" => [{ "startDate" => 1.month.ago }],
         "status" => "Active",
       },
     })

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_no_change_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_no_change_spec.rb
@@ -268,7 +268,7 @@ RSpec.describe "Transferring a mentor weith matching lead provider and delivery 
       "dob" => participant_data[:date_of_birth],
       "qualified_teacher_status" => { "qts_date" => 1.year.ago },
       "induction" => {
-        "start_date" => 1.month.ago,
+        "periods" => [{ "startDate" => 1.month.ago }],
         "status" => "Active",
       },
     })

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/unhappy_path_cannot_validate_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/unhappy_path_cannot_validate_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe "transferring participants", type: :feature, js: true do
           "dob" => participant_data[:date_of_birth],
           "qualified_teacher_status" => { "qts_date" => 1.year.ago },
           "induction" => {
-            "start_date" => 1.month.ago,
+            "periods" => [{ "startDate" => 1.month.ago }],
             "status" => "Active",
           },
         })

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -1487,7 +1487,7 @@ module ManageTrainingSteps
                              "dob" => participant_data[:date_of_birth],
                              "qualified_teacher_status" => { "qts_date" => 1.year.ago },
                              "induction" => {
-                               "start_date" => 1.month.ago,
+                               "periods" => [{ "startDate" => 1.month.ago }],
                                "status" => "Active",
                              },
     })

--- a/spec/requests/admin/participants/validate_details_spec.rb
+++ b/spec/requests/admin/participants/validate_details_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "Admin::Participants::ValidateDetailsController", type: :request 
             "qts_date": "2021-07-05T00:00:00Z",
           },
           "induction": {
-            "start_date": "2021-09-02T00:00:00Z",
+            "periods" => [{ "startDate" => "2021-09-02T00:00:00Z" }],
           },
         })
       end
@@ -95,7 +95,7 @@ RSpec.describe "Admin::Participants::ValidateDetailsController", type: :request 
             "qts_date": "2021-07-05T00:00:00Z",
           },
           "induction": {
-            "start_date": "2021-09-02T00:00:00Z",
+            "periods" => [{ "startDate" => "2021-09-02T00:00:00Z" }],
           },
         })
       end

--- a/spec/services/participant_validation_service_spec.rb
+++ b/spec/services/participant_validation_service_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ParticipantValidationService do
     let(:alert) { false }
     let(:induction_start_date) { Date.parse("2021-07-01T00:00:00Z") }
     let(:induction_completion_date) { Date.parse("2021-07-05T00:00:00Z") }
-    let(:induction) { nil }
+    let(:induction) { { "periods" => [{ "startDate" => nil }] } }
     let(:inactive_record) { false }
     let(:dqt_record) { build_dqt_record(trn:, nino:, full_name:, dob:, alert:, qts:, induction:, inactive: inactive_record) }
     let(:dqt_records) { [dqt_record] }
@@ -172,7 +172,7 @@ RSpec.describe ParticipantValidationService do
                            dob: Date.new(1990, 2, 1),
                            alert: false,
                            qts: nil,
-                           induction: nil)
+                           induction: { "periods" => [{ "startDate" => nil }] })
         end
         let(:dqt_records) { [record_for_other_trn, dqt_record] }
 
@@ -222,7 +222,7 @@ RSpec.describe ParticipantValidationService do
       context "when the participant has previously had an induction" do
         let(:induction) do
           {
-            "start_date" => induction_start_date,
+            "periods" => [{ "startDate" => induction_start_date }],
             "completion_date" => induction_completion_date,
             "status" => "Pass",
             "state" => 0,
@@ -238,7 +238,7 @@ RSpec.describe ParticipantValidationService do
       context "when the participant has an induction with nil start_date" do
         let(:induction) do
           {
-            "start_date" => nil,
+            "periods" => [{ "startDate" => nil }],
           }
         end
 
@@ -262,7 +262,7 @@ RSpec.describe ParticipantValidationService do
       context "when the participant's induction status is InProgress" do
         let(:induction) do
           {
-            "start_date" => induction_start_date,
+            "periods" => [{ "startDate" => induction_start_date }],
             "status" => "InProgress",
           }
         end
@@ -287,7 +287,7 @@ RSpec.describe ParticipantValidationService do
       context "when the participant's induction status is Not Yet Completed" do
         let(:induction) do
           {
-            "start_date" => induction_start_date,
+            "periods" => [{ "startDate" => induction_start_date }],
             "status" => "Not Yet Completed",
           }
         end
@@ -313,7 +313,7 @@ RSpec.describe ParticipantValidationService do
         let!(:eligibility) { create(:ineligible_participant, trn:, reason: :previous_participation) }
         let(:induction) do
           {
-            "start_date" => induction_start_date,
+            "periods" => [{ "startDate" => induction_start_date }],
             "completion_date" => induction_completion_date,
             "status" => "Pass",
             "state" => 0,
@@ -331,7 +331,7 @@ RSpec.describe ParticipantValidationService do
         let(:induction_completion_date) { nil }
         let(:induction) do
           {
-            "start_date" => induction_start_date,
+            "periods" => [{ "startDate" => induction_start_date }],
             "completion_date" => induction_completion_date,
             "status" => "Pass",
             "state" => 0,
@@ -349,7 +349,7 @@ RSpec.describe ParticipantValidationService do
         let(:induction_completion_date) { nil }
         let(:induction) do
           {
-            "start_date" => induction_start_date,
+            "periods" => [{ "startDate" => induction_start_date }],
             "completion_date" => induction_completion_date,
             "status" => "Pass",
             "state" => 0,
@@ -367,7 +367,7 @@ RSpec.describe ParticipantValidationService do
         let(:induction_completion_date) { nil }
         let(:induction) do
           {
-            "start_date" => induction_start_date,
+            "periods" => [{ "startDate" => induction_start_date }],
             "completion_date" => induction_completion_date,
             "status" => "Pass",
             "state" => 0,
@@ -383,7 +383,7 @@ RSpec.describe ParticipantValidationService do
       context "when the participant has an induction with the status of 'Exempt'" do
         let(:induction) do
           {
-            "start_date" => nil,
+            "periods" => [{ "startDate" => nil }],
             "completion_date" => nil,
             "status" => "Exempt",
             "state" => 0,

--- a/spec/services/participants/check_and_set_completion_date_spec.rb
+++ b/spec/services/participants/check_and_set_completion_date_spec.rb
@@ -16,7 +16,15 @@ RSpec.describe Participants::CheckAndSetCompletionDate do
   let(:completion_date) { 1.month.ago.to_date }
   let(:start_date) { 2.months.ago.to_date }
   let(:induction_start_date) { start_date }
-  let(:dqt_induction_record) { { "endDate" => completion_date, "startDate" => start_date } }
+  let(:dqt_induction_record) do
+    { "endDate" => completion_date,
+      "periods" => [
+        { "startDate" => start_date,
+          "endDate" => start_date + 1.week },
+        { "startDate" => start_date + 1.week,
+          "endDate" => start_date + 2.weeks },
+      ] }
+  end
 
   subject(:service_call) { described_class.call(participant_profile:) }
 

--- a/spec/support/features/pages/participant/participant_registration_wizard.rb
+++ b/spec/support/features/pages/participant/participant_registration_wizard.rb
@@ -110,7 +110,7 @@ module Pages
             "qts_date": "2021-07-05T00:00:00Z",
           },
           "induction": {
-            "start_date": "2021-09-02T00:00:00Z",
+            "periods" => [{ "startDate" => "2021-09-02T00:00:00Z" }],
           },
         }), headers: {})
 

--- a/spec/support/features/steps/changes_of_circumstance_steps.rb
+++ b/spec/support/features/steps/changes_of_circumstance_steps.rb
@@ -82,7 +82,7 @@ module Steps
               "dob" => participant_dob,
               "qualified_teacher_status" => { "qts_date" => 1.year.ago },
               "induction" => {
-                "start_date" => 1.month.ago,
+                "periods" => [{ "startDate" => 1.month.ago }],
                 "status" => "Active",
               },
             },


### PR DESCRIPTION
### Context

DQT records provide 2 ways to extract the induction start date of a participant:

“startDate” field in the “induction” section of the record

minimum “startDate” of the “periods” section in the “induction” section of the record.



Our service always has gone for 1. It seems the most accurate date is provided by 2. 

This ticket is about changing our code from 1. to 2. whenever we check DQT for a participant induction start date throughout the whole codebase.

- [Ticket](https://dfedigital.atlassian.net/browse/CST-2540)

### Changes proposed in this pull request

- Update `Participants::CheckAndSetCompletionDate` to get the DQT induction start date of a participant from the earliest `startDate` of the `induction` `periods` 
- Temporary workround (until we migrate this SO to DQT::V3) on `DQTRecordPresenter` to call V3 to pick the induction start date of the participant 

### Guidance to review

