### PR TITLE
Show reason for challenge to admins when partnership already exists

### DIFF
--- a/app/forms/admin/participants/change_relationship/change_relationship_wizard.rb
+++ b/app/forms/admin/participants/change_relationship/change_relationship_wizard.rb
@@ -109,6 +109,18 @@ module Admin
                                                                  end
         end
 
+        def existing_partnership
+          @existing_partnership = Partnership.find_by(cohort:, school:, lead_provider_id:, delivery_partner_id:)
+        end
+
+        def existing_partnership_challenged_at
+          existing_partnership.challenged_at.to_formatted_s(:govuk)
+        end
+
+        def existing_partnership_challenge_reason
+          existing_partnership.challenge_reason.humanize
+        end
+
         def selected_lead_provider_name
           selected_lead_provider&.name
         end

--- a/app/views/admin/participants/change_relationship/relationship_already_exists.html.erb
+++ b/app/views/admin/participants/change_relationship/relationship_already_exists.html.erb
@@ -17,6 +17,16 @@
         <% row.with_key { "Delivery partner" } %>
         <% row.with_value { @wizard.selected_delivery_partner_name } %>
       <% end %>
+      <% if @wizard.existing_partnership.challenged_at %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key { "Challenged at" } %>
+          <% row.with_value { @wizard.existing_partnership_challenged_at } %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key { "Challenge reason" } %>
+          <% row.with_value { @wizard.existing_partnership_challenge_reason } %>
+        <% end %>
+      <% end %>
     <% end %>
 
     <%= govuk_link_to "Return to change relationship", @wizard.show_path_for(step: :change_training_programme), no_visited_state: true %>


### PR DESCRIPTION
### Context

- Ticket: N/A

Enhance context for displaying the "This relationship already exists" page when Admins attempt to change participants' LP/DP in an already existing and challenged partnership.

### Changes proposed in this pull request
- Added the challenged date and challenge reason to the view

### Guidance to review

| Before | After |
|--------|--------|
|![Screenshot from 2024-06-05 13-42-46](https://github.com/DFE-Digital/early-careers-framework/assets/951947/1faa48c9-4f36-4656-b7e9-611c92618832)|![Screenshot from 2024-06-05 14-21-04](https://github.com/DFE-Digital/early-careers-framework/assets/951947/0e50eb06-3930-4038-baec-1fa5f7700c1e)|
