### PR TITLE
Relax validation on ChangeSchedule service for certain participants 

### DIFF
--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -72,10 +72,10 @@ class ParticipantProfile::ECF < ParticipantProfile
     query
   end
 
-  def eligible_to_change_cohort_back_to_their_payments_frozen_original?(cohort:)
+  def eligible_to_change_cohort_back_to_their_payments_frozen_original?(cohort:, current_cohort:)
     return false unless cohort_changed_after_payments_frozen?
     return false unless cohort.payments_frozen?
-    return false if participant_declarations.billable_or_changeable.where(cohort: schedule.cohort).exists?
+    return false if participant_declarations.billable_or_changeable.where(cohort: current_cohort).exists?
 
     participant_declarations.billable.where(cohort:).exists?
   end

--- a/app/models/participant_profile/ect.rb
+++ b/app/models/participant_profile/ect.rb
@@ -28,7 +28,7 @@ class ParticipantProfile::ECT < ParticipantProfile::ECF
     "Early career teacher"
   end
 
-  def self.eligible_to_change_cohort_and_continue_training(restrict_to_participant_ids: [])
-    super(restrict_to_participant_ids:).where(induction_completion_date: nil)
+  def self.eligible_to_change_cohort_and_continue_training(in_cohort_start_year:, restrict_to_participant_ids: [])
+    super(in_cohort_start_year:, restrict_to_participant_ids:).where(induction_completion_date: nil)
   end
 end

--- a/app/models/participant_profile/ect.rb
+++ b/app/models/participant_profile/ect.rb
@@ -28,7 +28,7 @@ class ParticipantProfile::ECT < ParticipantProfile::ECF
     "Early career teacher"
   end
 
-  def self.eligible_to_change_cohort_and_continue_training(in_cohort_start_year:, restrict_to_participant_ids: [])
-    super(in_cohort_start_year:, restrict_to_participant_ids:).where(induction_completion_date: nil)
+  def self.eligible_to_change_cohort_and_continue_training(cohort:, restrict_to_participant_ids: [])
+    super(cohort:, restrict_to_participant_ids:).where(induction_completion_date: nil)
   end
 end

--- a/app/models/participant_profile/mentor.rb
+++ b/app/models/participant_profile/mentor.rb
@@ -49,7 +49,7 @@ class ParticipantProfile::Mentor < ParticipantProfile::ECF
     "Mentor"
   end
 
-  def self.eligible_to_change_cohort_and_continue_training(in_cohort_start_year:, restrict_to_participant_ids: [])
-    super(in_cohort_start_year:, restrict_to_participant_ids:).where(mentor_completion_date: nil)
+  def self.eligible_to_change_cohort_and_continue_training(cohort:, restrict_to_participant_ids: [])
+    super(cohort:, restrict_to_participant_ids:).where(mentor_completion_date: nil)
   end
 end

--- a/app/models/participant_profile/mentor.rb
+++ b/app/models/participant_profile/mentor.rb
@@ -49,7 +49,7 @@ class ParticipantProfile::Mentor < ParticipantProfile::ECF
     "Mentor"
   end
 
-  def self.eligible_to_change_cohort_and_continue_training(restrict_to_participant_ids: [])
-    super(restrict_to_participant_ids:).where(mentor_completion_date: nil)
+  def self.eligible_to_change_cohort_and_continue_training(in_cohort_start_year:, restrict_to_participant_ids: [])
+    super(in_cohort_start_year:, restrict_to_participant_ids:).where(mentor_completion_date: nil)
   end
 end

--- a/app/services/change_schedule.rb
+++ b/app/services/change_schedule.rb
@@ -9,7 +9,7 @@ class ChangeSchedule
   attribute :course_identifier
   attribute :schedule_identifier
   attribute :cohort, :integer
-  attribute :attempt_to_change_cohort_leaving_billable_declarations, :boolean, default: false
+  attribute :allow_change_to_from_frozen_cohort, :boolean, default: false
 
   delegate :participant_profile_state, to: :participant_profile, allow_nil: true
   delegate :lead_provider, to: :cpd_lead_provider, allow_nil: true
@@ -83,7 +83,7 @@ private
 
   def changing_cohort_due_to_payments_frozen?
     return false unless participant_profile.ecf?
-    return false unless attempt_to_change_cohort_leaving_billable_declarations
+    return false unless allow_change_to_from_frozen_cohort
     return true if participant_profile.eligible_to_change_cohort_and_continue_training?(cohort:)
 
     participant_profile.eligible_to_change_cohort_back_to_their_payments_frozen_original?(cohort:, current_cohort:)

--- a/app/services/change_schedule.rb
+++ b/app/services/change_schedule.rb
@@ -84,9 +84,9 @@ private
   def can_change_cohort_leaving_billable_declarations?
     return false unless participant_profile.ecf?
     return false unless attempt_to_change_cohort_leaving_billable_declarations
