### PR TITLE
[CPDNPQ-1837] Added npq-senco release notes and swagger docs

### DIFF
--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -9,11 +9,12 @@ If you have any questions or comments about these notes, please contact DfE via 
 
 ## 14 June 2024
 
-We’ve added the new special educational needs coordinator (SENCO) NPQ to the test (sandbox) environment for the 2024 cohort.
+We’ve added the new special educational needs coordinator (SENCO) NPQ to the [test (sandbox) environment](https://sb.manage-training-for-early-career-teachers.education.gov.uk/) for the 2024 cohort.
 
-The new course’s identifier is npq-senco.
+The new course’s identifier is 'npq-senco'.
 
 Providers can access this within the sandbox environment for testing. Functionality will be the same as the other existing NPQ courses.
+
 We’ll notify providers when this new NPQ is available in the production environment.
 
 ## 10 June 2024

--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -11,7 +11,7 @@ If you have any questions or comments about these notes, please contact DfE via 
 
 We’ve added the new special educational needs coordinator (SENCO) NPQ to the [test (sandbox) environment](https://sb.manage-training-for-early-career-teachers.education.gov.uk/) for the 2024 cohort.
 
-The new course’s identifier is 'npq-senco'.
+The new course’s identifier is `npq-senco`.
 
 Providers can access this within the sandbox environment for testing. Functionality will be the same as the other existing NPQ courses.
 

--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -7,13 +7,27 @@ weight: 8
 
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
 
+## 14 June 2024
+
+We’ve added the new special educational needs coordinator (SENCO) NPQ to the test (sandbox) environment for the 2024 cohort.
+
+The new course’s identifier is npq-senco.
+
+Providers can access this within the sandbox environment for testing. Functionality will be the same as the other existing NPQ courses.
+We’ll notify providers when this new NPQ is available in the production environment.
+
 ## 10 June 2024
 
-We’ve introduced the `cohort_changed_after_payments_frozen` attribute to the participant response in the API v3 [test (sandbox) environment](https://sb.manage-training-for-early-career-teachers.education.gov.uk/).
+On 31 July we’re closing the funding contract for the 2021 cohort.
 
-This feature enables providers to identify participants who’ve migrated to a new cohort to continue their training, as payments for their original cohort were frozen. 
+This means ECTs and mentors with partial declarations currently assigned to the 2021 cohort will be moved to the 2024 cohort.
 
-The value will be `true` for these participants.
+Providers can now test the functionality for the migration of these ECTs and mentors.
+Participants who’ve moved can be identified by the new `cohort_changed_after_payments_frozen` attribute to the participant response in the [API v3 test (sandbox) environment](https://sb.manage-training-for-early-career-teachers.education.gov.uk/). The value shown for these participants will be `true`.
+
+Providers will be able to test future declaration submissions in the 2024 cohort but can no longer submit or void declarations for 2021 after the contract has closed.
+
+We’d welcome feedback on this sandbox update before it goes into production.
 
 ## 5 June 2024 
 

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -3899,7 +3899,8 @@
               "npq-headship",
               "npq-executive-leadership",
               "npq-early-years-leadership",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "npq-leading-teaching"
           },

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -3496,7 +3496,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ]
           },
           "email": {
@@ -3785,7 +3786,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ]
           },
           "status": {
@@ -3944,7 +3946,8 @@
               "npq-headship",
               "npq-executive-leadership",
               "npq-early-years-leadership",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "npq-leading-teaching"
           },
@@ -4185,7 +4188,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "npq-executive-leadership"
           },
@@ -4274,7 +4278,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "npq-headship"
           },
@@ -4333,7 +4338,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "npq-headship"
           }
@@ -4390,7 +4396,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "npq-headship"
           }
@@ -4463,7 +4470,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "npq-senior-leadership"
           }
@@ -4545,7 +4553,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "npq-senior-leadership"
           }
@@ -4637,7 +4646,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "npq-headship"
           }
