### PR TITLE
Add npq capping to Admin and Finance

### DIFF
--- a/app/components/admin/npq/participants/details.html.erb
+++ b/app/components/admin/npq/participants/details.html.erb
@@ -62,6 +62,13 @@
     row.with_value(text: npq_application.npq_course_name)
   end
 
+  if FeatureFlag.active?(:npq_capping)
+    sl.with_row do |row|
+      row.with_key(text: "Funded place")
+      row.with_value(text: funded_place)
+    end
+  end
+
   sl.with_row do |row|
     row.with_key(text: "Last updated")
     row.with_value(text: last_updated)

--- a/app/components/admin/npq/participants/details.rb
+++ b/app/components/admin/npq/participants/details.rb
@@ -33,6 +33,12 @@ module Admin
             &.max
             &.to_formatted_s(:govuk)
         end
+
+        def funded_place
+          return "" if npq_application.funded_place.nil?
+
+          npq_application.funded_place ? "Yes" : "No"
+        end
       end
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,6 +16,12 @@ module ApplicationHelper
     @data_layer ||= build_data_layer
   end
 
+  def boolean_to_yes_no_nil(value)
+    return "" if value.nil?
+
+    boolean_to_yes_no(value)
+  end
+
   def boolean_to_yes_no(value)
     value ? "Yes" : "No"
   end

--- a/app/views/admin/npq/applications/_funding_eligibility.html.erb
+++ b/app/views/admin/npq/applications/_funding_eligibility.html.erb
@@ -6,6 +6,13 @@
       row.with_value(text: boolean_red_green_tag(application.eligible_for_funding))
     end
 
+    if FeatureFlag.active?(:npq_capping)
+      sl.with_row do |row|
+        row.with_key(text: 'Funded place')
+        row.with_value(text: boolean_to_yes_no_nil(application.funded_place))
+      end
+    end
+
     sl.with_row do |row|
       row.with_key(text: 'Funding eligibility status code')
       row.with_value(text: application.funding_eligiblity_status_code || "-")

--- a/app/views/admin/npq/applications/edge_cases/show.html.erb
+++ b/app/views/admin/npq/applications/edge_cases/show.html.erb
@@ -86,6 +86,13 @@
       end
     end
 
+    if FeatureFlag.active?(:npq_capping)
+      sl.with_row do |row|
+        row.with_key(text: "Funded place")
+        row.with_value(text: boolean_to_yes_no_nil(@npq_application.funded_place))
+      end
+    end
+    
     sl.with_row do |row|
       row.with_key(text: "Funding eligibility status code")
       if @npq_application.eligible_for_funding?

--- a/app/views/finance/participants/_npq_application.html.erb
+++ b/app/views/finance/participants/_npq_application.html.erb
@@ -55,7 +55,7 @@
       <% row.with_value(text: boolean_to_yes_no_nil(application.funded_place)) %>
       <% row.with_action(text: :none) %>
     <% end %>
-  end
+  <% end %>
 
   <% summary_list.with_row do |row| %>
     <% row.with_key { "Created at" } %>

--- a/app/views/finance/participants/_npq_application.html.erb
+++ b/app/views/finance/participants/_npq_application.html.erb
@@ -49,7 +49,7 @@
     <% row.with_action(text: :none) %>
   <% end %>
 
-  if FeatureFlag.active?(:npq_capping)
+  <% if FeatureFlag.active?(:npq_capping) %>
     <% summary_list.with_row do |row| %>
       <% row.with_key { "Funded place" } %>
       <% row.with_value(text: boolean_to_yes_no_nil(application.funded_place)) %>

--- a/app/views/finance/participants/_npq_application.html.erb
+++ b/app/views/finance/participants/_npq_application.html.erb
@@ -49,6 +49,14 @@
     <% row.with_action(text: :none) %>
   <% end %>
 
