### PR TITLE
Add and configure `rails_semantic_logger`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,9 +24,6 @@ gem "zendesk_api"
 
 gem "secure_headers"
 
-# Cleaner logs, one line per request
-gem "lograge", "~> 0.14.0"
-gem "logstash-event"
 
 # Use postgresql as the database for Active Record
 gem "pg", "~> 1.5"

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem "zendesk_api"
 
 gem "secure_headers"
 
+gem "rails_semantic_logger"
 
 # Use postgresql as the database for Active Record
 gem "pg", "~> 1.5"
@@ -141,6 +142,9 @@ group :development, :test do
 
   # Linting
   gem "erb_lint", ">= 0.1.1", require: false
+
+  # Colourizing output
+  gem "amazing_print"
 end
 
 group :development, :test, :staging, :sandbox, :review, :performance, :migration do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -311,12 +311,6 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    lograge (0.14.0)
-      actionpack (>= 4)
-      activesupport (>= 4)
-      railties (>= 4)
-      request_store (~> 1.0)
-    logstash-event (1.2.02)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -737,8 +731,6 @@ DEPENDENCIES
   jsonapi-serializer
   launchy
   listen (~> 3.9)
-  lograge (~> 0.14.0)
-  logstash-event
   mail-notify (~> 1.2)
   memory_profiler
   multi_json

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,7 @@ GEM
       base64
       gyoku (>= 0.4.0)
       nokogiri
+    amazing_print (1.6.0)
     ar-uuid (0.2.3)
       activerecord
     ast (2.4.2)
@@ -436,6 +437,10 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails_semantic_logger (4.14.0)
+      rack
+      railties (>= 5.1)
+      semantic_logger (~> 4.13)
     railties (7.1.3.2)
       actionpack (= 7.1.3.2)
       activesupport (= 7.1.3.2)
@@ -567,6 +572,8 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    semantic_logger (4.15.0)
+      concurrent-ruby (~> 1.0)
     sentry-rails (5.17.3)
       railties (>= 5.0)
       sentry-ruby (~> 5.17.3)
@@ -699,6 +706,7 @@ DEPENDENCIES
   active_record_extended
   activerecord-explain-analyze
   activerecord-session_store (~> 2.1)
+  amazing_print
   ar-uuid (~> 0.2.3)
   auto_strip_attributes (~> 2.6)
   axe-core-rspec
@@ -752,6 +760,7 @@ DEPENDENCIES
   rack-mini-profiler
   rails (~> 7.1.3)
   rails-controller-testing (~> 1.0.5)
+  rails_semantic_logger
   ransack
   rouge
   rspec-default_http_header (~> 0.0.6)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -122,6 +122,14 @@ Rails.application.configure do
   # Logging
   config.log_level = :info
 
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    config.rails_semantic_logger.add_file_appender = false
+
+    $stdout.sync = true
+
+    config.semantic_logger.add_appender(io: $stdout, level: Rails.application.config.log_level, formatter: :json)
+  end
+
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -115,38 +115,12 @@ Rails.application.configure do
   # Tell Active Support which deprecation messages to disallow.
   config.active_support.disallowed_deprecation_warnings = []
 
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
-
   # Use a different logger for distributed setups.
   # require "syslog/logger"
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new "app-name")
 
   # Logging
   config.log_level = :info
-  config.log_tags = [:request_id] # Prepend all log lines with the following tags.
-  logger = ActiveSupport::Logger.new($stdout)
-  logger.formatter = config.log_formatter
-  config.logger = ActiveSupport::TaggedLogging.new(logger)
-  config.active_record.logger = nil # Don't log SQL in production
-
-  # Use Lograge for cleaner logging
-  config.lograge.enabled = true
-  config.lograge.base_controller_class = ["ActionController::API", "ActionController::Base"]
-  config.lograge.formatter = Lograge::Formatters::Logstash.new
-  config.lograge.ignore_actions = ["ApplicationController#check"]
-  config.lograge.logger = ActiveSupport::Logger.new($stdout)
-
-  # Include params in logs: https://github.com/roidrage/lograge#what-it-doesnt-do
-  config.lograge.custom_options = lambda do |event|
-    exceptions = %w[controller action format id]
-    {
-      params: event.payload[:params].except(*exceptions),
-      exception: event.payload[:exception], # ["ExceptionClass", "the message"]
-      current_user_class: event.payload[:current_user_class],
-      current_user_id: event.payload[:current_user_id],
-    }
-  end
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false

--- a/config/environments/sandbox.rb
+++ b/config/environments/sandbox.rb
@@ -125,29 +125,6 @@ Rails.application.configure do
 
   # Logging
   config.log_level = :info
-  config.log_tags = [:request_id] # Prepend all log lines with the following tags.
-  logger = ActiveSupport::Logger.new($stdout)
-  logger.formatter = config.log_formatter
-  config.logger = ActiveSupport::TaggedLogging.new(logger)
-  config.active_record.logger = nil # Don't log SQL in production
-
-  # Use Lograge for cleaner logging
-  config.lograge.enabled = true
-  config.lograge.base_controller_class = ["ActionController::API", "ActionController::Base"]
-  config.lograge.formatter = Lograge::Formatters::Logstash.new
-  config.lograge.ignore_actions = ["ApplicationController#check"]
-  config.lograge.logger = ActiveSupport::Logger.new($stdout)
-
-  # Include params in logs: https://github.com/roidrage/lograge#what-it-doesnt-do
-  config.lograge.custom_options = lambda do |event|
-    exceptions = %w[controller action format id]
-    {
-      params: event.payload[:params].except(*exceptions),
-      exception: event.payload[:exception], # ["ExceptionClass", "the message"]
-      current_user_class: event.payload[:current_user_class],
-      current_user_id: event.payload[:current_user_id],
-    }
-  end
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -125,29 +125,6 @@ Rails.application.configure do
 
   # Logging
   config.log_level = :info