-    return true if participant_profile.eligible_to_change_cohort_and_continue_training?(in_cohort_start_year: cohort.start_year)
+    return true if participant_profile.eligible_to_change_cohort_and_continue_training?(cohort:)
 
-    participant_profile.eligible_to_change_cohort_back_to_their_payments_frozen_original?(to_cohort_start_year: cohort.start_year)
+    participant_profile.eligible_to_change_cohort_back_to_their_payments_frozen_original?(cohort:)
   end
 
   def cohort_start_years_delta

--- a/app/services/change_schedule.rb
+++ b/app/services/change_schedule.rb
@@ -9,6 +9,7 @@ class ChangeSchedule
   attribute :course_identifier
   attribute :schedule_identifier
   attribute :cohort, :integer
+  attribute :attempt_to_change_cohort_leaving_billable_declarations, :boolean, default: false
 
   delegate :participant_profile_state, to: :participant_profile, allow_nil: true
   delegate :lead_provider, to: :cpd_lead_provider, allow_nil: true
@@ -80,6 +81,18 @@ class ChangeSchedule
 
 private
 
+  def can_change_cohort_leaving_billable_declarations?
+    return false unless participant_profile.ecf?
+    return false unless attempt_to_change_cohort_leaving_billable_declarations
+    return true if participant_profile.eligible_to_change_cohort_and_continue_training?(in_cohort_start_year: cohort.start_year)
+
+    participant_profile.eligible_to_change_cohort_back_to_their_payments_frozen_original?(to_cohort_start_year: cohort.start_year)
+  end
+
+  def cohort_start_years_delta
+    cohort.start_year - participant_profile.schedule.cohort.start_year
+  end
+
   def user
     @user ||= participant_identity&.user
   end
@@ -111,6 +124,12 @@ private
   end
 
   def update_school_cohort_and_schedule!
+    changing_cohort = new_schedule.cohort != participant_profile.schedule.cohort
+
+    if changing_cohort && can_change_cohort_leaving_billable_declarations?
+      participant_profile.toggle!(:cohort_changed_after_payments_frozen)
+    end
+
     participant_profile.update!(school_cohort: target_school_cohort, schedule: new_schedule)
   end
 
@@ -191,6 +210,7 @@ private
   def validate_new_schedule_valid_with_existing_declarations
     return if user.blank? || participant_profile.blank?
     return unless new_schedule
+    return if can_change_cohort_leaving_billable_declarations?
 
     applicable_declarations.each do |declaration|
       milestone = new_schedule.milestones.find_by!(declaration_type: declaration.declaration_type)
@@ -220,6 +240,7 @@ private
 
   def validate_cannot_change_cohort_ecf
     return unless participant_profile&.ecf?
+    return if can_change_cohort_leaving_billable_declarations?
 
     if applicable_declarations.any? &&
         relevant_induction_record &&

--- a/spec/services/change_schedule_spec.rb
+++ b/spec/services/change_schedule_spec.rb
@@ -74,8 +74,8 @@ RSpec.shared_examples "changing cohort and continuing training" do
 
       it { expect(new_cohort).not_to eq(cohort) }
 
-      context "attempt_to_change_cohort_leaving_billable_declarations is true" do
-        let(:attempt_to_change_cohort_leaving_billable_declarations) { true }
+      context "allow_change_to_from_frozen_cohort is true" do
+        let(:allow_change_to_from_frozen_cohort) { true }
 
         context "when the participant is not eligible to transfer and continue training" do
           it { is_expected.to be_invalid }
@@ -92,8 +92,8 @@ RSpec.shared_examples "changing cohort and continuing training" do
         end
       end
 
-      context "when attempt_to_change_cohort_leaving_billable_declarations is false" do
-        let(:attempt_to_change_cohort_leaving_billable_declarations) { false }
+      context "when allow_change_to_from_frozen_cohort is false" do
+        let(:allow_change_to_from_frozen_cohort) { false }
 
         context "when the participant is eligible to transfer and continue training" do
           before { cohort.update!(payments_frozen_at: Time.zone.now) }
@@ -206,7 +206,7 @@ RSpec.describe ChangeSchedule do
       participant_id:,
       course_identifier:,
       schedule_identifier:,
-      attempt_to_change_cohort_leaving_billable_declarations:,
+      allow_change_to_from_frozen_cohort:,
     }
   end
   let(:participant_identity) { create(:participant_identity) }
@@ -222,7 +222,7 @@ RSpec.describe ChangeSchedule do
     let(:participant_profile) { create(:ect, lead_provider: cpd_lead_provider.lead_provider, user:, cohort:) }
     let(:schedule_identifier) { "ecf-standard-september" }
     let(:course_identifier) { "ecf-induction" }
