### PR TITLE
Handle school transfer start date ArgumentError gracefully

### DIFF
--- a/app/forms/admin/school_transfer_form.rb
+++ b/app/forms/admin/school_transfer_form.rb
@@ -257,6 +257,8 @@ private
     elsif @start_date < latest_induction_record.start_date
       errors.add(:start_date, :before_start, date: latest_induction_record.start_date.to_date.to_fs(:govuk))
     end
+  rescue ArgumentError
+    errors.add(:start_date, :invalid)
   end
 
   def email_is_not_in_use

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -281,8 +281,8 @@ en:
             transfer_choice:
               blank: "Select which programme the participant will join"
             start_date:
-              blank: "Enter a start date"
-              invalid: "Enter a valid start date"
+              blank: "Enter a start date. For example, 14 7 2023"
+              invalid: "Enter a valid start date. For example, 14 7 2023"
               before_start: "Start date cannot be before the current induction record start (%{date})"
             email:
               <<: *email_error_messages

--- a/spec/forms/admin/school_transfer_form_spec.rb
+++ b/spec/forms/admin/school_transfer_form_spec.rb
@@ -245,6 +245,12 @@ RSpec.describe Admin::SchoolTransferForm, type: :model do
         expect(form.valid?(:start_date)).to be false
         expect(form.errors[:latest_induction_record]).to be_present
       end
+
+      it "handles argument errors on start_date" do
+        form.start_date = { 3 => 22, 2 => 111, 1 => 2222 }
+        expect(form.valid?(:start_date)).to be false
+        expect(form.errors.added?(:start_date, :invalid)).to be true
+      end
     end
 
     context "when email step" do


### PR DESCRIPTION
### Context

Entering an invalid value into the school transfer start date results in an ArgumentError being raised to the controller level and a redirect with a generic flash error message. We should be handling this as a validation error.

- Ticket: https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CST/boards/119?selectedIssue=CST-2514

### Changes proposed in this pull request

Handle ArgumentError gracefully
Provide an example date in the error message

![image](https://github.com/DFE-Digital/early-careers-framework/assets/93511/a2552938-f133-4c3c-9c5b-3227ebb1a96b)


### Guidance to review

