### PR TITLE
Travel to current cohort to avoid the new cohort setup pages in tests

### DIFF
--- a/spec/features/nominations/choose_how_to_continue_spec.rb
+++ b/spec/features/nominations/choose_how_to_continue_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "./nominate_induction_tutor_steps"
 
-RSpec.feature "School contact making cohort choice journey", type: :feature, js: true do
+RSpec.feature "School contact making cohort choice journey", type: :feature, js: true, mid_cohort: true do
   include NominateInductionTutorSteps
 
   shared_context "School choosing how to setup their cohort", shared_context: :metadata do

--- a/spec/features/nominations/nominate_induction_tutor_journey_spec.rb
+++ b/spec/features/nominations/nominate_induction_tutor_journey_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "./nominate_induction_tutor_steps"
 
-RSpec.feature "ECT nominate SIT journey", type: :feature, js: true do
+RSpec.feature "ECT nominate SIT journey", type: :feature, js: true, mid_cohort: true do
   include NominateInductionTutorSteps
 
   let(:academic_year_text) { Cohort.current.description }

--- a/spec/features/scenarios/participants/ect_doing_cip/no_validation_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_cip/no_validation_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "ECT doing CIP: no validation", type: :feature do
+RSpec.feature "ECT doing CIP: no validation", type: :feature, mid_cohort: true do
   let!(:participant_details) do
     NewSeeds::Scenarios::Participants::Ects::EctNoValidation
       .new(school_cohort:, full_name: participant_full_name)

--- a/spec/features/schools/participant_dashboard/completed_induction_participants_spec.rb
+++ b/spec/features/schools/participant_dashboard/completed_induction_participants_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../training_dashboard/manage_training_steps"
 
-RSpec.describe "Manage currently training participants", js: true do
+RSpec.describe "Manage currently training participants", js: true, mid_cohort: true do
   include ManageTrainingSteps
 
   before do

--- a/spec/features/schools/participant_dashboard/currently_mentoring_mentors_spec.rb
+++ b/spec/features/schools/participant_dashboard/currently_mentoring_mentors_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../training_dashboard/manage_training_steps"
 
-RSpec.describe "Manage currently training participants", js: true do
+RSpec.describe "Manage currently training participants", js: true, mid_cohort: true do
   include ManageTrainingSteps
 
   before do

--- a/spec/features/schools/participant_dashboard/manage_cip_participants_spec.rb
+++ b/spec/features/schools/participant_dashboard/manage_cip_participants_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../training_dashboard/manage_training_steps"
 
-RSpec.describe "Manage CIP participants", js: true, with_feature_flags: { eligibility_notifications: "active" } do
+RSpec.describe "Manage CIP participants", js: true, with_feature_flags: { eligibility_notifications: "active" }, mid_cohort: true do
   include ManageTrainingSteps
 
   before do

--- a/spec/features/schools/participant_dashboard/manage_fip_partnered_participants_spec.rb
+++ b/spec/features/schools/participant_dashboard/manage_fip_partnered_participants_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../training_dashboard/manage_training_steps"
 
-RSpec.describe "Manage FIP partnered participants with no change of circumstances", js: true, with_feature_flags: { eligibility_notifications: "active" } do
+RSpec.describe "Manage FIP partnered participants with no change of circumstances", js: true, with_feature_flags: { eligibility_notifications: "active" }, mid_cohort: true do
   include ManageTrainingSteps
 
   context "inactive change of circumstances flag" do
@@ -14,11 +14,11 @@ end
 RSpec.describe "Manage FIP partnered participants with change of circumstances", js: true, with_feature_flags: { eligibility_notifications: "active" } do
   include ManageTrainingSteps
 
-  context "active change of circumstances flag" do
+  context "active change of circumstances flag", mid_cohort: true do
     it_behaves_like "manage fip participants example"
   end
 
-  context "transferring participants" do
+  context "transferring participants", mid_cohort: true do
     before do
       given_there_is_a_school_that_has_chosen_fip_for_previous_cohort_and_partnered
       and_i_am_signed_in_as_an_induction_coordinator
@@ -53,7 +53,7 @@ RSpec.describe "Manage FIP partnered participants with change of circumstances",
     end
   end
 
-  context "participants that have transferred out" do
+  context "participants that have transferred out", mid_cohort: true do
     before do
       given_there_is_a_school_that_has_chosen_fip_and_partnered
       and_i_have_a_transferred_out_participant
@@ -61,7 +61,7 @@ RSpec.describe "Manage FIP partnered participants with change of circumstances",
       and_i_click(Cohort.current.description)
     end
 
-    scenario "Induction coordinator can view participants that have completed their transfer out" do
+    scenario "Induction coordinator can view participants that have completed their transfer out", mid_cohort: true do
       given_i_am_taken_to_fip_induction_dashboard
       when_i_navigate_to_ect_dashboard
       when_i_filter_by("No longer training (1)")

--- a/spec/features/schools/participant_dashboard/manage_fip_unpartnered_participants_spec.rb
+++ b/spec/features/schools/participant_dashboard/manage_fip_unpartnered_participants_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../training_dashboard/manage_training_steps"
 
-RSpec.describe "Manage FIP unpartnered participants", js: true, with_feature_flags: { eligibility_notifications: "active" } do
+RSpec.describe "Manage FIP unpartnered participants", js: true, with_feature_flags: { eligibility_notifications: "active" }, mid_cohort: true do
   include ManageTrainingSteps
 
   before do