-    let(:attempt_to_change_cohort_leaving_billable_declarations) { false }
+    let(:allow_change_to_from_frozen_cohort) { false }
     let!(:schedule) { Finance::Schedule::ECF.find_by(schedule_identifier: "ecf-standard-september", cohort:) }
     let(:new_cohort) { Cohort.previous }
     let!(:new_schedule) { create(:ecf_schedule, cohort: new_cohort, schedule_identifier: "ecf-replacement-april") }
@@ -244,7 +244,7 @@ RSpec.describe ChangeSchedule do
             course_identifier:,
             schedule_identifier:,
             cohort: new_cohort.start_year,
-            attempt_to_change_cohort_leaving_billable_declarations:,
+            allow_change_to_from_frozen_cohort:,
           }
         end
 
@@ -392,7 +392,7 @@ RSpec.describe ChangeSchedule do
             participant_id:,
             course_identifier:,
             schedule_identifier:,
-            attempt_to_change_cohort_leaving_billable_declarations:,
+            allow_change_to_from_frozen_cohort:,
             cohort: new_cohort.start_year,
           }
         end
@@ -431,7 +431,7 @@ RSpec.describe ChangeSchedule do
             participant_id:,
             course_identifier:,
             schedule_identifier: new_schedule.schedule_identifier,
-            attempt_to_change_cohort_leaving_billable_declarations:,
+            allow_change_to_from_frozen_cohort:,
             cohort:,
           }
         end
@@ -481,7 +481,7 @@ RSpec.describe ChangeSchedule do
     let!(:participant_profile) { create(:mentor, lead_provider: cpd_lead_provider.lead_provider, user:, cohort:) }
     let(:schedule_identifier) { "ecf-extended-april" }
     let(:course_identifier) { "ecf-mentor" }
-    let(:attempt_to_change_cohort_leaving_billable_declarations) { false }
+    let(:allow_change_to_from_frozen_cohort) { false }
     let(:new_cohort) { Cohort.previous }
     let!(:schedule) { create(:ecf_mentor_schedule, cohort:, schedule_identifier: "ecf-extended-april") }
 
@@ -501,7 +501,7 @@ RSpec.describe ChangeSchedule do
             participant_id:,
             course_identifier:,
             schedule_identifier:,
-            attempt_to_change_cohort_leaving_billable_declarations:,
+            allow_change_to_from_frozen_cohort:,
             cohort: new_cohort.start_year,
           }
         end
@@ -649,7 +649,7 @@ RSpec.describe ChangeSchedule do
     let(:participant_profile) { create(:npq_participant_profile, npq_lead_provider:, npq_course:, schedule:, user:, cohort:) }
     let(:course_identifier) { npq_course.identifier }
     let(:schedule_identifier) { new_schedule.schedule_identifier }
-    let(:attempt_to_change_cohort_leaving_billable_declarations) { false }
+    let(:allow_change_to_from_frozen_cohort) { false }
     let(:new_cohort) { Cohort.previous }
     let(:new_schedule) { Finance::Schedule::NPQ.find_by(cohort: new_cohort, schedule_identifier: "npq-leadership-spring") }
     let!(:npq_contract) { create(:npq_contract, :npq_senior_leadership, npq_lead_provider:, npq_course:) }
@@ -671,7 +671,7 @@ RSpec.describe ChangeSchedule do
             course_identifier:,
             schedule_identifier:,
             cohort: new_cohort.start_year,
-            attempt_to_change_cohort_leaving_billable_declarations:,
+            allow_change_to_from_frozen_cohort:,
           }
         end
 
@@ -700,8 +700,8 @@ RSpec.describe ChangeSchedule do
 
             before { create(:participant_declaration, participant_profile:, state:, course_identifier:, cpd_lead_provider:) }
 
-            context "attempt_to_change_cohort_leaving_billable_declarations is true" do
-              let(:attempt_to_change_cohort_leaving_billable_declarations) { true }
+            context "allow_change_to_from_frozen_cohort is true" do
+              let(:allow_change_to_from_frozen_cohort) { true }
 
               before { participant_profile.schedule.cohort.update!(payments_frozen_at: Time.zone.now) }
 

--- a/spec/services/change_schedule_spec.rb
+++ b/spec/services/change_schedule_spec.rb
@@ -72,7 +72,7 @@ RSpec.shared_examples "changing cohort and continuing training" do
 
       before { create(:participant_declaration, participant_profile:, cohort:, state:, course_identifier:, cpd_lead_provider:) }
 
-      it { expect(new_cohort).not_to eq(participant_profile.schedule.cohort) }
+      it { expect(new_cohort).not_to eq(cohort) }
 
       context "attempt_to_change_cohort_leaving_billable_declarations is true" do
         let(:attempt_to_change_cohort_leaving_billable_declarations) { true }
