### PR TITLE
[CPLD-3077] Update Eligibility logic to include funded place

### DIFF
--- a/app/models/npq_application.rb
+++ b/app/models/npq_application.rb
@@ -149,6 +149,7 @@ private
       .where.not(id:)
       .where(npq_course: npq_course.rebranded_alternative_courses)
       .where(eligible_for_funding: true)
+      .where(funded_place: [nil, true])
       .accepted
       .exists?
   end

--- a/app/models/npq_application.rb
+++ b/app/models/npq_application.rb
@@ -86,11 +86,11 @@ class NPQApplication < ApplicationRecord
   # eligible_for_funding is solely based on what NPQ app knows
   # eg school, course etc
   # here we need to account for previous enrollments too
-  def eligible_for_dfe_funding
+  def eligible_for_dfe_funding(with_funded_place: false)
     if previously_funded?
       false
     else
-      eligible_for_funding && (funded_place.nil? || funded_place)
+      funding_eligibility(with_funded_place:)
     end
   end
 
@@ -152,6 +152,12 @@ private
       .where(funded_place: [nil, true])
       .accepted
       .exists?
+  end
+
+  def funding_eligibility(with_funded_place:)
+    return eligible_for_funding unless with_funded_place
+
+    eligible_for_funding && (funded_place.nil? || funded_place)
   end
 
   def push_enrollment_to_big_query

--- a/app/models/npq_application.rb
+++ b/app/models/npq_application.rb
@@ -90,7 +90,7 @@ class NPQApplication < ApplicationRecord
     if previously_funded?
       false
     else
-      eligible_for_funding
+      eligible_for_funding && (funded_place.nil? || funded_place)
     end
   end
 

--- a/app/models/participant_profile/npq.rb
+++ b/app/models/participant_profile/npq.rb
@@ -73,7 +73,7 @@ class ParticipantProfile::NPQ < ParticipantProfile
   end
 
   def fundable?
-    npq_application&.eligible_for_dfe_funding
+    npq_application&.eligible_for_dfe_funding(with_funded_place: true)
   end
 
   def schedule_for(*)

--- a/app/services/api/v3/npq_applications_query.rb
+++ b/app/services/api/v3/npq_applications_query.rb
@@ -25,6 +25,7 @@ module Api
               WHERE a.id != npq_applications.id AND
                     a.participant_identity_id = npq_applications.participant_identity_id AND
                     a.eligible_for_funding = true AND
