### PR TITLE
Add X-With-Server-Date header support to migration env

### DIFF
--- a/config/environments/migration.rb
+++ b/config/environments/migration.rb
@@ -5,4 +5,7 @@ require Rails.root.join("config/environments/production")
 Rails.application.configure do
   config.log_level = :debug
   config.ssl_options = { redirect: { exclude: ->(request) { request.path.include?("/check") } } }
+
+  # Used to handle HTTP_X_WITH_SERVER_DATE header for server side datetime overwrite
+  config.middleware.use TimeTraveler
 end


### PR DESCRIPTION
We need this to be able to test some of the declaration scenarios.
