### PR TITLE
CST 2577 Handle payments frozen cohort when syncing start date from DQT

### DIFF
--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -39,14 +39,13 @@ class Cohort < ApplicationRecord
     starting_within(Date.current + 1.day, Date.current + 1.year)
   end
 
-  # Find the cohort an induction start date must be associated to:
-  #   - Cohort.current for dates ealier than Sept 2021 or
-  #   - The previous date's year cohort if the date is before Jun or
-  #   - the cohort starting the date's year otherwise.
-  def self.for_induction_start_date(date)
+  def self.for_date(date)
     return current if date < INITIAL_COHORT_START_DATE
 
-    Cohort.find_by_start_year(date.month < 6 ? date.year - 1 : date.year)
+    cohort = Cohort.find_by_start_year(date.month < 6 ? date.year - 1 : date.year)
+    return current if cohort&.payments_frozen?
+
+    cohort
   end
 
   def self.previous

--- a/app/services/participants/sync_dqt_induction_start_date.rb
+++ b/app/services/participants/sync_dqt_induction_start_date.rb
@@ -55,7 +55,7 @@ module Participants
     alias_method :save_error, :save_errors
 
     def target_cohort
-      @target_cohort ||= Cohort.for_induction_start_date(dqt_induction_start_date)
+      @target_cohort ||= Cohort.for_date(dqt_induction_start_date)
     end
 
     def cohort_missing

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -55,37 +55,50 @@ RSpec.describe Cohort, type: :model do
     end
   end
 
-  describe ".for_induction_start_date" do
-    subject { Cohort.for_induction_start_date(induction_start_date) }
+  describe ".for_date" do
+    subject { Cohort.for_date(date) }
 
     context "when the provided date is earlier than 2021" do
-      let(:induction_start_date) { Date.new(2020, 5, 1) }
+      let(:date) { Date.new(2020, 5, 1) }
 
       it { is_expected.to eq(Cohort.current) }
     end
 
     context "when the provided date is in 2021 before September" do
-      let(:induction_start_date) { Date.new(2021, 6, 1) }
+      let(:date) { Date.new(2021, 6, 1) }
 
       it { is_expected.to eq(Cohort.current) }
     end
 
     context "when the provided date is in 2021 since September" do
-      let(:induction_start_date) { Date.new(2021, 9, 1) }
+      let(:date) { Date.new(2021, 9, 1) }
 
       it { is_expected.to eq(Cohort.find_by_start_year(2021)) }
     end
 
     context "when the provided date is later than 2021 before June" do
-      let(:induction_start_date) { Date.new(2023, 3, 1) }
+      let(:date) { Date.new(2023, 3, 1) }
 
-      it { is_expected.to eq(Cohort.find_by_start_year(induction_start_date.year - 1)) }
+      it { is_expected.to eq(Cohort.find_by_start_year(date.year - 1)) }
     end
 
     context "when the provided date is later than 2021 since June" do
-      let(:induction_start_date) { Date.new(2022, 7, 1) }
+      let(:date) { Date.new(2022, 7, 1) }
 
-      it { is_expected.to eq(Cohort.find_by_start_year(induction_start_date.year)) }
+      it { is_expected.to eq(Cohort.find_by_start_year(date.year)) }
+    end
+
+    context "when the cohort has payments frozen" do
+      let(:date) { Date.new(2021, 7, 1) }
+      before { Cohort.find_by_start_year(2021).update!(payments_frozen_at: 1.minute.ago) }
+
+      it { is_expected.to eq(Cohort.current) }
+    end
+
+    context "when the cohort can't be found" do
+      let(:date) { 20.years.from_now }
+
+      it { is_expected.to be_nil }
     end
   end
 


### PR DESCRIPTION
### Context

When syncing a participant's induction start date with DQT, we should ensure that if the target cohort has payments frozen, the participant is assigned the current cohort.

- Ticket: https://dfedigital.atlassian.net.mcas.ms/browse/CST-2577

### Changes proposed in this pull request

Amend cohort determination logic for a given start date.

### Guidance to review

I've asserted that the cohort to move the participant to is the current one, could/should this be the active registration cohort instead?