--- a/spec/features/schools/participant_dashboard/mentor_training_spec.rb
+++ b/spec/features/schools/participant_dashboard/mentor_training_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../training_dashboard/manage_training_steps"
 
-RSpec.describe "Mentor training dashboard", js: true do
+RSpec.describe "Mentor training dashboard", js: true, mid_cohort: true do
   include ManageTrainingSteps
 
   before do

--- a/spec/features/schools/participant_dashboard/no_longer_training_participants_spec.rb
+++ b/spec/features/schools/participant_dashboard/no_longer_training_participants_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../training_dashboard/manage_training_steps"
 
-RSpec.describe "Manage currently training participants", js: true do
+RSpec.describe "Manage currently training participants", js: true, mid_cohort: true do
   include ManageTrainingSteps
 
   before do

--- a/spec/features/schools/participant_dashboard/not_mentoring_mentors_spec.rb
+++ b/spec/features/schools/participant_dashboard/not_mentoring_mentors_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../training_dashboard/manage_training_steps"
 
-RSpec.describe "Manage currently training participants", js: true do
+RSpec.describe "Manage currently training participants", js: true, mid_cohort: true do
   include ManageTrainingSteps
 
   before do

--- a/spec/features/schools/participants/add_participants/add_ect_as_mentor_spec.rb
+++ b/spec/features/schools/participants/add_participants/add_ect_as_mentor_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../../training_dashboard/manage_training_steps"
 
-RSpec.describe "Add ECT as mentor", js: true do
+RSpec.describe "Add ECT as mentor", js: true, mid_cohort: true do
   include ManageTrainingSteps
 
   before do

--- a/spec/features/schools/participants/add_participants/unhappy_path_already_on_ecf_training_spec.rb
+++ b/spec/features/schools/participants/add_participants/unhappy_path_already_on_ecf_training_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../../training_dashboard/manage_training_steps"
 
-RSpec.describe "Add participants", js: true do
+RSpec.describe "Add participants", js: true, mid_cohort: true do
   include ManageTrainingSteps
 
   before do

--- a/spec/features/schools/participants/add_participants/unhappy_path_can_validate_with_nino_spec.rb
+++ b/spec/features/schools/participants/add_participants/unhappy_path_can_validate_with_nino_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../../training_dashboard/manage_training_steps"
 
-RSpec.describe "Add participants", js: true do
+RSpec.describe "Add participants", js: true, mid_cohort: true do
   include ManageTrainingSteps
 
   before do

--- a/spec/features/schools/participants/add_participants/unhappy_path_can_validate_with_nino_spec.rb
+++ b/spec/features/schools/participants/add_participants/unhappy_path_can_validate_with_nino_spec.rb
@@ -17,22 +17,24 @@ RSpec.describe "Add participants", js: true, mid_cohort: true do
   end
 
   scenario "Induction tutor can add new ECT participant when dqt returns a match with nino" do
-    when_i_navigate_to_ect_dashboard
-    and_i_choose_to_add_an_ect_on_the_school_early_career_teachers_dashboard_page
-    and_i_choose_to_add_a_new_ect_on_the_school_add_participant_wizard
+    inside_auto_assignment_window do
+      when_i_navigate_to_ect_dashboard
+      and_i_choose_to_add_an_ect_on_the_school_early_career_teachers_dashboard_page
+      and_i_choose_to_add_a_new_ect_on_the_school_add_participant_wizard
 
-    when_i_add_full_name_to_the_school_add_participant_wizard @participant_data[:full_name]
-    and_i_add_teacher_reference_number_to_the_school_add_participant_wizard @participant_data[:full_name], @participant_data[:trn]
-    and_i_add_date_of_birth_to_the_school_add_participant_wizard @participant_data[:date_of_birth]
-    and_i_confirm_details_and_continue_on_the_school_add_participant_wizard
-    and_i_add_nino_to_the_school_add_participant_wizard @participant_data[:full_name], @participant_data[:nino]
-    and_i_add_email_address_to_the_school_add_participant_wizard "Sally Teacher", @participant_data[:email]
-    and_i_choose_a_mentor_on_the_school_add_participant_wizard @participant_profile_mentor.full_name
-    and_i_confirm_and_add_on_the_school_add_participant_wizard
+      when_i_add_full_name_to_the_school_add_participant_wizard @participant_data[:full_name]
+      and_i_add_teacher_reference_number_to_the_school_add_participant_wizard @participant_data[:full_name], @participant_data[:trn]
+      and_i_add_date_of_birth_to_the_school_add_participant_wizard @participant_data[:date_of_birth]
+      and_i_confirm_details_and_continue_on_the_school_add_participant_wizard
+      and_i_add_nino_to_the_school_add_participant_wizard @participant_data[:full_name], @participant_data[:nino]
+      and_i_add_email_address_to_the_school_add_participant_wizard "Sally Teacher", @participant_data[:email]
+      and_i_choose_a_mentor_on_the_school_add_participant_wizard @participant_profile_mentor.full_name
+      and_i_confirm_and_add_on_the_school_add_participant_wizard
 
