### PR TITLE
[CST-2547] Fix query for schools that have not registered participants

### DIFF
--- a/app/queries/schools/that_have_not_added_participants_query.rb
+++ b/app/queries/schools/that_have_not_added_participants_query.rb
@@ -21,9 +21,12 @@ module Schools
     end
 
     def school_cohorts_that_have_not_added_participants
+      # need to ensure that there are no induction programmes in the school/cohort with participants
+      # lots of schools have programmes without participants and programmes with participants
+      # and just using .missing(:induction_records) missed this nuance and gave us false positives
       scope = SchoolCohort
         .where(induction_programme_choice: %w[full_induction_programme core_induction_programme])
-        .where.missing(:induction_records)
+        .where.not(id: InductionProgramme.joins(:induction_records).select(:school_cohort_id))
 
       return scope if cohort.blank?
 

--- a/spec/queries/schools/that_have_not_added_participants_query_spec.rb
+++ b/spec/queries/schools/that_have_not_added_participants_query_spec.rb
@@ -50,6 +50,16 @@ RSpec.describe Schools::ThatHaveNotAddedParticipantsQuery do
           expect(query_result).to include(school)
         end
       end
+
+      context "and there are programmes with and without participants" do
+        let!(:induction_programme_2) { create(:seed_induction_programme, :fip, school_cohort:) }
+        let!(:induction_record) { create(:seed_induction_record, :valid, participant_profile:, induction_programme:) }
+        let(:query_cohort) { cohort }
+
+        it "does not include the school" do
+          expect(query_result).not_to include(school)
+        end
+      end
     end
 
     context "when school type codes are supplied" do
@@ -71,6 +81,15 @@ RSpec.describe Schools::ThatHaveNotAddedParticipantsQuery do
         context "when there are cohorts without participants" do
           it "includes the school" do
             expect(query_result).to include(school)
+          end
+        end
+
+        context "and there are programmes with and without participants" do
+          let!(:induction_programme_2) { create(:seed_induction_programme, :fip, school_cohort:) }
+          let!(:induction_record) { create(:seed_induction_record, :valid, participant_profile:, induction_programme:) }
+
+          it "does not include the school" do
+            expect(query_result).not_to include(school)
           end
         end
       end


### PR DESCRIPTION
### Context

- Ticket: [CST-2547](https://dfedigital.atlassian.net/browse/CST-2547)

Query that support the mailer was using `.missing` to find school cohorts that did not have induction records, however the hidden left joins underneath this with `induction_programmes` led to the inclusion of schools that had both empty and induction programmes with participants

### Changes proposed in this pull request
Change the query to be more explicit in not selecting school cohorts that have induction programmes with induction records.

### Guidance to review



[CST-2547]: https://dfedigital.atlassian.net/browse/CST-2547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