### PR TITLE
faked induction periods on magic dates needs to stick to DQT V3 syntax

### DIFF
--- a/app/services/dqt_record_check.rb
+++ b/app/services/dqt_record_check.rb
@@ -155,7 +155,7 @@ private
     if with_induction
       record.merge!("induction" => {
         "periods" => [
-          { "start_date" => induction_start_date },
+          { "startDate" => induction_start_date },
         ],
         "status" => "In Progress",
       })


### PR DESCRIPTION
### Context

Recently we changed the source where to pick induction start dates from DQT records from "induction", "start_date" to "induction", "periods", "startDate"

Magic dates need to get updated to the camelCase syntax coming from DQT V3.

- Ticket: 

### Changes proposed in this pull request

### Guidance to review