+                    (a.funded_place is null OR a.funded_place = true) AND
                     a.lead_provider_approval_status = 'accepted' AND
                     a.npq_course_id IN (
                       SELECT jsonb_array_elements_text(alt_courses->(npq_applications.npq_course_id::text))::uuid

--- a/app/services/npq/funding_eligibility.rb
+++ b/app/services/npq/funding_eligibility.rb
@@ -55,6 +55,7 @@ module NPQ
           user.npq_applications
               .where(npq_course: npq_course_and_rebranded_alternatives)
               .where(eligible_for_funding: true)
+              .where(funded_place: [nil, true])
               .accepted
               .pluck(:id)
         end

--- a/spec/models/npq_application_spec.rb
+++ b/spec/models/npq_application_spec.rb
@@ -100,19 +100,47 @@ RSpec.describe NPQApplication, type: :model do
       create(:npq_leadership_schedule, :with_npq_milestones)
     end
 
-    context "when first and only application and is eligible" do
-      subject { create(:npq_application, eligible_for_funding: true) }
+    context "when funded place is not set" do
+      context "when first and only application is eligible" do
+        subject { create(:npq_application, eligible_for_funding: true, funded_place: nil) }
 
-      it "returns true" do
-        expect(subject.eligible_for_dfe_funding).to be_truthy
+        it "returns true" do
+          expect(subject.eligible_for_dfe_funding).to be_truthy
+        end
+      end
+
+      context "when first and only application is not eligible" do
+        subject { create(:npq_application, eligible_for_funding: false, funded_place: nil) }
+
+        it "returns false" do
+          expect(subject.eligible_for_dfe_funding).to be_falsey
+        end
       end
     end
 
-    context "when first and only application and is not eligible" do
-      subject { create(:npq_application, eligible_for_funding: false) }
+    context "when funded place is set" do
+      context "when first and only application is not eligible and funded place is false" do
+        subject { create(:npq_application, eligible_for_funding: false, funded_place: false) }
 
-      it "returns false" do
-        expect(subject.eligible_for_dfe_funding).to be_falsey
+        it "returns false" do
+          expect(subject.eligible_for_dfe_funding).to be_falsey
+        end
+      end
+
+      context "when first and only application is eligible and funded place is true" do
+        subject { create(:npq_application, eligible_for_funding: true, funded_place: true) }
+
+        it "returns true" do
+          expect(subject.eligible_for_dfe_funding).to be_truthy
+        end
+      end
+
+      context "when first and only application is eligible and funded place is false" do
+        subject { create(:npq_application, eligible_for_funding: true, funded_place: false) }
+
+        it "returns false" do
+          expect(subject.eligible_for_dfe_funding).to be_falsey
+        end
       end
     end
 

--- a/spec/models/participant_profile/npq_spec.rb
+++ b/spec/models/participant_profile/npq_spec.rb
@@ -98,4 +98,41 @@ RSpec.describe ParticipantProfile::NPQ, type: :model do
       expect(subject.record_to_serialize_for(lead_provider:)).to eq(subject.user)
     end
   end
+
+  describe "#fundable?" do
+    context "when it is eligible_for_funding" do
+      let(:npq_application) { create(:npq_application, eligible_for_funding: true, funded_place: nil) }
+      subject { profile }
+
+      it { is_expected.to be_fundable }
+    end
+
+    context "when it is not eligible_for_funding" do
+      let(:npq_application) { create(:npq_application, eligible_for_funding: false, funded_place: nil) }
+      subject { profile }
+
+      it { is_expected.not_to be_fundable }
+    end
+
+    context "when it is eligible_for_funding but has no funded place" do
+      let(:npq_application) { create(:npq_application, eligible_for_funding: true, funded_place: false) }
+      subject { profile }
+
+      it { is_expected.not_to be_fundable }
+    end
+
+    context "when it is eligible_for_funding but and has a funded place" do
+      let(:npq_application) { create(:npq_application, eligible_for_funding: true, funded_place: true) }
+      subject { profile }
+
+      it { is_expected.to be_fundable }
+    end
+
+    context "when it is not eligible_for_funding but and has a funded place" do
+      let(:npq_application) { create(:npq_application, eligible_for_funding: false, funded_place: false) }
+      subject { profile }
+
+      it { is_expected.not_to be_fundable }
+    end
+  end
 end

--- a/spec/services/api/v3/npq_applications_query_spec.rb
+++ b/spec/services/api/v3/npq_applications_query_spec.rb
@@ -99,80 +99,221 @@ RSpec.describe Api::V3::NPQApplicationsQuery do
 
       it { expect(returned_application).not_to be_transient_previously_funded }
 
-      context "when there is a previous, rejected application that was eligible for funding" do
-        before do
-          create(
-            :npq_application,
-            :rejected,
-            npq_lead_provider:,
-            participant_identity: application.participant_identity,
-            eligible_for_funding: true,
-            npq_course: application.npq_course,
-          )
+      context "when funded place is nil" do
+        context "when there is a previous, rejected application that was eligible for funding" do
+          before do
+            create(
+              :npq_application,
+              :rejected,
+              npq_lead_provider:,
+              participant_identity: application.participant_identity,
+              eligible_for_funding: true,
+              funded_place: nil,
+              npq_course: application.npq_course,
+            )
+          end
+
+          it { expect(returned_application).not_to be_transient_previously_funded }
         end
 
-        it { expect(returned_application).not_to be_transient_previously_funded }
+        context "when there is a previous, accepted application that was not eligible for funding" do
+          before do
+            create(
+              :npq_application,
+              :accepted,
+              npq_lead_provider:,
+              participant_identity: application.participant_identity,
+              eligible_for_funding: false,
+              funded_place: nil,
+              npq_course: application.npq_course,
+            )
+          end
+
+          it { expect(returned_application).not_to be_transient_previously_funded }
+        end
+
+        context "when there is a previous, accepted application that was eligible for funding in a different (not rebranded) course" do
+          before do
+            create(
+              :npq_application,
+              :accepted,
+              npq_lead_provider:,
+              participant_identity: application.participant_identity,
+              eligible_for_funding: true,
+              funded_place: nil,
+              npq_course: create(:npq_specialist_course),
+            )
+          end
+
+          it { expect(returned_application).not_to be_transient_previously_funded }
+        end
+
+        context "when there is a previous, accepted application that was eligible for funding" do
+          before do
+            create(
+              :npq_application,
+              :accepted,
+              npq_lead_provider:,
+              participant_identity: application.participant_identity,
+              eligible_for_funding: true,
+              funded_place: nil,
+              npq_course: application.npq_course,
+            )
+          end
+
+          it { expect(returned_application).to be_transient_previously_funded }
+        end
+
+        context "when there is a previous, accepted application that was eligible for funding on a rebranded course" do
+          let(:npq_course) { create(:npq_ehco_course) }
+
+          before do
+            create(
+              :npq_application,
+              :accepted,
+              participant_identity: application.participant_identity,
+              eligible_for_funding: true,
+              funded_place: nil,
+              npq_course: create(:npq_aso_course),
+            )
+          end
+
+          it { expect(returned_application).to be_transient_previously_funded }
+        end
       end
 
-      context "when there is a previous, accepted application that was not eligible for funding" do
-        before do
-          create(
-            :npq_application,
-            :accepted,
-            npq_lead_provider:,
-            participant_identity: application.participant_identity,
-            eligible_for_funding: false,
-            npq_course: application.npq_course,
-          )
+      context "when funded place is true" do
+        context "when there is a previous, rejected application that was eligible for funding" do
+          before do
+            create(
+              :npq_application,
+              :rejected,
+              npq_lead_provider:,
+              participant_identity: application.participant_identity,
+              eligible_for_funding: true,
+              funded_place: true,
+              npq_course: application.npq_course,
+            )
+          end
+
+          it { expect(returned_application).not_to be_transient_previously_funded }
         end
 
-        it { expect(returned_application).not_to be_transient_previously_funded }
+        context "when there is a previous, accepted application that was eligible for funding in a different (not rebranded) course" do
+          before do
+            create(
+              :npq_application,
+              :accepted,
+              npq_lead_provider:,
+              participant_identity: application.participant_identity,
+              eligible_for_funding: true,
+              funded_place: true,
+              npq_course: create(:npq_specialist_course),
+            )
+          end
+
+          it { expect(returned_application).not_to be_transient_previously_funded }
+        end
+
+        context "when there is a previous, accepted application that was eligible for funding" do
+          before do
+            create(
+              :npq_application,
+              :accepted,
+              npq_lead_provider:,
+              participant_identity: application.participant_identity,
+              eligible_for_funding: true,
+              funded_place: true,
+              npq_course: application.npq_course,
+            )
+          end
+
+          it { expect(returned_application).to be_transient_previously_funded }
+        end
+
+        context "when there is a previous, accepted application that was eligible for funding on a rebranded course" do
+          let(:npq_course) { create(:npq_ehco_course) }
+
+          before do
+            create(
+              :npq_application,
+              :accepted,
+              participant_identity: application.participant_identity,
+              eligible_for_funding: true,
+              funded_place: true,
+              npq_course: create(:npq_aso_course),
+            )
+          end
+
+          it { expect(returned_application).to be_transient_previously_funded }
+        end
       end
 
-      context "when there is a previous, accepted application that was eligible for funding in a different (not rebranded) course" do
-        before do
-          create(
-            :npq_application,
-            :accepted,
-            npq_lead_provider:,
-            participant_identity: application.participant_identity,
-            eligible_for_funding: true,
-            npq_course: create(:npq_specialist_course),
-          )
+      context "when funded place is false" do
+        context "when there is a previous, rejected application that was not eligible for funding" do
+          before do
+            create(
+              :npq_application,
+              :rejected,
+              npq_lead_provider:,
+              participant_identity: application.participant_identity,
+              eligible_for_funding: true,
+              funded_place: false,
+              npq_course: application.npq_course,
+            )
+          end
+
+          it { expect(returned_application).not_to be_transient_previously_funded }
         end
 
-        it { expect(returned_application).not_to be_transient_previously_funded }
-      end
+        context "when there is a previous, accepted application that was not eligible for funding" do
+          before do
+            create(
+              :npq_application,
+              :accepted,
+              npq_lead_provider:,
+              participant_identity: application.participant_identity,
+              eligible_for_funding: true,
+              funded_place: false,
+              npq_course: application.npq_course,
+            )
+          end
 
-      context "when there is a previous, accepted application that was eligible for funding" do
-        before do
-          create(
-            :npq_application,
-            :accepted,
-            npq_lead_provider:,
-            participant_identity: application.participant_identity,
-            eligible_for_funding: true,
-            npq_course: application.npq_course,
-          )
+          it { expect(returned_application).not_to be_transient_previously_funded }
         end
 
-        it { expect(returned_application).to be_transient_previously_funded }
-      end
+        context "when there is a previous, accepted application that was not eligible for funding in a different (not rebranded) course" do
+          before do
+            create(
+              :npq_application,
+              :accepted,
+              npq_lead_provider:,
+              participant_identity: application.participant_identity,
+              eligible_for_funding: true,
+              funded_place: false,
+              npq_course: create(:npq_specialist_course),
+            )
+          end
 
-      context "when there is a previous, accepted application that was eligible for funding on a rebranded course" do
-        let(:npq_course) { create(:npq_ehco_course) }
-
-        before do
-          create(
-            :npq_application,
-            :accepted,
-            participant_identity: application.participant_identity,
-            eligible_for_funding: true,
-            npq_course: create(:npq_aso_course),
-          )
+          it { expect(returned_application).not_to be_transient_previously_funded }
         end
 
-        it { expect(returned_application).to be_transient_previously_funded }
+        context "when there is a previous, accepted application that was not eligible for funding on a rebranded course" do
+          let(:npq_course) { create(:npq_ehco_course) }
+
+          before do
+            create(
+              :npq_application,
+              :accepted,
+              participant_identity: application.participant_identity,
+              eligible_for_funding: true,
+              funded_place: false,
+              npq_course: create(:npq_aso_course),
+            )
+          end
+
+          it { expect(returned_application).not_to be_transient_previously_funded }
+        end
       end
     end
   end

--- a/spec/services/record_declaration_spec.rb
+++ b/spec/services/record_declaration_spec.rb
@@ -412,6 +412,21 @@ RSpec.describe RecordDeclaration do
     it_behaves_like "creates participant declaration attempt"
     it_behaves_like "checks for mentor completion event"
 
+    context "when declaration is not fundable" do
+      before do
+        participant_profile.npq_application.update(eligible_for_funding: true, funded_place: false)
+      end
+
+      it_behaves_like "creates a participant declaration"
+
+      it "sets the declaration to submitted" do
+        subject.call
+        declaration = ParticipantDeclaration.last
+
+        expect(declaration).to be_submitted
+      end
+    end
+
     context "for next cohort" do
       let!(:schedule) { create(:npq_specialist_schedule, cohort:) }
       let!(:statement) { create(:npq_statement, :output_fee, deadline_date: declaration_date + 6.weeks, cpd_lead_provider:, cohort:) }


### PR DESCRIPTION
### Context

We've introduced funded place to funding eligibility for NPQ from 2024 going forward. Previously we only calculated eligibility for declarations using `eligible_for_funding`. This looked into previously funded applications with the field set to true or the field itself.

We now have to account for `funded_place` as well. If it's not set we default to the `eligible_for_funding`. If it's set, then it is the deciding factor if the application is eligible for funding.

`eligible_for_dfe_funding` is used in the API and the record declaration logic, so we have to distinguish when we want to factor in the funded place logic as well. However previously funded is always included.

- Ticket: https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-3077

### Changes proposed in this pull request
- Amend the `eligible_for_dfe_funding` method to include funded place logic if the flag is set.
- Amend previously funded logic to include funded place logic always, across both the API and funding eligibility service which feeds back to the NPQ app
- Amend the `fundable` method to include funded place logic so declarations now rely on `funded_place` as well
- Amend the funding eligibility service to include previously funded logic as this feeds back to the NPQ app 

### Guidance to review

- commit by commit
- I avoided shared examples in most places there are subtle differences between every context for funded place `nil`/`false`/`true`

