### PR TITLE
CST-2565: move mentors out of frozen cohort when assigned an ect in u…

### DIFF
--- a/app/services/induction/change_mentor.rb
+++ b/app/services/induction/change_mentor.rb
@@ -8,7 +8,7 @@ class Induction::ChangeMentor < BaseService
         changes: { mentor_profile: },
       )
       induction_record.participant_profile.update!(mentor_profile:)
-      amend_mentor_cohort if sit_mentor_out_of_frozen_cohort?
+      amend_mentor_cohort if change_mentor_cohort?
       send_training_materials_if_needed
 
       mentor_profile&.user&.touch
@@ -56,7 +56,7 @@ private
      .deliver_later
   end
 
-  def sit_mentor_out_of_frozen_cohort?
+  def change_mentor_cohort?
     return false if ect_in_payments_frozen_cohort?
 
     mentor_profile.eligible_to_change_cohort_and_continue_training?(cohort: Cohort.active_registration_cohort)

--- a/app/services/induction/change_mentor.rb
+++ b/app/services/induction/change_mentor.rb
@@ -8,7 +8,7 @@ class Induction::ChangeMentor < BaseService
         changes: { mentor_profile: },
       )
       induction_record.participant_profile.update!(mentor_profile:)
-
+      amend_mentor_cohort if sit_mentor_out_of_frozen_cohort?
       send_training_materials_if_needed
 
       mentor_profile&.user&.touch
@@ -24,6 +24,28 @@ private
     @mentor_profile = mentor_profile
   end
 
+  def amend_mentor_cohort
+    Induction::AmendParticipantCohort.new(participant_profile: mentor_profile,
+                                          source_cohort_start_year: mentor_profile.schedule.cohort.start_year,
+                                          target_cohort_start_year: Cohort.active_registration_cohort.start_year).save
+  end
+
+  def cip_materials
+    induction_record.induction_programme.core_induction_programme
+  end
+
+  def ect_in_payments_frozen_cohort?
+    induction_record.cohort.payments_frozen?
+  end
+
+  def send_training_materials_if_needed
+    return unless sit_name
+
+    if induction_record.enrolled_in_cip? && cip_materials.present?
+      send_training_materials
+    end
+  end
+
   def send_training_materials
     MentorMailer.with(
       mentor_profile:,
@@ -34,19 +56,13 @@ private
      .deliver_later
   end
 
-  def cip_materials
-    induction_record.induction_programme.core_induction_programme
+  def sit_mentor_out_of_frozen_cohort?
+    return false if ect_in_payments_frozen_cohort?
+
+    mentor_profile.eligible_to_change_cohort_and_continue_training?(cohort: Cohort.active_registration_cohort)
   end
 
   def sit_name
     induction_record.school.induction_tutor&.full_name
-  end
-
-  def send_training_materials_if_needed
-    return unless sit_name
-
-    if induction_record.enrolled_in_cip? && cip_materials.present?
-      send_training_materials
-    end
   end
 end

--- a/spec/services/induction/change_mentor_spec.rb
+++ b/spec/services/induction/change_mentor_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe Induction::ChangeMentor do
 
     context "with CIP induction programme" do
       let!(:sit) { create(:induction_coordinator_profile, schools: [induction_record.school]).user }
+
       context "with SIT" do
         let(:induction_programme) { create(:induction_programme, :cip, school_cohort:) }
 
@@ -63,6 +64,24 @@ RSpec.describe Induction::ChangeMentor do
           service.call(induction_record:, mentor_profile: mentor_profile_2)
 
           expect(MentorMailer).not_to have_received(:with)
+        end
+      end
+
+      context "when the mentor is unfinished and the mentee in a non-frozen for payments cohort" do
+        let(:declaration) { create(:mentor_participant_declaration, :paid, declaration_type: :started, cohort: Cohort.previous) }
+        let(:mentor_profile) { declaration.participant_profile }
+        let(:current_cohort) { mentor_profile.schedule.cohort }
+        let(:cohort) { Cohort.active_registration_cohort }
+        let!(:school_cohort) { create(:school_cohort, :fip, :with_induction_programme, cohort:, school: mentor_profile.school) }
+
+        before do
+          current_cohort.update!(payments_frozen_at: Time.current)
+          service.call(induction_record:, mentor_profile:)
+        end
+
+        it "places the mentor in the currently active cohort for registration" do
+          expect(current_cohort).not_to eq(cohort)
+          expect(mentor_profile.reload.schedule.cohort_id).to eq(cohort.id)
         end
       end
     end


### PR DESCRIPTION
…nfrozen cohort

### Context

If a SIT creates a new link Mentor-ECT we might need to move any of them (ECT or Mentor or both) to 2024. 3 scenarios here:

unfinished 2021 mentor associated to a 2021 ECT (nothing to change)

unfinished 2021 mentor associated to a non-2021 ECT (move the mentor to 2024)

non-2021 mentor associated to a 2021 ECT (we could move the ECT to 2024 but we have decided not to implement it. Other triggers will catch this ECT and move them to 2024)

- [Ticket](https://dfedigital.atlassian.net/browse/CST-2565): 

### Changes proposed in this pull request

### Guidance to review

