### PR TITLE
Finance app: add funded_place to assurance CSV report

### DIFF
--- a/app/services/finance/npq/assurance_report/query.rb
+++ b/app/services/finance/npq/assurance_report/query.rb
@@ -26,6 +26,7 @@ module Finance
               c.identifier                            AS course_identifier,
               sch.schedule_identifier                 AS schedule,
               a.eligible_for_funding                  AS eligible_for_funding,
+              a.funded_place                          AS funded_place,
               nlp.name                                AS npq_lead_provider_name,
               nlp.id                                  AS npq_lead_provider_id,
               a.school_urn                            AS school_urn,

--- a/spec/serializers/finance/npq/assurance_report/csv_serializer_spec.rb
+++ b/spec/serializers/finance/npq/assurance_report/csv_serializer_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Finance::NPQ::AssuranceReport::CsvSerializer do
       context "when `npq_capping` Feature Flag is active" do
         before { FeatureFlag.activate(:npq_capping) }
 
-        it "does not include Funded place" do
+        it "includes Funded place in the header" do
           expected_header.insert(6, "Funded place")
 
           expect(header).to eq(expected_header)

--- a/spec/serializers/finance/npq/assurance_report/csv_serializer_spec.rb
+++ b/spec/serializers/finance/npq/assurance_report/csv_serializer_spec.rb
@@ -72,6 +72,10 @@ RSpec.describe Finance::NPQ::AssuranceReport::CsvSerializer do
 
           expect(header).to eq(expected_header)
         end
+
+        it "includes `funded_place` attribute" do
+          expect(rows.second).to include("funded-true")
+        end
       end
 
       context "when `npq_capping` Feature Flag is not active" do
@@ -80,22 +84,8 @@ RSpec.describe Finance::NPQ::AssuranceReport::CsvSerializer do
         it "does not included Funded place in the header" do
           expect(header).to eq(expected_header)
         end
-      end
-    end
 
-    describe "`funded_place attribute" do
-      context "when `npq_capping` Feature Flag is active" do
-        before { FeatureFlag.activate(:npq_capping) }
-
-        it "includes `funded_place`" do
-          expect(rows.second).to include("funded-true")
-        end
-      end
-
-      context "when `npq_capping` Feature Flag is not active" do
-        before { FeatureFlag.deactivate(:npq_capping) }
-
-        it "does not include Funded place" do
+        it "does not include `funded_place` attribute" do
           expect(rows.second).to_not include("funded-true")
         end
       end

