### PR TITLE
Disable deployments to migration environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -166,24 +166,26 @@ jobs:
           current-commit-sha: ${{ github.sha }}
           statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}
 
-  deploy_migration:
-    name: Deploy migration
-    needs: [deploy_staging]
-    runs-on: ubuntu-latest
-    environment:
-      name: migration
+  # Temporarily disabled while we manually deploy and test on the migration environment.
+  #
+  # deploy_migration:
+  #   name: Deploy migration
+  #   needs: [deploy_staging]
+  #   runs-on: ubuntu-latest
+  #   environment:
+  #     name: migration
 
-    steps:
-      - uses: actions/checkout@v3
+  #   steps:
+  #     - uses: actions/checkout@v3
 
-      - uses: ./.github/actions/deploy-environment-to-aks
-        id: deploy
-        with:
-          environment: migration
-          docker-image: ${{ needs.deploy_staging.outputs.docker-image }}
-          azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
-          current-commit-sha: ${{ github.sha }}
-          statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}
+  #     - uses: ./.github/actions/deploy-environment-to-aks
+  #       id: deploy
+  #       with:
+  #         environment: migration
+  #         docker-image: ${{ needs.deploy_staging.outputs.docker-image }}
+  #         azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
+  #         current-commit-sha: ${{ github.sha }}
+  #         statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}
 
   deploy_production:
     name: Deploy production


### PR DESCRIPTION
We want to manually deploy a specific branch to the migration environment so that we can perform testing ahead of the multi cohort rollout.