-    then_i_am_on_the_school_add_participant_completed_page
-    and_i_confirm_has_full_name_on_the_school_add_participant_completed_page @participant_data[:full_name]
-    and_i_confirm_has_participant_type_on_the_school_add_participant_completed_page "ECT"
+      then_i_am_on_the_school_add_participant_completed_page
+      and_i_confirm_has_full_name_on_the_school_add_participant_completed_page @participant_data[:full_name]
+      and_i_confirm_has_participant_type_on_the_school_add_participant_completed_page "ECT"
+    end
   end
 
   scenario "Induction tutor can add new mentor participant when dqt returns a match with nino inside the auto assignment window" do

--- a/spec/features/schools/participants/add_participants/unhappy_path_cannot_validate_with_nino_spec.rb
+++ b/spec/features/schools/participants/add_participants/unhappy_path_cannot_validate_with_nino_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../../training_dashboard/manage_training_steps"
 
-RSpec.describe "Add participants", js: true do
+RSpec.describe "Add participants", js: true, mid_cohort: true do
   include ManageTrainingSteps
 
   before do

--- a/spec/features/schools/participants/add_participants/unhappy_path_email_taken_spec.rb
+++ b/spec/features/schools/participants/add_participants/unhappy_path_email_taken_spec.rb
@@ -7,42 +7,46 @@ RSpec.describe "Add participants", js: true, mid_cohort: true do
   include ManageTrainingSteps
 
   before do
-    given_there_is_a_school_that_has_chosen_fip_and_partnered
-    and_i_have_added_an_ect
-    and_i_have_added_a_mentor
-    and_i_am_signed_in_as_an_induction_coordinator
-    and_i_click(@cohort.description)
-    then_i_am_taken_to_fip_induction_dashboard
-    set_dqt_validation_result
+    inside_auto_assignment_window do
+      given_there_is_a_school_that_has_chosen_fip_and_partnered
+      and_i_have_added_an_ect
+      and_i_have_added_a_mentor
+      and_i_am_signed_in_as_an_induction_coordinator
+      and_i_click(@cohort.description)
+      then_i_am_taken_to_fip_induction_dashboard
+      set_dqt_validation_result
+    end
   end
 
   scenario "Induction tutor cannot add existing ECT" do
-    when_i_navigate_to_ect_dashboard
-    when_i_click_to_add_a_new_ect
-    then_i_should_be_on_the_who_to_add_page
+    inside_auto_assignment_window do
+      when_i_navigate_to_ect_dashboard
+      when_i_click_to_add_a_new_ect
+      then_i_should_be_on_the_who_to_add_page
 
-    when_i_select_to_add_a "ECT"
-    when_i_click_on_continue
-    then_i_am_taken_to_the_what_we_need_to_know_about_this_ect_page
+      when_i_select_to_add_a "ECT"
+      when_i_click_on_continue
+      then_i_am_taken_to_the_what_we_need_to_know_about_this_ect_page
 
-    when_i_click_on_continue
-    then_i_am_taken_to_add_ect_name_page
+      when_i_click_on_continue
+      then_i_am_taken_to_add_ect_name_page
 
-    when_i_add_ect_name
-    when_i_click_on_continue
-    then_i_am_taken_to_add_teachers_trn_page
+      when_i_add_ect_name
+      when_i_click_on_continue
+      then_i_am_taken_to_add_teachers_trn_page
 
-    when_i_add_the_trn
-    when_i_click_on_continue
-    then_i_am_taken_to_add_date_of_birth_page
+      when_i_add_the_trn
+      when_i_click_on_continue
+      then_i_am_taken_to_add_date_of_birth_page
 
-    when_i_add_a_date_of_birth
-    when_i_click_on_continue
-    then_i_am_taken_to_add_ect_or_mentor_email_page
+      when_i_add_a_date_of_birth
+      when_i_click_on_continue
+      then_i_am_taken_to_add_ect_or_mentor_email_page
 
-    when_i_add_ect_or_mentor_email_that_already_exists
-    when_i_click_on_continue
-    then_i_am_taken_to_email_already_taken_page
-    then_the_page_should_be_accessible
+      when_i_add_ect_or_mentor_email_that_already_exists
+      when_i_click_on_continue
+      then_i_am_taken_to_email_already_taken_page
+      then_the_page_should_be_accessible
+    end
   end
 end

--- a/spec/features/schools/participants/add_participants/unhappy_path_email_taken_spec.rb
+++ b/spec/features/schools/participants/add_participants/unhappy_path_email_taken_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../../training_dashboard/manage_training_steps"
 
-RSpec.describe "Add participants", js: true do
+RSpec.describe "Add participants", js: true, mid_cohort: true do
   include ManageTrainingSteps
 
   before do

--- a/spec/features/schools/participants/add_participants/unhappy_path_sit_error_entering_validation_info_spec.rb
+++ b/spec/features/schools/participants/add_participants/unhappy_path_sit_error_entering_validation_info_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../../training_dashboard/manage_training_steps"
 
-RSpec.describe "Add participants", js: true do
+RSpec.describe "Add participants", js: true, mid_cohort: true do
   include ManageTrainingSteps
 
   before do

--- a/spec/features/schools/participants/add_participants/unhappy_path_sit_error_entering_validation_info_spec.rb
+++ b/spec/features/schools/participants/add_participants/unhappy_path_sit_error_entering_validation_info_spec.rb
@@ -7,50 +7,54 @@ RSpec.describe "Add participants", js: true, mid_cohort: true do
   include ManageTrainingSteps
 
   before do
