### PR TITLE
Fix broken specs in main

### DIFF
--- a/spec/services/change_schedule_spec.rb
+++ b/spec/services/change_schedule_spec.rb
@@ -144,7 +144,7 @@ RSpec.shared_examples "reversing a change of schedule/cohort" do
     end
 
     expect(second_change_of_schedule).not_to be_valid
-    expect(second_change_of_schedule.errors.messages_for(:cohort)).to include("The property '#/cohort' cannot be changed")
+    expect(second_change_of_schedule.errors.messages_for(:cohort)).to include("You cannot change the '#/cohort' field")
   end
 end
 

--- a/spec/support/shared_examples/change_cohort_and_continue_training_support.rb
+++ b/spec/support/shared_examples/change_cohort_and_continue_training_support.rb
@@ -79,7 +79,7 @@ RSpec.shared_examples "can change cohort and continue training" do |participant_
           create(declaration_type,
                  billable_declaration_type,
                  declaration_type: :completed,
-                 declaration_date: completed_milestone.start_date + 1.day,
+                 declaration_date: completed_milestone.start_date,
                  participant_profile:,
                  cpd_lead_provider: participant_profile.lead_provider.cpd_lead_provider)
         end


### PR DESCRIPTION
The `change_cohort_and_continue_training_support` specs were failing due to the milestone date and start date being set to the same value when we're at the end of the month. Updating the spec to use the `start_date` rather than adding `1.day` fixes it (as its greater than or equal to).

The cohort changed error message had changed in `main` since the change schedule for multi cohorts PR was raised and it was failing after being merged; this updates the error message to match.
