### PR TITLE
Fix `Rails.application.secrets` is deprecated in favor of `Rails.application.credentials` message

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -14,7 +14,7 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  config.secret_key = Rails.application.secrets.secret_key_base
+  config.secret_key = Rails.application.secret_key_base
 
   # Configure the class responsible to send e-mails.
   config.mailer = "UserMailer"


### PR DESCRIPTION
### Context

- Ticket: N/A

```
`Rails.application.secrets` is deprecated in favor of `Rails.application.credentials` and will be removed in Rails 7.2.
```

### Changes proposed in this pull request

Fix deprecation message above.
Checked all credentials files all have `secret_key_base` set correctly.