-    given_there_is_a_school_that_has_chosen_fip_and_partnered
-    and_i_have_added_an_ect
-    and_i_am_signed_in_as_an_induction_coordinator
-    then_i_am_taken_to_fip_induction_dashboard
+    inside_auto_assignment_window do
+      given_there_is_a_school_that_has_chosen_fip_and_partnered
+      and_i_have_added_an_ect
+      and_i_am_signed_in_as_an_induction_coordinator
+      then_i_am_taken_to_fip_induction_dashboard
+    end
   end
 
   scenario "Induction tutor can add new ECT participant" do
-    when_i_navigate_to_ect_dashboard
-    when_i_click_to_add_a_new_ect
-    then_i_should_be_on_the_who_to_add_page
+    inside_auto_assignment_window do
+      when_i_navigate_to_ect_dashboard
+      when_i_click_to_add_a_new_ect
+      then_i_should_be_on_the_who_to_add_page
 
-    when_i_select_to_add_a "ECT"
-    when_i_click_on_continue
-    then_i_am_taken_to_the_what_we_need_to_know_about_this_ect_page
+      when_i_select_to_add_a "ECT"
+      when_i_click_on_continue
+      then_i_am_taken_to_the_what_we_need_to_know_about_this_ect_page
 
-    when_i_click_on_continue
-    then_i_am_taken_to_add_ect_name_page
+      when_i_click_on_continue
+      then_i_am_taken_to_add_ect_name_page
 
-    when_i_add_ect_name
-    when_i_click_on_continue
-    then_i_am_taken_to_add_teachers_trn_page
+      when_i_add_ect_name
+      when_i_click_on_continue
+      then_i_am_taken_to_add_teachers_trn_page
 
-    when_i_add_the_wrong_trn
-    set_dqt_blank_validation_result
-    when_i_click_on_continue
-    then_i_am_taken_to_add_date_of_birth_page
+      when_i_add_the_wrong_trn
+      set_dqt_blank_validation_result
+      when_i_click_on_continue
+      then_i_am_taken_to_add_date_of_birth_page
 
-    when_i_add_a_date_of_birth
-    when_i_click_on_continue
-    then_i_am_taken_to_the_cannot_find_their_details
+      when_i_add_a_date_of_birth
+      when_i_click_on_continue
+      then_i_am_taken_to_the_cannot_find_their_details
 
-    when_i_click_on_change_trn
-    then_i_am_taken_to_add_teachers_trn_page
+      when_i_click_on_change_trn
+      then_i_am_taken_to_add_teachers_trn_page
 
-    when_i_add_the_trn
-    set_dqt_validation_result
-    when_i_click_on_continue
-    then_i_am_taken_to_add_ect_or_mentor_email_page
+      when_i_add_the_trn
+      set_dqt_validation_result
+      when_i_click_on_continue
+      then_i_am_taken_to_add_ect_or_mentor_email_page
 
-    when_i_add_ect_or_mentor_email
-    when_i_click_on_continue
-    then_i_am_taken_to_check_details_page
+      when_i_add_ect_or_mentor_email
+      when_i_click_on_continue
+      then_i_am_taken_to_check_details_page
 
-    when_i_click_confirm_and_add
-    then_i_am_taken_to_ect_confirmation_page
+      when_i_click_confirm_and_add
+      then_i_am_taken_to_ect_confirmation_page
+    end
   end
 end

--- a/spec/features/schools/participants/transferring_participants/already_enrolled_at_school_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/already_enrolled_at_school_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Transferring participants", type: :feature, js: true, rutabaga: false do
+RSpec.describe "Transferring participants", type: :feature, js: true, rutabaga: false, mid_cohort: true do
   context "Participant is already enrolled at the school" do
     before do
       set_participant_data

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_different_partner_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_different_partner_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Transferring ECT is with a different lead provider", type: :feature, js: true do
+RSpec.describe "Transferring ECT is with a different lead provider", type: :feature, js: true, mid_cohort: true do
   before do
     allow_participant_transfer_mailers
     set_participant_data

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_different_partner_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_different_partner_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe "Transferring ECT is with a different lead provider", type: :feat
   def when_i_add_a_valid_start_date
     legend = "When is #{@participant_data[:full_name]} moving to your school?"
 
-    fill_in_date(legend, with: "#{Cohort.next.start_year}-10-24")
+    fill_in_date(legend, with: 1.week.from_now.to_date)
   end
 
   def when_i_assign_a_mentor

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_no_change_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_no_change_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "ECT has matching lead provider and delivery partner", type: :feature, js: true do
+RSpec.describe "ECT has matching lead provider and delivery partner", type: :feature, js: true, mid_cohort: true do
   before do
     allow_participant_transfer_mailers
     set_participant_data

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_no_change_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_no_change_spec.rb
@@ -16,108 +16,110 @@ RSpec.describe "ECT has matching lead provider and delivery partner", type: :fea
   end
 
   scenario "Induction tutor can transfer an ECT to their school" do
-    when_i_click_to_add_an_ect
-    then_i_should_be_on_the_who_to_add_page
-    then_the_page_should_be_accessible
+    inside_auto_assignment_window do
+      when_i_click_to_add_an_ect
+      then_i_should_be_on_the_who_to_add_page
+      then_the_page_should_be_accessible
 
