### PR TITLE
Add the custom API related fields to log output

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/integer/time"
+require Rails.root.join("lib/semantic_logger/formatters/json_with_api_metadata")
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -127,7 +128,7 @@ Rails.application.configure do
 
     $stdout.sync = true
 
-    config.semantic_logger.add_appender(io: $stdout, level: Rails.application.config.log_level, formatter: :json)
+    config.semantic_logger.add_appender(io: $stdout, level: Rails.application.config.log_level, formatter: SemanticLogger::Formatters::JsonWithApiMetadata.new)
   end
 
   # Do not dump schema after migrations.

--- a/lib/semantic_logger/formatters/json_with_api_metadata.rb
+++ b/lib/semantic_logger/formatters/json_with_api_metadata.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module SemanticLogger
+  module Formatters
+    class JsonWithApiMetadata < Raw
+      def call(log, logger)
+        super(log, logger).merge(api_metrics).to_json
+      end
+
+    private
+
+      def api_metrics
+        return {} unless payload
+
+        {
+          params: payload[:params],
+          exception: payload[:exception],
+          current_user_class: payload[:current_user_class],
+          current_user_id: payload[:current_user_id],
+        }.compact
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

This may or may not be entirely correct, but I _think_ it's doing the right thing. Need help from an @lead-provider-cpd person to make sure.

### Extra tasks

* [x] ~~disable SQL logging in prod:~~ (it's disabled in prod by default already)
   ```ruby
    config.active_record.logger = nil # Don't log SQL in production
    ```