@@ -82,7 +82,7 @@ RSpec.shared_examples "changing cohort and continuing training" do
         end
 
         context "when the participant is eligible to transfer and continue training" do
-          before { participant_profile.schedule.cohort.update!(payments_frozen_at: Time.zone.now) }
+          before { cohort.update!(payments_frozen_at: Time.zone.now) }
 
           it_behaves_like "changing the schedule of a participant"
           it_behaves_like "reversing a change of schedule/cohort"
@@ -96,7 +96,7 @@ RSpec.shared_examples "changing cohort and continuing training" do
         let(:attempt_to_change_cohort_leaving_billable_declarations) { false }
 
         context "when the participant is eligible to transfer and continue training" do
-          before { participant_profile.schedule.cohort.update!(payments_frozen_at: Time.zone.now) }
+          before { cohort.update!(payments_frozen_at: Time.zone.now) }
 
           it { is_expected.to be_invalid }
         end

--- a/spec/support/shared_examples/change_cohort_and_continue_training_support.rb
+++ b/spec/support/shared_examples/change_cohort_and_continue_training_support.rb
@@ -9,7 +9,7 @@ RSpec.shared_examples "can change cohort and continue training" do |participant_
     let(:cpd_lead_provider) { eligible_participant.lead_provider.cpd_lead_provider }
     let(:eligible_participants) { create_list(declaration_type, 3, :payable, declaration_type: :started, cohort: Cohort.previous).map(&:participant_profile) }
     let(:eligible_participant) { eligible_participants.first }
-    let(:in_cohort_start_year) { Cohort.active_registration_cohort.start_year }
+    let(:cohort) { Cohort.active_registration_cohort }
 
     before do
       current_cohort.update!(payments_frozen_at: Time.zone.now)
@@ -33,9 +33,9 @@ RSpec.shared_examples "can change cohort and continue training" do |participant_
       end
     end
 
-    subject { described_class.eligible_to_change_cohort_and_continue_training(in_cohort_start_year:, restrict_to_participant_ids:) }
+    subject { described_class.eligible_to_change_cohort_and_continue_training(cohort:, restrict_to_participant_ids:) }
 
-    it { expect(current_cohort.start_year).not_to eq(in_cohort_start_year) }
+    it { expect(current_cohort).not_to eq(cohort) }
     it { is_expected.to contain_exactly(*eligible_participants) }
 
     context "when restricted to a set of participant IDs" do
@@ -49,25 +49,25 @@ RSpec.shared_examples "can change cohort and continue training" do |participant_
     let(:declaration) { create(declaration_type, :paid, declaration_type: :started, cohort: Cohort.previous) }
     let(:participant_profile) { declaration.participant_profile }
     let(:current_cohort) { participant_profile.schedule.cohort }
-    let(:in_cohort_start_year) { Cohort.active_registration_cohort.start_year }
+    let(:cohort) { Cohort.active_registration_cohort }
 
     before { current_cohort.update!(payments_frozen_at: Time.zone.now) }
 
     subject { participant_profile }
 
-    it { expect(current_cohort.start_year).not_to eq(in_cohort_start_year) }
-    it { is_expected.to be_eligible_to_change_cohort_and_continue_training(in_cohort_start_year:) }
+    it { expect(current_cohort).not_to eq(cohort) }
+    it { is_expected.to be_eligible_to_change_cohort_and_continue_training(cohort:) }
 
     context "when the participant is not in a payments frozen cohort" do
       before { current_cohort.update!(payments_frozen_at: nil) }
 
-      it { is_expected.not_to be_eligible_to_change_cohort_and_continue_training(in_cohort_start_year:) }
+      it { is_expected.not_to be_eligible_to_change_cohort_and_continue_training(cohort:) }
     end
 
     context "when the cohort they intend to continue training in is not the active registration cohort" do
-      let(:in_cohort_start_year) { Cohort.active_registration_cohort.previous }
+      let(:cohort) { Cohort.active_registration_cohort.previous }
 
-      it { is_expected.not_to be_eligible_to_change_cohort_and_continue_training(in_cohort_start_year:) }
+      it { is_expected.not_to be_eligible_to_change_cohort_and_continue_training(cohort:) }
     end
 
     %i[paid payable eligible].each do |billable_declaration_type|
@@ -84,20 +84,20 @@ RSpec.shared_examples "can change cohort and continue training" do |participant_
                  cpd_lead_provider: participant_profile.lead_provider.cpd_lead_provider)
         end
 
-        it { is_expected.not_to be_eligible_to_change_cohort_and_continue_training(in_cohort_start_year:) }
+        it { is_expected.not_to be_eligible_to_change_cohort_and_continue_training(cohort:) }
       end
     end
 
     context "when the participant does not have billable, not completed declarations" do
       before { declaration.destroy }
 
