### PR TITLE
Make initial cohort start date a constant

### DIFF
--- a/app/forms/schools/add_participants/wizard_steps/start_date_step.rb
+++ b/app/forms/schools/add_participants/wizard_steps/start_date_step.rb
@@ -45,7 +45,7 @@ module Schools
             begin
               @start_date = Date.parse (1..3).map { |n| start_date[n] }.join("/")
 
-              unless start_date.between?(Date.new(2021, 9, 1), Date.current + 1.year)
+              unless start_date.between?(Cohort::INITIAL_COHORT_START_DATE, Date.current + 1.year)
                 errors.add(:start_date, :invalid)
               end
             rescue Date::Error

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -5,6 +5,7 @@ class Cohort < ApplicationRecord
 
   NPQ_PLUS_1_YEAR = 2020
   OPEN_COHORTS_COUNT = 3
+  INITIAL_COHORT_START_DATE = Date.new(2021, 9, 1)
 
   has_many :call_off_contracts
   has_many :npq_contracts
@@ -44,7 +45,7 @@ class Cohort < ApplicationRecord
   #   - The previous date's year cohort if the date is before Jun or
   #   - the cohort starting the date's year otherwise.
   def self.for_induction_start_date(date)
-    return current if date < Date.new(2021, 9, 1)
+    return current if date < INITIAL_COHORT_START_DATE
 
     Cohort.find_by_start_year(date.month < 6 ? date.year - 1 : date.year)
   end

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -3,7 +3,7 @@
 class ParticipantProfile::ECF < ParticipantProfile
   # self.ignored_columns = %i[school_id]
 
-  POST_TRANSITIONAL_INDUCTION_START_DATE_DEADLINE = ActiveSupport::TimeZone["London"].local(2021, 9, 1).freeze
+  POST_TRANSITIONAL_INDUCTION_START_DATE_DEADLINE = ActiveSupport::TimeZone["London"].parse(Cohort::INITIAL_COHORT_START_DATE.to_s).freeze
   VALID_EVIDENCE_HELD = %w[training-event-attended self-study-material-completed other].freeze
   COURSE_IDENTIFIERS = %w[ecf-mentor ecf-induction].freeze
   WITHDRAW_REASONS = %w[

--- a/app/services/participant_validation_service.rb
+++ b/app/services/participant_validation_service.rb
@@ -44,7 +44,7 @@ private
     return false if validation_data.induction_in_progress?
 
     # this should always be a check against 2021 not Cohort.current.start_year
-    validation_data.induction_start_date < ActiveSupport::TimeZone["London"].local(2021, 9, 1)
+    validation_data.induction_start_date < ActiveSupport::TimeZone["London"].parse(Cohort::INITIAL_COHORT_START_DATE.to_s)
   end
 
   def check_first_name_only?

--- a/app/services/participants/sync_dqt_induction_start_date.rb
+++ b/app/services/participants/sync_dqt_induction_start_date.rb
@@ -2,7 +2,7 @@
 
 module Participants
   class SyncDQTInductionStartDate < BaseService
-    FIRST_2021_ACADEMIC_DATE = Date.new(2021, 9, 1)
+    FIRST_2021_ACADEMIC_DATE = Cohort::INITIAL_COHORT_START_DATE
     FIRST_2023_REGISTRATION_DATE = Cohort.find_by(start_year: 2023)&.registration_start_date || Date.new(2023, 6, 1)
 
     def initialize(dqt_induction_start_date, participant_profile)


### PR DESCRIPTION
### Context

We (re)declare this significant date throughout the codebase, it refers to the start date of the initial cohort. Using a constant would clarify that.

- Ticket: 

### Changes proposed in this pull request

Use a constant instead of repeatedly re-declaring this date.

### Guidance to review