+  if FeatureFlag.active?(:npq_capping)
+    <% summary_list.with_row do |row| %>
+      <% row.with_key { "Funded place" } %>
+      <% row.with_value(text: boolean_to_yes_no_nil(application.funded_place)) %>
+      <% row.with_action(text: :none) %>
+    <% end %>
+  end
+
   <% summary_list.with_row do |row| %>
     <% row.with_key { "Created at" } %>
     <% row.with_value { application.created_at.to_fs(:govuk) } %>

--- a/spec/factories/services/npq/npq_application.rb
+++ b/spec/factories/services/npq/npq_application.rb
@@ -83,7 +83,7 @@ FactoryBot.define do
 
     trait :accepted do
       after :create do |npq_application|
-        NPQ::Application::Accept.new(npq_application:).call
+        NPQ::Application::Accept.new(npq_application:, funded_place: npq_application.funded_place).call
         npq_application.reload
       end
     end

--- a/spec/features/admin/npq_applications/change_logs_spec.rb
+++ b/spec/features/admin/npq_applications/change_logs_spec.rb
@@ -23,6 +23,17 @@ RSpec.feature "Admin NPQ Application change logs", js: true, rutabaga: false do
     then_i_can_see_a_change_log_on_eligible_attribute
   end
 
+  scenario "Show participant details for an NPQ participant (funded place)",
+           with_feature_flags: { npq_capping: "active" } do
+    given_there_is_an_npq_application
+    and_i_am_signed_in_as_an_admin
+
+    when_i_visit the_npq_applications_edge_cases
+    when_i_select_the_first_applicant
+
+    then_i_can_see_the_participant_funded_place_attribute
+  end
+
   scenario "Show a change log for an Applicant (API - first version)" do
     given_there_is_an_npq_application_via_api
     and_i_am_signed_in_as_an_admin
@@ -39,9 +50,9 @@ RSpec.feature "Admin NPQ Application change logs", js: true, rutabaga: false do
 private
 
   def given_there_is_an_npq_application
-    application = create :npq_application, :edge_case
+    @application = create :npq_application, :edge_case, funded_place: false
 
-    allow(User).to receive(:find).and_return(application.user)
+    allow(User).to receive(:find).and_return(@application.user)
   end
 
   def given_there_is_an_npq_application_via_api
@@ -74,5 +85,9 @@ private
 
   def then_i_can_see_a_change_log_on_eligible_attribute
     expect(page).to have_selector("table.govuk-table:first-of-type tbody tr", text: /Eligible.*?No.*?Yes/)
+  end
+
+  def then_i_can_see_the_participant_funded_place_attribute
+    expect(page).to have_selector(".govuk-summary-list__row--no-actions", text: /Funded place.*?No/)
   end
 end

--- a/spec/features/admin/npq_applications/npq_applications_spec.rb
+++ b/spec/features/admin/npq_applications/npq_applications_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Admin NPQ application details", js: true, rutabaga: false do
+  before do
+    PaperTrail.config.enabled = true
+  end
+
+  after do
+    PaperTrail.config.enabled = false
+  end
+
+  scenario "Show applications details (funded place)",
+           with_feature_flags: { npq_capping: "active" } do
+    create :npq_application, :edge_case, funded_place: true
+
+    and_i_am_signed_in_as_an_admin
+
+    when_i_visit_the_npq_applications_section
+    when_i_display_an_npq_application
+
+    then_i_can_see_the_application_details
+  end
+
+private
+
+  def when_i_visit_the_npq_applications_section
+    click_on "NPQ"
+    click_on "Applications"
+  end
+
+  def when_i_display_an_npq_application
+    click_on "View"
+  end
+
+  def then_i_can_see_the_application_details
+    expect(page).to have_selector(".govuk-summary-list__row--no-actions", text: /Funded place.*?Yes/)
+  end
+end

