### PR TITLE
Rename `FullDQT` to `DQT`

### DIFF
--- a/app/presenters/dqt_record_presenter.rb
+++ b/app/presenters/dqt_record_presenter.rb
@@ -39,7 +39,7 @@ class DQTRecordPresenter < SimpleDelegator
 
     @induction_start_date = (
       dqt_record.dig("induction", "periods") ||
-        FullDQT::V3::Client.new.get_record(trn:)&.dig("induction", "periods")
+        DQT::V3::Client.new.get_record(trn:)&.dig("induction", "periods")
     ).to_a
      .map { |period| period["startDate"] }
      .compact

--- a/app/services/dqt/get_induction_record.rb
+++ b/app/services/dqt/get_induction_record.rb
@@ -18,6 +18,6 @@ private
   end
 
   def client
-    @client ||= FullDQT::V3::Client.new
+    @client ||= DQT::V3::Client.new
   end
 end

--- a/app/services/dqt_record_check.rb
+++ b/app/services/dqt_record_check.rb
@@ -35,11 +35,11 @@ private
   end
 
   def dqt_record(trn, nino)
-    full_dqt_client.get_record(trn:, birthdate: date_of_birth, nino:)
+    dqt_client.get_record(trn:, birthdate: date_of_birth, nino:)
   end
 
-  def full_dqt_client
-    @full_dqt_client ||= FullDQT::V1::Client.new
+  def dqt_client
+    @dqt_client ||= DQT::V1::Client.new
   end
 
   def check_record

--- a/config/initializers/dqt.rb
+++ b/config/initializers/dqt.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-require "full_dqt"
+require "dqt"

--- a/lib/dqt.rb
+++ b/lib/dqt.rb
@@ -1,23 +1,4 @@
 # frozen_string_literal: true
 
-# The contents of this file and ./dqt have mostly been copied from
-# github.com/DFE-Digital/claim-additional-payments-for-teaching/tree/master/lib
-# there is no independent library available at the moment of writing this
-
-module DQT
-  def self.configuration
-    @configuration ||= Configuration.new
-  end
-
-  def self.configure
-    yield(configuration) if block_given?
-  end
-end
-
-require_relative "dqt/api"
-require_relative "dqt/api/v1"
-require_relative "dqt/api/v1/dqt_record"
-require_relative "dqt/client"
-require_relative "dqt/client/response"
-require_relative "dqt/client/response_error"
-require_relative "dqt/configuration"
+require "dqt/v1/client"
+require "dqt/v3/client"

--- a/lib/dqt/v1/client.rb
+++ b/lib/dqt/v1/client.rb
@@ -4,7 +4,7 @@ require "net/http"
 
 # NOTE: Use this API for validation of participant data
 #
-module FullDQT
+module DQT
   module V1
     class Client
       def get_record(trn:, birthdate:, nino: nil)

--- a/lib/dqt/v3/client.rb
+++ b/lib/dqt/v3/client.rb
@@ -11,7 +11,7 @@ require "net/http"
 # but using the V1 API keeps the id matching logic on the API side whereas
 # using the V3 API we would need to match and validate everything our side)
 #
-module FullDQT
+module DQT
   module V3
     class Client < V1::Client
       def get_record(trn:, sections: %w[induction])

--- a/lib/full_dqt.rb
+++ b/lib/full_dqt.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module FullDQT
-end
-
-require "full_dqt/v1/client"
-require "full_dqt/v3/client"

--- a/spec/lib/dqt/v1/client_spec.rb
+++ b/spec/lib/dqt/v1/client_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe FullDQT::V1::Client do
+RSpec.describe DQT::V1::Client do
   subject { described_class.new }
 
   let(:trn) { "1001000" }

--- a/spec/lib/dqt/v3/client_spec.rb
+++ b/spec/lib/dqt/v3/client_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe FullDQT::V3::Client do
+RSpec.describe DQT::V3::Client do
   subject { described_class.new }
 
   let(:trn) { "1001000" }

--- a/spec/services/dqt/get_induction_record_spec.rb
+++ b/spec/services/dqt/get_induction_record_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe DQT::GetInductionRecord do
     subject(:service) { described_class }
 
     it "returns the induction section of the participants DQT record" do
-      expect_any_instance_of(FullDQT::V3::Client).to receive(:get_record).with(trn:).once.and_return(valid_record)
+      expect_any_instance_of(DQT::V3::Client).to receive(:get_record).with(trn:).once.and_return(valid_record)
 
       result = service.call(trn:)
 
@@ -36,7 +36,7 @@ RSpec.describe DQT::GetInductionRecord do
 
     context "when the record is not found" do
       it "returns nil" do
-        expect_any_instance_of(FullDQT::V3::Client).to receive(:get_record).with(trn:).once.and_return(nil)
+        expect_any_instance_of(DQT::V3::Client).to receive(:get_record).with(trn:).once.and_return(nil)
 
         result = service.call(trn:)
 

--- a/spec/services/dqt_record_check_spec.rb
+++ b/spec/services/dqt_record_check_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe DQTRecordCheck do
   shared_context "build fake DQT response" do
     before do
-      allow_any_instance_of(FullDQT::V1::Client).to(receive(:get_record).and_return(fake_api_response || default_api_response))
+      allow_any_instance_of(DQT::V1::Client).to(receive(:get_record).and_return(fake_api_response || default_api_response))
     end
   end
 

--- a/spec/services/participant_validation_service_spec.rb
+++ b/spec/services/participant_validation_service_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe ParticipantValidationService do
     let(:validation_result) { ParticipantValidationService.validate(trn:, nino:, full_name:, date_of_birth: dob) }
 
     it "calls get_record on the DQT API client" do
-      expect_any_instance_of(FullDQT::V1::Client).to receive(:get_record).with({ trn:, birthdate: dob, nino: })
+      expect_any_instance_of(DQT::V1::Client).to receive(:get_record).with({ trn:, birthdate: dob, nino: })
 
       validation_result
     end
@@ -50,14 +50,14 @@ RSpec.describe ParticipantValidationService do
       let(:trn) { nil }
 
       it "queries dqt with fake trn" do
-        expect_any_instance_of(FullDQT::V1::Client).to receive(:get_record).with({ trn: "0000001", birthdate: dob, nino: })
+        expect_any_instance_of(DQT::V1::Client).to receive(:get_record).with({ trn: "0000001", birthdate: dob, nino: })
         validation_result
       end
     end
 
     context "given that it calls the API" do
       before do
-        expect_any_instance_of(FullDQT::V1::Client).to receive(:get_record).and_return(*dqt_records)
+        expect_any_instance_of(DQT::V1::Client).to receive(:get_record).and_return(*dqt_records)
       end
 
       context "when the participant cannot be found" do


### PR DESCRIPTION
### Context

[We've removed the old `DQT` module code](https://github.com/DFE-Digital/early-careers-framework/pull/4791), so `FullDQT` can be renamed `DQT`

- Ticket: https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CST/boards/119?selectedIssue=CST-2546

### Changes proposed in this pull request

Rename `FullDQT` to `DQT` and update references.

### Guidance to review

