### PR TITLE
logit.io enabled on non-prod environment

### DIFF
--- a/terraform/application/application.tf
+++ b/terraform/application/application.tf
@@ -62,6 +62,8 @@ module "web_application" {
   probe_path = "/check"
   replicas   = var.webapp_replicas
   max_memory = var.webapp_memory_max
+
+  enable_logit = var.enable_logit
 }
 
 module "worker_application" {
@@ -85,4 +87,6 @@ module "worker_application" {
 
   replicas   = var.worker_replicas
   max_memory = var.worker_memory_max
+
+  enable_logit = var.enable_logit
 }

--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -135,3 +135,5 @@ variable "azure_cpu_threshold" {
   type    = number
   default = 60
 }
+
+variable "enable_logit" { default = false }

--- a/terraform/application/workspace_variables/review.tfvars.json
+++ b/terraform/application/workspace_variables/review.tfvars.json
@@ -4,5 +4,6 @@
   "deploy_azure_backing_services": false,
   "enable_monitoring": false,
   "namespace": "cpd-development",
-  "db_sslmode": "prefer"
+  "db_sslmode": "prefer",
+  "enable_logit": true
 }

--- a/terraform/application/workspace_variables/staging.tfvars.json
+++ b/terraform/application/workspace_variables/staging.tfvars.json
@@ -5,5 +5,6 @@
   "enable_monitoring": false,
   "namespace": "cpd-development",
   "domain": "st.manage-training-for-early-career-teachers.education.gov.uk",
-  "external_hostname": "st.manage-training-for-early-career-teachers.education.gov.uk/"
+  "external_hostname": "st.manage-training-for-early-career-teachers.education.gov.uk/",
+  "enable_logit": true
 }


### PR DESCRIPTION
### Context

Ticket: https://trello.com/c/bjfo0jo9/1812-onboard-services-to-logitio

### Changes proposed in this pull request
Enabling logit.io on non-prod environment , logs will appear on logitio.
### Guidance to review
Logitio logs for review apps : 
https://kibana-uk1.logit.io/s/b2876053-0173-44fc-983d-99567292ba31/app/data-explorer/discover#?_a=(discover:(columns:!(_source),isDirty:!f,sort:!()),metadata:(indexPattern:'8ac115c0-aac1-11e8-88ea-0383c11b333a',view:discover))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15m,to:now))&_q=(filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'8ac115c0-aac1-11e8-88ea-0383c11b333a',key:kubernetes.deployment.name,negate:!f,params:(query:cpd-ecf-review-4969-worker),type:phrase),query:(match_phrase:(kubernetes.deployment.name:cpd-ecf-review-4969-worker)))),query:(language:kuery,query:''))