### PR TITLE
Enable multi cohort flag in production API

### DIFF
--- a/app/serializers/api/v3/ecf/participant_serializer.rb
+++ b/app/serializers/api/v3/ecf/participant_serializer.rb
@@ -140,9 +140,8 @@ module Api
               created_at: profile.created_at.rfc3339,
               induction_end_date: profile.induction_completion_date&.strftime("%Y-%m-%d"),
               mentor_funding_end_date: profile.mentor_completion_date&.strftime("%Y-%m-%d"),
-            }.tap do |hash|
-              hash[:cohort_changed_after_payments_frozen] = profile.cohort_changed_after_payments_frozen if FeatureFlag.active?(:cohort_changed_after_payments_frozen)
-            end
+              cohort_changed_after_payments_frozen: profile.cohort_changed_after_payments_frozen,
+            }
           }.compact
         end
 

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -24,7 +24,6 @@ class FeatureFlag
     prevent_2023_ect_registrations
     school_participant_status_language
     npq_capping
-    cohort_changed_after_payments_frozen
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).index_with { |name|

--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -7,6 +7,16 @@ weight: 8
 
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
 
+## 18 June 2024 
+
+From today, schools have started moving ECTs and mentors with partial declarations currently assigned to the 2021 cohort to the 2024 cohort.  
+
+This is because we’re closing the funding contract for the 2021 cohort at the end of July. 
+
+Providers will be able to identify participants who’ve been moved by the new `cohort_changed_after_payments_frozen` attribute to the [participant response](/api-reference/reference-v3.html?#api-v3-participants-ecf-get-responses-examples) in the API v3 production environment. The value shown for these participants will be `true`. 
+
+Providers will no longer be able to submit or void declarations for the 2021 cohort after the contract closes on 31 July. 
+
 ## 14 June 2024
 
 We’ve added the new special educational needs coordinator (SENCO) NPQ to the [test (sandbox) environment](https://sb.manage-training-for-early-career-teachers.education.gov.uk/) for the 2024 cohort.

--- a/spec/requests/api/v3/ecf/participants_spec.rb
+++ b/spec/requests/api/v3/ecf/participants_spec.rb
@@ -334,6 +334,7 @@ RSpec.describe "API ECF Participants", type: :request do
                 "created_at": early_career_teacher_profile.created_at.rfc3339,
                 "induction_end_date": "2022-01-12",
                 "mentor_funding_end_date": nil,
+                "cohort_changed_after_payments_frozen": false,
               }],
               "participant_id_changes": [],
             },

--- a/spec/serializers/api/v3/ecf/participant_serializer_spec.rb
+++ b/spec/serializers/api/v3/ecf/participant_serializer_spec.rb
@@ -60,35 +60,12 @@ module Api
                       created_at: ect_profile.created_at.rfc3339,
                       induction_end_date: "2022-01-12",
                       mentor_funding_end_date: nil,
+                      cohort_changed_after_payments_frozen: true,
                     },
                   ],
                 participant_id_changes: [],
               },
             ])
-          end
-
-          context "when the cohort_changed_after_payments_frozen feature flag is active" do
-            before { FeatureFlag.activate(:cohort_changed_after_payments_frozen) }
-
-            it "includes the cohort_changed_after_payments_frozen" do
-              expect(ecf_enrolments[0][:cohort_changed_after_payments_frozen]).to be(true)
-            end
-
-            context "when the participant has not changed cohort after payments were frozen" do
-              before { ect_profile.update!(cohort_changed_after_payments_frozen: false) }
-
-              it "does not include the cohort_changed_after_payments_frozen" do
-                expect(ecf_enrolments[0][:cohort_changed_after_payments_frozen]).to be(false)
-              end
-            end
-          end
-
-          context "when the previous_payments_frozen feature flag is not active" do
-            before { FeatureFlag.deactivate(:cohort_changed_after_payments_frozen) }
-
-            it "does not include the cohort_changed_after_payments_frozen" do
-              expect(ecf_enrolments[0]).not_to have_key(:cohort_changed_after_payments_frozen)
-            end
           end
 
           describe "ecf_enrolments" do
@@ -130,6 +107,7 @@ module Api
                   created_at: mentor_profile.created_at.rfc3339,
                   induction_end_date: nil,
                   mentor_funding_end_date: "2021-04-19",
+                  cohort_changed_after_payments_frozen: false,
                 })
               end
             end


### PR DESCRIPTION
> ⚠️ Do not merge until 18th June.

[Jira-3146](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3146)

### Context

We have added the `cohort_changed_after_payments_frozen ` attribute to the participants API and it is currently enabled in the sandbox environment.

We want to enable this in production.

### Changes proposed in this pull request

- Enable the multi cohort flag in production

Remove the feature flag to enable this attribute in production and include a new release note.

### Guidance to review

