### PR TITLE
Don't attempt to send mail to nil induction coordinator

### DIFF
--- a/app/services/withdraw_participant.rb
+++ b/app/services/withdraw_participant.rb
@@ -35,7 +35,10 @@ class WithdrawParticipant
 
     unless participant_profile.npq?
       induction_coordinator = participant_profile.school.induction_coordinator_profiles.first
-      SchoolMailer.with(withdrawn_participant: participant_profile, induction_coordinator:).fip_provider_has_withdrawn_a_participant.deliver_later
+      if induction_coordinator.present?
+        SchoolMailer.with(withdrawn_participant: participant_profile, induction_coordinator:)
+                    .fip_provider_has_withdrawn_a_participant.deliver_later
+      end
     end
 
     participant_profile.record_to_serialize_for(lead_provider: cpd_lead_provider.lead_provider)

--- a/spec/services/withdraw_participant_spec.rb
+++ b/spec/services/withdraw_participant_spec.rb
@@ -103,7 +103,7 @@ RSpec.shared_examples "withdrawing a participant" do
 end
 
 RSpec.shared_examples "withdrawing an ECF participant" do
-  let(:induction_coordinator) { participant_profile.school.induction_coordinator_profiles.first }
+  let(:induction_coordinator) { create(:induction_coordinator_profile, schools: [participant_profile.school]) }
 
   it_behaves_like "withdrawing a participant"
 
@@ -118,6 +118,16 @@ RSpec.shared_examples "withdrawing an ECF participant" do
         },
         args: [],
       ).once
+  end
+
+  context "when the participant's school has no induction coordinator" do
+    it "does not send an alert email to the provider" do
+      participant_profile.school.induction_coordinator_profiles = []
+
+      expect {
+        service.call
+      }.not_to have_enqueued_mail(SchoolMailer, :fip_provider_has_withdrawn_a_participant)
+    end
   end
 
   it "creates a new withdrawn induction record" do


### PR DESCRIPTION
### Context

We attempt to mail the induction coordinator for the participant's school when withdrawing them but in some instances this IC profile is nil.

We have around 50 errors in Sentry relating to this.

- Ticket: https://dfedigital.atlassian.net.mcas.ms/browse/CST-2621
- Sentry error: https://dfe-teacher-services.sentry.io/issues/3023857336 

### Changes proposed in this pull request

Don't attempt to send email when the induction coordinator (ie. the email recipient) is nil.

### Guidance to review

