### PR TITLE
Add new school type code to eligible code types

### DIFF
--- a/app/models/concerns/gias_types.rb
+++ b/app/models/concerns/gias_types.rb
@@ -3,7 +3,8 @@
 module GiasTypes
   extend ActiveSupport::Concern
 
-  ELIGIBLE_TYPE_CODES = [1, 2, 3, 5, 6, 7, 8, 12, 14, 15, 18, 28, 31, 32, 33, 34, 35, 36, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48].freeze
+  # Code 57 is a new addition for "Academy secure 16 to 19" - these are eligible for FIP funding
+  ELIGIBLE_TYPE_CODES = [1, 2, 3, 5, 6, 7, 8, 12, 14, 15, 18, 28, 31, 32, 33, 34, 35, 36, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 57].freeze
   ELIGIBLE_STATUS_CODES = [1, 3].freeze
   CIP_ONLY_TYPE_CODES = [10, 11, 30, 37].freeze
   CIP_ONLY_EXCEPT_WELSH_CODES = [10, 11, 37].freeze


### PR DESCRIPTION
### Context

A new school type code `57` has been added. It represents `Academy secure 16 to 19` and this type is eligible for funded FIP training.  We need to add them to the list of eligible type codes in order to allow these to be imported into the service from GIAS.

### Changes proposed in this pull request
Add school type code `57` to the list of eligible type codes.
