### PR TITLE
[CST-2554] (part 2) Allow completed declarations to overwrite started not completed declarations until 31st July.

### DIFF
--- a/app/services/mentors/check_training_completion.rb
+++ b/app/services/mentors/check_training_completion.rb
@@ -3,9 +3,13 @@
 module Mentors
   class CheckTrainingCompletion < BaseService
     EARLY_ROLL_OUT_COMPLETION_DATE = Date.new(2021, 4, 19)
+    # hard coded for 2024 as we don't know what is required next year as yet
+    # this is the date when we will no longer accept 2021 declarations
+    DECLARATION_WINDOW_CLOSE_DATE = Date.new(2024, 7, 31)
 
     def call
       return unless mentor_profile.mentor?
+      return if marked_as_started_not_completed_after_declaration_window_closes?
 
       set_completion_values!
     end
@@ -37,6 +41,13 @@ module Mentors
 
     def completed_declaration
       @completed_declaration ||= find_valid_declaration
+    end
+
+    def marked_as_started_not_completed_after_declaration_window_closes?
+      return false if Time.zone.today < DECLARATION_WINDOW_CLOSE_DATE
+
+      # eg. set as complete via csv or manually for the rule 3 category (started but not completed)
+      mentor_profile.mentor_completion_date.present? && mentor_profile.started_not_completed?
     end
 
     def find_valid_declaration


### PR DESCRIPTION
### Context

- Ticket: Part of [Jira](https://dfedigital.atlassian.net/browse/CST-2554) which has been merged.
- This updates the `Mentors::CheckTrainingCompletion` service to prevent overwriting a manually added "started not completed" completion when a `completed` declaration is received after 31st July.  Until that date a completed declaration should override the completion date and reason if it has been marked as a "started not completed" completion.

### Changes proposed in this pull request
Adds logic to the completion check service.

### Guidance to review

