### PR TITLE
CST-2559: closing 2021 - transfer ect journey - take into account 2021 closing in cohort determination logic

### DIFF
--- a/app/forms/schools/add_participants/base_wizard.rb
+++ b/app/forms/schools/add_participants/base_wizard.rb
@@ -461,12 +461,12 @@ module Schools
         @participant_cohort ||= cohort_to_place_participant
       end
 
-      # NOTE: not preventing registration here just determining where to put the participant
       def cohort_to_place_participant
         return cohort_for_transfer if transfer?
         return cohort_for_ect_with_induction_start_date if ect_participant? && induction_start_date.present?
+        return Cohort.current if Cohort.within_automatic_assignment_period?
 
-        Cohort.within_automatic_assignment_period? ? Cohort.current : Cohort.next
+        Cohort.next
       end
 
       def cohort_for_ect_with_induction_start_date

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -110,11 +110,11 @@ class ParticipantProfile::ECF < ParticipantProfile
     self.class.archivable(restrict_to_participant_ids: [id]).exists?
   end
 
-  # def with_completion_date_or_declaration?
-  #   induction_completion_date.present? ||
-  #     participant_declarations.billable.for_declaration(:completed).exists? ||
-  #     latest_induction_record.completed_induction_status?
-  # end
+  def with_completion_date_status_or_declaration?
+    induction_completion_date.present? ||
+      participant_declarations.billable.for_declaration(:completed).exists? ||
+      latest_induction_record&.completed_induction_status?
+  end
 
   def completed_induction?
     induction_completion_date.present?

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -110,6 +110,12 @@ class ParticipantProfile::ECF < ParticipantProfile
     self.class.archivable(restrict_to_participant_ids: [id]).exists?
   end
 
+  # def with_completion_date_or_declaration?
+  #   induction_completion_date.present? ||
+  #     participant_declarations.billable.for_declaration(:completed).exists? ||
+  #     latest_induction_record.completed_induction_status?
+  # end
+
   def completed_induction?
     induction_completion_date.present?
   end

--- a/app/services/induction/enrol.rb
+++ b/app/services/induction/enrol.rb
@@ -3,16 +3,18 @@
 class Induction::Enrol < BaseService
   def call
     ActiveRecord::Base.transaction do
-      record_active_profile_participant_state! unless participant_profile_state_already_correct?
 
-      participant_profile.training_status_active!
-      participant_profile.update!(status: :active)
+      unless induction_completed
+        record_active_profile_participant_state! unless participant_profile_state_already_correct?
+        participant_profile.training_status_active!
+        participant_profile.update!(status: :active)
+      end
 
       participant_profile.induction_records.create!(
         induction_programme:,
         start_date:,
         training_status: :active,
-        induction_status: :active,
+        induction_status:,
         schedule: participant_profile.schedule,
         preferred_identity:,
         mentor_profile:,
@@ -24,12 +26,20 @@ class Induction::Enrol < BaseService
 
 private
 
-  attr_reader :participant_profile, :induction_programme, :start_date, :preferred_email, :mentor_profile, :school_transfer, :appropriate_body_id, :cpd_lead_provider_id
+  attr_reader :participant_profile, :induction_programme, :start_date, :preferred_email, :mentor_profile,
+              :school_transfer, :appropriate_body_id, :cpd_lead_provider_id, :induction_completed
 
   # preferred_email can be supplied if the participant_profile.participant_identity does not have
   # the required email for the induction i.e. a participant transferring schools might have a new email
   # address at their new school - really only used for display in the UI
-  def initialize(participant_profile:, induction_programme:, start_date: nil, preferred_email: nil, mentor_profile: nil, school_transfer: false, appropriate_body_id: nil)
+  def initialize(participant_profile:,
+                 induction_programme:,
+                 start_date: nil,
+                 preferred_email: nil,
+                 mentor_profile: nil,
+                 school_transfer: false,
+                 appropriate_body_id: nil,
+                 induction_completed: false)
     @participant_profile = participant_profile
     @induction_programme = induction_programme
     @cpd_lead_provider_id = induction_programme&.lead_provider&.cpd_lead_provider_id
@@ -38,6 +48,11 @@ private
     @mentor_profile = mentor_profile
     @school_transfer = school_transfer
     @appropriate_body_id = appropriate_body_id || school_appropriate_body_id
+    @induction_completed = induction_completed
+  end
+
+  def induction_status
+    induction_completed ? :completed : :active
   end
 
   def school_appropriate_body_id

--- a/app/services/induction/transfer_and_continue_existing_fip.rb
+++ b/app/services/induction/transfer_and_continue_existing_fip.rb
@@ -34,7 +34,8 @@ private
                           start_date:,
                           preferred_email:,
                           mentor_profile:,
-                          school_transfer: true)
+                          school_transfer: true,
+                          induction_completed:)
   end
 
   def update_mentor_pools_and_mentees