@@ -4715,7 +4725,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "npq-headship"
           }
@@ -4794,7 +4805,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "npq-leading-teaching-development"
           }
@@ -4960,7 +4972,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "ecf-induction"
           },
@@ -5069,7 +5082,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "ecf-induction"
           },

--- a/swagger/v1/component_schemas/NPQApplicationAttributes.yml
+++ b/swagger/v1/component_schemas/NPQApplicationAttributes.yml
@@ -29,6 +29,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
   email:
     description: "The email address registered for this NPQ participant"
     type: string

--- a/swagger/v1/component_schemas/NPQApplicationCsvRow.yml
+++ b/swagger/v1/component_schemas/NPQApplicationCsvRow.yml
@@ -98,6 +98,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
   status:
     description: "The current state of the NPQ application"
     type: string

--- a/swagger/v1/component_schemas/NPQOutcomeAttributes.yml
+++ b/swagger/v1/component_schemas/NPQOutcomeAttributes.yml
@@ -27,6 +27,7 @@ properties:
       - npq-executive-leadership
       - npq-early-years-leadership
       - npq-leading-primary-mathematics
+      - npq-senco
     example: npq-leading-teaching
   state:
     description: The state of the outcome (passed, failed or voided)

--- a/swagger/v1/component_schemas/NPQOutcomeAttributesRequest.yml
+++ b/swagger/v1/component_schemas/NPQOutcomeAttributesRequest.yml
@@ -17,6 +17,7 @@ properties:
       - npq-executive-leadership
       - npq-early-years-leadership
       - npq-leading-primary-mathematics
+      - npq-senco
     example: npq-leading-teaching
   state:
     description: The state of the outcome (passed or failed)

--- a/swagger/v1/component_schemas/NPQParticipantChangeScheduleAttributes.yml
+++ b/swagger/v1/component_schemas/NPQParticipantChangeScheduleAttributes.yml
@@ -33,6 +33,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
     example: npq-executive-leadership
   cohort:
     description: "Providers may change an NPQ participant's cohort up until the point of submitting a started declaration. The value indicates which call-off contract funds this participant's training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year."

--- a/swagger/v1/component_schemas/NPQParticipantDeclarationCompletedAttributesRequest.yml
+++ b/swagger/v1/component_schemas/NPQParticipantDeclarationCompletedAttributesRequest.yml
@@ -39,6 +39,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
     example: npq-headship
   has_passed:
     description: Whether the participant has failed or passed

--- a/swagger/v1/component_schemas/NPQParticipantDeclarationRetainedAttributesRequest.yml
+++ b/swagger/v1/component_schemas/NPQParticipantDeclarationRetainedAttributesRequest.yml
@@ -34,6 +34,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
     example: npq-headship
 required:
   - participant_id

--- a/swagger/v1/component_schemas/NPQParticipantDeclarationStartedAttributesRequest.yml
+++ b/swagger/v1/component_schemas/NPQParticipantDeclarationStartedAttributesRequest.yml
@@ -33,6 +33,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
     example: npq-headship
 required:
   - participant_id

--- a/swagger/v1/component_schemas/NPQParticipantDeferAttributes.yml
+++ b/swagger/v1/component_schemas/NPQParticipantDeferAttributes.yml
@@ -29,6 +29,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
     example: npq-senior-leadership
 example:
   reason: parental-leave

--- a/swagger/v1/component_schemas/NPQParticipantResumeAttributes.yml
+++ b/swagger/v1/component_schemas/NPQParticipantResumeAttributes.yml
@@ -16,6 +16,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
     example: npq-senior-leadership
 required:
   - course_identifier

--- a/swagger/v1/component_schemas/NPQParticipantRetainedDeclarationAttributes.yml
+++ b/swagger/v1/component_schemas/NPQParticipantRetainedDeclarationAttributes.yml
@@ -34,6 +34,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
     example: npq-headship
 required:
   - participant_id

