### PR TITLE
Add focus styles to enhance contrast

### DIFF
--- a/app/assets/stylesheets/primary-nav.scss
+++ b/app/assets/stylesheets/primary-nav.scss
@@ -23,11 +23,16 @@ $primaryNavHeight: 2.5rem;
 
       .govuk-link:focus {
         box-shadow: none;
+        color: $govuk-focus-text-colour;
       }
     }
 
     .nav-item__selected {
       border-bottom: solid govuk-colour("white") 4px;
+
+      &:focus-within {
+        border-bottom: solid $govuk-focus-text-colour 4px;
+      }
     }
   }
 }


### PR DESCRIPTION
### Context

Standard GOVUK focus styles are yellow background with dark text.
- Ticket:  https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CST/boards/119?selectedIssue=CST-2516

### Changes proposed in this pull request

The primary nav styles specify white text but no modifier for focus so add these.

![image](https://github.com/DFE-Digital/early-careers-framework/assets/93511/fa8d0d28-460b-4d98-a403-d997c289beff)


### Guidance to review