-      it { is_expected.not_to be_eligible_to_change_cohort_and_continue_training(in_cohort_start_year:) }
+      it { is_expected.not_to be_eligible_to_change_cohort_and_continue_training(cohort:) }
     end
 
     context "when the participant has a #{completed_training_at_attribute}" do
       before { participant_profile.update!("#{completed_training_at_attribute}": 1.month.ago) }
 
-      it { is_expected.not_to be_eligible_to_change_cohort_and_continue_training(in_cohort_start_year:) }
+      it { is_expected.not_to be_eligible_to_change_cohort_and_continue_training(cohort:) }
     end
   end
 
@@ -105,43 +105,43 @@ RSpec.shared_examples "can change cohort and continue training" do |participant_
     let(:declaration) { create(declaration_type, :paid, declaration_type: :started) }
     let(:participant_profile) { declaration.participant_profile }
     let(:current_cohort) { participant_profile.schedule.cohort }
-    let(:previous_cohort) { create(:cohort, payments_frozen_at: 1.week.ago, start_year: to_cohort_start_year) }
+    let(:cohort) { create(:cohort, payments_frozen_at: 1.week.ago, start_year: to_cohort_start_year) }
     let(:to_cohort_start_year) { current_cohort.start_year - 3 }
 
     before do
-      declaration.update!(cohort: previous_cohort)
+      declaration.update!(cohort:)
       participant_profile.update!(cohort_changed_after_payments_frozen: true)
-      previous_cohort.update!(payments_frozen_at: Time.zone.now)
+      cohort.update!(payments_frozen_at: Time.zone.now)
     end
 
     subject { participant_profile }
 
-    it { expect(current_cohort.start_year).not_to eq(to_cohort_start_year) }
-    it { is_expected.to be_eligible_to_change_cohort_back_to_their_payments_frozen_original(to_cohort_start_year:) }
+    it { expect(current_cohort).not_to eq(cohort) }
+    it { is_expected.to be_eligible_to_change_cohort_back_to_their_payments_frozen_original(cohort:) }
 
     context "when the participant does not have billable declarations in the previous cohort" do
       before { declaration.update!(state: :ineligible) }
 
-      it { is_expected.not_to be_eligible_to_change_cohort_back_to_their_payments_frozen_original(to_cohort_start_year:) }
+      it { is_expected.not_to be_eligible_to_change_cohort_back_to_their_payments_frozen_original(cohort:) }
     end
 
     context "when the previous cohort is not payments frozen" do
-      before { previous_cohort.update!(payments_frozen_at: nil) }
+      before { cohort.update!(payments_frozen_at: nil) }
 
-      it { is_expected.not_to be_eligible_to_change_cohort_back_to_their_payments_frozen_original(to_cohort_start_year:) }
+      it { is_expected.not_to be_eligible_to_change_cohort_back_to_their_payments_frozen_original(cohort:) }
     end
 
     context "when the participant is not cohort_changed_after_payments_frozen" do
       before { participant_profile.update!(cohort_changed_after_payments_frozen: false) }
 
-      it { is_expected.not_to be_eligible_to_change_cohort_back_to_their_payments_frozen_original(to_cohort_start_year:) }
+      it { is_expected.not_to be_eligible_to_change_cohort_back_to_their_payments_frozen_original(cohort:) }
     end
 
     %i[paid payable eligible submitted].each do |billable_or_changeable_declaration_type|
       context "when the participant has a #{billable_or_changeable_declaration_type} declaration for the current cohort" do
         before { create(declaration_type, :payable, declaration_type: "retained-1", participant_profile:, cpd_lead_provider: participant_profile.lead_provider.cpd_lead_provider) }
 
-        it { is_expected.not_to be_eligible_to_change_cohort_back_to_their_payments_frozen_original(to_cohort_start_year:) }
+        it { is_expected.not_to be_eligible_to_change_cohort_back_to_their_payments_frozen_original(cohort:) }
       end
     end
   end

--- a/spec/support/shared_examples/change_cohort_and_continue_training_support.rb
+++ b/spec/support/shared_examples/change_cohort_and_continue_training_support.rb
@@ -9,6 +9,7 @@ RSpec.shared_examples "can change cohort and continue training" do |participant_
     let(:cpd_lead_provider) { eligible_participant.lead_provider.cpd_lead_provider }
     let(:eligible_participants) { create_list(declaration_type, 3, :payable, declaration_type: :started).map(&:participant_profile) }
     let(:eligible_participant) { eligible_participants.first }
+    let(:in_cohort_start_year) { current_cohort.start_year + ParticipantProfile::ECF::CHANGE_COHORT_AND_CONTINUE_TRAINING_DELTA }
 
     before do
       current_cohort.update!(payments_frozen_at: Time.zone.now)
@@ -32,7 +33,7 @@ RSpec.shared_examples "can change cohort and continue training" do |participant_
       end
     end
 
