### PR TITLE
Flag multi cohort participants to providers

### DIFF
--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -99,6 +99,10 @@ class Cohort < ApplicationRecord
     self.class.find_by(start_year: start_year - 1)
   end
 
+  def freeze_payments!
+    update!(payments_frozen_at: Time.zone.now)
+  end
+
   # e.g. "2022"
   def to_param
     start_year.to_s

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -110,6 +110,16 @@ class ParticipantProfile::ECF < ParticipantProfile
     self.class.archivable(restrict_to_participant_ids: [id]).exists?
   end
 
+  def previous_payments_frozen_cohort
+    return nil unless cohort_changed_after_payments_frozen?
+
+    participant_declarations
+      .includes(:cohort)
+      .where.not(cohort: { payments_frozen_at: nil })
+      .where.not(cohort: schedule.cohort)
+      .pick("cohort.start_year")
+  end
+
   def completed_induction?
     induction_completion_date.present?
   end

--- a/app/presenters/admin/participant_presenter.rb
+++ b/app/presenters/admin/participant_presenter.rb
@@ -26,10 +26,7 @@ class Admin::ParticipantPresenter
 
     return current_cohort unless participant_profile.cohort_changed_after_payments_frozen
 
-    original_cohort = participant_profile.participant_declarations
-      .includes(:cohort)
-      .where.not(cohort: { start_year: current_cohort })
-      .pick("cohort.start_year")
+    original_cohort = participant_profile.previous_payments_frozen_cohort
 
     "#{current_cohort} (migrated after #{original_cohort || 'unknown cohort'} payments were frozen)"
   end

--- a/app/serializers/api/v3/ecf/participant_serializer.rb
+++ b/app/serializers/api/v3/ecf/participant_serializer.rb
@@ -140,8 +140,9 @@ module Api
               created_at: profile.created_at.rfc3339,
               induction_end_date: profile.induction_completion_date&.strftime("%Y-%m-%d"),
               mentor_funding_end_date: profile.mentor_completion_date&.strftime("%Y-%m-%d"),
-              previous_payments_frozen_cohort: profile.previous_payments_frozen_cohort,
-            }
+            }.tap do |hash|
+              hash[:previous_payments_frozen_cohort] = profile.previous_payments_frozen_cohort if FeatureFlag.active?(:previous_payments_frozen_cohort)
+            end
           }.compact
         end
 

--- a/app/serializers/api/v3/ecf/participant_serializer.rb
+++ b/app/serializers/api/v3/ecf/participant_serializer.rb
@@ -141,7 +141,7 @@ module Api
               induction_end_date: profile.induction_completion_date&.strftime("%Y-%m-%d"),
               mentor_funding_end_date: profile.mentor_completion_date&.strftime("%Y-%m-%d"),
             }.tap do |hash|
-              hash[:previous_payments_frozen_cohort] = profile.previous_payments_frozen_cohort if FeatureFlag.active?(:previous_payments_frozen_cohort)
+              hash[:cohort_changed_after_payments_frozen] = profile.cohort_changed_after_payments_frozen if FeatureFlag.active?(:cohort_changed_after_payments_frozen)
             end
           }.compact
         end

--- a/app/serializers/api/v3/ecf/participant_serializer.rb
+++ b/app/serializers/api/v3/ecf/participant_serializer.rb
@@ -140,6 +140,7 @@ module Api
               created_at: profile.created_at.rfc3339,
               induction_end_date: profile.induction_completion_date&.strftime("%Y-%m-%d"),
               mentor_funding_end_date: profile.mentor_completion_date&.strftime("%Y-%m-%d"),
+              previous_payments_frozen_cohort: profile.previous_payments_frozen_cohort,
             }
           }.compact
         end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -24,6 +24,7 @@ class FeatureFlag
     prevent_2023_ect_registrations
     school_participant_status_language
     npq_capping
