### PR TITLE
Exclude large tables from migration snapshot refresh

### DIFF
--- a/.github/actions/refresh-migration-database/action.yml
+++ b/.github/actions/refresh-migration-database/action.yml
@@ -39,7 +39,7 @@ runs:
     - name: Backup production DB
       shell: bash
       run: |
-        bin/konduit.sh cpd-ecf-${{ inputs.environment }}-web -- pg_dump -E utf8 --compress=1 --clean --if-exists --no-privileges --no-owner --verbose -f backup-${{ inputs.environment }}.sql.gz
+        bin/konduit.sh cpd-ecf-${{ inputs.environment }}-web -- pg_dump -E utf8 --exclude-table-data api_requests --exclude-table-data versions --compress=1 --clean --if-exists --no-privileges --no-owner --verbose -f backup-${{ inputs.environment }}.sql.gz
 
     - name: Restore to migration DB
       shell: bash

--- a/terraform/aks/workspace_variables/migration_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/migration_aks.tfvars.json
@@ -1,4 +1,5 @@
 {
+  "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
   "app_environment": "migration",
   "cluster": "production",
   "deploy_azure_backing_services": true,


### PR DESCRIPTION
### Context

Our migration env db refresh is hitting 100% CPU due to large tables, exclude largest tables from `pg_dump` to avoid this

- Ticket: n/a

### Changes proposed in this pull request

Exclude versions and api request tables from pg dump on migration db refresh from prod

### Guidance to review
This is a theory we would like to test
