### PR TITLE
Create a valid ParticipantDeclaration via factory methods

### DIFF
--- a/spec/features/schools/participants/add_participants/payments_frozen/common_steps.rb
+++ b/spec/features/schools/participants/add_participants/payments_frozen/common_steps.rb
@@ -6,7 +6,7 @@ def given_there_is_a_school_that_has_chosen_fip_for_four_cohorts_and_partnered
     school_cohort = SchoolCohort.create!(cohort:, school:, induction_programme_choice: "full_induction_programme")
     induction_programme = create(:induction_programme, :fip, school_cohort:, partnership: nil)
     school_cohort.update!(default_induction_programme: induction_programme)
-    partnership = create(:partnership, school:, lead_provider:, delivery_partner:, cohort:, challenge_deadline: 2.weeks.ago)
+    partnership = create(:partnership, school:, lead_provider:, delivery_partner:, cohort:)
     induction_programme.update!(partnership:)
 
     # Magic instance vars necessary for subsequent steps (!)
@@ -27,8 +27,12 @@ def target_school
   @target_school ||= FactoryBot.create(:school, name: "Target Fip School")
 end
 
+def cpd_lead_provider
+  @cpd_lead_provider ||= FactoryBot.create(:cpd_lead_provider, :with_lead_provider, name: "CPD Provider Ltd")
+end
+
 def lead_provider
-  @lead_provider ||= FactoryBot.create(:lead_provider, name: "Big Provider Ltd")
+  @lead_provider ||= LeadProvider.find_by(cpd_lead_provider:)
 end
 
 def delivery_partner
@@ -45,7 +49,7 @@ def and_there_is_another_school_that_has_chosen_fip_in_the_payments_frozen_cohor
   induction_programme = create(:induction_programme, :fip, school_cohort: target_school_cohort, partnership: nil)
   target_school_cohort.update!(default_induction_programme: induction_programme)
   partnership = create(:partnership, school: target_school,
-                       lead_provider:, delivery_partner:, cohort: earliest_cohort, challenge_deadline: 2.weeks.ago)
+                       lead_provider:, delivery_partner:, cohort: earliest_cohort)
   induction_programme.update!(partnership:)
 
   current_target_school_cohort = create(:school_cohort, school: target_school,

--- a/spec/features/schools/participants/add_participants/payments_frozen/transfer_ect_to_another_school_spec.rb
+++ b/spec/features/schools/participants/add_participants/payments_frozen/transfer_ect_to_another_school_spec.rb
@@ -60,22 +60,15 @@ RSpec.describe "SIT transfers ECT to another school", js: true, mid_cohort: true
     participant_profile = create(:ect_participant_profile, teacher_profile:,
                                  participant_identity:,
                                  schedule:, school_cohort: @school_cohort,
-                                 induction_start_date: Date.new(earliest_cohort.start_year, 9, 1),
-                                 induction_completion_date: Date.new(earliest_cohort.start_year + 1, 9, 1))
+                                 induction_start_date: Date.new(earliest_cohort.start_year, 9, 1))
 
-    # FIXME: This factory fails validation on participant_id, despite this being present on participant identity.
-    # Stubbing the eligibility check to return the participant_profile for now.
-    # create(:ect_participant_declaration, participant_profile:, declaration_type: "completed")
-    allow(ParticipantProfile::ECT).to receive(:eligible_to_change_cohort_and_continue_training)
-                                        .and_return(ParticipantProfile::ECT.where(id: participant_profile.id))
-
-    induction_programme = InductionProgramme.find_by(school_cohort: @school_cohort)
     create(:ecf_participant_validation_data, participant_profile:,
-           full_name: "Sally Teacher", trn: @participant_data[:trn], date_of_birth: Date.new(1990, 10, 24))
-
-    set_dqt_validation_result
-
+           full_name: "Sally Teacher", trn: @participant_data[:trn], date_of_birth: @participant_data[:date_of_birth])
+    induction_programme = InductionProgramme.find_by(school_cohort: @school_cohort)
     Induction::Enrol.call(participant_profile:, induction_programme:)
+
+    create(:ect_participant_declaration, participant_profile:, cpd_lead_provider:, state: :eligible)
+    set_dqt_validation_result
   end
 
   def then_i_should_be_on_the_confirm_transfer_page

--- a/spec/features/schools/participants/add_participants/payments_frozen/transfer_mentor_to_another_school_spec.rb
+++ b/spec/features/schools/participants/add_participants/payments_frozen/transfer_mentor_to_another_school_spec.rb
@@ -60,22 +60,15 @@ RSpec.describe "SIT transfers mentor to another school", js: true, mid_cohort: t
     participant_profile = create(:mentor_participant_profile, teacher_profile:,
                                  participant_identity:,
                                  schedule:, school_cohort: @school_cohort,
-                                 induction_start_date: Date.new(earliest_cohort.start_year, 9, 1),
-                                 induction_completion_date: Date.new(earliest_cohort.start_year + 1, 9, 1))
-
-    # FIXME: This factory fails validation on participant_id, despite this being present on participant identity.
-    # Stubbing the eligibility check to return the participant_profile for now.
-    # create(:ect_participant_declaration, participant_profile:, declaration_type: "completed")
-    allow(ParticipantProfile::Mentor).to receive(:eligible_to_change_cohort_and_continue_training)
-                                           .and_return(ParticipantProfile::Mentor.where(id: participant_profile.id))
+                                 induction_start_date: Date.new(earliest_cohort.start_year, 9, 1))
 
     induction_programme = InductionProgramme.find_by(school_cohort: @school_cohort)
     create(:ecf_participant_validation_data, participant_profile:,
            full_name: "Sally Teacher", trn: @participant_data[:trn], date_of_birth: Date.new(1990, 10, 24))
-
-    set_dqt_validation_result
-
     Induction::Enrol.call(participant_profile:, induction_programme:)
+
+    create(:ect_participant_declaration, participant_profile:, cpd_lead_provider:, state: :eligible, course_identifier: "ecf-mentor")
+    set_dqt_validation_result
   end
 
   def then_i_should_be_on_the_confirm_transfer_page


### PR DESCRIPTION
### Context

Removes the need to [stub the `ParticipantProfile#eligible_to_*` method](https://github.com/DFE-Digital/early-careers-framework/pull/4955/files#diff-1e85d4c555e66843a491433bde0eb9f9ac33940f39aad02f5216f2ba9c3a9f0cL66) in payments frozen feature specs.
Supersedes https://github.com/DFE-Digital/early-careers-framework/pull/4913

- Ticket: 

### Changes proposed in this pull request

Uses factory methods to create valid records for `ParticipantProfile#eligible_to_*` methods.

### Guidance to review

