### PR TITLE
Use declaration cohort when attaching to statement

### DIFF
--- a/app/services/finance/clawback_declaration.rb
+++ b/app/services/finance/clawback_declaration.rb
@@ -27,8 +27,8 @@ module Finance
     attr_accessor :participant_declaration
 
     def output_fee_statement_available
+      cohort = participant_declaration.cohort
       cpd_lead_provider = participant_declaration.cpd_lead_provider
-      cohort = participant_declaration.participant_profile.schedule_for(cpd_lead_provider:).cohort
 
       next_output_fee_statement = if participant_declaration.ecf?
                                     cpd_lead_provider.lead_provider.next_output_fee_statement(cohort)

--- a/app/services/finance/declaration_statement_attacher.rb
+++ b/app/services/finance/declaration_statement_attacher.rb
@@ -23,7 +23,7 @@ module Finance
     attr_accessor :participant_declaration
 
     def cohort
-      participant_declaration.participant_profile.schedule_for(cpd_lead_provider:).cohort
+      participant_declaration.cohort
     end
 
     def cpd_lead_provider

--- a/spec/services/finance/clawback_declaration_spec.rb
+++ b/spec/services/finance/clawback_declaration_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Finance::ClawbackDeclaration do
       it "returns an error" do
         expect(subject).to be_invalid
 
-        cohort = participant_profile.schedule.cohort.start_year
+        cohort = participant_declaration.cohort.start_year
         expect(subject.errors.messages_for(:participant_declaration)).to include(/You cannot submit or void declarations for the #{cohort}/)
       end
 
@@ -60,7 +60,7 @@ RSpec.describe Finance::ClawbackDeclaration do
         it "returns an error" do
           expect(subject).to be_invalid
 
-          cohort = participant_profile.schedule.cohort.start_year
+          cohort = participant_declaration.cohort.start_year
           expect(subject.errors.messages_for(:participant_declaration)).to include(/You cannot submit or void declarations for the #{cohort}/)
         end
       end

--- a/spec/services/finance/npq/statement_calculator_spec.rb
+++ b/spec/services/finance/npq/statement_calculator_spec.rb
@@ -103,7 +103,8 @@ RSpec.describe Finance::NPQ::StatementCalculator do
     context "when there are clawbacks" do
       let!(:participant_declaration) do
         travel_to milestone.start_date do
-          create(:npq_participant_declaration, :paid, declaration_type:, cpd_lead_provider:, participant_profile:)
+          cohort = participant_profile.schedule.cohort
+          create(:npq_participant_declaration, :paid, declaration_type:, cpd_lead_provider:, participant_profile:, cohort:)
         end
       end
       let!(:previous_statement) { participant_declaration.statement_line_items.first.statement }

--- a/spec/services/void_participant_declaration_spec.rb
+++ b/spec/services/void_participant_declaration_spec.rb
@@ -134,7 +134,8 @@ RSpec.describe VoidParticipantDeclaration do
       end
       let(:participant_declaration) do
         travel_to declaration_date do
-          create(:npq_participant_declaration, participant_profile:, cpd_lead_provider:, declaration_type:, declaration_date:, state: "paid", has_passed: true)
+          cohort = participant_profile.schedule.cohort
+          create(:npq_participant_declaration, participant_profile:, cpd_lead_provider:, declaration_type:, declaration_date:, state: "paid", has_passed: true, cohort:)
         end
       end
 


### PR DESCRIPTION
[Jira-3171](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3171)

### Context

Currently, we look to the latest induction record for the lead provider to find the cohort when attaching a declaration to a statement. This is no longer correct for participants that have declarations in 2021 and have since been moved to 2024. It would result in the declaration being voided against a 2024 statement instead of the original 2021 statement.

To correct this behaviour we can take the `declaration.cohort` when attaching to a statement, which will always be the cohort that the declaration was initially created in.

### Changes proposed in this pull request

- Use declaration cohort when attaching to statement

### Guidance to review

We have made changes to ensure we retain the logic around checking a participant has induction records for the CPD lead provider. This may or may not be required, but it was a byproduct of the original logic so we're airing on the side of caution 😅 
