### PR TITLE
Add optional cohort on ParticipantDeclaration

### DIFF
--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -9,7 +9,8 @@ class Cohort < ApplicationRecord
   has_many :npq_contracts
   has_many :partnerships
   has_many :schedules, class_name: "Finance::Schedule"
-  has_many :statements
+  has_many :statements, class_name: "Finance::Statement"
+  has_many :participant_declarations
 
   scope :between_years, ->(lower, upper) { where(start_year: lower..upper) }
   scope :between_2021_and, ->(upper) { between_years(2021, upper) }

--- a/app/models/participant_declaration.rb
+++ b/app/models/participant_declaration.rb
@@ -5,6 +5,7 @@ class ParticipantDeclaration < ApplicationRecord
 
   belongs_to :cpd_lead_provider
   belongs_to :user
+  belongs_to :cohort, optional: true
   belongs_to :participant_profile
   belongs_to :superseded_by, class_name: "ParticipantDeclaration", optional: true
   belongs_to :delivery_partner, optional: true

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -91,6 +91,7 @@
   - pupil_premium_uplift
   - delivery_partner_id
   - mentor_user_id
+  - cohort_id
   :npq_applications:
   - id
   - npq_lead_provider_id

--- a/db/migrate/20240513085459_add_cohort_to_participant_declaration.rb
+++ b/db/migrate/20240513085459_add_cohort_to_participant_declaration.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddCohortToParticipantDeclaration < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :participant_declarations, :cohort, null: true, index: { algorithm: :concurrently }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_08_142515) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_13_085459) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -829,6 +829,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_08_142515) do
     t.boolean "pupil_premium_uplift"
     t.uuid "delivery_partner_id"
     t.uuid "mentor_user_id"
+    t.uuid "cohort_id"
+    t.index ["cohort_id"], name: "index_participant_declarations_on_cohort_id"
     t.index ["cpd_lead_provider_id", "participant_profile_id", "declaration_type", "course_identifier", "state"], name: "unique_declaration_index", unique: true, where: "((state)::text = ANY (ARRAY[('submitted'::character varying)::text, ('eligible'::character varying)::text, ('payable'::character varying)::text, ('paid'::character varying)::text]))"
     t.index ["cpd_lead_provider_id"], name: "index_participant_declarations_on_cpd_lead_provider_id"
     t.index ["declaration_type"], name: "index_participant_declarations_on_declaration_type"

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -5,6 +5,15 @@ require "rails_helper"
 RSpec.describe Cohort, type: :model do
   let!(:cohort_2024) { FactoryBot.create :seed_cohort, start_year: 2024 }
 
+  describe "associations" do
+    it { is_expected.to have_many(:call_off_contracts) }
+    it { is_expected.to have_many(:npq_contracts) }
+    it { is_expected.to have_many(:partnerships) }
+    it { is_expected.to have_many(:schedules).class_name("Finance::Schedule") }
+    it { is_expected.to have_many(:statements).class_name("Finance::Statement") }
+    it { is_expected.to have_many(:participant_declarations) }
+  end
+
   describe "scopes" do
     describe ".between_years" do
       it "generates a BETWEEN clause with the given years" do

--- a/spec/models/participant_declaration_spec.rb
+++ b/spec/models/participant_declaration_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe ParticipantDeclaration, type: :model do
     it { is_expected.to belong_to(:participant_profile) }
     it { is_expected.to have_many(:declaration_states) }
     it { is_expected.to belong_to(:mentor_user).class_name("User").optional }
+    it { is_expected.to belong_to(:cohort).optional }
   end
 
   describe "state transitions" do


### PR DESCRIPTION
### Context

We are creating a direct link between `Cohort` and `ParticipantDeclaration` so that we can support declarations across multiple cohorts (after schedule changes by participants).

### Changes proposed in this pull request

- Add `cohort` as an optional reference on `ParticipantDeclaration`.

### Guidance to review

We will populate and backfill in follow-up PRs before making it a required field