--- a/spec/serializers/finance/npq/assurance_report/csv_serializer_spec.rb
+++ b/spec/serializers/finance/npq/assurance_report/csv_serializer_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Finance::NPQ::AssuranceReport::CsvSerializer do
+  let(:record) { build_record }
+
+  describe "attributes" do
+    let(:records) { [record] }
+    subject { described_class.new(records, double) }
+
+    let(:rows) { subject.call.split("\n") }
+    let(:header) { rows.first.split(",") }
+    let(:data) { rows.second.split(",") }
+
+    it "includes all attributes in the row" do
+      expect(data).to match_array(
+        [
+          "123",
+          "John Doe",
+          "TRN123",
+          "course-id-123",
+          "schedule-123",
+          "eligible-true",
+          "provider-name",
+          "school-urn",
+          "school-name",
+          "active",
+          "active-reason",
+          "declaration-id-123",
+          "submitted",
+          "started",
+          "2022-02-01T12:00:00Z",
+          "2022-01-01T12:00:00Z",
+          "statement-name",
+          "satement-id-123",
+          "target-delivery-funding",
+        ],
+      )
+    end
+
+    describe "csv_headers" do
+      let(:expected_header) do
+        [
+          "Participant ID",
+          "Participant Name",
+          "TRN",
+          "Course Identifier",
+          "Schedule",
+          "Eligible For Funding",
+          "Lead Provider Name",
+          "School Urn",
+          "School Name",
+          "Training Status",
+          "Training Status Reason",
+          "Declaration ID",
+          "Declaration Status",
+          "Declaration Type",
+          "Declaration Date",
+          "Declaration Created At",
+          "Statement Name",
+          "Statement ID",
+          "Targeted Delivery Funding",
+        ]
+      end
+
+      context "when `npq_capping` Feature Flag is active" do
+        before { FeatureFlag.activate(:npq_capping) }
+
+        it "does not include Funded place" do
+          expected_header.insert(6, "Funded place")
+
+          expect(header).to eq(expected_header)
+        end
+      end
+
+      context "when `npq_capping` Feature Flag is not active" do
+        before { FeatureFlag.deactivate(:npq_capping) }
+
+        it "includes Funded place" do
+          expect(header).to eq(expected_header)
+        end
+      end
+    end
+
+    describe "`funded_place attribute" do
+      context "when `npq_capping` Feature Flag is active" do
+        before { FeatureFlag.activate(:npq_capping) }
+
+        it "includes `funded_place`" do
+          expect(rows.second).to include("funded-true")
+        end
+      end
+
+      context "when `npq_capping` Feature Flag is not active" do
+        before { FeatureFlag.deactivate(:npq_capping) }
+
+        it "does not include Funded place" do
+          expect(rows.second).to_not include("funded-true")
+        end
+      end
+    end
+  end
+
+  def build_record
+    double(
+      participant_id: "123",
+      participant_name: "John Doe",
+      trn: "TRN123",
+      course_identifier: "course-id-123",
+      schedule: "schedule-123",
+      eligible_for_funding: "eligible-true",
+      funded_place: "funded-true",
+      npq_lead_provider_name: "provider-name",
+      school_urn: "school-urn",
+      school_name: "school-name",
+      training_status: "active",
+      training_status_reason: "active-reason",
+      declaration_id: "declaration-id-123",
+      declaration_status: "submitted",
+      declaration_type: "started",
+      declaration_date: Time.zone.local(2022, 2, 1, 12, 0, 0),
+      declaration_created_at: Time.zone.local(2022, 1, 1, 12, 0, 0),
+      statement_name: "statement-name",
+      statement_id: "satement-id-123",
+      targeted_delivery_funding: "target-delivery-funding",
+    )
+  end
+end

--- a/spec/serializers/finance/npq/assurance_report/csv_serializer_spec.rb
+++ b/spec/serializers/finance/npq/assurance_report/csv_serializer_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Finance::NPQ::AssuranceReport::CsvSerializer do
       context "when `npq_capping` Feature Flag is not active" do
         before { FeatureFlag.deactivate(:npq_capping) }
 
-        it "includes Funded place" do
+        it "does not included Funded place in the header" do
           expect(header).to eq(expected_header)
         end
       end

--- a/spec/services/finance/npq/assurance_report/query_spec.rb
+++ b/spec/services/finance/npq/assurance_report/query_spec.rb
@@ -47,6 +47,22 @@ RSpec.describe Finance::NPQ::AssuranceReport::Query do
         participant_profile.update!(participant_identity: new_participant_identity)
       end
 
+      describe "funded_place attribute" do
+        it "includes the application funded place" do
+          participant_profile.npq_application.update!(funded_place: true)
+
+          participant_declaration = query.participant_declarations.first
+          expect(participant_declaration.funded_place).to be_truthy
+        end
+
+        it "includes the declaration funded place when `nil`" do
+          participant_profile.npq_application.update!(funded_place: nil)
+
+          participant_declaration = query.participant_declarations.first
+          expect(participant_declaration.funded_place).to be_nil
+        end
+      end
+
       it "includes the declaration" do
         expect(query.participant_declarations).to eq([participant_declaration])
       end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-2955

### Description

Within the financial statements, we have the functionality for assurance to ‘download declarations’. The download declarations query pulls together multiple bits of information regarding the participants declarations. 

This PR adds ‘funded_place’ added as an additional field to the query.

