### PR TITLE
CST-2558: newly registered participants with induction start date in …

### DIFF
--- a/app/forms/schools/add_participants/base_wizard.rb
+++ b/app/forms/schools/add_participants/base_wizard.rb
@@ -467,8 +467,9 @@ module Schools
         if transfer?
           existing_participant_cohort || existing_participant_profile&.schedule&.cohort
         elsif ect_participant? && induction_start_date.present?
-          Cohort.containing_date(induction_start_date).tap do |cohort|
+          Cohort.for_induction_start_date(induction_start_date).tap do |cohort|
             return Cohort.current if cohort.blank? || cohort.npq_plus_one_or_earlier?
+            return Cohort.active_registration_cohort if cohort.payments_frozen?
           end
         elsif Cohort.within_automatic_assignment_period?
           # true from 1/9 to end of automatic assignment period

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Cohort, type: :model do
-  let!(:cohort_2024) { FactoryBot.create :seed_cohort, start_year: 2024 }
+  let!(:cohort_2024) { Cohort.find_by_start_year(2024) }
 
   describe "associations" do
     it { is_expected.to have_many(:call_off_contracts) }


### PR DESCRIPTION
…payments-frozen cohort are now placed in the cohort currently open for registration

### Context

As part of the journey that allows a SIT to add a new ECT to their school there is some logic behind the scenes to determine and sit the participant in a provisional/temporary cohort.

We need to extend that logic to sit in 2024/25 cohort a potential new participant whose DQT induction start date at the time of registration would sit the participant in 2021/22 cohort.

- [Ticket](https://dfedigital.atlassian.net/browse/CST-2558): 

### Changes proposed in this pull request

### Guidance to review

