### PR TITLE
[CST-2546] Use DQT API V3 Get Teacher endpoint

### DIFF
--- a/app/presenters/dqt_record_presenter.rb
+++ b/app/presenters/dqt_record_presenter.rb
@@ -44,11 +44,17 @@ class DQTRecordPresenter < SimpleDelegator
   end
 
   def induction_start_date
-    dqt_record.dig("induction", "startDate")
+    induction_periods.to_a
+                     .map { |period| period["startDate"] }
+                     .compact
+                     .min
   end
 
   def induction_completion_date
-    dqt_record.dig("induction", "endDate")
+    induction_periods.to_a
+                     .map { |period| period["endDate"] }
+                     .compact
+                     .max
   end
 
   def exempt?
@@ -60,6 +66,10 @@ class DQTRecordPresenter < SimpleDelegator
   end
 
 private
+
+  def induction_periods
+    dqt_record.dig("induction", "periods")
+  end
 
   def dqt_record
     __getobj__

--- a/app/presenters/dqt_record_presenter.rb
+++ b/app/presenters/dqt_record_presenter.rb
@@ -8,7 +8,7 @@ class DQTRecordPresenter < SimpleDelegator
   end
 
   def first_name
-    dqt_record["firstName"]
+    dqt_record["firstName"] || dqt_record["name"]&.split(" ")&.first
   end
 
   def middle_name
@@ -16,7 +16,7 @@ class DQTRecordPresenter < SimpleDelegator
   end
 
   def last_name
-    dqt_record["lastName"]
+    dqt_record["lastName"] || dqt_record["name"]&.split(" ")&.last
   end
 
   def trn
@@ -24,37 +24,37 @@ class DQTRecordPresenter < SimpleDelegator
   end
 
   def active?
-    dqt_record.present?
+    dqt_record.present? || dqt_record&.fetch("state_name", nil) == "Active"
   end
 
   def dob
-    dqt_record["dateOfBirth"]
+    dqt_record["dateOfBirth"] || dqt_record["dob"]
   end
 
   def ni_number
-    dqt_record["nationalInsuranceNumber"]
+    dqt_record["nationalInsuranceNumber"] || dqt_record["ni_number"]
   end
 
   def active_alert?
-    dqt_record["alerts"]&.any?
+    dqt_record["alerts"]&.any? || dqt_record["active_alert"].present?
   end
 
   def qts_date
-    dqt_record.dig("qts", "awarded")
+    dqt_record.dig("qts", "awarded") || dqt_record.dig("qualified_teacher_status", "qts_date")
   end
 
   def induction_start_date
     induction_periods.to_a
                      .map { |period| period["startDate"] }
                      .compact
-                     .min
+                     .min || dqt_record.dig("induction", "start_date")
   end
 
   def induction_completion_date
     induction_periods.to_a
                      .map { |period| period["endDate"] }
                      .compact
-                     .max
+                     .max || dqt_record.dig("induction", "completion_date")
   end
 
   def exempt?

--- a/app/services/dqt/get_teacher_record.rb
+++ b/app/services/dqt/get_teacher_record.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class DQT::GetTeacherRecord < ::BaseService
+  def call
+    dqt_record
+  end
+
+private
+
+  attr_reader :date_of_birth, :nino, :trn
+
+  def initialize(trn:, date_of_birth: nil, nino: nil)
+    @trn = trn
+    @date_of_birth = date_of_birth
+    @nino = nino
+  end
+
+  def dqt_record
+    @dqt_record ||= client.get_record(**endpoint_args)
+  end
+
+  def endpoint_args
+    if v3?
+      { trn:, date_of_birth: }.compact
+    else
+      { trn:, birthdate: date_of_birth, nino: }
+    end
+  end
+
+  def client
+    @client ||= v3? ? FullDQT::V3::Client.new : FullDQT::V1::Client.new
+  end
+
+  def v3?
+    nino.nil?
+  end
+end

--- a/lib/full_dqt.rb
+++ b/lib/full_dqt.rb
@@ -3,5 +3,6 @@
 module FullDQT
 end
 
+require "full_dqt/client"
 require "full_dqt/v1/client"
 require "full_dqt/v3/client"

--- a/lib/full_dqt/client.rb
+++ b/lib/full_dqt/client.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "net/http"
+
+# NOTE: Use this API for validation of participant data
+#
+module FullDQT
+  class Client
+    def get_record(**_args)
+      raise NotImplementedError "This method must be implemented in a subclass"
+    end
+
+  private
+
+    def call_api(uri:)
+      request = Net::HTTP::Get.new(uri)
+      request["Authorization"] = "Bearer #{api_key}"
+
+      response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true, read_timeout: 20) do |http|
+        http.request(request)
+      end
+
+      if response.code == "200"
+        translate_hash(JSON.parse(response.body))
+      end
+    end
+
+    def translate_hash(hash)
+      hash.deep_transform_values do |value|
+        case value
+        when /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/
+          Time.zone.parse(value)
+        when /^\d{4}-\d{2}-\d{2}/
+          Date.parse(value)
+        else
+          value
+        end
+      end
+    end
+
+    def api_key
+      Rails.configuration.dqt_api_key
+    end
+
+    def api_url
+      Rails.configuration.dqt_api_url
+    end
+  end
+end

--- a/lib/full_dqt/v1/client.rb
+++ b/lib/full_dqt/v1/client.rb
@@ -6,59 +6,15 @@ require "net/http"
 #
 module FullDQT
   module V1
-    class Client
+    class Client < FullDQT::Client
       def get_record(trn:, birthdate:, nino: nil)
         call_api(uri: endpoint_uri(trn:, birthdate:, nino:))
       end
 
     private
 
-      def call_api(uri:)
-        request = Net::HTTP::Get.new(uri)
-        request["Authorization"] = "Bearer #{api_key}"
-
-        response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true, read_timeout: 20) do |http|
-          http.request(request)
-        end
-
-        if response.code == "200"
-          translate_hash(JSON.parse(response.body))
-        end
-      end
-
-      def translate_hash(hash)
-        hash.deep_transform_values do |value|
-          case value
-          when /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/
-            Time.zone.parse(value)
-          when /^\d{4}-\d{2}-\d{2}/
-            Date.parse(value)
-          else
-            value
-          end
-        end
-      end
-
-      def api_key
-        Rails.configuration.dqt_api_key
-      end
-
-      def api_url
-        Rails.configuration.dqt_api_url
-      end
-
       def endpoint_uri(trn:, birthdate:, nino: nil)
-        URI("#{api_url}/v1/teachers/#{trn}?#{query_string_object(birthdate:, nino:).to_query}")
-      end
-
-      def query_string_object(birthdate:, nino: nil)
-        object = {
-          birthdate:,
-        }
-
-        object[:nino] = nino if nino
-
-        object
+        URI("#{api_url}/v1/teachers/#{trn}?#{{ birthdate:, nino: }.compact.to_query}")
       end
     end
   end

--- a/lib/full_dqt/v3/client.rb
+++ b/lib/full_dqt/v3/client.rb
@@ -13,16 +13,18 @@ require "net/http"
 #
 module FullDQT
   module V3
