### PR TITLE
CST-2557: new field on ParticipantProfile to flag participants moved …

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -184,6 +184,7 @@
   - induction_completion_date
   - mentor_completion_date
   - mentor_completion_reason
+  - cohort_changed_after_payments_frozen
   :cohorts_lead_providers:
   - id
   - lead_provider_id

--- a/db/migrate/20240522114103_add_cohort_changed_after_payments_frozen_to_participant_profile.rb
+++ b/db/migrate/20240522114103_add_cohort_changed_after_payments_frozen_to_participant_profile.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCohortChangedAfterPaymentsFrozenToParticipantProfile < ActiveRecord::Migration[7.1]
+  def change
+    add_column :participant_profiles, :cohort_changed_after_payments_frozen, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_17_214659) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_22_114103) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -958,6 +958,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_17_214659) do
     t.date "induction_completion_date"
     t.date "mentor_completion_date"
     t.string "mentor_completion_reason"
+    t.boolean "cohort_changed_after_payments_frozen", default: false
     t.index ["cohort_id"], name: "index_participant_profiles_on_cohort_id"
     t.index ["core_induction_programme_id"], name: "index_participant_profiles_on_core_induction_programme_id"
     t.index ["mentor_profile_id"], name: "index_participant_profiles_on_mentor_profile_id"


### PR DESCRIPTION
…after closing payments in their cohort

### Context

This new boolean field will flag a participant moved to the current cohort due to their current cohort being frozen for payments. 

This way we have fully identified the participants moved to 2024 from 2021 closing event.

- [Ticket](https://dfedigital.atlassian.net/browse/CST-2557): 

### Changes proposed in this pull request

### Guidance to review