+    previous_payments_frozen_cohort
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).index_with { |name|

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -24,7 +24,7 @@ class FeatureFlag
     prevent_2023_ect_registrations
     school_participant_status_language
     npq_capping
-    previous_payments_frozen_cohort
+    cohort_changed_after_payments_frozen
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).index_with { |name|

--- a/spec/factories/cohorts.rb
+++ b/spec/factories/cohorts.rb
@@ -27,6 +27,10 @@ FactoryBot.define do
       start_year { Date.current.year + (Date.current.month < 9 ? 0 : 1) }
     end
 
+    trait :payments_frozen do
+      payments_frozen_at { Time.zone.now }
+    end
+
     trait :consecutive_years do
       start_year { generate(:base_year) }
     end

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -200,6 +200,16 @@ RSpec.describe Cohort, type: :model do
     end
   end
 
+  describe "#freeze_payments!" do
+    let(:cohort) { Cohort.previous }
+
+    it "sets payments_frozen_at to the current time" do
+      freeze_time do
+        expect { cohort.freeze_payments! }.to change { cohort.payments_frozen_at }.from(nil).to(Time.zone.now)
+      end
+    end
+  end
+
   describe "#schedules" do
     subject { described_class.create!(start_year: 3000) }
 

--- a/spec/models/participant_profile/ecf_spec.rb
+++ b/spec/models/participant_profile/ecf_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe ParticipantProfile::ECF, type: :model do
     it { is_expected.to be_nil }
 
     context "when payments were frozen on a previous cohort" do
-      let(:previous_cohort) { Cohort.previous.tap { |c| c.update!(payments_frozen_at: Time.zone.now) } }
+      let(:previous_cohort) { Cohort.previous.tap(&:freeze_payments!) }
       let(:cpd_lead_provider) { participant_profile.lead_provider.cpd_lead_provider }
       let(:participant_profile) { create(:ect, cohort_changed_after_payments_frozen: true) }
 

--- a/spec/models/participant_profile/ecf_spec.rb
+++ b/spec/models/participant_profile/ecf_spec.rb
@@ -262,6 +262,26 @@ RSpec.describe ParticipantProfile::ECF, type: :model do
     end
   end
 
+  describe "#previous_payments_frozen_cohort" do
+    let(:participant_profile) { create(:ect) }
+
+    subject { participant_profile.previous_payments_frozen_cohort }
+
+    it { is_expected.to be_nil }
+
+    context "when payments were frozen on a previous cohort" do
+      let(:previous_cohort) { Cohort.previous.tap { |c| c.update!(payments_frozen_at: Time.zone.now) } }
+      let(:cpd_lead_provider) { participant_profile.lead_provider.cpd_lead_provider }
+      let(:participant_profile) { create(:ect, cohort_changed_after_payments_frozen: true) }
+
+      before do
+        create(:participant_declaration, participant_profile:, cohort: previous_cohort, state: :paid, cpd_lead_provider:, course_identifier: "ecf-induction")
+      end
+
+      it { is_expected.to eq(previous_cohort.start_year) }
+    end
+  end
+
   describe "#withdrawn_for" do
     let(:cpd_lead_provider) { subject.induction_records.latest&.cpd_lead_provider }
 

--- a/spec/presenters/admin/participant_presenter_spec.rb
+++ b/spec/presenters/admin/participant_presenter_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe(Admin::ParticipantPresenter) do
           end
 
           context "when the previous cohort can be determined" do
-            let(:previous_cohort) { Cohort.previous }
+            let(:previous_cohort) { Cohort.previous.tap { |c| c.update!(payments_frozen_at: Time.zone.now) } }
             let(:cpd_lead_provider) { participant_profile.lead_provider.cpd_lead_provider }
             let(:course_identifier) { "ecf-induction" }
 

--- a/spec/presenters/admin/participant_presenter_spec.rb
+++ b/spec/presenters/admin/participant_presenter_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe(Admin::ParticipantPresenter) do
           end
 
           context "when the previous cohort can be determined" do
-            let(:previous_cohort) { Cohort.previous.tap { |c| c.update!(payments_frozen_at: Time.zone.now) } }
+            let(:previous_cohort) { Cohort.previous.tap(&:freeze_payments!) }
             let(:cpd_lead_provider) { participant_profile.lead_provider.cpd_lead_provider }
             let(:course_identifier) { "ecf-induction" }
 

--- a/spec/serializers/api/v3/ecf/participant_serializer_spec.rb
+++ b/spec/serializers/api/v3/ecf/participant_serializer_spec.rb
@@ -17,6 +17,7 @@ module Api
           let!(:ect_profile) { create(:ect, :eligible_for_funding, school_cohort:, user: participant, induction_completion_date: Date.parse("2022-01-12"), cohort_changed_after_payments_frozen: true) }
           let(:previous_cohort) { Cohort.previous.tap(&:freeze_payments!) }
           let!(:previous_cohort_declaration) { create(:participant_declaration, participant_profile: ect_profile, cohort: previous_cohort, state: :paid, cpd_lead_provider:, course_identifier: "ecf-induction") }
+          let(:ecf_enrolments) { result[:data][0][:attributes][:ecf_enrolments] }
 
           before { freeze_time }
 
@@ -59,12 +60,35 @@ module Api
                       created_at: ect_profile.created_at.rfc3339,
                       induction_end_date: "2022-01-12",
                       mentor_funding_end_date: nil,
-                      previous_payments_frozen_cohort: previous_cohort.start_year,
                     },
                   ],
                 participant_id_changes: [],
               },
             ])