--- a/spec/features/admin/npq_applications/participant_details_spec.rb
+++ b/spec/features/admin/npq_applications/participant_details_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Admin NPQ participant details", js: true, rutabaga: false do
+  before do
+    PaperTrail.config.enabled = true
+  end
+
+  after do
+    PaperTrail.config.enabled = false
+  end
+
+  let(:npq_course) { create(:npq_leadership_course, identifier: "npq-senior-leadership") }
+  let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_npq_lead_provider) }
+  let(:npq_lead_provider) { cpd_lead_provider.npq_lead_provider }
+
+  scenario "Show participant details for an NPQ participant (funded place)",
+           with_feature_flags: { npq_capping: "active" } do
+    given_there_is_an_npq_participant
+    and_i_am_signed_in_as_an_admin
+
+    when_i_visit_the_npq_applications_participants
+    when_i_display_an_npq_participant
+
+    then_i_can_see_the_participant_funded_place_attribute
+  end
+
+private
+
+  def when_i_visit_the_npq_applications_participants
+    click_on "Participants"
+    select "NPQ", from: "Filter by type"
+    click_on "Search"
+  end
+
+  def when_i_display_an_npq_participant
+    click_on @npq_participant_profile.user.full_name
+  end
+
+  def given_there_is_an_npq_participant
+    statement = create(:npq_statement, :next_output_fee, cpd_lead_provider: npq_lead_provider.cpd_lead_provider, cohort: Cohort.current)
+    create(:npq_contract, npq_lead_provider:, cohort: statement.cohort, course_identifier: npq_course.identifier, version: statement.contract_version, funding_cap: 10)
+    npq_application = create(:npq_application, :accepted, :eligible_for_funding, funded_place: false, npq_course:, npq_lead_provider:, cohort: statement.cohort)
+
+    @npq_participant_profile = npq_application.profile
+  end
+
+  def then_i_can_see_the_participant_funded_place_attribute
+    expect(page).to have_selector(".govuk-summary-list__row--no-actions", text: /Funded place.*?No/)
+  end
+end

--- a/spec/features/finance/npq/participant_details_spec.rb
+++ b/spec/features/finance/npq/participant_details_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "NPQ view participant details", js: true, rutabaga: false do
+  let(:npq_course) { create(:npq_leadership_course, identifier: "npq-senior-leadership") }
+  let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_npq_lead_provider) }
+  let(:npq_lead_provider) { cpd_lead_provider.npq_lead_provider }
+
+  scenario "Show participant details for an NPQ participant (funded place)",
+           with_feature_flags: { npq_capping: "active" } do
+    given_i_am_logged_in_as_a_finance_user
+    given_there_is_an_npq_participant
+
+    when_i_display_an_npq_participant
+
+    then_i_can_see_the_participant_funded_place_attribute
+  end
+
+private
+
+  def when_i_display_an_npq_participant
+    visit finance_participant_path(@npq_participant_profile)
+  end
+
+  def given_there_is_an_npq_participant
+    statement = create(:npq_statement, :next_output_fee, cpd_lead_provider: npq_lead_provider.cpd_lead_provider, cohort: Cohort.current)
+    create(:npq_contract, npq_lead_provider:, cohort: statement.cohort, course_identifier: npq_course.identifier, version: statement.contract_version, funding_cap: 10)
+    npq_application = create(:npq_application, :accepted, :eligible_for_funding, funded_place: false, npq_course:, npq_lead_provider:, cohort: statement.cohort)
+
+    @npq_participant_profile = npq_application.profile
+  end
+
+  def then_i_can_see_the_participant_funded_place_attribute
+    expect(page).to have_selector(".govuk-summary-list__row", text: /Funded place.*?No/)
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -122,6 +122,20 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
+  describe "#boolean_to_yes_no_nil" do
+    it 'returns "Yes" when value is true' do
+      expect(helper.boolean_to_yes_no_nil(true)).to eq("Yes")
+    end
+
+    it 'returns "No" when value is false' do
+      expect(helper.boolean_to_yes_no_nil(false)).to eq("No")
+    end
+
+    it "returns `empty string` when value is nil" do
+      expect(helper.boolean_to_yes_no_nil(nil)).to eq("")
+    end
+  end
+
   describe "#service_name" do
     it "displays the default service name" do
       helper.request.path = "/"


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-2954

### Description

To help internal users identify if a participant is allocated to a funded place after an application is accepted we need to introduce funded place to the UI for both the admin and finance app.

