### PR TITLE
Use selectable_by_schools scope for AB selection

### DIFF
--- a/app/forms/admin/schools/cohorts/appropriate_bodies/update_form.rb
+++ b/app/forms/admin/schools/cohorts/appropriate_bodies/update_form.rb
@@ -50,7 +50,7 @@ module Admin
           end
 
           def appropriate_bodies
-            AppropriateBody.active_in_year(cohort_start_year)
+            AppropriateBody.selectable_by_schools.active_in_year(cohort_start_year)
           end
 
           def listed_appropriate_bodies

--- a/app/views/admin/appropriate_bodies/users/edit.html.erb
+++ b/app/views/admin/appropriate_bodies/users/edit.html.erb
@@ -10,7 +10,7 @@
 
     <%= form_with model: @appropriate_bodies_user_form, scope: :appropriate_bodies_user_form, url: admin_appropriate_bodies_user_path(@appropriate_body_profile) do |f| %>
       <%= f.govuk_error_summary %>
-      <%= f.govuk_collection_select(:appropriate_body_id, AppropriateBody.name_order, :id, :name, label: { text: "Appropriate body" }, options: { include_blank: true }, class: ["js-location-select"]) %>
+      <%= f.govuk_collection_select(:appropriate_body_id, AppropriateBody.selectable_by_schools.name_order, :id, :name, label: { text: "Appropriate body" }, options: { include_blank: true }, class: ["js-location-select"]) %>
       <%= f.govuk_text_field(:full_name, label: { text: "Full name" }) %>
       <%= f.govuk_email_field(:email, label: { text: "Email" }) %>
       <div class="govuk-button-group">

--- a/app/views/admin/appropriate_bodies/users/new.html.erb
+++ b/app/views/admin/appropriate_bodies/users/new.html.erb
@@ -10,7 +10,7 @@
 
     <%= form_with model: @appropriate_bodies_user_form, scope: :appropriate_bodies_user_form, url: admin_appropriate_bodies_users_path do |f| %>
       <%= f.govuk_error_summary %>
-      <%= f.govuk_collection_select(:appropriate_body_id, AppropriateBody.name_order, :id, :name, label: { text: "Appropriate body" }, options: { include_blank: true }, class: ["js-location-select"]) %>
+      <%= f.govuk_collection_select(:appropriate_body_id, AppropriateBody.selectable_by_schools.name_order, :id, :name, label: { text: "Appropriate body" }, options: { include_blank: true }, class: ["js-location-select"]) %>
       <%= f.govuk_text_field(:full_name, label: { text: "Full name" }) %>
       <%= f.govuk_email_field(:email, label: { text: "Email" }) %>
       <%= f.govuk_submit "Add user" %>


### PR DESCRIPTION
### Context

- Spotted 2 places in the Admin UI that don't use the new `AppropriateBody.selectable_by_schools` scope to constrain the list of available ABs

### Changes proposed in this pull request
Add `.selectable_by_schools` scope to AB queries

### Guidance to review

