### PR TITLE
Support migrating declarations to paid/payable statements

### DIFF
--- a/app/services/oneoffs/npq/migrate_declarations_between_statements.rb
+++ b/app/services/oneoffs/npq/migrate_declarations_between_statements.rb
@@ -9,7 +9,16 @@ module Oneoffs::NPQ
 
     include HasRecordableInformation
 
-    def initialize(cohort:, from_statement_name:, to_statement_name:, from_statement_output_fee: false, to_statement_updates: {}, restrict_to_lead_providers: nil, restrict_to_declaration_types: nil)
+    def initialize(
+      cohort:, 
+      from_statement_name:, 
+      to_statement_name:, 
+      from_statement_output_fee: false, 
+      to_statement_updates: {}, 
+      restrict_to_lead_providers: nil, 
+      restrict_to_declaration_types: nil, 
+      restrict_to_declaration_states: nil
+    )
       @cohort = cohort
       @from_statement_name = from_statement_name
       @to_statement_name = to_statement_name
@@ -17,6 +26,7 @@ module Oneoffs::NPQ
       @to_statement_updates = to_statement_updates
       @restrict_to_lead_providers = restrict_to_lead_providers
       @restrict_to_declaration_types = restrict_to_declaration_types
+      @restrict_to_declaration_states = restrict_to_declaration_states
     end
 
     def migrate(dry_run: true)
@@ -37,7 +47,10 @@ module Oneoffs::NPQ
 
   private
 
-    attr_reader :cohort, :from_statement_name, :to_statement_name, :to_statement_updates, :restrict_to_lead_providers, :restrict_to_declaration_types, :from_statement_output_fee
+    attr_reader :cohort, :from_statement_name, :to_statement_name, 
+      :to_statement_updates, :restrict_to_lead_providers, 
+      :restrict_to_declaration_types, :from_statement_output_fee, 
+      :restrict_to_declaration_states
 
     def update_to_statement_attributes!
       return if to_statement_updates.blank?
@@ -62,6 +75,12 @@ module Oneoffs::NPQ
         statement_line_items = statement_line_items
           .includes(:participant_declaration)
           .where(participant_declaration: { declaration_type: restrict_to_declaration_types })
+      end
+
+      if restrict_to_declaration_states
+        statement_line_items = statement_line_items
+          .includes(:participant_declaration)
+          .where(participant_declaration: { state: restrict_to_declaration_states })
       end
 
       record_line_items_info(provider, statement_line_items)

--- a/spec/services/oneoffs/npq/migrate_declarations_between_statements_spec.rb
+++ b/spec/services/oneoffs/npq/migrate_declarations_between_statements_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 describe Oneoffs::NPQ::MigrateDeclarationsBetweenStatements do
+  let(:from_statement_updates) { {} }
   let(:to_statement_updates) { {} }
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_npq_lead_provider) }
   let(:npq_lead_provider) { cpd_lead_provider.npq_lead_provider }
@@ -18,6 +19,7 @@ describe Oneoffs::NPQ::MigrateDeclarationsBetweenStatements do
       cohort:,
       from_statement_name:,
       to_statement_name:,
+      from_statement_updates:,
       to_statement_updates:,
       restrict_to_lead_providers:,
       restrict_to_declaration_types:,
@@ -144,6 +146,19 @@ describe Oneoffs::NPQ::MigrateDeclarationsBetweenStatements do
             expect(declaration2.statement_line_items.map(&:statement)).to all(eq(to_statement2))
             expect(declaration.statement_line_items.map(&:statement)).to all(eq(from_statement))
           end
+        end
+      end
+
+      context "when from_statement_updates are provided" do
+        let(:from_statement_updates) { { output_fee: false } }
+
+        it "updates the to statements" do
+          migrate
+
+          expect(from_statement.reload).to have_attributes(from_statement_updates)
+          expect(instance).to have_recorded_info([
+            "Statement #{from_statement.name} for #{from_statement.npq_lead_provider.name} updated with #{from_statement_updates}",
+          ])
         end
       end
 


### PR DESCRIPTION
[Jira-3169](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3169)

### Context

We want to migrate a number of declarations `awaiting_clawback` for SLN from one statement to another (payable) statement.

The current declaration migrator service does not support this as it:

- Is restricted to migrating only to future dated statements
- Will change the `output_fee` to `false` for all from statements
- Does not support migrating to paid/payable statements

We want to update the migration service to support the new scenario.

### Changes proposed in this pull request

- Support filtering by states in MigrateDeclarationsBetweenStatements

We want the ability to only migrate a subset of declarations with a particular state or states.

- Relax restrictions on MigrateDeclarationsBetweenStatements

Up until now we have restricted the usage to only statements that are future dated. This is too restrictive for a new use case, so we are relaxing it to migrate those that are not future dated (albeit with a warning).

We also want to remove the requirement of having to specify an `output_fee` for the from statement after the migration has completed. If we find we want to modify the from statement again in the future we could re-introduce in a more flexible way, such as with a `from_statement_updates` hash (similar to the `to_statement_updates` already supported).

-  Support migrating declarations to payable/paid statements

When we migrate declarations and their statement line items to a new statement and that statement is paid/payable, we need to ensure that we run the declarations through the appropriate service to get them inline with the new statement.

- Support generic updates to from statement

Similar to how we allow generic attribute updates for the to statements, we want to allow generic updates to the from statements. This can be useful for ensuring the statement declarations are migrated from ends up being `output_fee: false` after the migration, for example.


### Guidance to review

