### PR TITLE
Write use of `method_missing` in page objects helper to file

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -114,6 +114,12 @@ RSpec.configure do |config|
   config.include Capybara::RSpecMatchers, type: :component
   config.include Rails.application.routes.url_helpers
 
+  config.add_setting :methods_missing_reporter
+  methods_missing_reporter = RSpec::Core::Reporter.new(config)
+  formatter = RSpec::Core::Formatters::BaseTextFormatter.new(File.open("tmp/rspec-magic-page-object-methods.txt", "wb"))
+  methods_missing_reporter.register_listener(formatter, "message")
+  config.methods_missing_reporter = methods_missing_reporter
+
   config.before(:each, exceptions_app: true) do
     # Make the app behave how it does in non dev/test environments and use the
     # ErrorsController via config.exceptions_app = routes in config/application.rb

--- a/spec/support/features/steps/generic_page_object_steps.rb
+++ b/spec/support/features/steps/generic_page_object_steps.rb
@@ -24,9 +24,12 @@ module Steps
         page_object = page_object.new
       end
 
-      puts "Called non-existing method #{method_symbol}"
-      puts "Call was re-rerouted to #{page_object_name.camelize}##{method_name} with query_params: #{query_params}, query_values: #{query_values}"
-      puts "Please create your own method, we are planning to delete this helper"
+      RSpec.configuration.methods_missing_reporter&.message([
+        "Missing method: #{method_symbol}",
+        "Generic call: #{page_object_name.camelize}##{method_name}",
+        "Query params: #{query_params}",
+        "Query values: #{query_values}",
+      ].join(", "))
 
       generic_call page_object, method_name, query_params, query_values
     end


### PR DESCRIPTION
### Context

We get a lot of `puts` messages about calls to missing page object methods which write to stdout.

- Ticket: 

### Changes proposed in this pull request

Instead of filling stdout with messages about these missing page object method calls, log them in a file per RSpec suite run.

### Guidance to review

