### PR TITLE
[CST-2593] Provide attribute to flag ABs that are no longer acting as AB

### DIFF
--- a/app/models/appropriate_body.rb
+++ b/app/models/appropriate_body.rb
@@ -16,6 +16,10 @@ class AppropriateBody < ApplicationRecord
   default_scope { order(:name) }
 
   scope :name_order, -> { order("UPPER(name)") }
+
+  # provide means to keep AB for history but prevent selection in UI
+  scope :selectable_by_schools, -> { where(selectable_by_schools: true) }
+
   scope :local_authorities, -> { where(body_type: :local_authority) }
   scope :teaching_school_hubs, -> { where(body_type: :teaching_school_hub) }
   scope :nationals, -> { where(body_type: :national) }

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -157,6 +157,7 @@
   - disable_from_year
   - listed
   - listed_for_school_type_codes
+  - selectable_by_schools
   :participant_profiles:
   - id
   - school_id

--- a/db/migrate/20240610122201_add_selectable_by_schools_to_appropriate_body.rb
+++ b/db/migrate/20240610122201_add_selectable_by_schools_to_appropriate_body.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSelectableBySchoolsToAppropriateBody < ActiveRecord::Migration[7.1]
+  def change
+    add_column :appropriate_bodies, :selectable_by_schools, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_22_114103) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_10_122201) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -208,6 +208,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_22_114103) do
     t.integer "disable_from_year"
     t.boolean "listed", default: false, null: false
     t.integer "listed_for_school_type_codes", default: [], array: true
+    t.boolean "selectable_by_schools", default: true, null: false
     t.index ["body_type", "name"], name: "index_appropriate_bodies_on_body_type_and_name", unique: true
   end
 

--- a/spec/models/appropriate_body_spec.rb
+++ b/spec/models/appropriate_body_spec.rb
@@ -42,4 +42,13 @@ RSpec.describe AppropriateBody, type: :model do
     expect(AppropriateBody.active_in_year(2021).count).to eq(2)
     expect(AppropriateBody.active_in_year(2022).count).to eq(1)
   end
+
+  it "filters ABs removed from selection" do
+    ab1 = create(:appropriate_body_local_authority, name: "Acting")
+    ab2 = create(:appropriate_body_local_authority, name: "No Longer Acting", selectable_by_schools: false)
+    ab3 = create(:appropriate_body_local_authority, name: "from 2021", disable_from_year: 2021)
+    expect(AppropriateBody.all).to match_array [ab1, ab2, ab3]
+    expect(AppropriateBody.selectable_by_schools).to match_array [ab1, ab3]
+    expect(AppropriateBody.selectable_by_schools.active_in_year(2022)).to match_array [ab1]
+  end
 end


### PR DESCRIPTION
### Context

- Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-2593)
- Provide new attribute `AppropriateBody.selectable_by_schools` as a way to filter ABs that are no longer acting and should not be available to be selected by schools for any year.
- This does not include updating the queries where this should be used as there is other ongoing work that can be updated later.

### Changes proposed in this pull request
Adds `AppropriateBody.selectable_by_schools` attribute with default value `true`
Adds scope for the attribute

### Guidance to review

