### PR TITLE
[CST-2438] Update admin registration summary for 2024

### DIFF
--- a/app/controllers/admin/performance/overview_controller.rb
+++ b/app/controllers/admin/performance/overview_controller.rb
@@ -5,17 +5,18 @@ module Admin::Performance
     skip_after_action :verify_authorized, only: :show
     skip_after_action :verify_policy_scoped, only: :show
 
-    # show 2023 pilot stats
+    # show active registration cohort stats
     def show
-      @pilot_stats = get_pilot_stats
+      @pilot_stats = get_registration_stats
     end
 
   private
 
-    def get_pilot_stats
+    def get_registration_stats
       choices = programme_choices
 
       OpenStruct.new({
+        cohort:,
         cip_total: choices.fetch("core_induction_programme", 0),
         diy_total: choices.fetch("design_our_own", 0),
         fip_total: choices.fetch("full_induction_programme", 0),
@@ -56,7 +57,7 @@ module Admin::Performance
     end
 
     def cohort
-      @cohort ||= Cohort.find_by(start_year: 2023)
+      @cohort ||= Cohort.active_registration_cohort
     end
   end
 end

--- a/app/views/admin/performance/overview/show.html.erb
+++ b/app/views/admin/performance/overview/show.html.erb
@@ -6,7 +6,7 @@
     <h1 class="govuk-heading-l">Overview</h1>
 
     <table class="govuk-table govuk-!-margin-bottom-9">
-      <caption class="govuk-table__caption govuk-table__caption--m">Schools registered for 2023 to 2024</caption>
+      <caption class="govuk-table__caption govuk-table__caption--m">Schools registered for <%= @pilot_stats.cohort.description %></caption>
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header">Training programme</th>
@@ -51,7 +51,7 @@
 
 
     <table class="govuk-table">
-      <caption class="govuk-table__caption govuk-table__caption--m">Participants registered for 2023 to 2024</caption>
+      <caption class="govuk-table__caption govuk-table__caption--m">Participants registered for <%= @pilot_stats.cohort.description %></caption>
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header">Participant type</th>


### PR DESCRIPTION
### Context

- Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-2438)
- Update admin summary stats so we can see registration process for the 2024 cohort.
- Make the code use the `Cohort.active_registration_cohort` instead of a hard coded year.

### Changes proposed in this pull request
Update to summary and views to use `Cohort.active_registration_cohort`

### Guidance to review

