### PR TITLE
Add visually hidden text to AB summary list actions

### DIFF
--- a/app/views/schools/dashboard/_school_cohort_details.html.erb
+++ b/app/views/schools/dashboard/_school_cohort_details.html.erb
@@ -30,13 +30,13 @@
     <% list.with_row do |row| %>
       <% row.with_key(text: "Appropriate body") %>
       <% row.with_value(text: school_cohort.appropriate_body.name) %>
-      <% row.with_action(text: "Change", href: change_appropriate_body_schools_cohort_path(cohort_id: school_cohort.cohort.start_year)) %>
+      <% row.with_action(text: "Change", visually_hidden_text: "appropriate body", href: change_appropriate_body_schools_cohort_path(cohort_id: school_cohort.cohort.start_year)) %>
     <% end %>
   <% else %>
     <% list.with_row do |row| %>
       <% row.with_key(text: "Appropriate body") %>
       <% row.with_value(text: "") %>
-      <% row.with_action(text: "Add", href: add_appropriate_body_schools_cohort_path(cohort_id: school_cohort.cohort.start_year)) %>
+      <% row.with_action(text: "Add", visually_hidden_text: "appropriate body", href: add_appropriate_body_schools_cohort_path(cohort_id: school_cohort.cohort.start_year)) %>
     <% end %>
   <% end %>
 

--- a/spec/features/schools/add_appropriate_body_spec.rb
+++ b/spec/features/schools/add_appropriate_body_spec.rb
@@ -111,11 +111,11 @@ private
   end
 
   def and_i_can_add_appropriate_body
-    expect(page).to have_summary_row_action("Appropriate body", "Add")
+    expect(page).to have_summary_row_action("Appropriate body", "Add appropriate body")
   end
 
   def and_i_can_change_appropriate_body
-    expect(page).to have_summary_row_action("Appropriate body", "Change")
+    expect(page).to have_summary_row_action("Appropriate body", "Change appropriate body")
   end
 
   def and_appropriate_body_is_appointed(appropriate_body)
@@ -123,7 +123,7 @@ private
   end
 
   def when_i_click_on_add_appropriate_body
-    when_i_click_on_summary_row_action("Appropriate body", "Add")
+    when_i_click_on_summary_row_action("Appropriate body", "Add appropriate body")
   end
 
   def when_i_choose_appropriate_body(appropriate_body)


### PR DESCRIPTION
### Context

On the "Manage your training," page the _add_ link to add an **Appropriate body** lacks detail in visual or hidden link text. Adding hidden text _appropriate body_ would provide more context to the user.

- Ticket: https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CST/boards/119?selectedIssue=CST-2515

### Changes proposed in this pull request

Add _appropriate body_ hidden text to _Add_ link on AB summary list.

![image](https://github.com/DFE-Digital/early-careers-framework/assets/93511/9f9146f9-affc-4b68-bacd-5b162e54c4dd)


### Guidance to review

