### PR TITLE
New way to determine when a cohort has been frozen

### DIFF
--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -92,7 +92,7 @@ class Cohort < ApplicationRecord
   end
 
   def payments_frozen?
-    payments_frozen_at.present?
+    payments_frozen_at.present? && Time.current >= payments_frozen_at
   end
 
   def previous

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -183,15 +183,34 @@ RSpec.describe Cohort, type: :model do
   end
 
   describe "#payments_frozen?" do
-    context "when a date to freeze payments has been set" do
-      before do
-        subject.payments_frozen_at = Date.current
+    context "when the time to freeze payments was set to be in the past" do
+      it do
+        freeze_time do
+          subject.payments_frozen_at = 1.second.ago
+          is_expected.to be_payments_frozen
+        end
       end
-
-      it { is_expected.to be_payments_frozen }
     end
 
-    context "when a date to freeze payments has not been set" do
+    context "when the time to freeze payments is set to be now" do
+      it do
+        freeze_time do
+          subject.payments_frozen_at = Time.current
+          is_expected.to be_payments_frozen
+        end
+      end
+    end
+
+    context "when the time to freeze payments is set to be in the future" do
+      it do
+        freeze_time do
+          subject.payments_frozen_at = 1.second.from_now
+          is_expected.not_to be_payments_frozen
+        end
+      end
+    end
+
+    context "when the datetime to freeze payments has not been set" do
       before do
         subject.payments_frozen_at = nil
       end


### PR DESCRIPTION
### Context

To avoid manually doing it the day we open a new registration year, we are going to determine if a Cohort has been frozen or not based on the date store in the database.

So when the time setup comes, the service will automatically detect the new status of the cohort and enable all the dependant features.

### Changes proposed in this pull request
  Redefine the logic in `Cohort#payments_frozen?` 

### Guidance to review