-    subject { described_class.eligible_to_change_cohort_and_continue_training(restrict_to_participant_ids:) }
+    subject { described_class.eligible_to_change_cohort_and_continue_training(in_cohort_start_year:, restrict_to_participant_ids:) }
 
     it { is_expected.to contain_exactly(*eligible_participants) }
 
@@ -47,17 +48,28 @@ RSpec.shared_examples "can change cohort and continue training" do |participant_
     let(:declaration) { create(declaration_type, :paid, declaration_type: :started) }
     let(:participant_profile) { declaration.participant_profile }
     let(:current_cohort) { participant_profile.schedule.cohort }
+    let(:in_cohort_start_year) { current_cohort.start_year + ParticipantProfile::ECF::CHANGE_COHORT_AND_CONTINUE_TRAINING_DELTA }
 
     before { current_cohort.update!(payments_frozen_at: Time.zone.now) }
 
     subject { participant_profile }
 
-    it { is_expected.to be_eligible_to_change_cohort_and_continue_training }
+    it { is_expected.to be_eligible_to_change_cohort_and_continue_training(in_cohort_start_year:) }
 
     context "when the participant is not in a payments frozen cohort" do
       before { current_cohort.update!(payments_frozen_at: nil) }
 
-      it { is_expected.not_to be_eligible_to_change_cohort_and_continue_training }
+      it { is_expected.not_to be_eligible_to_change_cohort_and_continue_training(in_cohort_start_year:) }
+    end
+
+    context "when the participant is not in the correct payments frozen cohort" do
+      before do
+        schedule = create(:ecf_schedule, cohort: current_cohort.next)
+        current_cohort.next.update!(payments_frozen_at: Time.zone.now)
+        participant_profile.update!(schedule:)
+      end
+
+      it { is_expected.not_to be_eligible_to_change_cohort_and_continue_training(in_cohort_start_year:) }
     end
 
     %i[paid payable eligible].each do |billable_declaration_type|
@@ -74,20 +86,64 @@ RSpec.shared_examples "can change cohort and continue training" do |participant_
                  cpd_lead_provider: participant_profile.lead_provider.cpd_lead_provider)
         end
 
-        it { is_expected.not_to be_eligible_to_change_cohort_and_continue_training }
+        it { is_expected.not_to be_eligible_to_change_cohort_and_continue_training(in_cohort_start_year:) }
       end
     end
 
     context "when the participant does not have billable, not completed declarations" do
       before { declaration.destroy }
 
-      it { is_expected.not_to be_eligible_to_change_cohort_and_continue_training }
+      it { is_expected.not_to be_eligible_to_change_cohort_and_continue_training(in_cohort_start_year:) }
     end
 
     context "when the participant has a #{completed_training_at_attribute}" do
       before { participant_profile.update!("#{completed_training_at_attribute}": 1.month.ago) }
 
-      it { is_expected.not_to be_eligible_to_change_cohort_and_continue_training }
+      it { is_expected.not_to be_eligible_to_change_cohort_and_continue_training(in_cohort_start_year:) }
+    end
+  end
+
+  describe "#eligible_to_change_cohort_back_to_their_payments_frozen_original?" do
+    let(:declaration) { create(declaration_type, :paid, declaration_type: :started) }
+    let(:participant_profile) { declaration.participant_profile }
+    let(:current_cohort) { participant_profile.schedule.cohort }
+    let(:previous_cohort) { create(:cohort, payments_frozen_at: 1.week.ago, start_year: to_cohort_start_year) }
+    let(:to_cohort_start_year) { current_cohort.start_year - ParticipantProfile::ECF::CHANGE_COHORT_AND_CONTINUE_TRAINING_DELTA }
+
+    before do
+      declaration.update!(cohort: previous_cohort)
+      participant_profile.update!(cohort_changed_after_payments_frozen: true)
+      previous_cohort.update!(payments_frozen_at: Time.zone.now)
+    end
+
+    subject { participant_profile }
+
+    it { is_expected.to be_eligible_to_change_cohort_back_to_their_payments_frozen_original(to_cohort_start_year:) }
+
+    context "when the to_cohort_start_year is not 3 years before the current cohort" do
+      let(:to_cohort_start_year) { current_cohort.start_year - 1 }
+
+      it { is_expected.not_to be_eligible_to_change_cohort_back_to_their_payments_frozen_original(to_cohort_start_year:) }
+    end
+
+    context "when the previous cohort is not payments frozen" do
+      before { previous_cohort.update!(payments_frozen_at: nil) }
+
+      it { is_expected.not_to be_eligible_to_change_cohort_back_to_their_payments_frozen_original(to_cohort_start_year:) }
+    end
+
+    context "when the participant is not cohort_changed_after_payments_frozen" do
+      before { participant_profile.update!(cohort_changed_after_payments_frozen: false) }
+
+      it { is_expected.not_to be_eligible_to_change_cohort_back_to_their_payments_frozen_original(to_cohort_start_year:) }
+    end
+
+    %i[paid payable eligible submitted].each do |billable_or_changeable_declaration_type|
+      context "when the participant has a #{billable_or_changeable_declaration_type} declaration for the current cohort" do
+        before { create(declaration_type, :payable, declaration_type: "retained-1", participant_profile:, cpd_lead_provider: participant_profile.lead_provider.cpd_lead_provider) }
+
+        it { is_expected.not_to be_eligible_to_change_cohort_back_to_their_payments_frozen_original(to_cohort_start_year:) }
+      end
     end
   end
 end

