### PR TITLE
Amend healthcheck to not fail if database not populated

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,6 +38,7 @@ Rails/UnknownEnv:
     - production
     - review
     - sandbox
+    - migration
     - staging
     - test
     - performance

--- a/spec/requests/healthcheck_spec.rb
+++ b/spec/requests/healthcheck_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Healthcheck" do
+  describe "GET /healtcheck" do
+    let(:git_sha) { "911403d" }
+    let(:release_version) { "3.2" }
+    let(:migration_version) { ApplicationRecord.connection.migration_context.current_version }
+    let(:response_body) { JSON.parse(perform_request.body, symbolize_names: true) }
+
+    before do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("SHA") { git_sha }
+      allow(ENV).to receive(:[]).with("RELEASE_VERSION") { release_version }
+      stub_request(:get, HealthcheckController::NOTIFY_STATUS_API).to_return(status: 200, body: { "status": { "indicator": "none" } }.to_json)
+    end
+
+    subject(:perform_request) do
+      get healthcheck_path
+      response
+    end
+
+    context "with a populated database" do
+      let!(:school) { create(:school) }
+      let!(:schedule) { create(:ecf_schedule) }
+
+      it { is_expected.to be_successful }
+      it { expect(response_body[:sha]).to eq(git_sha) }
+      it { expect(response_body[:version]).to eq(release_version) }
+      it { expect(response_body[:database]).to match({ connected: true, populated: true, migration_version: }) }
+      it { expect(response_body[:notify][:incident_status]).to eq("none") }
+    end
+
+    context "when the database is not connected" do
+      context "when ApplicationRecord#connected? raises an error" do
+        before { allow(ApplicationRecord).to receive(:connected?).and_raise(RuntimeError) }
+
+        it { is_expected.to be_server_error }
+        it { expect(response_body[:database]).to include({ connected: false, populated: false }) }
+      end
+
+      context "when ApplicationRecord#connected? returns false" do
+        before { allow(ApplicationRecord).to receive(:connected?).and_return(false) }
+
+        it { is_expected.to be_server_error }
+        it { expect(response_body[:database]).to include({ connected: false, populated: false }) }
+      end
+    end
+
+    context "when the database is not populated" do
+      it { is_expected.to be_server_error }
+      it { expect(response_body[:database]).to include({ connected: true, populated: false }) }
+
+      context "when the environment supports refreshing the database via a GitHub action" do
+        before { allow(Rails).to receive(:env) { "migration".inquiry } }
+
+        it { is_expected.to be_successful }
+        it { expect(response_body[:database]).to include({ connected: true, populated: false }) }
+      end
+    end
+
+    context "when notify has an incident" do
+      before { stub_request(:get, HealthcheckController::NOTIFY_STATUS_API).to_return(status: 500) }
+      it { is_expected.to be_server_error }
+      it { expect(response_body[:notify][:incident_status]).to eq("Status request failed") }
+    end
+  end
+end


### PR DESCRIPTION
### Context 
To allow the migraiton environment database to be restored from production there will be a certain amount of time the database is empty. Keeping the healthcheck happy means we can keep the refresh going as otherwise the pipeline will be broken since we rely on the migration web container to be up and healthy.

This work is similar to NPQ thanks @ethax-ross 
https://github.com/DFE-Digital/npq-registration/pull/1283



- Ticket: n/a

### Changes proposed in this pull request

- Amend healthcheck to ignore migration environment on db populated check
- Add specs for healthcheck


### Guidance to review

