### PR TITLE
Amend sorting in NPQ participants query

### DIFF
--- a/app/services/api/v3/npq_participants_query.rb
+++ b/app/services/api/v3/npq_participants_query.rb
@@ -18,7 +18,7 @@ module Api
         scope = npq_lead_provider
           .npq_participants
           .includes(:teacher_profile, :participant_id_changes, npq_profiles: [:npq_course, :participant_profile_states, :participant_identity, { schedule: [:cohort], npq_application: [npq_lead_provider: :cpd_lead_provider] }])
-          .order(sort_order(default: "npq_profiles.created_at ASC", model: User))
+          .order(sort_order(default: "users.created_at ASC", model: User))
           .distinct
         scope = scope.where("users.updated_at > ?", updated_since) if updated_since_filter.present?
         scope = scope.where(npq_profiles: { training_status: }) if training_status.present?

--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -7,6 +7,14 @@ weight: 8
 
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
 
+## 13 June 2024
+
+We’ve fixed an issue with the API v3 NPQ participants endpoint where performing a full sync with pagination resulted in IDs beings omitted. No other endpoint was affected.
+
+The NPQ participants endpoint and the pagination will now return all users in the NPQ GET participants endpoint.
+
+Providers are recommended to perform a full re-sync at the earliest convenience to retrieve all participant records.
+
 ## 10 June 2024
 
 On 31 July we’re closing the funding contract for the 2021 cohort.

--- a/spec/services/api/v3/npq_participants_query_spec.rb
+++ b/spec/services/api/v3/npq_participants_query_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Api::V3::NPQParticipantsQuery do
       end
 
       context "when no sort parameter is specified" do
-        it "returns all records ordered by participant profile created_at ascending by default" do
+        it "returns all records ordered by the user created_at ascending by default" do
           expect(participants.map(&:id)).to eq(
             [another_participant_profile, participant_profile].map(&:user_id),
           )


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-3182

Currently the default sorting looks into the nested `npq_profiles` created at timestamp. Without pagination this works ok, however with pagination, pagy includes the timestamp on the profiles in the limit/offset distinct query, which means that if a user has multiple profiles with different timestamps we return duplicate ids instead of the real ids for users.

Instead sort by user created at to avoid any timestamps being included in the pagy queries when calculating which ids to offset and return.

The test fails with the previous sorting but doesn't with the current one.

### Changes proposed in this pull request

Amend the sorting on the participants npq query to look at users rather than npq profiles nested model. This ensures that we do not include the timestamp in the distinct query.

### Guidance to review
I have run a script to paginate every v3 endpoint, and the only issue is with NPQ participants. I have run the script with the new ordering and we get no issues