--- a/swagger/v1/component_schemas/NPQParticipantStartedDeclarationAttributes.yml
+++ b/swagger/v1/component_schemas/NPQParticipantStartedDeclarationAttributes.yml
@@ -34,6 +34,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
     example: npq-headship
 required:
   - participant_id

--- a/swagger/v1/component_schemas/NPQParticipantWithdrawAttributes.yml
+++ b/swagger/v1/component_schemas/NPQParticipantWithdrawAttributes.yml
@@ -37,6 +37,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
     example: npq-leading-teaching-development
 required:
   - reason

--- a/swagger/v1/component_schemas/ParticipantDeclarationAttributes.yml
+++ b/swagger/v1/component_schemas/ParticipantDeclarationAttributes.yml
@@ -51,6 +51,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
     example: ecf-induction
   eligible_for_payment:
     description: "[Deprecated - use state instead] Indicates whether this declaration would be eligible for funding from the DfE"

--- a/swagger/v1/component_schemas/ParticipantDeclarationCsvRow.yml
+++ b/swagger/v1/component_schemas/ParticipantDeclarationCsvRow.yml
@@ -56,6 +56,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
     example: ecf-induction
   eligible_for_payment:
     description: "[Deprecated - use state instead] Indicates whether this declaration would be eligible for funding from the DfE"

--- a/swagger/v2/api_spec.json
+++ b/swagger/v2/api_spec.json
@@ -3368,7 +3368,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ]
           },
           "email": {
@@ -3657,7 +3658,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ]
           },
           "status": {
@@ -3735,7 +3737,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ]
           },
           "schedule_identifier": {
@@ -3832,7 +3835,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ]
           },
           "schedule_identifier": {
@@ -3943,7 +3947,8 @@
               "npq-headship",
               "npq-executive-leadership",
               "npq-early-years-leadership",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "npq-leading-teaching"
           },
@@ -3989,7 +3994,8 @@
               "npq-headship",
               "npq-executive-leadership",
               "npq-early-years-leadership",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "npq-leading-teaching"
           },
@@ -4223,7 +4229,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "npq-executive-leadership"
           },
@@ -4312,7 +4319,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "npq-headship"
           },
@@ -4371,7 +4379,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "npq-headship"
           }
@@ -4428,7 +4437,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "npq-headship"
           }
@@ -4501,7 +4511,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "npq-senior-leadership"
           }
@@ -4583,7 +4594,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "npq-senior-leadership"
           }
@@ -4675,7 +4687,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "npq-headship"
           }
@@ -4753,7 +4766,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "npq-headship"
           }
@@ -4832,7 +4846,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "npq-leading-teaching-development"
           }
@@ -4949,7 +4964,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "ecf-induction"
           },
@@ -5042,7 +5058,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "ecf-induction"
           },

--- a/swagger/v2/component_schemas/NPQApplicationAttributes.yml
+++ b/swagger/v2/component_schemas/NPQApplicationAttributes.yml
@@ -29,6 +29,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
   email:
     description: "The email address registered for this NPQ participant"
     type: string

--- a/swagger/v2/component_schemas/NPQApplicationCsvRow.yml
+++ b/swagger/v2/component_schemas/NPQApplicationCsvRow.yml
@@ -98,6 +98,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
   status:
     description: "The current state of the NPQ application"
     type: string

--- a/swagger/v2/component_schemas/NPQEnrolment.yml
+++ b/swagger/v2/component_schemas/NPQEnrolment.yml
@@ -24,6 +24,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
   schedule_identifier:
     description: "The schedule the participant is enrolled in"
     type: string

--- a/swagger/v2/component_schemas/NPQEnrolmentCsvRow.yml
+++ b/swagger/v2/component_schemas/NPQEnrolmentCsvRow.yml
@@ -31,6 +31,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
   schedule_identifier:
     description: "The schedule currently applied to this enrolment"
     type: string