-    # when_i_select_transfer_teacher_option
-    when_i_select_the_ect_option
-    click_on "Continue"
-    then_i_should_be_on_what_we_need_page
-    then_the_page_should_be_accessible
+      # when_i_select_transfer_teacher_option
+      when_i_select_the_ect_option
+      click_on "Continue"
+      then_i_should_be_on_what_we_need_page
+      then_the_page_should_be_accessible
 
-    click_on "Continue"
-    then_i_should_be_on_full_name_page
-    then_the_page_should_be_accessible
+      click_on "Continue"
+      then_i_should_be_on_full_name_page
+      then_the_page_should_be_accessible
 
-    click_on "Continue"
-    then_i_receive_a_missing_name_error_message
+      click_on "Continue"
+      then_i_receive_a_missing_name_error_message
 
-    when_i_update_the_name_with(@participant_data[:full_name])
-    click_on "Continue"
-    then_i_should_be_on_trn_page
-    then_the_page_should_be_accessible
+      when_i_update_the_name_with(@participant_data[:full_name])
+      click_on "Continue"
+      then_i_should_be_on_trn_page
+      then_the_page_should_be_accessible
 
-    click_on "Continue"
-    then_i_should_see_a_enter_trn_error_message
+      click_on "Continue"
+      then_i_should_see_a_enter_trn_error_message
 
-    when_i_add_an_invalid_trn
-    click_on "Continue"
-    then_i_should_see_invalid_trn_message
+      when_i_add_an_invalid_trn
+      click_on "Continue"
+      then_i_should_see_invalid_trn_message
 
-    when_i_add_a_valid_trn
-    click_on "Continue"
-    then_i_should_be_on_the_date_of_birth_page
-    then_the_page_should_be_accessible
+      when_i_add_a_valid_trn
+      click_on "Continue"
+      then_i_should_be_on_the_date_of_birth_page
+      then_the_page_should_be_accessible
 
-    click_on "Continue"
-    then_i_should_see_enter_date_of_birth_error_message
+      click_on "Continue"
+      then_i_should_see_enter_date_of_birth_error_message
 
-    when_i_add_an_invalid_date_of_birth
-    click_on "Continue"
-    then_i_should_see_invalid_date_of_birth_error_message
+      when_i_add_an_invalid_date_of_birth
+      click_on "Continue"
+      then_i_should_see_invalid_date_of_birth_error_message
 
-    when_i_add_a_valid_date_of_birth
-    click_on "Continue"
+      when_i_add_a_valid_date_of_birth
+      click_on "Continue"
 
-    then_i_should_be_on_the_confirm_transfer_page
-    then_the_page_should_be_accessible
-    click_on "Confirm"
+      then_i_should_be_on_the_confirm_transfer_page
+      then_the_page_should_be_accessible
+      click_on "Confirm"
 
-    then_i_should_be_on_the_teacher_start_date_page
-    then_the_page_should_be_accessible
+      then_i_should_be_on_the_teacher_start_date_page
+      then_the_page_should_be_accessible
 
-    click_on "Continue"
-    then_i_should_see_enter_start_date_error_message
-    when_i_add_an_invalid_start_date
-    click_on "Continue"
-    then_i_should_see_invalid_start_date_error_message
+      click_on "Continue"
+      then_i_should_see_enter_start_date_error_message
+      when_i_add_an_invalid_start_date
+      click_on "Continue"
+      then_i_should_see_invalid_start_date_error_message
 
-    when_i_add_a_date_prior_to_the_participants_induction_start
-    click_on "Continue"
-    then_i_should_see_start_date_must_be_after_error_message
+      when_i_add_a_date_prior_to_the_participants_induction_start
+      click_on "Continue"
+      then_i_should_see_start_date_must_be_after_error_message
 
-    when_i_add_a_valid_start_date
-    click_on "Continue"
+      when_i_add_a_valid_start_date
+      click_on "Continue"
 
-    then_i_should_be_on_the_add_email_page
-    then_the_page_should_be_accessible
+      then_i_should_be_on_the_add_email_page
+      then_the_page_should_be_accessible
 
-    click_on "Continue"
-    then_i_should_see_blank_email_date_error_message
+      click_on "Continue"
+      then_i_should_see_blank_email_date_error_message
 
-    when_i_update_the_email_with("sally-teacher")
-    click_on "Continue"
-    then_i_should_see_invalid_email_date_error_message
+      when_i_update_the_email_with("sally-teacher")
+      click_on "Continue"
+      then_i_should_see_invalid_email_date_error_message
 
-    when_i_update_the_email_with("sally-teacher@example.com")
-    click_on "Continue"
-    then_i_should_be_on_the_select_mentor_page
-    then_the_page_should_be_accessible
-    and_it_should_list_the_schools_mentors
+      when_i_update_the_email_with("sally-teacher@example.com")
+      click_on "Continue"
+      then_i_should_be_on_the_select_mentor_page
+      then_the_page_should_be_accessible
+      and_it_should_list_the_schools_mentors
 
-    click_on "Continue"
-    then_i_should_see_select_option_error_message
+      click_on "Continue"
+      then_i_should_see_select_option_error_message
 
-    when_i_assign_a_mentor
-    click_on "Continue"
-    then_i_should_be_taken_to_the_teachers_current_programme_page
+      when_i_assign_a_mentor
+      click_on "Continue"
+      then_i_should_be_taken_to_the_teachers_current_programme_page
 