@@ -76,6 +77,14 @@ private
     to_school.active_partnerships.find_by(cohort: school_cohort.cohort, lead_provider:, delivery_partner:)
   end
 
+  def induction_completed
+    participant_profile.with_completion_date_status_or_declaration?
+  end
+
+  def induction_programme
+    @induction_programme ||= existing_school_induction_programme || create_induction_programme
+  end
+
   def latest_induction_record
     @latest_induction_record ||= participant_profile.induction_records.latest
   end
@@ -86,9 +95,5 @@ private
 
   def partnership
     @partnership ||= existing_school_partnership || create_relationship
-  end
-
-  def induction_programme
-    @induction_programme ||= existing_school_induction_programme || create_induction_programme
   end
 end

--- a/app/services/induction/transfer_to_schools_programme.rb
+++ b/app/services/induction/transfer_to_schools_programme.rb
@@ -18,7 +18,8 @@ class Induction::TransferToSchoolsProgramme < BaseService
                                                start_date:,
                                                preferred_email: email,
                                                mentor_profile:,
-                                               school_transfer: true)
+                                               school_transfer: true,
+                                               induction_completed:)
 
       if participant_profile.mentor?
         Mentors::ChangeSchool.call(mentor_profile: participant_profile,
@@ -45,8 +46,12 @@ private
     @mentor_profile = mentor_profile
   end
 
+  def induction_completed
+    participant_profile.with_completion_date_status_or_declaration?
+  end
+
   def latest_induction_record
-    participant_profile.induction_records.latest
+    @latest_induction_record ||= participant_profile.induction_records.latest
   end
 
   def check_different_school!

--- a/spec/services/induction/enrol_spec.rb
+++ b/spec/services/induction/enrol_spec.rb
@@ -22,6 +22,18 @@ RSpec.describe Induction::Enrol do
 
     it_behaves_like "creates a new active participant_profile_state record"
 
+    context "when the participant has completed induction" do
+      subject { described_class.call(participant_profile:, induction_programme:, induction_completed: true) }
+
+      it "do not create a new participant_profile_state record" do
+        expect { subject }.to not_change(ParticipantProfileState, :count)
+                                .and not_change(participant_profile, :training_status)
+                                       .and not_change(participant_profile, :status)
+      end
+
+      it { is_expected.to be_completed_induction_status }
+    end
+
     context "when a participant_profile_state already exists" do
       let(:cpd_lead_provider_id) { induction_programme.lead_provider&.cpd_lead_provider_id }
       let!(:existing_participant_profile_state) { create(:participant_profile_state, participant_profile:, state: existing_state, cpd_lead_provider_id:) }


### PR DESCRIPTION
### Context

As part of the journey that allows a SIT to transfer an (already registered at a different school) ECT to their school there is some logic behind the scenes that keeps the ECT in the cohort they are already sitting.

We need to extend that logic to sit in 2024/25 cohort a transferring ECT currently sitting in 2021/22 cohort and not having completed induction.

Those with completed induction will be transferred school (not cohort) but there status should not be set to active but completed.

- [Ticket](https://dfedigital.atlassian.net/browse/CST-2559): 

### Changes proposed in this pull request

### Guidance to review

