### PR TITLE
Ensure next output fee statement exists when attaching declaration

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,7 @@ en:
   bad_request: "Bad request"
   bad_parameter: "Bad parameter"
   invalid_transition: "Invalid action"
+  no_output_fee_statements_for_cohort: "You cannot submit or void declarations for the %{cohort} cohort. The funding contract for this cohort has ended. Get in touch if you need to discuss this with us"
   invalid_page_parameters: "The '#/page[page]' and '#/page[per_page]' parameter values must be a valid number (equal and more than 1)"
   cannot_change_cohort: "You cannot change the '#/cohort' field"
   cannot_create_completed_declaration: "Could not create completed declaration. Contact the DfE for support."

--- a/spec/factories/participant_declaration.rb
+++ b/spec/factories/participant_declaration.rb
@@ -63,9 +63,6 @@ FactoryBot.define do
         NPQContract.find_by(opts) || create(:npq_contract, opts)
       end
 
-      service = RecordDeclaration.new(params)
-      raise ArgumentError, service.errors.full_messages unless service.valid?
-
       if participant_profile.is_a?(ParticipantProfile::NPQ) && participant_profile.fundable?
         cohort = participant_profile.npq_application.cohort
         next_output_fee_statement = cpd_lead_provider.npq_lead_provider.next_output_fee_statement(cohort)
@@ -77,6 +74,9 @@ FactoryBot.define do
         next_output_fee_statement = cpd_lead_provider.lead_provider.next_output_fee_statement(cohort)
         create(:ecf_statement, :next_output_fee, cpd_lead_provider:, cohort:) unless next_output_fee_statement
       end
+
+      service = RecordDeclaration.new(params)
+      raise ArgumentError, service.errors.full_messages unless service.valid?
 
       service.call
     end

--- a/spec/requests/api/v2/participant_declarations_spec.rb
+++ b/spec/requests/api/v2/participant_declarations_spec.rb
@@ -195,6 +195,19 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
         expect(response).to have_http_status(:unprocessable_entity)
       end
 
+      it "returns 422 when there are no output fee statements available" do
+        Finance::Statement.update!(output_fee: false)
+
+        post "/api/v2/participant-declarations", params: build_params(valid_params)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(parsed_response["errors"])
+          .to eq([
+            "title" => "cohort",
+            "detail" => "You cannot submit or void declarations for the #{ect_profile.schedule.cohort.start_year} cohort. The funding contract for this cohort has ended. Get in touch if you need to discuss this with us",
+          ])
+      end
+
       it "returns 422 when a required parameter is missing", :aggregation_failures do
         missing_attribute = valid_params.except(:participant_id)
         post "/api/v2/participant-declarations", params: build_params(missing_attribute)
@@ -632,6 +645,37 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
       it "returns a 200" do
         put "/api/v2/participant-declarations/#{declaration.id}/void"
         expect(response.status).to eql(200)
+      end
+    end
+
+    context "when the declaration is paid" do
+      let(:declaration) { create(:ect_participant_declaration, :paid, cpd_lead_provider:) }
+      let(:cohort) { declaration.participant_profile.schedule.cohort }
+
+      before { create(:ecf_statement, :next_output_fee, cpd_lead_provider:, cohort:) }
+
+      it "can be clawed back" do
+        expect {
+          put "/api/v2/participant-declarations/#{declaration.id}/void"
+        }.to change { declaration.reload.state }.from("paid").to("awaiting_clawback")
+      end
+
+      it "returns a 200" do
+        put "/api/v2/participant-declarations/#{declaration.id}/void"
+        expect(response.status).to eql(200)
+      end
+
+      it "returns 422 when there are no output fee statements available" do
+        Finance::Statement.update!(output_fee: false)
+
+        put "/api/v2/participant-declarations/#{declaration.id}/void"
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(parsed_response["errors"])
+          .to eq([
+            "title" => "Invalid action",
+            "detail" => "Participant declaration You cannot submit or void declarations for the #{cohort.start_year} cohort. The funding contract for this cohort has ended. Get in touch if you need to discuss this with us",
+          ])
       end
     end
 

--- a/spec/requests/api/v3/participant_declarations_spec.rb
+++ b/spec/requests/api/v3/participant_declarations_spec.rb
@@ -507,6 +507,19 @@ RSpec.describe "API Participant Declarations", type: :request do
         expect(response).to have_http_status(:unprocessable_entity)
       end
 
+      it "returns 422 when there are no output fee statements available" do
+        Finance::Statement.update!(output_fee: false)
+
+        post "/api/v3/participant-declarations", params: build_params(valid_params)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(parsed_response["errors"])
+          .to eq([
+            "title" => "cohort",
+            "detail" => "You cannot submit or void declarations for the #{ect_profile.schedule.cohort.start_year} cohort. The funding contract for this cohort has ended. Get in touch if you need to discuss this with us",
+          ])
+      end
+
       it "returns 422 when a required parameter is missing", :aggregation_failures do
         missing_attribute = valid_params.except(:participant_id)
         post "/api/v3/participant-declarations", params: build_params(missing_attribute)
@@ -829,6 +842,37 @@ RSpec.describe "API Participant Declarations", type: :request do
         it "returns a 200" do
           put "/api/v3/participant-declarations/#{participant_declaration.id}/void"
           expect(response.status).to eql(200)