+          end
+
+          context "when the previous_payments_frozen_cohort feature flag is active" do
+            before { FeatureFlag.activate(:previous_payments_frozen_cohort) }
+
+            it "includes the previous_payments_frozen_cohort" do
+              expect(ecf_enrolments[0][:previous_payments_frozen_cohort]).to eql(previous_cohort.start_year)
+            end
+
+            context "when the participant has not changed cohort after payments were frozen" do
+              before { ect_profile.update!(cohort_changed_after_payments_frozen: false) }
+
+              it "does not include the previous_payments_frozen_cohort" do
+                expect(ecf_enrolments[0][:previous_payments_frozen_cohort]).to be_nil
+              end
+            end
+          end
+
+          context "when the previous_payments_frozen feature flag is not active" do
+            before { FeatureFlag.deactivate(:previous_payments_frozen_cohort) }
+
+            it "does not include the previous_payments_frozen_cohort" do
+              expect(ecf_enrolments[0]).not_to have_key(:previous_payments_frozen_cohort)
+            end
           end
 
           describe "ecf_enrolments" do
@@ -73,19 +97,20 @@ module Api
               let!(:mentor_profile) { create(:mentor, school_cohort: another_school_cohort, user: participant) }
 
               it "only includes enrolments from the querying provider" do
-                expect(result[:data][0][:attributes][:ecf_enrolments].size).to be(1)
+                expect(ecf_enrolments.size).to be(1)
               end
             end
 
             context "when there are multiple profiles involved" do
               let!(:mentor_profile) { create(:mentor, school_cohort:, user: participant) }
+              let(:mentor_enrolement) { ecf_enrolments.find { |efce| efce[:participant_type] == :mentor } }
 
               before do
                 mentor_profile.update!(mentor_completion_date: Date.new(2021, 4, 19))
               end
 
               it "includes the second profile data" do