--- a/spec/support/shared_examples/change_cohort_and_continue_training_support.rb
+++ b/spec/support/shared_examples/change_cohort_and_continue_training_support.rb
@@ -117,31 +117,31 @@ RSpec.shared_examples "can change cohort and continue training" do |participant_
     subject { participant_profile }
 
     it { expect(current_cohort).not_to eq(cohort) }
-    it { is_expected.to be_eligible_to_change_cohort_back_to_their_payments_frozen_original(cohort:) }
+    it { is_expected.to be_eligible_to_change_cohort_back_to_their_payments_frozen_original(cohort:, current_cohort:) }
 
     context "when the participant does not have billable declarations in the previous cohort" do
       before { declaration.update!(state: :ineligible) }
 
-      it { is_expected.not_to be_eligible_to_change_cohort_back_to_their_payments_frozen_original(cohort:) }
+      it { is_expected.not_to be_eligible_to_change_cohort_back_to_their_payments_frozen_original(cohort:, current_cohort:) }
     end
 
     context "when the previous cohort is not payments frozen" do
       before { cohort.update!(payments_frozen_at: nil) }
 
-      it { is_expected.not_to be_eligible_to_change_cohort_back_to_their_payments_frozen_original(cohort:) }
+      it { is_expected.not_to be_eligible_to_change_cohort_back_to_their_payments_frozen_original(cohort:, current_cohort:) }
     end
 
     context "when the participant is not cohort_changed_after_payments_frozen" do
       before { participant_profile.update!(cohort_changed_after_payments_frozen: false) }
 
-      it { is_expected.not_to be_eligible_to_change_cohort_back_to_their_payments_frozen_original(cohort:) }
+      it { is_expected.not_to be_eligible_to_change_cohort_back_to_their_payments_frozen_original(cohort:, current_cohort:) }
     end
 
     %i[paid payable eligible submitted].each do |billable_or_changeable_declaration_type|
       context "when the participant has a #{billable_or_changeable_declaration_type} declaration for the current cohort" do
         before { create(declaration_type, :payable, declaration_type: "retained-1", participant_profile:, cpd_lead_provider: participant_profile.lead_provider.cpd_lead_provider) }
 
-        it { is_expected.not_to be_eligible_to_change_cohort_back_to_their_payments_frozen_original(cohort:) }
+        it { is_expected.not_to be_eligible_to_change_cohort_back_to_their_payments_frozen_original(cohort:, current_cohort:) }
       end
     end
   end

--- a/spec/support/shared_examples/change_cohort_and_continue_training_support.rb
+++ b/spec/support/shared_examples/change_cohort_and_continue_training_support.rb
@@ -7,9 +7,9 @@ RSpec.shared_examples "can change cohort and continue training" do |participant_
     let(:current_cohort) { eligible_participant.schedule.cohort }
     let(:restrict_to_participant_ids) { [] }
     let(:cpd_lead_provider) { eligible_participant.lead_provider.cpd_lead_provider }
-    let(:eligible_participants) { create_list(declaration_type, 3, :payable, declaration_type: :started).map(&:participant_profile) }
+    let(:eligible_participants) { create_list(declaration_type, 3, :payable, declaration_type: :started, cohort: Cohort.previous).map(&:participant_profile) }
     let(:eligible_participant) { eligible_participants.first }
-    let(:in_cohort_start_year) { current_cohort.start_year + ParticipantProfile::ECF::CHANGE_COHORT_AND_CONTINUE_TRAINING_DELTA }
+    let(:in_cohort_start_year) { Cohort.active_registration_cohort.start_year }
 
     before do
       current_cohort.update!(payments_frozen_at: Time.zone.now)
@@ -35,6 +35,7 @@ RSpec.shared_examples "can change cohort and continue training" do |participant_
 
     subject { described_class.eligible_to_change_cohort_and_continue_training(in_cohort_start_year:, restrict_to_participant_ids:) }
 
+    it { expect(current_cohort.start_year).not_to eq(in_cohort_start_year) }
     it { is_expected.to contain_exactly(*eligible_participants) }
 
     context "when restricted to a set of participant IDs" do
