### PR TITLE
Disable NPQ capping validation for ECF in ChangeSchedule

### DIFF
--- a/app/services/change_schedule.rb
+++ b/app/services/change_schedule.rb
@@ -283,6 +283,7 @@ private
   end
 
   def validate_application_funded_place
+    return unless participant_profile&.npq?
     return unless FeatureFlag.active?(:npq_capping)
     return unless npq_contract.cohort != target_npq_contract.cohort
 

--- a/spec/services/change_schedule_spec.rb
+++ b/spec/services/change_schedule_spec.rb
@@ -348,6 +348,12 @@ RSpec.describe ChangeSchedule do
 
       it_behaves_like "changing the schedule of a participant"
 
+      context "when the npq_capping feature is enabled" do
+        before { FeatureFlag.activate(:npq_capping) }
+
+        it_behaves_like "changing the schedule of a participant"
+      end
+
       it "updates the schedule on the relevant induction record" do
         service.call
         relevant_induction_record = participant_profile.current_induction_record
@@ -605,6 +611,12 @@ RSpec.describe ChangeSchedule do
       let!(:new_schedule) { create(:ecf_mentor_schedule, schedule_identifier: "ecf-replacement-april", name: "Mentor Standard") }
 
       it_behaves_like "changing the schedule of a participant"
+
+      context "when the npq_capping feature is enabled" do
+        before { FeatureFlag.activate(:npq_capping) }
+
+        it_behaves_like "changing the schedule of a participant"
+      end
 
       it "updates the schedule on the relevant induction record" do
         service.call


### PR DESCRIPTION
The validation rule calls `npq_applications`, which doesn't exist for ECF participants; we only want to apply it to NPQ participants.
