### PR TITLE
Redirect induction coordinator to schools index when they are not associated to any schools

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -34,7 +34,7 @@ module ApplicationHelper
   end
 
   def induction_coordinator_dashboard_path(user)
-    return schools_dashboard_index_path if user.schools.count > 1
+    return schools_dashboard_index_path if user.schools.count != 1
 
     school = user.induction_coordinator_profile.schools.first
     return schools_choose_programme_path(school_id: school.slug, cohort_id: Cohort.active_registration_cohort) if school.school_cohorts.empty?

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -56,6 +56,16 @@ RSpec.describe ApplicationHelper, type: :helper do
         expect(helper.induction_coordinator_dashboard_path(induction_coordinator)).to eq("/schools")
       end
     end
+
+    context "when the induction coordinator has no schools" do
+      before do
+        induction_coordinator.induction_coordinator_profile.schools = []
+      end
+
+      it "return the schools dashboard path (index)" do
+        expect(helper.induction_coordinator_dashboard_path(induction_coordinator)).to eq("/schools")
+      end
+    end
   end
 
   describe "#participant_start_path" do


### PR DESCRIPTION
### Context

They can at least see they don't have an association to any schools as the index page will be empty.
We are currently raising a Sentry error and not catching this case.

- Ticket:  https://dfedigital.atlassian.net.mcas.ms/browse/CST-2621
- Sentry error: https://dfe-teacher-services.sentry.io/issues/4486911502 there are currently ~550 errors like this

### Changes proposed in this pull request

Check that the induction coordinator is associated to a school before attempting to return a school dashboard path. If they aren't redirect to the schools index.

### Guidance to review