-  config.log_tags = [:request_id] # Prepend all log lines with the following tags.
-  logger = ActiveSupport::Logger.new($stdout)
-  logger.formatter = config.log_formatter
-  config.logger = ActiveSupport::TaggedLogging.new(logger)
-  config.active_record.logger = nil # Don't log SQL in production
-
-  # Use Lograge for cleaner logging
-  config.lograge.enabled = true
-  config.lograge.base_controller_class = ["ActionController::API", "ActionController::Base"]
-  config.lograge.formatter = Lograge::Formatters::Logstash.new
-  config.lograge.ignore_actions = ["ApplicationController#check"]
-  config.lograge.logger = ActiveSupport::Logger.new($stdout)
-
-  # Include params in logs: https://github.com/roidrage/lograge#what-it-doesnt-do
-  config.lograge.custom_options = lambda do |event|
-    exceptions = %w[controller action format id]
-    {
-      params: event.payload[:params].except(*exceptions),
-      exception: event.payload[:exception], # ["ExceptionClass", "the message"]
-      current_user_class: event.payload[:current_user_class],
-      current_user_id: event.payload[:current_user_id],
-    }
-  end
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false


### PR DESCRIPTION
### Context

We're about to start shipping logs to logit.io again so want to change the log format to JSON with the Rails semantic Logger.

To ease development this PR also introduces amazing_print which colourises the logs in development.

### Changes proposed in this pull request

- **Remove logstash/lograge and associated config**
- **Add rails_semantic_logger and amazing_print gems**
- **Configure semantic logging in production**

### Manual local testing

#### Production

Running ECF in production with `RAILS_LOG_TO_STDOUT=1 RAILS_ENV=production`

```
~/p/d/c/ecf (enable-semantic-logging) (✚4)
❯ RAILS_LOG_TO_STDOUT=1 RAILS_ENV=production be rails s
=> Booting Puma
=> Rails 7.1.3.2 application starting in production
=> Run `bin/rails server --help` for more startup options
Puma starting in single mode...
* Puma version: 5.6.8 (ruby 3.2.2-p53) ("Birdie's Version")
*  Min threads: 5
*  Max threads: 5
*  Environment: production
*          PID: 2301135
* Listening on http://0.0.0.0:3000
Use Ctrl-C to stop
{"host":"graphia-workstation","application":"Semantic Logger","environment":"production","timestamp":"2024-05-31T11:56:05.377485Z","level":"info","level_index":2,"pid":2301135,"thread":"puma srv tp 001","name":"Rails","message":"Enqueued DfE::Analytics::SendEvents (Job
ID: 19438d3e-925f-48bf-9918-66f897153f7a) to Sidekiq(dfe_analytics)","payload":{"event_name":"enqueue.active_job","adapter":"Sidekiq","queue":"dfe_analytics","job_class":"DfE::Analytics::SendEvents","job_id":"19438d3e-925f-48bf-9918-66f897153f7a","provider_job_id":"1f3e
d863be7b1b36aee8eb20","arguments":""}}
{"host":"graphia-workstation","application":"Semantic Logger","environment":"production","timestamp":"2024-05-31T11:56:05.377703Z","level":"info","level_index":2,"pid":2301135,"thread":"puma srv tp 001","name":"Rails","message":"Enqueued DfE::Analytics::SendEvents (Job
ID: 9006bc93-fa5f-4252-b009-2bace417fad4) to Sidekiq(dfe_analytics)","payload":{"event_name":"enqueue.active_job","adapter":"Sidekiq","queue":"dfe_analytics","job_class":"DfE::Analytics::SendEvents","job_id":"9006bc93-fa5f-4252-b009-2bace417fad4","provider_job_id":"ce63
f700e1683a2f8437dbb7","arguments":""}}
{"host":"graphia-workstation","application":"Semantic Logger","environment":"production","timestamp":"2024-05-31T11:56:05.377767Z","level":"info","level_index":2,"pid":2301135,"thread":"puma srv tp 001","duration_ms":32.20083999633789,"duration":"32.2ms","name":"StartCo
ntroller","message":"Completed #index","payload":{"controller":"StartController","action":"index","format":"HTML","method":"GET","path":"/","status":200,"view_runtime":16.35,"db_runtime":9.41,"current_user_class":null,"current_user_id":null,"allocations":42258,"status_m
essage":"OK"}}
^C- Gracefully stopping, waiting for requests to finish
=== puma shutdown: 2024-05-31 12:56:59 +0100 ===
- Goodbye!
Exiting
{"host":"graphia-workstation","application":"Semantic Logger","environment":"production","timestamp":"2024-05-31T11:56:59.734495Z","level":"info","level_index":2,"pid":2301135,"thread":"7320","name":"Rails","message":"sentry -- [Transport] Sending envelope with items [c
lient_report]  to Sentry"}
{"host":"graphia-workstation","application":"Semantic Logger","environment":"production","timestamp":"2024-05-31T11:56:59.735008Z","level":"info","level_index":2,"pid":2301135,"thread":"worker-1","name":"Rails","message":"sentry -- [Transport] Sending envelope with item
s [sessions]  to Sentry"}
```

#### Development

Pretty colours.

![Screenshot from 2024-05-31 12-39-14](https://github.com/DFE-Digital/early-careers-framework/assets/128088/53e00ff6-25c5-4313-9920-4506d9604baf)