### PR TITLE
[CST-2582] Update the content on the nomination pages

### DIFF
--- a/app/views/nominations/nominate_induction_coordinator/check.html.erb
+++ b/app/views/nominations/nominate_induction_coordinator/check.html.erb
@@ -37,7 +37,7 @@
         </dl>
 
         <%= form_for @nominate_induction_tutor_form, url: { action: :create }, method: :post do |f| %>
-            <%= f.govuk_submit "Confirm and nominate" %>
+            <%= f.govuk_submit "Confirm details" %>
         <% end %>
 
     </div>

--- a/app/views/nominations/nominate_induction_coordinator/nominate_school_lead_success.html.erb
+++ b/app/views/nominations/nominate_induction_coordinator/nominate_school_lead_success.html.erb
@@ -11,7 +11,11 @@
         ) %>
 
         <h2 class="govuk-heading-m">What happens next</h2>
-        <p class="govuk-body">This person is now our single point of contact for ECF-based training at your school. They'll use our service to:</p>
+        <p class="govuk-body">We've sent them an email to confirm you nominated them.</p>
+
+        <p class="govuk-body">This person is now our single point of contact for ECF-based training at your school.</p>
+
+        <p class="govuk-body">They'll use our service to:</p>
 
         <ul class="govuk-list govuk-list--bullet">
             <li>report how your school will run training for early career teachers (ECTs)</li>

--- a/app/views/nominations/nominate_induction_coordinator/start_nomination.html.erb
+++ b/app/views/nominations/nominate_induction_coordinator/start_nomination.html.erb
@@ -9,23 +9,26 @@
         <span class="govuk-caption-l"><%= @nominate_induction_tutor_form.school.name %></span>
         <h1 class="govuk-heading-x">Nominate an induction tutor for your school</h1>
 
-        <p class="govuk-body">Your induction tutor will be our single point of contact for ECF-based training at your school. They’ll use our service to:</p>
+        <p class="govuk-body">Your induction tutor will be our single point of contact for ECF-based training at your school.</p>
+        <p>They’ll use our service to:</p>
         <ul class="govuk-list govuk-list--bullet">
             <li>report how your school will run training for early career teachers (ECTs)</li>
             <li>register ECTs and their mentors</li>
             <li>tell us about any changes your school needs to make</li>
         </ul>
 
+        <%= govuk_button_link_to "Continue", full_name_nominate_induction_coordinator_path %>
+
         <h2 class="govuk-heading-m">Who you can nominate</h2>
 
         <p class="govuk-body">
-            <%= govuk_link_to "Read more about the induction tutor role in our guidance",
+            <%= govuk_link_to "Read more about the induction tutor role in our guidance.",
             page_path(page: 'what-each-person-does'),
             class: "govuk-link govuk-link--no-visited-state" %>.
         </p>
+
         <p class="govuk-body govuk-!-margin-bottom-7">If you’re supported by a MAT (multi-academy trust) or federation, you can choose someone who manages training for a number of schools.</p>
 
-        <%= govuk_button_link_to "Continue", full_name_nominate_induction_coordinator_path %>
 
     </div>
 </div>

--- a/spec/features/induction_nomination_spec.rb
+++ b/spec/features/induction_nomination_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature "Nominating tutors", :js do
       expect(page).to have_summary_row("Name", "John Smith")
       expect(page).to have_summary_row("Email", "a-new-john-smith@example.com")
 
-      click_on "Confirm and nominate"
+      click_on "Confirm details"
 
       expect(page).to have_css(".govuk-panel--confirmation", text: "Induction tutor nominated")
 

--- a/spec/features/nominations/nominate_induction_tutor_journey_spec.rb
+++ b/spec/features/nominations/nominate_induction_tutor_journey_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature "ECT nominate SIT journey", type: :feature, js: true, mid_cohort: 
     click_on "Continue"
     then_i_should_be_on_the_check_details_page
 