-    when_i_select "Yes"
-    click_on "Continue"
-    then_i_should_be_taken_to_the_check_your_answers_page
-    then_the_page_should_be_accessible
+      when_i_select "Yes"
+      click_on "Continue"
+      then_i_should_be_taken_to_the_check_your_answers_page
+      then_the_page_should_be_accessible
 
-    click_on "Confirm and add"
-    then_i_should_be_on_the_complete_page
-    then_the_page_should_be_accessible
-    and_the_schools_current_provider_is_notified
+      click_on "Confirm and add"
+      then_i_should_be_on_the_complete_page
+      then_the_page_should_be_accessible
+      and_the_schools_current_provider_is_notified
 
-    click_on "View your ECTs"
-    then_i_am_taken_to_manage_ects_page
+      click_on "View your ECTs"
+      then_i_am_taken_to_manage_ects_page
 
-    # click_on "Moving school"
-    # then_i_should_see_the_transferring_participant
+      # click_on "Moving school"
+      # then_i_should_see_the_transferring_participant
+    end
   end
   # given
 

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_different_partner_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_different_partner_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Transferring a mentor with a different provider", type: :feature, js: true do
+RSpec.describe "Transferring a mentor with a different provider", type: :feature, js: true, mid_cohort: true do
   before do
     allow_participant_transfer_mailers
     set_participant_data

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_different_partner_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_different_partner_spec.rb
@@ -16,107 +16,111 @@ RSpec.describe "Transferring a mentor with a different provider", type: :feature
   end
 
   scenario "Induction tutor can transfer an Mentor to their schools programme" do
-    when_i_click_to_add_a_new_mentor
-    then_i_should_be_on_the_who_to_add_page
+    inside_auto_assignment_window do
+      when_i_click_to_add_a_new_mentor
+      then_i_should_be_on_the_who_to_add_page
 
-    when_i_select_the_mentor_option
-    click_on "Continue"
-    then_i_should_be_on_what_we_need_page
+      when_i_select_the_mentor_option
+      click_on "Continue"
+      then_i_should_be_on_what_we_need_page
 
-    click_on "Continue"
-    then_i_should_be_on_full_name_page
+      click_on "Continue"
+      then_i_should_be_on_full_name_page
 
-    when_i_update_the_name_with(@participant_data[:full_name])
-    click_on "Continue"
-    then_i_should_be_on_trn_page
+      when_i_update_the_name_with(@participant_data[:full_name])
+      click_on "Continue"
+      then_i_should_be_on_trn_page
 
-    when_i_add_a_valid_trn
-    click_on "Continue"
-    then_i_should_be_on_the_date_of_birth_page
+      when_i_add_a_valid_trn
+      click_on "Continue"
+      then_i_should_be_on_the_date_of_birth_page
 
-    when_i_add_a_valid_date_of_birth
-    click_on "Continue"
+      when_i_add_a_valid_date_of_birth
+      click_on "Continue"
 
-    then_i_should_be_on_the_only_mentor_at_your_school_page
-    then_the_page_should_be_accessible
-    when_i_select "Yes"
-    click_on "Confirm"
+      then_i_should_be_on_the_only_mentor_at_your_school_page
+      then_the_page_should_be_accessible
+      when_i_select "Yes"
+      click_on "Confirm"
 
-    then_i_should_be_on_the_teacher_start_date_page
-    then_the_page_should_be_accessible
+      then_i_should_be_on_the_teacher_start_date_page
+      then_the_page_should_be_accessible
 
-    when_i_add_a_valid_start_date
-    click_on "Continue"
+      when_i_add_a_valid_start_date
+      click_on "Continue"
 
-    then_i_should_be_on_the_add_email_page
+      then_i_should_be_on_the_add_email_page
 
-    when_i_update_the_email_with("sally-mentor@example.com")
-    click_on "Continue"
+      when_i_update_the_email_with("sally-mentor@example.com")
+      click_on "Continue"
 
-    then_i_should_be_taken_to_the_teachers_current_programme_page
-    when_i_select "No"
-    click_on "Continue"
+      then_i_should_be_taken_to_the_teachers_current_programme_page
+      when_i_select "No"
+      click_on "Continue"
 
-    then_i_should_be_taken_to_the_schools_current_programme_page
-    when_i_select @lead_provider.name
-    click_on "Continue"
+      then_i_should_be_taken_to_the_schools_current_programme_page
+      when_i_select @lead_provider.name
+      click_on "Continue"
 
-    then_i_should_be_taken_to_the_check_your_answers_page
+      then_i_should_be_taken_to_the_check_your_answers_page
 
-    click_on "Confirm and add"
-    then_i_should_be_on_the_complete_page
-    and_the_schools_current_provider_is_notified
-    and_the_participants_current_provider_is_notified
+      click_on "Confirm and add"
+      then_i_should_be_on_the_complete_page
+      and_the_schools_current_provider_is_notified
+      and_the_participants_current_provider_is_notified
 
-    click_on "View your mentors"
-    then_i_am_taken_to_manage_mentors_page
+      click_on "View your mentors"
+      then_i_am_taken_to_manage_mentors_page
+    end
   end
 
   scenario "Induction tutor can transfer an Mentor and they can continue their current programme" do
-    when_i_click_to_add_a_new_mentor
-    then_i_should_be_on_the_who_to_add_page
+    inside_auto_assignment_window do
+      when_i_click_to_add_a_new_mentor
+      then_i_should_be_on_the_who_to_add_page
 
