### PR TITLE
Show database as populated in migration regardless of check

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -35,7 +35,7 @@ private
   end
 
   def status
-    if database_connected? && (database_supports_refreshing? || database_populated?)
+    if database_connected? && database_populated?
       :ok
     else
       :internal_server_error
@@ -54,7 +54,7 @@ private
   end
 
   def database_populated?
-    database_connected? && School.any? && Finance::Schedule.any?
+    database_supports_refreshing? || (database_connected? && School.any? && Finance::Schedule.any?)
   rescue StandardError
     false
   end

--- a/spec/requests/healthcheck_spec.rb
+++ b/spec/requests/healthcheck_spec.rb
@@ -7,13 +7,28 @@ RSpec.describe "Healthcheck" do
     let(:git_sha) { "911403d" }
     let(:release_version) { "3.2" }
     let(:migration_version) { ApplicationRecord.connection.migration_context.current_version }
+
+    let(:sidekiq_job_count) { 1 }
+    let(:sidekiq_errors) { 2 }
+    let(:sidekiq_failed) { 3 }
+    let(:sidekiq_queue) { instance_double(Sidekiq::Queue, size: sidekiq_job_count) }
+    let(:sidekiq_retries) { instance_double(Sidekiq::RetrySet, size: sidekiq_errors) }
+    let(:sidekiq_deadset) { instance_double(Sidekiq::DeadSet, size: sidekiq_failed, to_a: []) }
+    let(:puma_stats) { { backlog: 0, running: 5 } }
+
     let(:response_body) { JSON.parse(perform_request.body, symbolize_names: true) }
 
     before do
       allow(ENV).to receive(:[]).and_call_original
       allow(ENV).to receive(:[]).with("SHA") { git_sha }
       allow(ENV).to receive(:[]).with("RELEASE_VERSION") { release_version }
-      stub_request(:get, HealthcheckController::NOTIFY_STATUS_API).to_return(status: 200, body: { "status": { "indicator": "none" } }.to_json)
+
+      allow(Sidekiq::Queue).to receive(:all).and_return([sidekiq_queue])
+      allow(Sidekiq::RetrySet).to receive(:new).and_return(sidekiq_retries)
+      allow(Sidekiq::DeadSet).to receive(:new).and_return(sidekiq_deadset)
+
+      stub_request(:get, HealthcheckController::NOTIFY_STATUS_API).to_return(status: 200, body: { status: { indicator: "none" } }.to_json)
+      allow(Puma).to receive(:stats).and_return(puma_stats.to_json)
     end
 
     subject(:perform_request) do
@@ -21,7 +36,7 @@ RSpec.describe "Healthcheck" do
       response
     end
 
-    context "with a populated database" do
+    context "when the database is populated" do
       let!(:school) { create(:school) }
       let!(:schedule) { create(:ecf_schedule) }
 
@@ -29,7 +44,14 @@ RSpec.describe "Healthcheck" do
       it { expect(response_body[:sha]).to eq(git_sha) }
       it { expect(response_body[:version]).to eq(release_version) }
       it { expect(response_body[:database]).to match({ connected: true, populated: true, migration_version: }) }
+
+      it { expect(response_body[:sidekiq][:job_count]).to eq(sidekiq_job_count) }
+      it { expect(response_body[:sidekiq][:errors]).to eq(sidekiq_errors) }
+      it { expect(response_body[:sidekiq][:failed]).to eq(sidekiq_failed) }
+      it { expect(response_body[:sidekiq][:sidekiq_last_failure]).to be_nil }
+
       it { expect(response_body[:notify][:incident_status]).to eq("none") }
+      it { expect(response_body[:puma]).to eq(puma_stats) }
     end
 
     context "when the database is not connected" do
@@ -64,6 +86,19 @@ RSpec.describe "Healthcheck" do
       before { stub_request(:get, HealthcheckController::NOTIFY_STATUS_API).to_return(status: 500) }
       it { is_expected.to be_server_error }
       it { expect(response_body[:notify][:incident_status]).to eq("Status request failed") }
+    end
+
+    context "when notify has an incident" do
+      before { stub_request(:get, HealthcheckController::NOTIFY_STATUS_API).to_return(status: 200, body: { status: { indicator: "incident_in_progress" } }.to_json) }
+      it { is_expected.to be_server_error }
+      it { expect(response_body[:notify][:incident_status]).to eq("incident_in_progress") }
+    end
+
+    context "when puma stats are unavailable" do
+      before { allow(Puma).to receive(:stats).and_raise(StandardError) }
+
+      it { is_expected.to be_server_error }
+      it { expect(response_body[:puma]).to eq("FAIL") }
     end
   end
 end

--- a/spec/requests/healthcheck_spec.rb
+++ b/spec/requests/healthcheck_spec.rb
@@ -56,11 +56,11 @@ RSpec.describe "Healthcheck" do
         before { allow(Rails).to receive(:env) { "migration".inquiry } }
 
         it { is_expected.to be_successful }
-        it { expect(response_body[:database]).to include({ connected: true, populated: false }) }
+        it { expect(response_body[:database]).to include({ connected: true, populated: true }) }
       end
     end
 
-    context "when notify has an incident" do
+    context "when notify API is down" do
       before { stub_request(:get, HealthcheckController::NOTIFY_STATUS_API).to_return(status: 500) }
       it { is_expected.to be_server_error }
       it { expect(response_body[:notify][:incident_status]).to eq("Status request failed") }


### PR DESCRIPTION
### Context

- Ticket: n/a

Previous fix allowed the health check to return healthy if database not populated in the migration env. However this means the smoke test fails.

### Changes proposed in this pull request
- Allow the database populated check to return true in the migration env to avoid smoke test failure
- Beef up specs for all of healthcheck and stop being lazy

### Guidance to review

