### PR TITLE
Set `config.fixture_paths` instead of `config.fixture_path`

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,6 +11,7 @@ require File.expand_path("../config/environment", __dir__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require "rspec/rails"
+require "rspec/core/formatters/base_text_formatter"
 # Add additional requires below this line. Rails is not loaded until this point!
 Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 require "devise"
@@ -65,7 +66,7 @@ RSpec.configure do |config|
   end
   config.include Devise::Test::IntegrationHelpers, type: :request
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = ::Rails.root.join("spec/fixtures").to_path
+  config.fixture_paths = [::Rails.root.join("spec/fixtures").to_path]
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
### Context

The singular fixture_path is now deprecated, use `#fixture_paths` and set an array instead.

https://github.com/rspec/rspec-rails/blob/main/lib/rspec/rails/configuration.rb#L167
