### PR TITLE
Populate cohort on recording declaration

### DIFF
--- a/app/services/record_declaration.rb
+++ b/app/services/record_declaration.rb
@@ -130,7 +130,9 @@ private
   end
 
   def participant_declaration
-    @participant_declaration ||= find_participant_declaration.tap { |pd| pd.update!(uplift_flags) }
+    @participant_declaration ||= find_participant_declaration.tap do |pd|
+      pd.update!(uplift_flags.merge(cohort:))
+    end
   end
 
   def find_participant_declaration

--- a/spec/factories/participant_declaration.rb
+++ b/spec/factories/participant_declaration.rb
@@ -3,13 +3,13 @@
 FactoryBot.define do
   factory :participant_declaration do
     declaration_type { "started" }
+    cohort { Cohort.current || create(:cohort, :current) }
 
     declaration_date do
       participant_profile.schedule.milestones.find_by!(declaration_type:).start_date
     end
 
     transient do
-      cohort         { Cohort.current || create(:cohort, :current) }
       profile_traits { [] }
       uplifts        { [] }
       has_passed     { false }
@@ -33,7 +33,6 @@ FactoryBot.define do
       transient do
         npq_course { create(:npq_course) }
         school_urn {}
-        cohort     { Cohort.current || create(:cohort, :current) }
       end
       cpd_lead_provider   { create(:cpd_lead_provider, :with_npq_lead_provider) }
       participant_profile { create(:npq_application, :accepted, *profile_traits, npq_lead_provider: cpd_lead_provider.npq_lead_provider, npq_course:, school_urn:, cohort:).profile }

--- a/spec/services/record_declaration_spec.rb
+++ b/spec/services/record_declaration_spec.rb
@@ -232,6 +232,7 @@ RSpec.shared_examples "creates a participant declaration" do
     expect(declaration.course_identifier).to eq(course_identifier)
     expect(declaration.evidence_held).to eq("other")
     expect(declaration.cpd_lead_provider).to eq(cpd_lead_provider)
+    expect(declaration.cohort).to eq(schedule.cohort)
   end
 end
 


### PR DESCRIPTION
### Context

[Jira-3057](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3057)

We now have a `cohort` field on `ParticipantDeclaration`. We want to ensure all new declarations are stamped with the relevant cohort at the time of creation.

### Changes proposed in this pull request

- Populate cohort on recording a declaration

### Guidance to review

We take the `participant_profile.schedule.cohort` as this is the one we use for validation.

We stamp the cohort _after_ find/creating the declaration so as not to break the existing find/create logic (for declarations already in the system that do not yet have the cohort set).