--- a/swagger/v2/component_schemas/NPQOutcomeAttributes.yml
+++ b/swagger/v2/component_schemas/NPQOutcomeAttributes.yml
@@ -27,6 +27,7 @@ properties:
       - npq-executive-leadership
       - npq-early-years-leadership
       - npq-leading-primary-mathematics
+      - npq-senco
     example: npq-leading-teaching
   state:
     description: The state of the outcome (passed or failed)

--- a/swagger/v2/component_schemas/NPQOutcomeAttributesRequest.yml
+++ b/swagger/v2/component_schemas/NPQOutcomeAttributesRequest.yml
@@ -17,6 +17,7 @@ properties:
       - npq-executive-leadership
       - npq-early-years-leadership
       - npq-leading-primary-mathematics
+      - npq-senco
     example: npq-leading-teaching
   state:
     description: The state of the outcome (passed or failed)

--- a/swagger/v2/component_schemas/NPQParticipantChangeScheduleAttributes.yml
+++ b/swagger/v2/component_schemas/NPQParticipantChangeScheduleAttributes.yml
@@ -33,6 +33,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
     example: npq-executive-leadership
   cohort:
     description: "Providers may change an NPQ participant's cohort up until the point of submitting a started declaration. The value indicates which call-off contract funds this participant's training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year."

--- a/swagger/v2/component_schemas/NPQParticipantDeclarationCompletedAttributesRequest.yml
+++ b/swagger/v2/component_schemas/NPQParticipantDeclarationCompletedAttributesRequest.yml
@@ -39,6 +39,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
     example: npq-headship
   has_passed:
     description: Whether the participant has failed or passed

--- a/swagger/v2/component_schemas/NPQParticipantDeclarationRetainedAttributesRequest.yml
+++ b/swagger/v2/component_schemas/NPQParticipantDeclarationRetainedAttributesRequest.yml
@@ -34,6 +34,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
     example: npq-headship
 required:
   - participant_id

--- a/swagger/v2/component_schemas/NPQParticipantDeclarationStartedAttributesRequest.yml
+++ b/swagger/v2/component_schemas/NPQParticipantDeclarationStartedAttributesRequest.yml
@@ -33,6 +33,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
     example: npq-headship
 required:
   - participant_id

--- a/swagger/v2/component_schemas/NPQParticipantDeferAttributes.yml
+++ b/swagger/v2/component_schemas/NPQParticipantDeferAttributes.yml
@@ -29,6 +29,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
     example: npq-senior-leadership
 example:
   reason: parental-leave

--- a/swagger/v2/component_schemas/NPQParticipantResumeAttributes.yml
+++ b/swagger/v2/component_schemas/NPQParticipantResumeAttributes.yml
@@ -16,6 +16,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
     example: npq-senior-leadership
 required:
   - course_identifier

--- a/swagger/v2/component_schemas/NPQParticipantRetainedDeclarationAttributes.yml
+++ b/swagger/v2/component_schemas/NPQParticipantRetainedDeclarationAttributes.yml
@@ -34,6 +34,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
     example: npq-headship
 required:
   - participant_id

--- a/swagger/v2/component_schemas/NPQParticipantStartedDeclarationAttributes.yml
+++ b/swagger/v2/component_schemas/NPQParticipantStartedDeclarationAttributes.yml
@@ -34,6 +34,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
     example: npq-headship
 required:
   - participant_id

--- a/swagger/v2/component_schemas/NPQParticipantWithdrawAttributes.yml
+++ b/swagger/v2/component_schemas/NPQParticipantWithdrawAttributes.yml
@@ -37,6 +37,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
     example: npq-leading-teaching-development
 required:
   - reason

--- a/swagger/v2/component_schemas/ParticipantDeclarationAttributes.yml
+++ b/swagger/v2/component_schemas/ParticipantDeclarationAttributes.yml
@@ -49,6 +49,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
     example: ecf-induction
   state:
     description: "Indicates the state of this payment declaration"

