### PR TITLE
Set milestone date in the future

### DIFF
--- a/spec/support/shared_examples/change_cohort_and_continue_training_support.rb
+++ b/spec/support/shared_examples/change_cohort_and_continue_training_support.rb
@@ -74,7 +74,7 @@ RSpec.shared_examples "can change cohort and continue training" do |participant_
       context "when the participant has a completed, #{billable_declaration_type} declaration" do
         before do
           completed_milestone = participant_profile.schedule.milestones.find_by(declaration_type: :completed)
-          completed_milestone.update!(start_date: 1.month.ago)
+          completed_milestone.update!(start_date: 1.month.ago, milestone_date: 1.day.from_now)
 
           create(declaration_type,
                  billable_declaration_type,


### PR DESCRIPTION
### Context

A declaration creation will fail if the milestone date is in the past due to validations. Set the milestone date in the future

- Ticket: n/a

### Changes proposed in this pull request
Set milestone date to always be in the future to avoid failures on dates changing and massing May

### Guidance to review