@@ -45,15 +46,16 @@ RSpec.shared_examples "can change cohort and continue training" do |participant_
   end
 
   describe "#eligible_to_change_cohort_and_continue_training?" do
-    let(:declaration) { create(declaration_type, :paid, declaration_type: :started) }
+    let(:declaration) { create(declaration_type, :paid, declaration_type: :started, cohort: Cohort.previous) }
     let(:participant_profile) { declaration.participant_profile }
     let(:current_cohort) { participant_profile.schedule.cohort }
-    let(:in_cohort_start_year) { current_cohort.start_year + ParticipantProfile::ECF::CHANGE_COHORT_AND_CONTINUE_TRAINING_DELTA }
+    let(:in_cohort_start_year) { Cohort.active_registration_cohort.start_year }
 
     before { current_cohort.update!(payments_frozen_at: Time.zone.now) }
 
     subject { participant_profile }
 
+    it { expect(current_cohort.start_year).not_to eq(in_cohort_start_year) }
     it { is_expected.to be_eligible_to_change_cohort_and_continue_training(in_cohort_start_year:) }
 
     context "when the participant is not in a payments frozen cohort" do
@@ -62,12 +64,8 @@ RSpec.shared_examples "can change cohort and continue training" do |participant_
       it { is_expected.not_to be_eligible_to_change_cohort_and_continue_training(in_cohort_start_year:) }
     end
 
-    context "when the participant is not in the correct payments frozen cohort" do
-      before do
-        schedule = create(:ecf_schedule, cohort: current_cohort.next)
-        current_cohort.next.update!(payments_frozen_at: Time.zone.now)
-        participant_profile.update!(schedule:)
-      end
+    context "when the cohort they intend to continue training in is not the active registration cohort" do
+      let(:in_cohort_start_year) { Cohort.active_registration_cohort.previous }
 
       it { is_expected.not_to be_eligible_to_change_cohort_and_continue_training(in_cohort_start_year:) }
     end
@@ -108,7 +106,7 @@ RSpec.shared_examples "can change cohort and continue training" do |participant_
     let(:participant_profile) { declaration.participant_profile }
     let(:current_cohort) { participant_profile.schedule.cohort }
     let(:previous_cohort) { create(:cohort, payments_frozen_at: 1.week.ago, start_year: to_cohort_start_year) }
-    let(:to_cohort_start_year) { current_cohort.start_year - ParticipantProfile::ECF::CHANGE_COHORT_AND_CONTINUE_TRAINING_DELTA }
+    let(:to_cohort_start_year) { current_cohort.start_year - 3 }
 
     before do
       declaration.update!(cohort: previous_cohort)
@@ -118,10 +116,11 @@ RSpec.shared_examples "can change cohort and continue training" do |participant_
 
     subject { participant_profile }
 
+    it { expect(current_cohort.start_year).not_to eq(to_cohort_start_year) }
     it { is_expected.to be_eligible_to_change_cohort_back_to_their_payments_frozen_original(to_cohort_start_year:) }
 
-    context "when the to_cohort_start_year is not 3 years before the current cohort" do
-      let(:to_cohort_start_year) { current_cohort.start_year - 1 }
+    context "when the participant does not have billable declarations in the previous cohort" do
+      before { declaration.update!(state: :ineligible) }
 
       it { is_expected.not_to be_eligible_to_change_cohort_back_to_their_payments_frozen_original(to_cohort_start_year:) }
     end


### PR DESCRIPTION
### Context

We want to allow ECTs and mentors to change schedule/cohort even if they have billable declarations under certain scenarios.

The participants eligible are identified by `eligible_to_change_cohort_and_continue_training`.

Participants that change cohort using this mechanism should be able to change back to their original cohort providing no billable declarations were created against the new cohort.

### Changes proposed in this pull request

- Relax validation on ChangeSchedule service for certain participants 

By default the service will not allow eligible participants to transfer; it needs to be called explicitly with `attempt_to_transfer_leaving_billable_declarations` set to `true`. This is to prevent lead providers performing these changes for now.

### Guidance to review

A participant will be able to transfer if:

- `attempt_to_transfer_leaving_billable_declarations` is `true`
- their participant profile is `eligible_to_change_cohort_and_continue_training?`
- the cohort they are transferring to is the active registration cohort
- their current cohort has payments frozen

On transferring, the `cohort_changed_after_payments_frozen` will be `true`.

A participant will be able to transfer _back_ if:

- `attempt_to_transfer_leaving_billable_declarations` is `true`
- they have no billable declarations on the cohort they are leaving
- `cohort_changed_after_payments_frozen` is true on the profile
- they have billable declarations in the profile they are transferring back to
- the cohort they are transferring back to is `payments_frozen`

On transferring back, the `cohort_changed_after_payments_frozen` will be `false`.
