### PR TITLE
Filter Sentry gtag errors

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+FILTERABLE_JS_ERRORS = [
+  "Failed to fetch",
+  "NetworkError when attempting to fetch resource.",
+].freeze
+
+def filterable_js_event?(event, hint)
+  hint[:exception].is_a?(TypeError) && event.exception.values.any? do |exception|
+    FILTERABLE_JS_ERRORS.include?(exception.value)
+  end
+end
+
 Sentry.init do |config|
   config.enabled_environments = %w[production sandbox staging review]
   config.dsn = config.enabled_environments.include?(Rails.env) ? Rails.application.credentials.SENTRY_DSN : "disabled"
@@ -7,7 +18,9 @@ Sentry.init do |config|
   config.release = "#{ENV['RELEASE_VERSION']}-#{ENV['SHA']}"
 
   filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
-  config.before_send = lambda do |event, _hint|
+  config.before_send = lambda do |event, hint|
+    return nil if filterable_js_event?(event, hint)
+
     # use Rails' parameter filter to sanitize the event
     filter.filter(event.to_hash)
   end


### PR DESCRIPTION
### Context

We have gtag related fetch errors in production which we can't really action.

- Ticket: https://dfedigital.atlassian.net.mcas.ms/browse/CST-2621
- Sentry errors: https://dfe-teacher-services.sentry.io/issues/5506745977

### Changes proposed in this pull request

Filter out failed JS fetch errors from Sentry.

### Guidance to review

See https://github.com/DFE-Digital/apply-for-qualified-teacher-status/commit/1dd0190309c326118ca017b1606b261e66f80105 for working implementation of how we access Sentry error descriptions to filter errors.