### PR TITLE
Flag multi cohort participants in admin dashboard

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -54,7 +54,6 @@ module AdminHelper
     full_name = profile.full_name
     role = admin_participant_role_name(profile.class.name)
     trn = profile.teacher_profile.trn
-    start_year = presenter.start_year
 
     visually_hidden = tag.span(" - #{section}", class: "govuk-visually-hidden")
 
@@ -75,7 +74,7 @@ module AdminHelper
         safe_join(
           [
             tag.span("Cohort: ", class: "govuk-body govuk-!-font-weight-bold"),
-            start_year,
+            presenter.detailed_cohort_information,
           ],
         )
       end,

--- a/app/presenters/admin/participant_presenter.rb
+++ b/app/presenters/admin/participant_presenter.rb
@@ -21,6 +21,19 @@ class Admin::ParticipantPresenter
     relevant_cohort_location.cohort
   end
 
+  def detailed_cohort_information
+    current_cohort = cohort&.start_year
+
+    return current_cohort unless participant_profile.cohort_changed_after_payments_frozen
+
+    original_cohort = participant_profile.participant_declarations
+      .includes(:cohort)
+      .where.not(cohort: { start_year: current_cohort })
+      .pick("cohort.start_year")
+
+    "#{current_cohort} (migrated after #{original_cohort || 'unknown cohort'} payments were frozen)"
+  end
+
   def declarations
     @declarations ||= @participant_profile
                         .participant_declarations


### PR DESCRIPTION
[Jira-3140](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3140)

### Context

We want it to be clear in the admin dashboard participants view when a participant has migrated from a cohort due to the payments being frozen.

### Changes proposed in this pull request

- Expose multi cohort in admin dashboard

### Guidance to review

| No cohort change    | Cohort change | Cohort change (edge case) |
| -------- | ------- | --------- |
| <img width="1202" alt="Screenshot 2024-05-29 at 09 38 14" src="https://github.com/DFE-Digital/early-careers-framework/assets/29867726/b07cd535-15c4-406c-a97f-1efce768ce5b"> | <img width="1202" alt="Screenshot 2024-05-29 at 09 39 00" src="https://github.com/DFE-Digital/early-careers-framework/assets/29867726/8d182363-04c3-4150-82b4-ca1e09aa6c14"> |  <img width="1202" alt="Screenshot 2024-05-29 at 09 38 39" src="https://github.com/DFE-Digital/early-careers-framework/assets/29867726/683a274b-0faf-4223-93c5-4dea4190e55e"> |