--- a/swagger/v2/component_schemas/ParticipantDeclarationCsvRow.yml
+++ b/swagger/v2/component_schemas/ParticipantDeclarationCsvRow.yml
@@ -54,6 +54,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
     example: ecf-induction
   state:
     description: "Indicates the state of this payment declaration"

--- a/swagger/v3/api_spec.json
+++ b/swagger/v3/api_spec.json
@@ -5216,7 +5216,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ]
           },
           "status": {
@@ -5455,7 +5456,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ]
           },
           "schedule_identifier": {
@@ -5622,7 +5624,8 @@
               "npq-headship",
               "npq-executive-leadership",
               "npq-early-years-leadership",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "npq-leading-teaching"
           },
@@ -5674,7 +5677,8 @@
               "npq-headship",
               "npq-executive-leadership",
               "npq-early-years-leadership",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "npq-leading-teaching"
           },
@@ -5898,7 +5902,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "npq-executive-leadership"
           },
@@ -5989,7 +5994,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "npq-leading-teaching"
           },
@@ -6140,7 +6146,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "npq-headship"
           },
@@ -6226,7 +6233,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "npq-headship"
           }
@@ -6283,7 +6291,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "npq-headship"
           }
@@ -6356,7 +6365,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "npq-senior-leadership"
           }
@@ -6438,7 +6448,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "npq-senior-leadership"
           }
@@ -6518,7 +6529,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "npq-leading-teaching"
           },
@@ -6657,7 +6669,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "npq-leading-teaching"
           },
@@ -6823,7 +6836,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "npq-leading-teaching-development"
           }
@@ -7111,7 +7125,8 @@
               "npq-early-years-leadership",
               "npq-additional-support-offer",
               "npq-early-headship-coaching-offer",
-              "npq-leading-primary-mathematics"
+              "npq-leading-primary-mathematics",
+              "npq-senco"
             ],
             "example": "ecf-induction"
           },

--- a/swagger/v3/component_schemas/NPQApplicationAttributes.yml
+++ b/swagger/v3/component_schemas/NPQApplicationAttributes.yml
@@ -29,6 +29,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
   email:
     description: "The email address registered for this NPQ participant"
     type: string

--- a/swagger/v3/component_schemas/NPQEnrolment.yml
+++ b/swagger/v3/component_schemas/NPQEnrolment.yml
@@ -30,6 +30,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
   schedule_identifier:
     description: "The schedule the participant is enrolled in. For the possible values please refer to the <a href=\"/api-reference/npq/schedules-and-milestone-dates.html#schedules-and-milestone-dates\" class=\"govuk-link\">NPQ schedules and milestone dates guidance</a>."
     type: string

--- a/swagger/v3/component_schemas/NPQOutcomeAttributes.yml
+++ b/swagger/v3/component_schemas/NPQOutcomeAttributes.yml
@@ -28,6 +28,7 @@ properties:
       - npq-executive-leadership
       - npq-early-years-leadership
       - npq-leading-primary-mathematics
+      - npq-senco
     example: npq-leading-teaching
   state:
     description: The state of the outcome (passed, failed or voided)

--- a/swagger/v3/component_schemas/NPQOutcomeAttributesRequest.yml
+++ b/swagger/v3/component_schemas/NPQOutcomeAttributesRequest.yml
@@ -17,6 +17,7 @@ properties:
       - npq-executive-leadership
       - npq-early-years-leadership
       - npq-leading-primary-mathematics
+      - npq-senco
     example: npq-leading-teaching
   state:
     description: The state of the outcome (passed or failed)

--- a/swagger/v3/component_schemas/NPQParticipantChangeScheduleAttributes.yml
+++ b/swagger/v3/component_schemas/NPQParticipantChangeScheduleAttributes.yml
@@ -33,6 +33,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
     example: npq-executive-leadership
   cohort:
     description: "Providers may change an NPQ participant's cohort up until the point of submitting a started declaration. The value indicates which call-off contract funds this participant's training. 2021 indicates a participant that has started, or will start, their training in the 2021/22 academic year."

