### PR TITLE
CST-2571: closing 2021 - change induction start date - include 2021 closing logic to sit the participant in 2024 cohort

### DIFF
--- a/app/services/admin/participants/change_induction_start_date.rb
+++ b/app/services/admin/participants/change_induction_start_date.rb
@@ -10,7 +10,7 @@ module Admin::Participants
     end
 
     def call
-      participant_profile.update!(induction_start_date:)
+      Participants::SyncDQTInductionStartDate.call(induction_start_date, participant_profile)
     end
   end
 end

--- a/spec/services/admin/participants/change_induction_start_date_spec.rb
+++ b/spec/services/admin/participants/change_induction_start_date_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Admin::Participants::ChangeInductionStartDate do
-  let(:participant_profile) { double(ParticipantProfile, update!: true) }
+  let(:participant_profile) { ParticipantProfile.new }
   let(:induction_start_date) { 3.weeks.from_now }
 
   subject { described_class.new(participant_profile, induction_start_date:) }
@@ -19,9 +19,11 @@ RSpec.describe Admin::Participants::ChangeInductionStartDate do
 
   describe "#call" do
     it "updates the participant profile's induction_start_date field with the supplied date when called" do
+      allow(Participants::SyncDQTInductionStartDate).to receive(:call)
+
       subject.call
 
-      expect(participant_profile).to have_received(:update!).with(induction_start_date:)
+      expect(Participants::SyncDQTInductionStartDate).to have_received(:call).with(induction_start_date, participant_profile)
     end
   end
 end


### PR DESCRIPTION
### Context

There is an admin functionality to change induction start date of a participant.

We need to review this code to accomodate it to the closing 21 cohort scenario.

Similar to what we do for the re-validation in admin console.

- [Ticket](https://dfedigital.atlassian.net/browse/CST-2571): 

### Changes proposed in this pull request

### Guidance to review

