### PR TITLE
Pin azurerm version to 3.104.2 as the latest 3.105.0 version made the build to fail

### DIFF
--- a/terraform/application/terraform.tf
+++ b/terraform/application/terraform.tf
@@ -4,6 +4,10 @@ terraform {
   backend "azurerm" {}
 
   required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "3.104.2"
+    }
     statuscake = {
       source  = "StatusCakeDev/statuscake"
       version = ">= 2.0.5"

--- a/terraform/custom_domains/environment_domains/terraform.tf
+++ b/terraform/custom_domains/environment_domains/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.69.0"
+      version = "3.104.2"
     }
   }
   backend "azurerm" {

--- a/terraform/custom_domains/infrastructure/terraform.tf
+++ b/terraform/custom_domains/infrastructure/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.69.0"
+      version = "3.104.2"
     }
   }
   backend "azurerm" {


### PR DESCRIPTION
### Context

We're fetching the latest version of `azurerm 3.105.0` which is now defaulting `public_network_access_enabled` from false to true.

`public_network_access_enabled = false -> true`
https://github.com/DFE-Digital/early-careers-framework/actions/runs/9222398909/job/25374325095

### Changes proposed in this pull request

We need to pin/fix the version to the previous version `3.104.2` for now.

Ideally we'd need to set the variable as false in module https://github.com/DFE-Digital/terraform-modules/blob/main/aks/postgres/resources.tf#L39 but that'd cause many projects to get upgraded.
