### PR TITLE
Enable time travelling in the API in staging

### DIFF
--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -8,6 +8,8 @@ Rails.application.configure do
   # Code is not reloaded between requests.
   config.cache_classes = true
 
+  # Used to handle HTTP_X_WITH_SERVER_DATE header for server side datetime overwrite
+  config.middleware.use TimeTraveler
   config.middleware.use ApiRequestMiddleware
 
   # Eager load code on boot. This eager loads most of Rails and


### PR DESCRIPTION
to help with testing declarations

### Context

- Ticket: n/a

### Changes proposed in this pull request
To allow testing cohort 2024 in staging we need to allow setting the `X-With-Server-Date`. This allows creating declarations in the future

### Guidance to review

