### PR TITLE
Add new content to ECT confirmation screen

### DIFF
--- a/app/views/schools/add_participants/complete.html.erb
+++ b/app/views/schools/add_participants/complete.html.erb
@@ -9,7 +9,13 @@
     <% elsif exempt_from_induction?(@wizard.participant_profile) %>
       <%= render partial: 'schools/add_participants/eligibility_confirmation/exempt_from_induction', locals: { profile: @wizard.participant_profile } %>
     <% else %>
-      <%= govuk_panel title_text: "#{@wizard.full_name} has been added as #{@wizard.ect_participant? ? "an ECT" : "a mentor"}", text: nil, classes: "govuk-!-margin-bottom-7" %>
+      <%= govuk_panel(
+        title_text: "#{@wizard.full_name} has been added as #{@wizard.ect_participant? ? "an ECT" : "a mentor"}",
+        text: "Please check they’re registered with your appropriate body",
+        classes: "govuk-!-margin-bottom-7",
+      ) %>
+
+      <%= render 'schools/add_participants/eligibility_confirmation/appropriate_body_guidance' %>
 
       <h2>What happens next</h2>
       <% if @wizard.transfer? %>

--- a/app/views/schools/add_participants/eligibility_confirmation/_appropriate_body_guidance.html.erb
+++ b/app/views/schools/add_participants/eligibility_confirmation/_appropriate_body_guidance.html.erb
@@ -1,0 +1,1 @@
+<p class="govuk-body">ECTs cannot start their induction until you’ve <%= govuk_link_to("appointed an appropriate body", "https://www.gov.uk/government/publications/statutory-teacher-induction-appropriate-bodies/find-an-appropriate-body") %>.</p>

--- a/app/views/schools/add_participants/eligibility_confirmation/_post_transitional.html.erb
+++ b/app/views/schools/add_participants/eligibility_confirmation/_post_transitional.html.erb
@@ -1,6 +1,9 @@
 <div class="govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-7">
   <h1 class="govuk-panel__title"><%= profile.full_name %> has been added as an ECT</h1>
+  <div class="govuk-panel__body">Please check they’re registered with your appropriate body</div>
 </div>
+
+<%= render 'schools/add_participants/eligibility_confirmation/appropriate_body_guidance' %>
 
 <h2 class="govuk-heading-m">What happens next</h2>
 <p class="govuk-body">We’ll let this person know you’ve registered them for ECF-based training at your school. They do not need to provide us with any further information.</p>

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -1169,6 +1169,11 @@ module ManageTrainingSteps
 
   def then_i_am_taken_to_ect_confirmation_page
     expect(page).to have_selector("h1", text: "#{@participant_data[:full_name]} has been added as an ECT")
+    expect(page).to have_text("Please check they’re registered with your appropriate body")
+    expect(page).to have_link(
+      "appointed an appropriate body",
+      href: "https://www.gov.uk/government/publications/statutory-teacher-induction-appropriate-bodies/find-an-appropriate-body",
+    )
     expect(page).to have_text("What happens next")
   end
 


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net.mcas.ms/browse/CST-2611

### Changes proposed in this pull request

Add panel body text and a paragraph with link to guidance on appointing an appropriate body.

![image](https://github.com/DFE-Digital/early-careers-framework/assets/93511/cb98d5e1-5a92-49ab-80d9-818f07e3f853)



### Guidance to review