-    class Client < V1::Client
-      def get_record(trn:, sections: %w[induction])
-        call_api(uri: endpoint_uri(trn:, sections:))
+    class Client < FullDQT::Client
+      def get_record(trn:, date_of_birth: nil, sections: %w[induction])
+        call_api(uri: endpoint_uri(trn:, date_of_birth:, sections:))
       end
 
     private
 
-      def endpoint_uri(trn:, sections:)
+      def endpoint_uri(trn:, date_of_birth:, sections:)
         path = "/v3/teachers/#{trn}"
-        path += "?include=#{sections.join(',')}" unless sections.empty?
+        params = { date_of_birth: }.compact
+        params["include"] = sections.join(",") unless sections.empty?
+        path += "?#{params.to_query}" unless params.empty?
 
         URI("#{api_url}#{path}")
       end

--- a/spec/features/schools/participants/add_participants/add_previously_withdrawn_ect_spec.rb
+++ b/spec/features/schools/participants/add_participants/add_previously_withdrawn_ect_spec.rb
@@ -252,12 +252,11 @@ private
 
   def valid_dqt_response
     DQTRecordPresenter.new(
-      "name" => "George ECT",
+      "firstName" => "George",
+      "lastName" => "ECT",
       "trn" => ect_trn,
-      "state_name" => "Active",
-      "dob" => Date.new(1998, 11, 22),
-      "qualified_teacher_status" => { "qts_date" => 1.year.ago },
-      "induction_start_date" => induction_start_date.to_date,
+      "dateOfBirth" => Date.new(1998, 11, 22),
+      "qts" => { "awarded" => 1.year.ago },
       "induction" => {
         "periods" => [{ "startDate" => induction_start_date }],
         "status" => "Active",

--- a/spec/features/schools/participants/add_participants/add_previously_withdrawn_mentor_spec.rb
+++ b/spec/features/schools/participants/add_participants/add_previously_withdrawn_mentor_spec.rb
@@ -293,12 +293,11 @@ private
 
   def valid_dqt_response
     DQTRecordPresenter.new({
-      "name" => "George Mentor",
+      "firstName" => "George",
+      "lastName" => "Mentor",
       "trn" => ect_trn,
-      "state_name" => "Active",
-      "dob" => Date.new(1998, 11, 22),
-      "qualified_teacher_status" => { "qts_date" => 1.year.ago },
-      "induction_start_date" => induction_start_date.to_date,
+      "dateOfBirth" => Date.new(1998, 11, 22),
+      "qts" => { "awarded" => 1.year.ago },
       "induction" => {
         "periods" => [{ "startDate" => induction_start_date }],
         "status" => "Active",

--- a/spec/features/schools/participants/add_participants/reporting_participants_with_trn_spec.rb
+++ b/spec/features/schools/participants/add_participants/reporting_participants_with_trn_spec.rb
@@ -203,11 +203,11 @@ RSpec.describe "Reporting participants with a known TRN", type: :feature, js: tr
 
   def valid_dqt_response(participant_data)
     DQTRecordPresenter.new({
-      "name" => participant_data[:full_name],
+      "firstName" => participant_data[:full_name].split(" ").first,
+      "lastName" => participant_data[:full_name].split(" ").last,
       "trn" => participant_data[:trn],
-      "state_name" => "Active",
-      "dob" => participant_data[:date_of_birth],
-      "qualified_teacher_status" => { "qts_date" => 1.year.ago },
+      "dateOfBirth" => participant_data[:date_of_birth],
+      "qts" => { "awarded" => 1.year.ago },
       "induction" => {
         "periods" => [{ "startDate" => 1.month.ago }],
         "status" => "Active",

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -1481,15 +1481,18 @@ module ManageTrainingSteps
 
   def valid_dqt_response(participant_data)
     DQTRecordPresenter.new({
-      "name" => participant_data[:full_name],
-                             "trn" => participant_data[:trn],
-                             "state_name" => "Active",
-                             "dob" => participant_data[:date_of_birth],
-                             "qualified_teacher_status" => { "qts_date" => 1.year.ago },
-                             "induction" => {
-                               "periods" => [{ "startDate" => 1.month.ago }],
-                               "status" => "Active",
-                             },
+      "firstName" => participant_data[:full_name].split(" ").first,
+      "lastName" => participant_data[:full_name].split(" ").last,
+      "trn" => participant_data[:trn],
+      "dateOfBirth" => participant_data[:date_of_birth],
+      "qts" => { "awarded" => 1.year.ago },
+      "induction" => {
+        "startDate" => 1.month.ago,
+        "status" => "Active",
+        "periods" => [
+          { "startDate" => 1.month.ago, "endDate" => nil },
+        ],
+      },
     })
   end
 

--- a/spec/presenters/dqt_record_presenter_spec.rb
+++ b/spec/presenters/dqt_record_presenter_spec.rb
@@ -14,7 +14,16 @@ RSpec.describe DQTRecordPresenter, type: :model do
       "nationalInsuranceNumber" => "AB123456C",
       "alerts" => [],
       "qts" => { "awarded" => "01/01/2000" },
-      "induction" => { "startDate" => "01/01/2000", "endDate" => "01/01/2001", "status" => "InProgress" },
+      "induction" => {
+        "startDate" => "01/01/2000",
+        "endDate" => "01/01/2001",
+        "status" => "InProgress",
+        "periods" => [
+          { "startDate" => "01/01/2003", "endDate" => "10/11/2003" },
+          { "startDate" => "01/01/2000", "endDate" => "01/01/2001" },
+          { "startDate" => nil, "endDate" => nil },
+        ],
+      },
     }
   end
 
@@ -69,14 +78,14 @@ RSpec.describe DQTRecordPresenter, type: :model do
   end
 
   describe "#induction_start_date" do
-    it "returns the induction start date" do
+    it "returns the start date of the earliest induction period" do
       expect(presenter.induction_start_date).to eq "01/01/2000"
     end
   end
 
   describe "#induction_completion_date" do
-    it "returns the induction completion date" do
-      expect(presenter.induction_completion_date).to eq "01/01/2001"
+    it "returns the last end date of the latest induction period" do
+      expect(presenter.induction_completion_date).to eq "10/11/2003"
     end
   end
 

--- a/spec/presenters/dqt_record_presenter_spec.rb
+++ b/spec/presenters/dqt_record_presenter_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DQTRecordPresenter, type: :model do
+  let(:dqt_record) do
+    {
+      "firstName" => "John",
+      "middleName" => "Doe",
+      "lastName" => "Smith",
+      "trn" => "1234567",
+      "state_name" => "Active",
+      "dateOfBirth" => "01/01/2000",
+      "nationalInsuranceNumber" => "AB123456C",
+      "alerts" => [],
+      "qts" => { "awarded" => "01/01/2000" },
+      "induction" => { "startDate" => "01/01/2000", "endDate" => "01/01/2001", "status" => "InProgress" },
+    }
+  end
+
+  subject(:presenter) { described_class.new(dqt_record) }
+
+  describe "#full_name" do
+    it "returns the full name" do
+      expect(presenter.full_name).to eq "John Doe Smith"
+    end
+  end
+
+  describe "#dob" do
+    it "returns the date of birth" do
+      expect(presenter.dob).to eq "01/01/2000"
+    end
+  end
+
+  describe "#ni_number" do
+    it "returns the national insurance number" do
+      expect(presenter.ni_number).to eq "AB123456C"
+    end
+  end
+
+  describe "#active?" do
+    it "returns true when the state is Active" do
+      expect(presenter.active?).to be true
+    end
+
+    context "when the DQT record is nil" do
+      let(:dqt_record) { nil }
+      it "returns false" do
+        expect(presenter.active?).to be false
+      end
+    end
+  end
+
+  describe "#active_alert?" do
+    it "returns false when there are no alerts" do
+      expect(presenter.active_alert?).to be false
+    end
+
+    it "returns true when alerts are present" do
+      dqt_record["alerts"] = %w[Alert]
+      expect(presenter.active_alert?).to be true
+    end
+  end
+
+  describe "#qts_date" do
+    it "returns the QTS awarded date" do
+      expect(presenter.qts_date).to eq "01/01/2000"
+    end
+  end
+
+  describe "#induction_start_date" do
+    it "returns the induction start date" do
+      expect(presenter.induction_start_date).to eq "01/01/2000"
+    end
+  end
+
+  describe "#induction_completion_date" do
+    it "returns the induction completion date" do
+      expect(presenter.induction_completion_date).to eq "01/01/2001"
+    end
+  end
+
+  describe "#exempt?" do
+    it "returns false when the induction status is not Exempt" do
+      expect(presenter.exempt?).to be false
+    end
+
+    it "returns true when the induction status is Exempt" do
+      dqt_record["induction"]["status"] = "Exempt"
+      expect(presenter.exempt?).to be true
+    end
+  end
+end

--- a/spec/presenters/dqt_record_presenter_spec.rb
+++ b/spec/presenters/dqt_record_presenter_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe DQTRecordPresenter, type: :model do
       "middleName" => "Doe",
       "lastName" => "Smith",
       "trn" => "1234567",
-      "state_name" => "Active",
       "dateOfBirth" => "01/01/2000",
       "nationalInsuranceNumber" => "AB123456C",
       "alerts" => [],
@@ -97,6 +96,66 @@ RSpec.describe DQTRecordPresenter, type: :model do
     it "returns true when the induction status is Exempt" do
       dqt_record["induction"]["status"] = "Exempt"
       expect(presenter.exempt?).to be true
+    end
+  end
+
+  context "with a v1 DQT record" do
+    let(:dqt_record) do
+      {
+        "name" => "John Smith",
+        "trn" => "1234567",
+        "state_name" => "Active",
+        "dob" => "02/02/2002",
+        "ni_number" => "AB123456C",
+        "active_alert" => false,
+        "qualified_teacher_status" => {
+          "qts_date" => "01/01/2020",
+        },
+        "induction" => {
+          "start_date" => "01/01/2018",
+          "completion_date" => "01/01/2019",
+        },
+      }
+    end
+
+    it "returns the full name" do
+      expect(presenter.full_name).to eq "John Smith"
+    end
+
+    it "returns the first name" do
+      expect(presenter.first_name).to eq "John"
+    end
+
+    it "returns the last name" do
+      expect(presenter.last_name).to eq "Smith"
+    end
+
+    it "returns the date of birth" do
+      expect(presenter.dob).to eq "02/02/2002"
+    end
+
+    it "returns the national insurance number" do
+      expect(presenter.ni_number).to eq "AB123456C"
+    end
+
+    it "returns true when the state is Active" do
+      expect(presenter.active?).to be true
+    end
+
+    it "returns false when there are no alerts" do
+      expect(presenter.active_alert?).to be false
+    end
+
+    it "returns the QTS awarded date" do
+      expect(presenter.qts_date).to eq "01/01/2020"
+    end
+
+    it "returns the induction start date" do
+      expect(presenter.induction_start_date).to eq "01/01/2018"
+    end
+
+    it "returns the induction completion date" do
+      expect(presenter.induction_completion_date).to eq "01/01/2019"
     end
   end
 end

--- a/spec/requests/admin/participants/validate_details_spec.rb
+++ b/spec/requests/admin/participants/validate_details_spec.rb
@@ -16,7 +16,9 @@ RSpec.describe "Admin::Participants::ValidateDetailsController", type: :request 
   end
   let(:validation_result) { { a: "value" } }
 
-  let(:full_name) { "John Doe" }
+  let(:first_name) { "John" }
+  let(:last_name) { "Doe" }
+  let(:full_name) { "#{first_name} #{last_name}" }
   let(:trn) { "1234567" }
   let(:date_of_birth) { Date.new(1987, 12, 13) }
 
@@ -30,7 +32,7 @@ RSpec.describe "Admin::Participants::ValidateDetailsController", type: :request 
   # despite all that, nothing gets persisted to the database.
   describe "GET /admin/participants/:participant_id/validation-data" do
     before do
-      stub_request(:get, "https://dtqapi.example.com/dqt-crm/v1/teachers/#{trn}?birthdate=#{date_of_birth}")
+      stub_request(:get, "https://dtqapi.example.com/dqt-crm/v3/teachers/#{trn}?&date_of_birth=1987-12-13&include=induction")
         .with(
           headers: {
             "Accept" => "*/*",
@@ -46,14 +48,14 @@ RSpec.describe "Admin::Participants::ValidateDetailsController", type: :request 
     context "when the participant has a DQT match" do
       let(:dqt_response) do
         JSON.generate({
-          "name": full_name,
-          "dob": "#{date_of_birth}T00:00:00",
+          "firstName": first_name,
+          "lastName": last_name,
+          "dateOfBirth": "#{date_of_birth}T00:00:00",
           "trn": trn,
-          "ni_number": "AB123456D",
-          "active_alert": false,
-          "state_name": "Active",
-          "qualified_teacher_status": {
-            "qts_date": "2021-07-05T00:00:00Z",
+          "nationalInsuranceNumber": "AB123456D",
+          "alerts": [],
+          "qts": {
+            "awarded": "2021-07-05T00:00:00Z",
           },
           "induction": {
             "periods" => [{ "startDate" => "2021-09-02T00:00:00Z" }],
@@ -85,14 +87,14 @@ RSpec.describe "Admin::Participants::ValidateDetailsController", type: :request 
     context "when the participant does not have a DQT match" do
       let(:dqt_response) do
         JSON.generate({
-          "name": "#{full_name}-mismatch",
-          "dob": "#{date_of_birth}T00:00:00",
-          "trn": trn.reverse,
-          "ni_number": SecureRandom.uuid,
-          "active_alert": false,
-          "state_name": "Active",
-          "qualified_teacher_status": {
-            "qts_date": "2021-07-05T00:00:00Z",
+          "firstName": first_name,
+          "lastName": "someothername",
+          "dateOfBirth": "#{date_of_birth}T00:00:00",
+          "trn": trn,
+          "nationalInsuranceNumber": "AB123456D",
+          "alerts": [],
+          "qts": {
+            "awarded": "2021-07-05T00:00:00Z",
           },
           "induction": {
             "periods" => [{ "startDate" => "2021-09-02T00:00:00Z" }],

--- a/spec/services/dqt/get_teacher_record_spec.rb
+++ b/spec/services/dqt/get_teacher_record_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+RSpec.describe DQT::GetTeacherRecord do
+  describe "#call" do
+    let(:trn) { "1000864" }
+    let(:date_of_birth) { Date.new(1987, 3, 1) }
+    let(:nino) { "QQ123456Q" }
+    let(:valid_record) do
+      {
+        "trn" => "1000864",
+        "firstName" => "Peter",
+        "middleName"=>"",
+        "lastName" => "Bonetti",
+        "dateOfBirth"=> date_of_birth,
+        "nationalInsuranceNumber" => nino,
+        "email" => nil,
+        "qts" => { "awarded" => 2.years.ago.to_date },
+        "eyts" => nil,
+        "induction" => { "startDate" => 18.months.ago.to_date,
+                         "endDate" => nil,
+                         "status" => "InProgress",
+                         "periods"=>[{ "startDate" => 18.months.ago.to_date,
+                                      "endDate" => nil,
+                                      "terms" => nil,
+                                      "appropriateBody" => { "name" => "The Most Fantasic AB Ltd" } }] },
+      }
+    end
+
+    subject(:service) { described_class }
+
+    it "returns the participants DQT record" do
+      expect_any_instance_of(FullDQT::V3::Client).to receive(:get_record).with(trn:).once.and_return(valid_record)
+
+      result = service.call(trn:)
+
+      expect(result).to eq valid_record
+    end
+
+    context "when the record is not found" do
+      it "returns nil" do
+        expect_any_instance_of(FullDQT::V3::Client).to receive(:get_record).with(trn:).once.and_return(nil)
+
+        result = service.call(trn:)
+
+        expect(result).to be_nil
+      end
+    end
+
+    context "when date_of_birth is provided" do
+      it "returns the participants DQT record" do
+        expect_any_instance_of(FullDQT::V3::Client).to receive(:get_record).with(trn:, date_of_birth:).once.and_return(valid_record)
+
+        result = service.call(trn:, date_of_birth:)
+
+        expect(result).to eq valid_record
+      end
+    end
+
+    context "when nino is provided" do
+      it "returns the participants DQT record" do
+        expect_any_instance_of(FullDQT::V1::Client).to receive(:get_record)
+          .with(trn: nil, birthdate: date_of_birth, nino:)
+          .once.and_return(valid_record)
+
+        result = service.call(trn: nil, date_of_birth:, nino:)
+
+        expect(result).to eq valid_record
+      end
+    end
+  end
+end

--- a/spec/services/dqt_record_check_spec.rb
+++ b/spec/services/dqt_record_check_spec.rb
@@ -5,27 +5,29 @@ require "rails_helper"
 RSpec.describe DQTRecordCheck do
   shared_context "build fake DQT response" do
     before do
-      allow_any_instance_of(FullDQT::V1::Client).to(receive(:get_record).and_return(fake_api_response || default_api_response))
+      allow_any_instance_of(FullDQT::V3::Client).to(receive(:get_record).and_return(fake_api_response || default_api_response))
     end
   end
 
+  let(:first_name) { "Nelson" }
+  let(:last_name) { "Muntz" }
+  let(:full_name) { [first_name, last_name].join(" ") }
   let(:trn) { "1234567" }
   let(:nino) { "QQ123456A" }
   let(:date_of_birth) { 25.years.ago.to_date }
-  let(:full_name) { "Mr Nelson Muntz" }
-  let(:kwargs) { { full_name:, trn:, date_of_birth:, nino: } }
   let(:default_api_response) do
     {
-      "state_name" => "Active",
       "trn" => trn,
-      "name" => full_name,
-      "ni_number" => nino,
-      "dob" => 25.years.ago.to_date,
+      "firstName" => first_name,
+      "middleName" => nil,
+      "lastName" => last_name,
+      "nationalInsuranceNumber" => nino,
+      "dateOfBirth" => date_of_birth,
     }
   end
   let(:fake_api_response) { nil }
 
-  subject { DQTRecordCheck.new(**kwargs) }
+  subject { DQTRecordCheck.new(full_name:, date_of_birth:, trn:, nino:) }
 
   context "when trn and national insurance number are blank" do
     let(:trn) { "" }
@@ -40,7 +42,7 @@ RSpec.describe DQTRecordCheck do
       let(:fake_api_response) { { "state_name" => "Inactive" } }
     end
 
-    it { expect(subject.call.failure_reason).to be(:found_but_not_active) }
+    it { expect(subject.call.failure_reason).to be(:no_match_found) }
   end
 
   context "when active" do
@@ -77,7 +79,7 @@ RSpec.describe DQTRecordCheck do
 
         context "when there is whitespace around the name in the API response" do
           include_context "build fake DQT response" do
-            let(:fake_api_response) { default_api_response.merge("name" => " #{full_name} ") }
+            let(:fake_api_response) { default_api_response.merge("lastName" => " #{last_name} ") }
           end
 
           it("#name_matches is true") { expect(subject.call.name_matches).to be(true) }
@@ -85,7 +87,7 @@ RSpec.describe DQTRecordCheck do
 
         context "when first names are different but surnames are the same" do
           include_context "build fake DQT response" do
-            let(:fake_api_response) { default_api_response.merge("name" => "Mr Eddie Muntz") }
+            let(:fake_api_response) { default_api_response.merge("firstName" => "Eddie") }
           end
 
           it("#name_matches is false") { expect(subject.call.name_matches).to be(false) }
@@ -113,7 +115,7 @@ RSpec.describe DQTRecordCheck do
       end
 
       context "when check_first_name_only: false" do
-        let(:kwargs) { { full_name:, trn:, date_of_birth:, nino:, check_first_name_only: false } }
+        subject { DQTRecordCheck.new(full_name:, date_of_birth:, trn:, nino:, check_first_name_only: false) }
 
         context "when exact" do
           include_context "build fake DQT response"
@@ -123,7 +125,7 @@ RSpec.describe DQTRecordCheck do
 
         context "when first names match but surnames are different" do
           include_context "build fake DQT response" do
-            let(:fake_api_response) { default_api_response.merge("name" => "Mr Nelson Piquet") }
+            let(:fake_api_response) { default_api_response.merge("lastName" => "Piquet") }
           end
 
           it("#name_matches is false") { expect(subject.call.name_matches).to be(false) }
@@ -133,7 +135,7 @@ RSpec.describe DQTRecordCheck do
           let(:full_name) { nil }
 
           include_context "build fake DQT response" do
-            let(:fake_api_response) { default_api_response.merge("name" => "Nelson Muntz") }
+            let(:fake_api_response) { default_api_response.merge("firstName" => "Nelson", "lastName" => "Muntz") }
           end
 
           it("#name_matches is false") { expect(subject.call.name_matches).to be(false) }
@@ -160,7 +162,7 @@ RSpec.describe DQTRecordCheck do
 
       context "when different" do
         include_context "build fake DQT response" do
-          let(:fake_api_response) { default_api_response.merge("dob" => 27.years.ago.to_date) }
+          let(:fake_api_response) { default_api_response.merge("dateOfBirth" => 27.years.ago.to_date) }
         end
 
         it("#dob_matches is false") { expect(subject.call.dob_matches).to be(false) }
@@ -184,7 +186,7 @@ RSpec.describe DQTRecordCheck do
 
       context "when different" do
         include_context "build fake DQT response" do
-          let(:fake_api_response) { default_api_response.merge("ni_number" => "ZZ123456X") }
+          let(:fake_api_response) { default_api_response.merge("nationalInsuranceNumber" => "ZZ123456X") }
         end
 
         it("#nino_matches is false") { expect(subject.call.nino_matches).to be(false) }
@@ -200,27 +202,38 @@ RSpec.describe DQTRecordCheck do
       end
     end
 
-    context "when there are less than three matches excluding TRN" do
-      include_context "build fake DQT response" do
-        let(:fake_api_response) { default_api_response.except("dob").merge("ni_number" => "QQ121212Q") }
-      end
+    context "when there are less than three matches" do
+      context "and TRN does not match but there are 2 other matches" do
+        subject { DQTRecordCheck.new(full_name:, date_of_birth: date_of_birth + 1, trn: "9988776", nino:) }
 
-      before do
-        allow_any_instance_of(DQTRecordCheck).to receive(:check_record).and_call_original
-      end
+        include_context "build fake DQT response"
 
-      it "sets trn to 0000001 and calls check_record again" do
-        expect(subject.send(:trn)).to eql(trn)
+        before do
+          allow_any_instance_of(DQTRecordCheck).to receive(:check_record).and_call_original
+          allow_any_instance_of(FullDQT::V1::Client)
+            .to receive(:get_record)
+            .and_return(default_api_response.merge("trn" => "9988776"))
+        end
 
-        subject.call
+        it "calls check_record again with_nino: true" do
+          result = subject.call
 
-        expect(subject.send(:trn)).to eql("0000001")
-        expect(subject).to have_received(:check_record).twice
+          expect(subject).to have_received(:check_record).once.with(no_args)
+          expect(subject).to have_received(:check_record).once.with(with_nino: true)
+          expect(result.total_matched).to eq(3)
+          expect(result.failure_reason).to be_nil
+          expect(result.trn_matches).to be(true)
+          expect(result.name_matches).to be(true)
+          expect(result.dob_matches).to be(false)
+          expect(result.nino_matches).to be(true)
+        end
       end
 
       context "when the TRN matches and DoB or Nino but the name doesn't match (2 matches)" do
         include_context "build fake DQT response" do
-          let(:fake_api_response) { default_api_response.except("dob").merge("name" => "Jimbo Jones") }
+          let(:fake_api_response) do
+            default_api_response.except("dateOfBirth").merge("firstName" => "Jimbo", "lastName" => "Jones")
+          end
         end
 
         it "returns the record and match results" do
@@ -230,6 +243,23 @@ RSpec.describe DQTRecordCheck do
           expect(result.dqt_record).to be_present
           expect(result.total_matched).to eql(2)
         end
+      end
+    end
+
+    context "when date of birth matches magic test data" do
+      include_context "build fake DQT response" do
+        let(:date_of_birth) { Time.zone.local(1900, 1, 5) }
+      end
+
+      before do
+        allow(Rails.env).to receive(:production?).and_return(false)
+        allow(Rails.env).to receive(:test?).and_return(false)
+        allow_any_instance_of(DQTRecordCheck).to receive(:magic_response).and_call_original
+      end
+
+      it "calls the magic_dqt_record_check method" do
+        subject.call
+        expect(subject).to have_received(:magic_response).once
       end
     end
   end

--- a/spec/services/participant_validation_service_spec.rb
+++ b/spec/services/participant_validation_service_spec.rb
@@ -10,15 +10,15 @@ RSpec.describe ParticipantValidationService do
   describe "#validate" do
     let(:trn) { "1234567" }
     let(:nino) { "QQ123456A" }
-    let(:full_name) { "John Smith" }
+    let(:first_name) { "John" }
+    let(:last_name) { "Smith" }
+    let(:full_name) { [first_name, last_name].join(" ") }
     let(:dob) { Date.new(1970, 1, 2) }
     let(:qts_date) { 6.weeks.ago.to_date }
     let(:qts) do
       {
-        "name" => "Qualified teacher (trained)",
-        "qts_date" => qts_date,
-        "state" => 0,
-        "state_name" => "Active",
+        "awarded" => qts_date,
+        "statusDescription" => "Active",
       }
     end
     let(:alert) { false }
@@ -26,16 +26,25 @@ RSpec.describe ParticipantValidationService do
     let(:induction_completion_date) { Date.parse("2021-07-05T00:00:00Z") }
     let(:induction) { { "periods" => [{ "startDate" => nil }] } }
     let(:inactive_record) { false }
-    let(:dqt_record) { build_dqt_record(trn:, nino:, full_name:, dob:, alert:, qts:, induction:, inactive: inactive_record) }
-    let(:dqt_records) { [dqt_record] }
-
-    let(:validation_result) { ParticipantValidationService.validate(trn:, nino:, full_name:, date_of_birth: dob) }
-
-    it "calls get_record on the DQT API client" do
-      expect_any_instance_of(FullDQT::V1::Client).to receive(:get_record).with({ trn:, birthdate: dob, nino: })
-
-      validation_result
+    let(:induction) { nil }
+    let(:dqt_record) do
+      {
+        "trn" => trn,
+        "nationalInsuranceNumber" => nino,
+        "firstName" => first_name,
+        "lastName" => last_name,
+        "dateOfBirth" => dob,
+        "qts" => qts,
+        "induction" => induction,
+        "alerts" => alert ? %w[Alert] : [],
+      }
     end
+
+    let(:check_service) { instance_double(DQTRecordCheck) }
+    let(:presented_dqt_record) { DQTRecordPresenter.new(dqt_record) }
+    let(:check_result) { DQTRecordCheck::CheckResult.new(presented_dqt_record, true, true, true, true, 4, nil) }
+    let(:no_result) { DQTRecordCheck::CheckResult.new(nil, false, false, false, false, 0, :no_match_found) }
+    let(:validation_result) { ParticipantValidationService.validate(trn:, nino:, full_name:, date_of_birth: dob) }
 
     context "when neither trn nor nino is provided" do
       let(:trn) { nil }
@@ -46,33 +55,17 @@ RSpec.describe ParticipantValidationService do
       end
     end
 
-    context "when trn is not provided, but nino is" do
-      let(:trn) { nil }
-
-      it "queries dqt with fake trn" do
-        expect_any_instance_of(FullDQT::V1::Client).to receive(:get_record).with({ trn: "0000001", birthdate: dob, nino: })
-        validation_result
-      end
-    end
-
-    context "given that it calls the API" do
+    context "given that it calls DQTCheckRecord" do
       before do
-        expect_any_instance_of(FullDQT::V1::Client).to receive(:get_record).and_return(*dqt_records)
+        allow(DQTRecordCheck).to receive(:new).and_return(check_service)
+        allow(check_service).to receive(:call).and_return(check_result)
       end
 
       context "when the participant cannot be found" do
-        let(:dqt_records) { [nil] }
+        let(:check_result) { no_result }
 
         it "returns nil" do
           expect(validation_result).to eql nil
-        end
-      end
-
-      context "when an inactive record is returned" do
-        let(:inactive_record) { true }
-
-        it "returns nil" do
-          expect(validation_result).to be_nil
         end
       end
 
@@ -130,19 +123,21 @@ RSpec.describe ParticipantValidationService do
         end
       end
 
-      context "when 3 of 4 things match and only first name matches" do
-        let(:validation_result) do
-          ParticipantValidationService.validate(
-            trn:,
-            nino: "WRONG",
-            full_name: full_name.split(" ").first.to_s,
-            date_of_birth: dob,
-          )
-        end
-        let(:dqt_records) { [dqt_record, nil] }
+      context "when 3 of 4 things match" do
+        context "when only first name matches" do
+          let(:check_result) { no_result }
+          let(:validation_result) do
+            ParticipantValidationService.validate(
+              trn:,
+              nino: "WRONG",
+              full_name: full_name.split(" ").first.to_s,
+              date_of_birth: dob,
+            )
+          end
 
-        it "returns nil" do
-          expect(validation_result).to be_nil
+          it "returns nil" do
+            expect(validation_result).to be_nil
+          end
         end
 
         context "when config check_first_name_only: true" do
@@ -150,39 +145,15 @@ RSpec.describe ParticipantValidationService do
             ParticipantValidationService.validate(
               trn:,
               nino: "WRONG",
-              full_name: full_name.split(" ").first.to_s,
+              full_name: first_name,
               date_of_birth: dob,
               config: { check_first_name_only: true },
             )
           end
-          let(:dqt_records) { [dqt_record] }
 
           it "returns validated details" do
             expect(validation_result).to eql(build_validation_result(trn:))
           end
-        end
-      end
-
-      context "when the wrong trn is provided" do
-        let(:other_trn) { "7654321" }
-        let(:record_for_other_trn) do
-          build_dqt_record(trn: other_trn,
-                           nino: "AA654321A",
-                           full_name: "Jenny Mathews",
-                           dob: Date.new(1990, 2, 1),
-                           alert: false,
-                           qts: nil,
-                           induction: { "periods" => [{ "startDate" => nil }] })
-        end
-        let(:dqt_records) { [record_for_other_trn, dqt_record] }
-
-        it "returns the correct details" do
-          expect(ParticipantValidationService.validate(
-                   trn: other_trn,
-                   nino:,
-                   full_name:,
-                   date_of_birth: dob,
-                 )).to eql(build_validation_result(trn:))
         end
       end
 
@@ -202,15 +173,6 @@ RSpec.describe ParticipantValidationService do
         end
       end
 
-      context "when the DQT nino is blank" do
-        let(:nino) { "" }
-        let(:dqt_records) { [dqt_record, nil] }
-
-        it "does not count blank NINos as matching" do
-          expect(ParticipantValidationService.validate(trn:, nino: "", full_name: "John Smithe", date_of_birth: dob)).to be_nil
-        end
-      end
-
       context "when the participant has previously participated" do
         let!(:eligibility) { create(:ineligible_participant, trn:, reason: :previous_induction_and_participation) }
 
@@ -219,180 +181,230 @@ RSpec.describe ParticipantValidationService do
         end
       end
 
-      context "when the participant has previously had an induction" do
+      context "with induction data" do
+        let(:induction_status) { "Pass" }
+        let(:induction_periods) do
+          [{ "startDate" => induction_start_date, "endDate" => induction_completion_date }]
+        end
         let(:induction) do
           {
-            "periods" => [{ "startDate" => induction_start_date }],
-            "completion_date" => induction_completion_date,
-            "status" => "Pass",
-            "state" => 0,
-            "state_name" => "Active",
+            "startDate" => induction_start_date,
+            "endDate" => induction_completion_date,
+            "status" => induction_status,
+            "periods" => induction_periods,
           }
         end
 
-        it "returns returns the correct previous_participation flags" do
-          expect(validation_result).to eql(build_validation_result(trn:, options: { previous_induction: true, no_induction: false, induction_start_date: }))
-        end
-      end
-
-      context "when the participant has an induction with nil start_date" do
-        let(:induction) do
-          {
-            "periods" => [{ "startDate" => nil }],
-          }
+        context "when the participant has previously had an induction" do
+          it "returns returns the correct previous_participation flags" do
+            expect(validation_result).to eql(build_validation_result(trn:, options: { previous_induction: true, no_induction: false, induction_start_date: }))
+          end
         end
 
-        it "does not raise an error" do
-          expect { validation_result }.not_to raise_error
+        context "when the participant has an induction with nil start_date" do
+          let(:induction_start_date) { nil }
+          let(:induction_completion_date) { nil }
+          let(:induction_periods) { [] }
+
+          it "does not raise an error" do
+            expect { validation_result }.not_to raise_error
+          end
+
+          it "returns previous_induction as false" do
+            expect(validation_result[:previous_induction]).to eq false
+          end
+
+          it "returns no_induction as true" do
+            expect(validation_result[:no_induction]).to eq true
+          end
+
+          it "returns induction_start_date as nil" do
+            expect(validation_result[:induction_start_date]).to be_nil
+          end
         end
 
-        it "returns previous_induction as false" do
-          expect(validation_result[:previous_induction]).to eq false
+        context "when the participant's induction status is InProgress" do
+          let(:induction_status) { "InProgress" }
+          let(:induction_completion_date) { nil }
+
+          it "does not raise an error" do
+            expect { validation_result }.not_to raise_error
+          end
+
+          it "returns previous_induction as false" do
+            expect(validation_result[:previous_induction]).to eq false
+          end
+
+          it "returns no_induction as false" do
+            expect(validation_result[:no_induction]).to eq false
+          end
+
+          it "returns induction_start_date" do
+            expect(validation_result[:induction_start_date]).to eq(induction_start_date)
+          end
         end
 
-        it "returns no_induction as true" do
-          expect(validation_result[:no_induction]).to eq true
+        context "when the participant's induction status is Not Yet Completed" do
+          let(:induction_status) { "Not Yet Completed" }
+          let(:induction_completion_date) { nil }
+
+          it "does not raise an error" do
+            expect { validation_result }.not_to raise_error
+          end
+
+          it "returns previous_induction as false" do
+            expect(validation_result[:previous_induction]).to eq false
+          end
+
+          it "returns no_induction as false" do
+            expect(validation_result[:no_induction]).to eq false
+          end
+
+          it "returns induction_start_date" do
+            expect(validation_result[:induction_start_date]).to eq(induction_start_date)
+          end
         end
 
-        it "returns induction_start_date as nil" do
-          expect(validation_result[:induction_start_date]).to be_nil
-        end
-      end
+        context "when the participant has previously had an induction and participation" do
+          let!(:eligibility) { create(:ineligible_participant, trn:, reason: :previous_participation) }
 
-      context "when the participant's induction status is InProgress" do
-        let(:induction) do
-          {
-            "periods" => [{ "startDate" => induction_start_date }],
-            "status" => "InProgress",
-          }
+          it "returns returns both flags" do
+            expect(validation_result).to eql(build_validation_result(trn:, options: { previous_induction: true, previous_participation: true, no_induction: false, induction_start_date: }))
+          end
         end
 
-        it "does not raise an error" do
-          expect { validation_result }.not_to raise_error
+        context "when the participant has an induction start date in or after September this year" do
+          let(:induction_start_date) { Time.zone.parse("2021-09-01T00:00:00Z") }
+          let(:induction_completion_date) { nil }
+
+          it "returns false for previous induction" do
+            expect(validation_result).to eql(build_validation_result(trn:, options: { previous_induction: false, no_induction: false, induction_start_date: }))
+          end
         end
 
-        it "returns previous_induction as false" do
-          expect(validation_result[:previous_induction]).to eq false
+        context "when the participant has an induction start date is exactly on the threshold" do
+          let(:induction_start_date) { Time.zone.parse("2021-08-31T23:00:00Z") }
+          let(:induction_completion_date) { nil }
+
+          it "returns false for previous induction and parses timezones correctly" do
+            expect(validation_result).to eql(build_validation_result(trn:, options: { previous_induction: false, no_induction: false, induction_start_date: }))
+          end
         end
 
-        it "returns no_induction as false" do
-          expect(validation_result[:no_induction]).to eq false
+        context "when the participant has an induction start date before September 2021" do
+          let(:induction_start_date) { Time.zone.parse("2021-08-31T22:59:59Z") }
+          let(:induction_completion_date) { nil }
+
+          it "returns true for previous induction" do
+            expect(validation_result).to eql(build_validation_result(trn:, options: { previous_induction: true, no_induction: false, induction_start_date: }))
+          end
         end
 
-        it "returns induction_start_date" do
-          expect(validation_result[:induction_start_date]).to eq(induction_start_date)
-        end
-      end
+        context "when the participant has an induction with the status of 'Exempt'" do
+          let(:induction_status) { "Exempt" }
+          let(:induction_start_date) { nil }
+          let(:induction_completion_date) { nil }
+          let(:induction_periods) { [] }
 
-      context "when the participant's induction status is Not Yet Completed" do
-        let(:induction) do
-          {
-            "periods" => [{ "startDate" => induction_start_date }],
-            "status" => "Not Yet Completed",
-          }
+          it "sets exempt_from_induction to true" do
+            expect(validation_result).to eql(build_validation_result(trn:, options: { exempt_from_induction: true, no_induction: true }))
+          end
         end
 
-        it "does not raise an error" do
-          expect { validation_result }.not_to raise_error
+        context "when the participant's induction status is Not Yet Completed" do
+          let(:induction) do
+            {
+              "periods" => [{ "startDate" => induction_start_date }],
+              "status" => "Not Yet Completed",
+            }
+          end
+
+          it "does not raise an error" do
+            expect { validation_result }.not_to raise_error
+          end
+
+          it "returns previous_induction as false" do
+            expect(validation_result[:previous_induction]).to eq false
+          end
+
+          it "returns no_induction as false" do
+            expect(validation_result[:no_induction]).to eq false
+          end
+
+          it "returns induction_start_date" do
+            expect(validation_result[:induction_start_date]).to eq(induction_start_date)
+          end
         end
 
-        it "returns previous_induction as false" do
-          expect(validation_result[:previous_induction]).to eq false
+        context "when the participant has previously had an induction and participation" do
+          let!(:eligibility) { create(:ineligible_participant, trn:, reason: :previous_participation) }
+          let(:induction) do
+            {
+              "periods" => [{ "startDate" => induction_start_date }],
+              "completion_date" => induction_completion_date,
+              "status" => "Pass",
+              "state" => 0,
+              "state_name" => "Active",
+            }
+          end
+
+          it "returns returns both flags" do
+            expect(validation_result).to eql(build_validation_result(trn:, options: { previous_induction: true, previous_participation: true, no_induction: false, induction_start_date: }))
+          end
         end
 
-        it "returns no_induction as false" do
-          expect(validation_result[:no_induction]).to eq false
+        context "when the participant has an induction start date in or after September this year" do
+          let(:induction_start_date) { Time.zone.parse("2021-09-01T00:00:00Z") }
+          let(:induction_completion_date) { nil }
+          let(:induction) do
+            {
+              "periods" => [{ "startDate" => induction_start_date }],
+              "completion_date" => induction_completion_date,
+              "status" => "Pass",
+              "state" => 0,
+              "state_name" => "Active",
+            }
+          end
+
+          it "returns false for previous induction" do
+            expect(validation_result).to eql(build_validation_result(trn:, options: { previous_induction: false, no_induction: false, induction_start_date: }))
+          end
         end
 
-        it "returns induction_start_date" do
-          expect(validation_result[:induction_start_date]).to eq(induction_start_date)
-        end
-      end
+        context "when the participant has an induction start date is exactly on the threshold" do
+          let(:induction_start_date) { Time.zone.parse("2021-08-31T23:00:00Z") }
+          let(:induction_completion_date) { nil }
+          let(:induction) do
+            {
+              "periods" => [{ "startDate" => induction_start_date }],
+              "completion_date" => induction_completion_date,
+              "status" => "Pass",
+              "state" => 0,
+              "state_name" => "Active",
+            }
+          end
 
-      context "when the participant has previously had an induction and participation" do
-        let!(:eligibility) { create(:ineligible_participant, trn:, reason: :previous_participation) }
-        let(:induction) do
-          {
-            "periods" => [{ "startDate" => induction_start_date }],
-            "completion_date" => induction_completion_date,
-            "status" => "Pass",
-            "state" => 0,
-            "state_name" => "Active",
-          }
-        end
-
-        it "returns returns both flags" do
-          expect(validation_result).to eql(build_validation_result(trn:, options: { previous_induction: true, previous_participation: true, no_induction: false, induction_start_date: }))
-        end
-      end
-
-      context "when the participant has an induction start date in or after September this year" do
-        let(:induction_start_date) { Time.zone.parse("2021-09-01T00:00:00Z") }
-        let(:induction_completion_date) { nil }
-        let(:induction) do
-          {
-            "periods" => [{ "startDate" => induction_start_date }],
-            "completion_date" => induction_completion_date,
-            "status" => "Pass",
-            "state" => 0,
-            "state_name" => "Active",
-          }
+          it "returns false for previous induction and parses timezones correctly" do
+            expect(validation_result).to eql(build_validation_result(trn:, options: { previous_induction: false, no_induction: false, induction_start_date: }))
+          end
         end
 
-        it "returns false for previous induction" do
-          expect(validation_result).to eql(build_validation_result(trn:, options: { previous_induction: false, no_induction: false, induction_start_date: }))
-        end
-      end
+        context "when the participant has an induction start date before September 2021" do
+          let(:induction_start_date) { Time.zone.parse("2021-08-31T22:59:59Z") }
+          let(:induction_completion_date) { nil }
+          let(:induction) do
+            {
+              "periods" => [{ "startDate" => induction_start_date }],
+              "completion_date" => induction_completion_date,
+              "status" => "Pass",
+              "state" => 0,
+              "state_name" => "Active",
+            }
+          end
 
-      context "when the participant has an induction start date is exactly on the threshold" do
-        let(:induction_start_date) { Time.zone.parse("2021-08-31T23:00:00Z") }
-        let(:induction_completion_date) { nil }
-        let(:induction) do
-          {
-            "periods" => [{ "startDate" => induction_start_date }],
-            "completion_date" => induction_completion_date,
-            "status" => "Pass",
-            "state" => 0,
-            "state_name" => "Active",
-          }
-        end
-
-        it "returns false for previous induction and parses timezones correctly" do
-          expect(validation_result).to eql(build_validation_result(trn:, options: { previous_induction: false, no_induction: false, induction_start_date: }))
-        end
-      end
-
-      context "when the participant has an induction start date before September 2021" do
-        let(:induction_start_date) { Time.zone.parse("2021-08-31T22:59:59Z") }
-        let(:induction_completion_date) { nil }
-        let(:induction) do
-          {
-            "periods" => [{ "startDate" => induction_start_date }],
-            "completion_date" => induction_completion_date,
-            "status" => "Pass",
-            "state" => 0,
-            "state_name" => "Active",
-          }
-        end
-
-        it "returns true for previous induction" do
-          expect(validation_result).to eql(build_validation_result(trn:, options: { previous_induction: true, no_induction: false, induction_start_date: }))
-        end
-      end
-
-      context "when the participant has an induction with the status of 'Exempt'" do
-        let(:induction) do
-          {
-            "periods" => [{ "startDate" => nil }],
-            "completion_date" => nil,
-            "status" => "Exempt",
-            "state" => 0,
-            "state_name" => "Exempt",
-          }
-        end
-
-        it "sets exempt_from_induction to true" do
-          expect(validation_result).to eql(build_validation_result(trn:, options: { exempt_from_induction: true, no_induction: true }))
+          it "returns true for previous induction" do
+            expect(validation_result).to eql(build_validation_result(trn:, options: { previous_induction: true, no_induction: false, induction_start_date: }))
+          end
         end
       end
     end
@@ -409,61 +421,5 @@ RSpec.describe ParticipantValidationService do
       exempt_from_induction: false,
       induction_start_date: nil,
     }.merge(options)
-  end
-
-  def build_dqt_record(trn:, nino:, full_name:, dob:, alert:, qts:, induction:, inactive: false)
-    {
-      "trn" => trn,
-      "ni_number" => nino,
-      "name" => full_name,
-      "dob" => dob,
-      "active_alert" => alert,
-      "state" => (inactive ? 1 : 0),
-      "state_name" => (inactive ? "Inactive" : "Active"),
-      "qualified_teacher_status" => qts,
-      "induction" => induction,
-      "initial_teacher_training" => {
-        "programme_start_date" => "2021-06-27T00:00:00Z",
-        "programme_end_date" => "2021-07-04T00:00:00Z",
-        "programme_type" => "Overseas Trained Teacher Programme",
-        "result" => "Pass",
-        "subject1" => "applied biology",
-        "subject2" => "applied chemistry",
-        "subject3" => "applied computing",
-        "qualification" => "BA (Hons)",
-        "state" => 0,
-        "state_name" => "Active",
-      },
-      "qualifications" => [
-        {
-          "name" => "Higher Education",
-          "date_awarded" => nil,
-        },
-        {
-          "name" => "NPQH",
-          "date_awarded" => "2021-07-05T00:00:00Z",
-        },
-        {
-          "name" => "Mandatory Qualification",
-          "date_awarded" => nil,
-        },
-        {
-          "name" => "HLTA",
-          "date_awarded" => nil,
-        },
-        {
-          "name" => "NPQML",
-          "date_awarded" => "2021-07-05T00:00:00Z",
-        },
-        {
-          "name" => "NPQSL",
-          "date_awarded" => "2021-07-04T00:00:00Z",
-        },
-        {
-          "name" => "NPQEL",
-          "date_awarded" => "2021-07-04T00:00:00Z",
-        },
-      ],
-    }
   end
 end

--- a/spec/support/features/pages/participant/participant_registration_wizard.rb
+++ b/spec/support/features/pages/participant/participant_registration_wizard.rb
@@ -89,7 +89,7 @@ module Pages
 
     def setup_response_from_dqt(participant_name, dob, trn)
       birth_date = "#{dob.year}-#{sprintf('%02i', dob.month)}-#{sprintf('%02i', dob.day)}"
-      stub_request(:get, "https://dtqapi.example.com/dqt-crm/v1/teachers/#{trn}?birthdate=#{birth_date}")
+      stub_request(:get, "https://dtqapi.example.com/dqt-crm/v3/teachers/#{trn}?include=induction")
         .with(
           headers: {
             "Accept" => "*/*",
@@ -100,14 +100,14 @@ module Pages
           },
         )
         .to_return(status: 200, body: JSON.generate({
-          "name": participant_name,
-          "dob": "#{birth_date}T00:00:00",
+          "firstName": participant_name.split(" ").first,
+          "lastName": participant_name.split(" ").last,
+          "dateOfBirth": "#{birth_date}T00:00:00",
           "trn": trn,
-          "ni_number": "AB123456D",
-          "active_alert": false,
-          "state_name": "Active",
-          "qualified_teacher_status": {
-            "qts_date": "2021-07-05T00:00:00Z",
+          "nationalInsuranceNumber": "AB123456D",
+          "alerts": [],
+          "qts": {
+            "awarded": "2021-07-05T00:00:00Z",
           },
           "induction": {
             "periods" => [{ "startDate" => "2021-09-02T00:00:00Z" }],


### PR DESCRIPTION
### Context

We currently check a teachers record via the DQT API using the v1 endpoint.

This doesn’t give us reliable induction start and end dates.

V3 of the DQT API exposes an array of induction periods which each have a start and end date, we should derive induction start date and end date from the oldest/latest dates in this array.

- Ticket:  https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CST/boards/119?selectedIssue=CST-2546

### Changes proposed in this pull request

- Amend DQT Record presentation to use DQT API V3 [GetTeacherResponse](https://preprod.teacher-qualifications-api.education.gov.uk/swagger/index.html?urls.primaryName=v3#/Teachers/GetTeacherByTrn) fields
- Fetch and attempt to match DQT records via the V3 API.
- Derive induction start and end dates from induction periods.
- Rework `DQTRecordCheck` with an additional check via the v1 API endpoint in the case of a TRN mismatch.

### Guidance to review

