### PR TITLE
Add a custom error for cohort setup wizard

### DIFF
--- a/config/locales/schools/cohorts/setup_wizard.yml
+++ b/config/locales/schools/cohorts/setup_wizard.yml
@@ -1,0 +1,8 @@
+en:
+  activemodel:
+    errors:
+      models:
+        schools/cohorts/wizard_steps/how_will_you_run_training_step:
+          attributes:
+            how_will_you_run_training:
+              inclusion: "Select how you will run training"


### PR DESCRIPTION
### Context

When a user submits the cohort setup wizard step "How will you run training..." without selecting a choice the error message is the default Rails _is not included in the list_ text.

- Ticket:  https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CST/boards/119?selectedIssue=CST-2515

### Changes proposed in this pull request

Add a custom error message for the setup wizard.
![image](https://github.com/DFE-Digital/early-careers-framework/assets/93511/26780e76-56cf-4f77-9c9b-0521380c9eef)


### Guidance to review

