### PR TITLE
Update error message when moving to not funded cohort

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -109,7 +109,7 @@ en:
   npq_application:
     missing_npq_application: "The entered '#/npq_application' is missing from your request. Check details and try again."
     missing_funded_place: "The entered '#/funded_place' is missing from your request. Check details and try again."
-    cohort_does_not_accept_capping: "Leave the funded_place field blank. It's only needed for participants starting NPQs from autumn 2024 onwards"
+    cohort_does_not_accept_capping: "Leave the '#/funded_place' field blank. It's only needed for participants starting NPQs from autumn 2024 onwards"
     has_another_accepted_application: The participant has already had an application accepted for this course.
     has_already_been_accepted: This NPQ application has already been accepted
     has_already_been_rejected: This NPQ application has already been rejected

--- a/spec/services/npq/application/change_funded_place_spec.rb
+++ b/spec/services/npq/application/change_funded_place_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe NPQ::Application::ChangeFundedPlace do
           npq_contract.update!(funding_cap: nil)
 
           service.call
-          expect(service.errors.messages_for(:npq_application)).to include("Leave the funded_place field blank. It's only needed for participants starting NPQs from autumn 2024 onwards")
+          expect(service.errors.messages_for(:npq_application)).to include("Leave the '#/funded_place' field blank. It's only needed for participants starting NPQs from autumn 2024 onwards")
         end
 
         it "is invalid if the cohort does not accept capping and we set a funded place to false" do
@@ -112,7 +112,7 @@ RSpec.describe NPQ::Application::ChangeFundedPlace do
           npq_contract.update!(funding_cap: nil)
 
           service.call
-          expect(service.errors.messages_for(:npq_application)).to include("Leave the funded_place field blank. It's only needed for participants starting NPQs from autumn 2024 onwards")
+          expect(service.errors.messages_for(:npq_application)).to include("Leave the '#/funded_place' field blank. It's only needed for participants starting NPQs from autumn 2024 onwards")
         end
 
         context "when the application is not accepted" do


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-2949

### Changes proposed in this pull request

Updates copy for API error message when a `funded_cap` attribute is set for a non-funded cohort.