### PR TITLE
Restore funded_place if modified after acceptance

### DIFF
--- a/app/services/npq/change_to_pending.rb
+++ b/app/services/npq/change_to_pending.rb
@@ -34,7 +34,7 @@ module NPQ
         end
         npq_application.update!(lead_provider_approval_status: "pending")
         if FeatureFlag.active?(:npq_capping) && !npq_application.funded_place.nil?
-          npq_application.update!(funded_place: false)
+          npq_application.update!(funded_place: nil)
         end
       end
 

--- a/spec/services/npq/change_to_pending_spec.rb
+++ b/spec/services/npq/change_to_pending_spec.rb
@@ -66,20 +66,20 @@ RSpec.describe NPQ::ChangeToPending do
           FeatureFlag.activate(:npq_capping)
         end
 
-        it "marks the funded place as false if funded place is true" do
+        it "marks the funded place as nil if funded place is true" do
           npq_application.update!(funded_place: true)
 
           subject.call
 
-          expect(npq_application.reload.funded_place).to eq(false)
+          expect(npq_application.reload.funded_place).to eq(nil)
         end
 
-        it "does not change `funded place` if funded place is false" do
+        it "marks the funded place as nil if funded place is false" do
           npq_application.update!(funded_place: false)
 
           subject.call
 
-          expect(npq_application.reload.funded_place).to eq(false)
+          expect(npq_application.reload.funded_place).to eq(nil)
         end
 
         it "does not change `funded place` if funded place is nil" do
@@ -87,7 +87,7 @@ RSpec.describe NPQ::ChangeToPending do
 
           subject.call
 
-          expect(npq_application.reload.funded_place).to eq(nil)
+          expect { subject.call }.not_to change(npq_application, :funded_place)
         end
       end
     end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-3071

### Description

We set a funded place when an application is accepted. If we revert the acceptance we also need to unset the capping change.