+        end
+      end
+
+      context "when the declaration is paid" do
+        let(:participant_declaration) { create(:ect_participant_declaration, :paid, cpd_lead_provider:) }
+        let(:cohort) { participant_declaration.participant_profile.schedule.cohort }
+
+        before { create(:ecf_statement, :next_output_fee, cpd_lead_provider:, cohort:) }
+
+        it "can be clawed back" do
+          expect {
+            put "/api/v3/participant-declarations/#{participant_declaration.id}/void"
+          }.to change { participant_declaration.reload.state }.from("paid").to("awaiting_clawback")
+        end
+
+        it "returns a 200" do
+          put "/api/v3/participant-declarations/#{participant_declaration.id}/void"
+          expect(response.status).to eql(200)
+        end
+
+        it "returns 422 when there are no output fee statements available" do
+          Finance::Statement.update!(output_fee: false)
+
+          put "/api/v3/participant-declarations/#{participant_declaration.id}/void"
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(parsed_response["errors"])
+            .to eq([
+              "title" => "Invalid action",
+              "detail" => "Participant declaration You cannot submit or void declarations for the #{cohort.start_year} cohort. The funding contract for this cohort has ended. Get in touch if you need to discuss this with us",
+            ])
         end
       end
 

--- a/spec/services/record_declaration_spec.rb
+++ b/spec/services/record_declaration_spec.rb
@@ -9,6 +9,42 @@ RSpec.shared_examples "checks for mentor completion event" do
   end
 end
 
+RSpec.shared_examples "validates the next output fee statement is available" do
+  context "when there are no available output fee statements" do
+    before { Finance::Statement.update!(output_fee: false) }
+
+    context "when the declarations is submitted" do
+      it { is_expected.to be_valid }
+    end
+
+    context "when the declaration is eligible" do
+      it "returns an error" do
+        create(:ecf_participant_eligibility, :eligible, participant_profile:) if participant_profile.ecf?
+        participant_profile.npq_application.update!(eligible_for_funding: true) if participant_profile.npq?
+
+        expect(service).to be_invalid
+
+        cohort = participant_profile.schedule.cohort.start_year
+        expect(service.errors.messages_for(:cohort)).to include(/You cannot submit or void declarations for the #{cohort}/)
+      end
+    end
+
+    context "when there is an existing billable declaration" do
+      before do
+        existing_declaration = described_class.new(params).call
+        existing_declaration.update!(state: :paid)
+      end
+
+      it "returns an error" do
+        expect(service).to be_invalid
+
+        cohort = participant_profile.schedule.cohort.start_year
+        expect(service.errors.messages_for(:cohort)).to include(/You cannot submit or void declarations for the #{cohort}/)
+      end
+    end
+  end
+end
+
 RSpec.shared_examples "validates the declaration for a withdrawn participant" do
   context "when a participant has been withdrawn" do
     before do
@@ -357,6 +393,7 @@ RSpec.describe RecordDeclaration do
         end
       end
 
+      it_behaves_like "validates the next output fee statement is available"
       it_behaves_like "validates the declaration for a withdrawn participant"
       it_behaves_like "validates the course_identifier, cpd_lead_provider, participant_id"
       it_behaves_like "validates existing declarations"
@@ -370,6 +407,7 @@ RSpec.describe RecordDeclaration do
       let(:participant_type) { :mentor }
       let(:course_identifier) { "ecf-mentor" }
 
+      it_behaves_like "validates the next output fee statement is available"
       it_behaves_like "validates the declaration for a withdrawn participant"
       it_behaves_like "validates the course_identifier, cpd_lead_provider, participant_id"
       it_behaves_like "validates existing declarations"
@@ -404,6 +442,7 @@ RSpec.describe RecordDeclaration do
       end
     end
 
+    it_behaves_like "validates the next output fee statement is available"
     it_behaves_like "validates the declaration for a withdrawn participant"
     it_behaves_like "validates the course_identifier, cpd_lead_provider, participant_id"
     it_behaves_like "validates existing declarations"


### PR DESCRIPTION
[Jira-3142](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3142)

### Context

Currently, if we attempt to attach a declaration when there are no output fee statements available it will result in a 500 error. Instead, we want to surface a helpful error message to lead providers encountering this scenario.

### Changes proposed in this pull request

- Ensure next output fee statement exists when attaching declaration

Update `RecordDeclaration` and `ClawbackDeclaration` to ensure the next output fee statement exists. 

### Guidance to review

Originally I tried to add this validation to the `StatementAttacher` and bubble it up from there, but we can't do that without a substantial refactoring due it being called _after_ the `RecordDeclaration` validation as part of the transaction (if we call it during the validation it would result in the declaration being created prematurely). 

I also attempted to extract this into a custom validator, but the differences between the two services that call the statement attacher means this isn't viable/clean.

The only other option would be to raise an error during `call` in the `StatementAttacher` when the statement does not exist and handle it at the controller-level, but I opted to have it validate on `valid?` instead which was a bit more work but keeps the behaviour consistent.

The `StatementAttacher` is also called as part of `RecordDeclarations::Actions::MakeDeclarationsEligibleForParticipantProfile`, however this doesn't appear to be exposed to lead providers/handle errors in general, so I've left as-is.