-    when_i_select_the_mentor_option
-    click_on "Continue"
-    then_i_should_be_on_what_we_need_page
+      when_i_select_the_mentor_option
+      click_on "Continue"
+      then_i_should_be_on_what_we_need_page
 
-    click_on "Continue"
-    then_i_should_be_on_full_name_page
+      click_on "Continue"
+      then_i_should_be_on_full_name_page
 
-    when_i_update_the_name_with(@participant_data[:full_name])
-    click_on "Continue"
-    then_i_should_be_on_trn_page
+      when_i_update_the_name_with(@participant_data[:full_name])
+      click_on "Continue"
+      then_i_should_be_on_trn_page
 
-    when_i_add_a_valid_trn
-    click_on "Continue"
-    then_i_should_be_on_the_date_of_birth_page
+      when_i_add_a_valid_trn
+      click_on "Continue"
+      then_i_should_be_on_the_date_of_birth_page
 
-    when_i_add_a_valid_date_of_birth
-    click_on "Continue"
-    then_i_should_be_on_the_only_mentor_at_your_school_page
+      when_i_add_a_valid_date_of_birth
+      click_on "Continue"
+      then_i_should_be_on_the_only_mentor_at_your_school_page
 
-    when_i_select "Yes"
-    click_on "Confirm"
-    then_i_should_be_on_the_teacher_start_date_page
+      when_i_select "Yes"
+      click_on "Confirm"
+      then_i_should_be_on_the_teacher_start_date_page
 
-    when_i_add_a_valid_start_date
-    click_on "Continue"
-    then_i_should_be_on_the_add_email_page
+      when_i_add_a_valid_start_date
+      click_on "Continue"
+      then_i_should_be_on_the_add_email_page
 
-    when_i_update_the_email_with("sally-mentor@example.com")
-    click_on "Continue"
+      when_i_update_the_email_with("sally-mentor@example.com")
+      click_on "Continue"
 
-    then_i_should_be_taken_to_the_teachers_current_programme_page
-    when_i_select "Yes"
-    click_on "Continue"
-    then_i_should_be_taken_to_the_check_your_answers_page_for_an_existing_induction
+      then_i_should_be_taken_to_the_teachers_current_programme_page
+      when_i_select "Yes"
+      click_on "Continue"
+      then_i_should_be_taken_to_the_check_your_answers_page_for_an_existing_induction
 
-    click_on "Confirm and add"
-    then_i_should_be_on_the_complete_page_for_an_existing_induction
-    and_the_participants_current_provider_is_notified
+      click_on "Confirm and add"
+      then_i_should_be_on_the_complete_page_for_an_existing_induction
+      and_the_participants_current_provider_is_notified
 
-    click_on "View your mentors"
-    then_i_am_taken_to_manage_mentors_page
+      click_on "View your mentors"
+      then_i_am_taken_to_manage_mentors_page
+    end
   end
 
   # given

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_no_change_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_no_change_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Transferring a mentor weith matching lead provider and delivery partner", type: :feature, js: true do
+RSpec.describe "Transferring a mentor weith matching lead provider and delivery partner", type: :feature, js: true, mid_cohort: true do
   before do
     allow_participant_transfer_mailers
     set_participant_data

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/unhappy_path_cannot_validate_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/unhappy_path_cannot_validate_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "transferring participants", type: :feature, js: true do
+RSpec.describe "transferring participants", type: :feature, js: true, mid_cohort: true do
   context "Attempting to transfer an ECT to a school" do
     context "ECT cannot be validated" do
       before do

--- a/spec/features/schools/participants/update_participants_details_spec.rb
+++ b/spec/features/schools/participants/update_participants_details_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe "Changing participant details from check answers", type: :feature
   end
 end
 
-RSpec.describe "Changing participant details from the dashboard", type: :feature, js: true do
+RSpec.describe "Changing participant details from the dashboard", type: :feature, js: true, mid_cohort: true do
   include ManageTrainingSteps
 
   before do

--- a/spec/features/schools/participants/update_participants_details_spec.rb
+++ b/spec/features/schools/participants/update_participants_details_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../training_dashboard/manage_training_steps"
 
-RSpec.describe "Changing participant details from check answers", type: :feature, js: true do
+RSpec.describe "Changing participant details from check answers", type: :feature, js: true, mid_cohort: true do
   include ManageTrainingSteps
 
   before do

--- a/spec/features/schools/training_dashboard/manage_design_our_own_training_spec.rb
+++ b/spec/features/schools/training_dashboard/manage_design_our_own_training_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "./manage_training_steps"
 
-RSpec.describe "Manage Design Our Own training", js: true do
+RSpec.describe "Manage Design Our Own training", js: true, mid_cohort: true do
   include ManageTrainingSteps
 
   scenario "Design Our Own Induction Coordinator" do

--- a/spec/features/schools/training_dashboard/manage_no_ect_training_spec.rb
+++ b/spec/features/schools/training_dashboard/manage_no_ect_training_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "./manage_training_steps"
 
-RSpec.describe "Manage No ECT training", js: true do
+RSpec.describe "Manage No ECT training", js: true, mid_cohort: true do
   include ManageTrainingSteps
 
   scenario "Manage No ECT Induction Coordinator" do

--- a/spec/features/schools/training_dashboard/manage_schools_spec.rb
+++ b/spec/features/schools/training_dashboard/manage_schools_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "./manage_training_steps"
 
