### PR TITLE
Update cohort change logic to use payments_frozen_at field

### DIFF
--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -4,7 +4,6 @@ class Cohort < ApplicationRecord
   has_paper_trail
 
   NPQ_PLUS_1_YEAR = 2020
-  OPEN_COHORTS_COUNT = 3
 
   has_many :call_off_contracts
   has_many :npq_contracts

--- a/app/models/participant_profile/ect.rb
+++ b/app/models/participant_profile/ect.rb
@@ -10,12 +10,10 @@ class ParticipantProfile::ECT < ParticipantProfile::ECF
     where(induction_start_date: nil).joins(:ecf_participant_eligibility).merge(ECFParticipantEligibility.waiting_for_induction)
   }
 
-  def self.archivable(for_cohort_start_year:, restrict_to_participant_ids: [])
-    latest_induction_start_date = Date.new(for_cohort_start_year, 9, 1)
-
-    super(for_cohort_start_year:, restrict_to_participant_ids:)
+  def self.archivable(restrict_to_participant_ids: [])
+    super(restrict_to_participant_ids:)
       .where(induction_completion_date: nil)
-      .where("induction_start_date IS NULL OR induction_start_date < ?", latest_induction_start_date)
+      .where("induction_start_date IS NULL OR induction_start_date < make_date(cohorts.start_year, 9, 1)")
   end
 
   def ect?
@@ -30,7 +28,7 @@ class ParticipantProfile::ECT < ParticipantProfile::ECF
     "Early career teacher"
   end
 
-  def self.eligible_to_change_cohort_and_continue_training(in_cohort_start_year:, restrict_to_participant_ids:)
-    super(in_cohort_start_year:, restrict_to_participant_ids:).where(induction_completion_date: nil)
+  def self.eligible_to_change_cohort_and_continue_training(restrict_to_participant_ids: [])
+    super(restrict_to_participant_ids:).where(induction_completion_date: nil)
   end
 end

--- a/app/models/participant_profile/mentor.rb
+++ b/app/models/participant_profile/mentor.rb
@@ -21,8 +21,8 @@ class ParticipantProfile::Mentor < ParticipantProfile::ECF
     started_not_completed: "started_not_completed",
   }
 
-  def self.archivable(for_cohort_start_year:, restrict_to_participant_ids: [])
-    super(for_cohort_start_year:, restrict_to_participant_ids:)
+  def self.archivable(restrict_to_participant_ids: [])
+    super(restrict_to_participant_ids:)
       .where(mentor_completion_date: nil)
       .where.not(id: InductionRecord.where.not(mentor_profile_id: nil).select(:mentor_profile_id).distinct)
   end
@@ -49,7 +49,7 @@ class ParticipantProfile::Mentor < ParticipantProfile::ECF
     "Mentor"
   end
 
-  def self.eligible_to_change_cohort_and_continue_training(in_cohort_start_year:, restrict_to_participant_ids:)
-    super(in_cohort_start_year:, restrict_to_participant_ids:).where(mentor_completion_date: nil)
+  def self.eligible_to_change_cohort_and_continue_training(restrict_to_participant_ids: [])
+    super(restrict_to_participant_ids:).where(mentor_completion_date: nil)
   end
 end

--- a/spec/models/participant_profile/ect_spec.rb
+++ b/spec/models/participant_profile/ect_spec.rb
@@ -58,11 +58,11 @@ describe ParticipantProfile::ECT, type: :model do
     end
 
     describe ".archivable" do
-      subject { described_class.archivable(for_cohort_start_year:) }
+      subject { described_class.archivable }
 
-      it "does not include participants where the induction_start_date is 1/9/<for_cohort_start_year> or later" do
-        build_profile(cohort: eligible_cohort, induction_start_date: Date.new(for_cohort_start_year, 9, 1))
-        build_profile(cohort: eligible_cohort, induction_start_date: Date.new(for_cohort_start_year + 1, 3, 1))
+      it "does not include participants where the induction_start_date is 1/9/<cohort_start_year> or later" do
+        build_profile(cohort: eligible_cohort, induction_start_date: Date.new(eligible_cohort.start_year, 9, 1))
+        build_profile(cohort: eligible_cohort, induction_start_date: Date.new(eligible_cohort.start_year + 1, 3, 1))
 
         eligible_participant = build_profile(cohort: eligible_cohort)
 

--- a/spec/models/participant_profile/mentor_spec.rb
+++ b/spec/models/participant_profile/mentor_spec.rb
@@ -72,7 +72,7 @@ describe ParticipantProfile::Mentor, type: :model do
     end
 
     describe ".archivable" do
-      subject { described_class.archivable(for_cohort_start_year:) }
+      subject { described_class.archivable }
 
       it "does not include participants that have mentees" do
         build_profile(cohort: eligible_cohort).tap do |mentor_profile|


### PR DESCRIPTION
### Context

When these methods were initially written we assumed that if a cohort was 3 years older than the current/latest cohort it could be considered 'closed'.

The schools team have since added a dedicated flag to `Cohort` to indicate that it is closed/has had payments frozen that we want to utilise instead.

### Changes proposed in this pull request

- Update cohort change logic to use payments_frozen_at field

Update the `eligible_to_change_cohort_and_continue_training` and `archivable` methods to use this flag instead of the 3 years previous logic.

### Guidance to review

Re-tested on snapshot DB:

```
Cohort.find_by(start_year: 2021).update!(payments_frozen_at: Time.zone.now)

ParticipantProfile::ECT.eligible_to_change_cohort_and_continue_training.count
=> 3176

ParticipantProfile::Mentor.eligible_to_change_cohort_and_continue_training.count
=> 10248

ParticipantProfile::Mentor.archivable.count
=> 1087

ParticipantProfile::ECT.archivable.count
=> 202

Cohort.find_by(start_year: 2021).update!(payments_frozen_at: nil)
```