-    click_on "Confirm and nominate"
+    click_on "Confirm details"
     then_i_should_be_on_the_nominate_sit_success_page
     and_the_page_should_be_accessible
   end
@@ -98,7 +98,7 @@ RSpec.feature "ECT nominate SIT journey", type: :feature, js: true, mid_cohort: 
     then_i_should_be_on_the_check_details_page
     and_the_page_should_be_accessible
 
-    click_on "Confirm and nominate"
+    click_on "Confirm details"
     then_i_should_be_on_the_nominate_sit_success_page
     and_the_page_should_be_accessible
   end
@@ -122,7 +122,7 @@ RSpec.feature "ECT nominate SIT journey", type: :feature, js: true, mid_cohort: 
     click_on "Continue"
     then_i_should_be_on_the_check_details_page
 
-    click_on "Confirm and nominate"
+    click_on "Confirm details"
     then_i_should_be_on_the_nominate_sit_success_page
   end
 end

--- a/spec/features/nominations/nominate_induction_tutor_steps.rb
+++ b/spec/features/nominations/nominate_induction_tutor_steps.rb
@@ -71,7 +71,8 @@ module NominateInductionTutorSteps
 
   def then_i_should_be_on_the_start_nomination_page
     expect(page).to have_selector("h1", text: "Nominate an induction tutor for your school")
-    expect(page).to have_text("Your induction tutor will be our single point of contact for ECF-based training at your school. They’ll use our service to:")
+    expect(page).to have_text("Your induction tutor will be our single point of contact for ECF-based training at your school.")
+    expect(page).to have_text("They’ll use our service to:")
     expect(page).to have_text("report how your school will run training for early career teachers (ECTs)")
   end
 
@@ -94,7 +95,9 @@ module NominateInductionTutorSteps
   def then_i_should_be_on_the_nominate_sit_success_page
     expect(page).to have_selector("h1", text: "Induction tutor nominated")
     expect(page).to have_selector("h2", text: "What happens next")
-    expect(page).to have_text("This person is now our single point of contact for ECF-based training at your school. They'll use our service to:")
+    expect(page).to have_text("This person is now our single point of contact for ECF-based training at your school.")
+    expect(page).to have_text("They'll use our service to:")
+    expect(page).to have_text("We've sent them an email to confirm you nominated them.")
   end
 
   def then_i_should_be_redirected_to_name_different_page


### PR DESCRIPTION
### Context

- Ticket: CST-2582

A few content changes in the nomination journey.

### Changes proposed in this pull request
- Updated the content according to the provided designs

### Guidance to review
| Before | After |
|--------|--------|
|<img width="651" alt="Screenshot 2024-06-13 at 15 12 44" src="https://github.com/DFE-Digital/early-careers-framework/assets/951947/965c65ef-c155-4e3f-974a-71e6aeaf4293">|<img width="645" alt="Screenshot 2024-06-13 at 15 12 33" src="https://github.com/DFE-Digital/early-careers-framework/assets/951947/a426b977-547d-4028-8869-3393bbce7e52">|
|<img width="653" alt="Screenshot 2024-06-13 at 15 13 30" src="https://github.com/DFE-Digital/early-careers-framework/assets/951947/ac9165c6-c6ea-4968-b3da-85dfeaa34f42">|<img width="653" alt="Screenshot 2024-06-13 at 15 13 40" src="https://github.com/DFE-Digital/early-careers-framework/assets/951947/aafb8a4a-138f-4d6f-a044-3dae4db3bc9f">|
|<img width="645" alt="Screenshot 2024-06-13 at 15 12 12" src="https://github.com/DFE-Digital/early-careers-framework/assets/951947/f65a5193-9939-408c-9461-d7b564fc193a">|<img width="650" alt="Screenshot 2024-06-13 at 15 11 57" src="https://github.com/DFE-Digital/early-careers-framework/assets/951947/049d1534-0784-43a8-874f-786d3ba55ab3">|