-                expect(result[:data][0][:attributes][:ecf_enrolments].find { |efce| efce[:participant_type] == :mentor }).to eq({
+                expect(mentor_enrolement).to eq({
                   training_record_id: mentor_profile.id,
                   email: participant.email,
                   mentor_id: nil,
@@ -105,7 +130,6 @@ module Api
                   created_at: mentor_profile.created_at.rfc3339,
                   induction_end_date: nil,
                   mentor_funding_end_date: "2021-04-19",
-                  previous_payments_frozen_cohort: nil,
                 })
               end
             end
@@ -117,8 +141,8 @@ module Api
               end
 
               it "includes a withdrawal object" do
-                expect(result[:data][0][:attributes][:ecf_enrolments][0][:withdrawal][:reason]).to eq("other")
-                expect(result[:data][0][:attributes][:ecf_enrolments][0][:withdrawal][:date]).to eql(ect_profile.participant_profile_state.created_at.rfc3339)
+                expect(ecf_enrolments[0][:withdrawal][:reason]).to eq("other")
+                expect(ecf_enrolments[0][:withdrawal][:date]).to eql(ect_profile.participant_profile_state.created_at.rfc3339)
               end
             end
 
@@ -129,8 +153,8 @@ module Api
               end
 
               it "includes a deferral object" do
-                expect(result[:data][0][:attributes][:ecf_enrolments][0][:deferral][:reason]).to eq("other")
-                expect(result[:data][0][:attributes][:ecf_enrolments][0][:deferral][:date]).to eql(ect_profile.participant_profile_state.created_at.rfc3339)
+                expect(ecf_enrolments[0][:deferral][:reason]).to eq("other")
+                expect(ecf_enrolments[0][:deferral][:date]).to eql(ect_profile.participant_profile_state.created_at.rfc3339)
               end
             end
 
@@ -147,7 +171,7 @@ module Api
               subject { described_class.new([participant_from_query], params: { cpd_lead_provider: }) }
 
               it "selects the latest induction record correctly" do
-                expect(result[:data][0][:attributes][:ecf_enrolments][0][:email]).to eq(latest_induction_record.preferred_identity.email)
+                expect(ecf_enrolments[0][:email]).to eq(latest_induction_record.preferred_identity.email)
               end
             end
           end

--- a/spec/serializers/api/v3/ecf/participant_serializer_spec.rb
+++ b/spec/serializers/api/v3/ecf/participant_serializer_spec.rb
@@ -15,7 +15,7 @@ module Api
           let!(:provider_relationship) { create(:provider_relationship, cohort:, delivery_partner:, lead_provider: cpd_lead_provider.lead_provider) }
           let(:participant) { create(:user) }
           let!(:ect_profile) { create(:ect, :eligible_for_funding, school_cohort:, user: participant, induction_completion_date: Date.parse("2022-01-12"), cohort_changed_after_payments_frozen: true) }
-          let(:previous_cohort) { Cohort.previous.tap { |c| c.update!(payments_frozen_at: Time.zone.now) } }
+          let(:previous_cohort) { Cohort.previous.tap(&:freeze_payments!) }
           let!(:previous_cohort_declaration) { create(:participant_declaration, participant_profile: ect_profile, cohort: previous_cohort, state: :paid, cpd_lead_provider:, course_identifier: "ecf-induction") }
 
           before { freeze_time }

--- a/spec/serializers/api/v3/ecf/participant_serializer_spec.rb
+++ b/spec/serializers/api/v3/ecf/participant_serializer_spec.rb
@@ -67,27 +67,27 @@ module Api
             ])
           end
 
-          context "when the previous_payments_frozen_cohort feature flag is active" do
-            before { FeatureFlag.activate(:previous_payments_frozen_cohort) }
+          context "when the cohort_changed_after_payments_frozen feature flag is active" do
+            before { FeatureFlag.activate(:cohort_changed_after_payments_frozen) }
 
-            it "includes the previous_payments_frozen_cohort" do
-              expect(ecf_enrolments[0][:previous_payments_frozen_cohort]).to eql(previous_cohort.start_year)
+            it "includes the cohort_changed_after_payments_frozen" do
+              expect(ecf_enrolments[0][:cohort_changed_after_payments_frozen]).to be(true)
             end
 
             context "when the participant has not changed cohort after payments were frozen" do
               before { ect_profile.update!(cohort_changed_after_payments_frozen: false) }
 