-RSpec.feature "School Tutors should be able to manage schools", type: :feature, js: true, rutabaga: false do
+RSpec.feature "School Tutors should be able to manage schools", type: :feature, js: true, rutabaga: false, mid_cohort: true do
   include ManageTrainingSteps
 
   scenario "Change school" do

--- a/spec/forms/schools/add_participants/transfer_wizard_spec.rb
+++ b/spec/forms/schools/add_participants/transfer_wizard_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Schools::AddParticipants::TransferWizard, type: :model do
+RSpec.describe Schools::AddParticipants::TransferWizard, type: :model, mid_cohort: true do
   let(:cohort) { Cohort.previous || create(:cohort, :previous) }
   let(:next_cohort) { Cohort.current || create(:cohort, :current) }
   let(:data_store) do

--- a/spec/requests/nominations/choose_how_to_continue_spec.rb
+++ b/spec/requests/nominations/choose_how_to_continue_spec.rb
@@ -24,7 +24,7 @@ RSpec.shared_examples "redirects to start nomination" do |how_to_continue|
   end
 end
 
-RSpec.describe "Choosing how to continue with nominations", type: :request do
+RSpec.describe "Choosing how to continue with nominations", type: :request, mid_cohort: true do
   let!(:cohort) { create(:cohort, :current) }
 
   describe "GET /nominations/start" do

--- a/spec/requests/schools/core_programme/materials_spec.rb
+++ b/spec/requests/schools/core_programme/materials_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Schools::CoreProgramme::Materials", type: :request do
+RSpec.describe "Schools::CoreProgramme::Materials", type: :request, mid_cohort: true do
   let(:user) { create(:user, :induction_coordinator) }
   let(:school) { user.induction_coordinator_profile.schools.first }
   let!(:cohort) { Cohort.current || create(:cohort, :current) }

--- a/spec/requests/schools/early_career_teachers_request_spec.rb
+++ b/spec/requests/schools/early_career_teachers_request_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Schools::EarlyCareerTeachers", type: :request, js: true, with_feature_flags: { eligibility_notifications: "active" } do
+RSpec.describe "Schools::EarlyCareerTeachers", type: :request, js: true, with_feature_flags: { eligibility_notifications: "active" }, mid_cohort: true do
   let(:user) { create(:user, :induction_coordinator, school_ids: [school.id]) }
   let!(:lead_provider) { create(:cpd_lead_provider, :with_lead_provider, name: "Lead Provider").lead_provider }
 

--- a/spec/requests/schools/mentors_request_spec.rb
+++ b/spec/requests/schools/mentors_request_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Schools::Participants", type: :request, js: true, with_feature_flags: { eligibility_notifications: "active" } do
+RSpec.describe "Schools::Participants", type: :request, js: true, with_feature_flags: { eligibility_notifications: "active" }, mid_cohort: true do
   let(:user) { create(:user, :induction_coordinator, school_ids: [school.id]) }
   let!(:lead_provider) { create(:cpd_lead_provider, :with_lead_provider, name: "Lead Provider").lead_provider }
 

--- a/spec/requests/schools/participants_request_spec.rb
+++ b/spec/requests/schools/participants_request_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Schools::Participants", type: :request, js: true, with_feature_flags: { eligibility_notifications: "active" } do
+RSpec.describe "Schools::Participants", type: :request, js: true, with_feature_flags: { eligibility_notifications: "active" }, mid_cohort: true do
   let(:user) { create(:user, :induction_coordinator, school_ids: [school.id]) }
   let!(:lead_provider) { create(:cpd_lead_provider, :with_lead_provider, name: "Lead Provider").lead_provider }
 

--- a/spec/requests/schools/partnerships_spec.rb
+++ b/spec/requests/schools/partnerships_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Schools::Partnerships", type: :request do
+RSpec.describe "Schools::Partnerships", type: :request, mid_cohort: true do
   let(:user) { create(:user, :induction_coordinator) }
   let!(:school) { user.induction_coordinator_profile.schools.first }
   let(:cohort) { Cohort.current || create(:cohort, :current) }

--- a/spec/services/induction/amend_participant_cohort_spec.rb
+++ b/spec/services/induction/amend_participant_cohort_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Induction::AmendParticipantCohort do
+RSpec.describe Induction::AmendParticipantCohort, mid_cohort: true do
   describe "#save" do
     let(:participant_profile) {}
     let(:source_cohort_start_year) { Cohort.previous.start_year }

--- a/spec/support/cohort_periods.rb
+++ b/spec/support/cohort_periods.rb
@@ -14,3 +14,10 @@ end
 def outside_auto_assignment_window(cohort: Cohort.current, &block)
   travel_to(cohort.automatic_assignment_period_end_date + 1.week, &block)
 end
+
+# time travel to after the current cohort opens
+RSpec.configure do |config|
+  config.before(mid_cohort: true) do
+    travel_to(Cohort.current.academic_year_start_date + 2.days)
+  end
+end


### PR DESCRIPTION
### Context
The factory cohort setup moved into registration for the next cohort, so a lot of tests have failed. This is due to registration setup pages being presented instead of mid cohort pages.

- Ticket: n/a

### Changes proposed in this pull request
- Add an rspec tag to travel to mid cohort
- When registration opens we see different views to the current cohort. Travel to the time the current cohort opens so we don't see setup pages on specific tests

### Guidance to review
yey!