--- a/swagger/v3/component_schemas/NPQParticipantCompletedDeclarationAttributes.yml
+++ b/swagger/v3/component_schemas/NPQParticipantCompletedDeclarationAttributes.yml
@@ -40,6 +40,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
     example: npq-leading-teaching
   state:
     description: "Indicates the state of this payment declaration"

--- a/swagger/v3/component_schemas/NPQParticipantDeclarationCompletedAttributesRequest.yml
+++ b/swagger/v3/component_schemas/NPQParticipantDeclarationCompletedAttributesRequest.yml
@@ -39,6 +39,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
     example: npq-headship
   has_passed:
     description: Whether the participant has failed or passed

--- a/swagger/v3/component_schemas/NPQParticipantDeclarationRetainedAttributesRequest.yml
+++ b/swagger/v3/component_schemas/NPQParticipantDeclarationRetainedAttributesRequest.yml
@@ -34,6 +34,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
     example: npq-headship
 required:
   - participant_id

--- a/swagger/v3/component_schemas/NPQParticipantDeclarationStartedAttributesRequest.yml
+++ b/swagger/v3/component_schemas/NPQParticipantDeclarationStartedAttributesRequest.yml
@@ -33,6 +33,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
     example: npq-headship
 required:
   - participant_id

--- a/swagger/v3/component_schemas/NPQParticipantDeferAttributes.yml
+++ b/swagger/v3/component_schemas/NPQParticipantDeferAttributes.yml
@@ -29,6 +29,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
     example: npq-senior-leadership
 example:
   reason: parental-leave

--- a/swagger/v3/component_schemas/NPQParticipantResumeAttributes.yml
+++ b/swagger/v3/component_schemas/NPQParticipantResumeAttributes.yml
@@ -16,6 +16,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
     example: npq-senior-leadership
 required:
   - course_identifier

--- a/swagger/v3/component_schemas/NPQParticipantRetainedDeclarationAttributes.yml
+++ b/swagger/v3/component_schemas/NPQParticipantRetainedDeclarationAttributes.yml
@@ -41,6 +41,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
     example: npq-leading-teaching
   state:
     description: "Indicates the state of this payment declaration"

--- a/swagger/v3/component_schemas/NPQParticipantStartedDeclarationAttributes.yml
+++ b/swagger/v3/component_schemas/NPQParticipantStartedDeclarationAttributes.yml
@@ -40,6 +40,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
     example: npq-leading-teaching
   state:
     description: "Indicates the state of this payment declaration"

--- a/swagger/v3/component_schemas/NPQParticipantWithdrawAttributes.yml
+++ b/swagger/v3/component_schemas/NPQParticipantWithdrawAttributes.yml
@@ -37,6 +37,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
     example: npq-leading-teaching-development
 required:
   - reason

--- a/swagger/v3/component_schemas/ParticipantDeclarationAttributes.yml
+++ b/swagger/v3/component_schemas/ParticipantDeclarationAttributes.yml
@@ -49,6 +49,7 @@ properties:
       - npq-additional-support-offer
       - npq-early-headship-coaching-offer
       - npq-leading-primary-mathematics
+      - npq-senco
     example: ecf-induction
   state:
     description: "Indicates the state of this payment declaration"


### PR DESCRIPTION
### Context
Update api documentation for senco npq course

#### Ticket:
https://dfedigital.atlassian.net/browse/CPDNPQ-1837

#### Changes proposed in this pull request
Swagger directory now contains the npq-senco identifier. Identifiers have been added to the files NPQApplicationAttributes.yml and api_spec.json in the directories v1, v2, and v3.

#### Description:
New Course Identifier: We have introduced a new course with identifier npq-senco, which is now available for use by lead providers. This identifier facilitates the retrieval of applications specifically for the senco course.