-              it "does not include the previous_payments_frozen_cohort" do
-                expect(ecf_enrolments[0][:previous_payments_frozen_cohort]).to be_nil
+              it "does not include the cohort_changed_after_payments_frozen" do
+                expect(ecf_enrolments[0][:cohort_changed_after_payments_frozen]).to be(false)
               end
             end
           end
 
           context "when the previous_payments_frozen feature flag is not active" do
-            before { FeatureFlag.deactivate(:previous_payments_frozen_cohort) }
+            before { FeatureFlag.deactivate(:cohort_changed_after_payments_frozen) }
 
-            it "does not include the previous_payments_frozen_cohort" do
-              expect(ecf_enrolments[0]).not_to have_key(:previous_payments_frozen_cohort)
+            it "does not include the cohort_changed_after_payments_frozen" do
+              expect(ecf_enrolments[0]).not_to have_key(:cohort_changed_after_payments_frozen)
             end
           end
 

--- a/spec/support/shared_examples/archivable_support.rb
+++ b/spec/support/shared_examples/archivable_support.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples "can archive participant profile" do |other_participant_type, completed_training_at_attribute|
-  let(:eligible_cohort) { create(:cohort, :current, payments_frozen_at: Time.zone.now) }
+  let(:eligible_cohort) { create(:cohort, :current, :payments_frozen) }
   let(:ineligible_cohort) { eligible_cohort.next }
 
   def build_profile(attrs = {})

--- a/spec/support/shared_examples/change_cohort_and_continue_training_support.rb
+++ b/spec/support/shared_examples/change_cohort_and_continue_training_support.rb
@@ -12,7 +12,7 @@ RSpec.shared_examples "can change cohort and continue training" do |participant_
     let(:cohort) { Cohort.active_registration_cohort }
 
     before do
-      current_cohort.update!(payments_frozen_at: Time.zone.now)
+      current_cohort.freeze_payments!
 
       # Extra declaration on the same participant to ensure the results are distinct.
       create(declaration_type, :payable, declaration_type: :"retained-1", participant_profile: eligible_participant, cpd_lead_provider:)
@@ -51,7 +51,7 @@ RSpec.shared_examples "can change cohort and continue training" do |participant_
     let(:current_cohort) { participant_profile.schedule.cohort }
     let(:cohort) { Cohort.active_registration_cohort }
 
-    before { current_cohort.update!(payments_frozen_at: Time.zone.now) }
+    before { current_cohort.freeze_payments! }
 
     subject { participant_profile }
 


### PR DESCRIPTION
[Jira-3145](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3145)

### Context

When a participant is migrated from a payments frozen cohort, we want to expose this to lead providers in the participant response so that they can identify them.

### Changes proposed in this pull request

- Expose previous, frozen cohort to lead providers

Add `previous_payments_frozen_cohort` field to participant serializers that will be `nil` if the participant has not migrated cohort due to payments being frozen and will be the cohort start year of the frozen cohort if they have been migrated.

- Update ParticipantPresenter to use previous_payments_frozen_cohort

This was added for the serializers and we may as well use it here as well. It also contains an extra check to make sure the previous cohort is frozen, in case the participant moved cohort using the normal schedule change and then migrated cohort due to payments being frozen.

- Add freeze_payments! convenience method to Cohort

Add a convenience method to freeze payments on a cohort and also add a trait to the cohorts factory for creating frozen cohorts.

- Wrap previous_payments_frozen_cohort in feature flag

We only want to display this in sandbox initially.

- Change cohort_changed_after_payments_frozen flag to boolean

Change the flag to indicate a participant migrated cohorts due to payments being frozen on their original cohort to a boolean value for better performance. Rename to `cohort_changed_after_payments_frozen`.

### Guidance to review

This will be enabled in the `migration` environment initially and without documentation/release notes.
