### PR TITLE
participants moved from cohort frozen for payments need to be placed …

### DIFF
--- a/app/services/induction/amend_participant_cohort.rb
+++ b/app/services/induction/amend_participant_cohort.rb
@@ -169,13 +169,9 @@ module Induction
     end
 
     def schedule
-      @schedule ||= if induction_record && in_target_cohort?(induction_record)
-                      induction_record.schedule
-                    else
-                      Finance::Schedule::ECF.find_by(cohort: target_cohort,
-                                                     schedule_identifier: induction_record&.schedule_identifier) ||
-                        Finance::Schedule::ECF.default_for(cohort: target_cohort)
-                    end
+      @schedule ||= Induction::ScheduleForNewCohort.call(cohort: target_cohort,
+                                                         induction_record:,
+                                                         cohort_changed_after_payments_frozen:)
     end
 
     def source_cohort

--- a/app/services/induction/schedule_for_new_cohort.rb
+++ b/app/services/induction/schedule_for_new_cohort.rb
@@ -1,22 +1,26 @@
 # frozen_string_literal: true
 
 class Induction::ScheduleForNewCohort < BaseService
+  EXTENDED_SCHEDULE_IDENTIFIER = "ecf-extended-september"
+
   def call
-    if induction_record && induction_record.cohort == cohort
-      induction_record.schedule
-    else
-      Finance::Schedule::ECF.find_by(cohort:,
-                                     schedule_identifier: induction_record&.schedule_identifier) ||
-        Finance::Schedule::ECF.default_for(cohort:)
-    end
+    return induction_record.schedule if induction_record && induction_record.cohort == cohort
+
+    Finance::Schedule::ECF.find_by(cohort:, schedule_identifier:) ||
+      Finance::Schedule::ECF.default_for(cohort:)
   end
 
 private
 
-  attr_reader :cohort, :induction_record
+  attr_reader :cohort, :induction_record, :cohort_changed_after_payments_frozen
 
-  def initialize(cohort:, induction_record:)
+  def initialize(cohort:, induction_record:, cohort_changed_after_payments_frozen: false)
     @cohort = cohort
     @induction_record = induction_record
+    @cohort_changed_after_payments_frozen = cohort_changed_after_payments_frozen
+  end
+
+  def schedule_identifier
+    cohort_changed_after_payments_frozen ? EXTENDED_SCHEDULE_IDENTIFIER : induction_record&.schedule_identifier
   end
 end

--- a/app/services/induction/transfer_and_continue_existing_fip.rb
+++ b/app/services/induction/transfer_and_continue_existing_fip.rb
@@ -103,6 +103,8 @@ private
   end
 
   def schedule
-    @schedule ||= Induction::ScheduleForNewCohort.call(cohort:, induction_record: latest_induction_record)
+    @schedule ||= Induction::ScheduleForNewCohort.call(cohort:,
+                                                       induction_record: latest_induction_record,
+                                                       cohort_changed_after_payments_frozen:)
   end
 end

--- a/app/services/induction/transfer_to_schools_programme.rb
+++ b/app/services/induction/transfer_to_schools_programme.rb
@@ -64,6 +64,8 @@ private
   end
 
   def schedule
-    @schedule ||= Induction::ScheduleForNewCohort.call(cohort:, induction_record: latest_induction_record)
+    @schedule ||= Induction::ScheduleForNewCohort.call(cohort:,
+                                                       induction_record: latest_induction_record,
+                                                       cohort_changed_after_payments_frozen:)
   end
 end

--- a/lib/tasks/extended_schedules.rake
+++ b/lib/tasks/extended_schedules.rake
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+namespace :extended_schedules do
+  desc "Fix schedule for unfinished 2021 participants moved to 2024 cohort"
+  task run: :environment do
+    schedule_identifier = "ecf-extended-september"
+    cohort = Cohort.find_by_start_year(2024)
+    schedule = Finance::Schedule::ECF.find_by(cohort:, schedule_identifier:)
+    participants = ParticipantProfile.where(cohort_changed_after_payments_frozen: true).to_a
+
+    participants.map do |participant_profile|
+      # exclude those already in the extended schedule
+      if participant_profile.schedule == schedule
+        puts "#{participant_profile.id}: already in extended schedule!"
+        next
+      end
+
+      # exclude those with submitted or billable declarations in a non-frozen cohort
+      if participant_profile.participant_declarations
+                            .joins(:cohort)
+                            .billable_or_changeable
+                            .where(cohorts: { payments_frozen_at: nil })
+                            .exists?
+        puts "#{participant_profile.id}: failed! (has blocking declarations in not frozen cohort)"
+        next
+      end
+
+      induction_record = participant_profile.latest_induction_record
+      school = induction_record.school
+      target_school_cohort = SchoolCohort.find_by(school:, cohort:)
+      induction_programme = if induction_record && induction_record.cohort == cohort
+                              induction_record.induction_programme
+                            else
+                              target_school_cohort&.default_induction_programme
+                            end
+
+      ActiveRecord::Base.transaction do
+        Induction::ChangeInductionRecord.call(induction_record:,
+                                              changes: { induction_programme:, schedule: })
+        participant_profile.update!(school_cohort: target_school_cohort, schedule:)
+
+        puts "#{participant_profile.id}: success!"
+      rescue ActiveRecord::RecordInvalid => e
+        puts "#{participant_profile.id}: failed! (#{e.message})"
+      end
+    end
+  end
+end

--- a/spec/services/induction/amend_participant_cohort_spec.rb
+++ b/spec/services/induction/amend_participant_cohort_spec.rb
@@ -398,11 +398,19 @@ RSpec.describe Induction::AmendParticipantCohort do
                 before do
                   source_cohort.update!(payments_frozen_at: Time.current)
                   allow(participant_profile).to receive(:eligible_to_change_cohort_and_continue_training?).and_return(true)
+                  create(:ecf_extended_schedule, cohort: target_cohort)
                 end
 
                 it "mark the participant as transferred for that reason" do
                   expect(form.save).to be_truthy
                   expect(participant_profile).to be_cohort_changed_after_payments_frozen
+                end
+
+                it "sets the schedule to ecf-extended-september" do
+                  expect(form.save).to be_truthy
+                  expect(participant_profile.reload.schedule.schedule_identifier).to eq("ecf-extended-september")
+                  expect(participant_profile.schedule.cohort).to eq(target_cohort)
+                  expect(participant_profile.latest_induction_record.schedule).to eq(participant_profile.schedule)
                 end
 
                 it "mark the participant as transferred from the original cohort" do

--- a/spec/services/induction/schedule_for_new_cohort_spec.rb
+++ b/spec/services/induction/schedule_for_new_cohort_spec.rb
@@ -4,7 +4,9 @@ RSpec.describe Induction::ScheduleForNewCohort do
   describe "#call" do
     let(:cohort) { Cohort.current }
     let(:schedule_identifier) { "ecf-standard-september" }
-    let(:service) { described_class.call(cohort:, induction_record:) }
+    let(:schedule) { double(Finance::Schedule::ECF, schedule_identifier:) }
+    let(:cohort_changed_after_payments_frozen) { false }
+    let(:service) { described_class.call(cohort:, induction_record:, cohort_changed_after_payments_frozen:) }
 
     context "when induction record is nil" do
       let(:default_schedule) { double(Finance::Schedule::ECF) }
@@ -29,16 +31,74 @@ RSpec.describe Induction::ScheduleForNewCohort do
     end
 
     context "when the induction record is not in the cohort" do
-      let(:schedule) { double(Finance::Schedule::ECF, schedule_identifier:) }
-      let(:new_schedule) { double(Finance::Schedule::ECF, schedule_identifier:, cohort:) }
       let(:induction_record) { double(InductionRecord, cohort: Cohort.previous, schedule_identifier:) }
+      let(:new_schedule) { double(Finance::Schedule::ECF, schedule_identifier:, cohort:) }
 
-      before do
-        allow(Finance::Schedule::ECF).to receive(:find_by).with(cohort:, schedule_identifier:).and_return(new_schedule)
+      context "when cohort_changed_after_payments_frozen is true" do
+        let(:cohort_changed_after_payments_frozen) { true }
+
+        context "when the ecf-extended-september schedule in the cohort exists" do
+          let(:default_schedule) { double(Finance::Schedule::ECF, cohort:, schedule_identifier: "ecf-extended-september") }
+
+          before do
+            allow(Finance::Schedule::ECF).to receive(:find_by)
+                                               .with(cohort:, schedule_identifier: "ecf-extended-september")
+                                               .and_return(default_schedule)
+          end
+
+          it "return the 'ecf-extended-september' schedule for the cohort" do
+            expect(service.schedule_identifier).to eq("ecf-extended-september")
+            expect(service.cohort).to eq(cohort)
+          end
+        end
+
+        context "when the ecf-extended-september schedule in the cohort does not exist" do
+          let(:default_schedule) { double(Finance::Schedule::ECF, cohort:, schedule_identifier: "ecf-default") }
+
+          before do
+            allow(Finance::Schedule::ECF).to receive(:find_by)
+                                               .with(cohort:, schedule_identifier: "ecf-extended-september")
+            allow(Finance::Schedule::ECF).to receive(:default_for).with(cohort:).and_return(default_schedule)
+          end
+
+          it "return the default schedule for the cohort" do
+            expect(service.schedule_identifier).to eq("ecf-default")
+            expect(service.cohort).to eq(cohort)
+          end
+        end
       end
 
-      it "return a new schedule in the cohort keeping the same schedule-identifier" do
-        expect(service).to eql(new_schedule)
+      context "when cohort_changed_after_payments_frozen is false" do
+        let(:cohort_changed_after_payments_frozen) { false }
+
+        context "when a schedule in the cohort exists with the same schedule-identifier as the induction record's schedule" do
+          let(:default_schedule) { double(Finance::Schedule::ECF, cohort:, schedule_identifier:) }
+
+          before do
+            allow(Finance::Schedule::ECF).to receive(:find_by)
+                                               .with(cohort:, schedule_identifier:)
+                                               .and_return(default_schedule)
+          end
+
+          it "return it" do
+            expect(service.schedule_identifier).to eq(schedule_identifier)
+            expect(service.cohort).to eq(cohort)
+          end
+        end
+
+        context "when a schedule in the cohort do not exist with the same schedule-identifier as the induction record's schedule" do
+          let(:default_schedule) { double(Finance::Schedule::ECF, cohort:, schedule_identifier: "ecf-default") }
+
+          before do
+            allow(Finance::Schedule::ECF).to receive(:find_by).with(cohort:, schedule_identifier:)
+            allow(Finance::Schedule::ECF).to receive(:default_for).with(cohort:).and_return(default_schedule)
+          end
+
+          it "return the default schedule for the cohort" do
+            expect(service.schedule_identifier).to eq("ecf-default")
+            expect(service.cohort).to eq(cohort)
+          end
+        end
       end
     end
   end

--- a/spec/services/induction/transfer_and_continue_existing_fip_spec.rb
+++ b/spec/services/induction/transfer_and_continue_existing_fip_spec.rb
@@ -55,15 +55,29 @@ RSpec.describe Induction::TransferAndContinueExistingFip do
     end
 
     context "when the participant is eligible to be moved from a frozen cohort to the target one" do
+      let(:school_cohort_2) do
+        create(:school_cohort,
+               :fip,
+               :with_induction_programme,
+               cohort: Cohort.next,
+               lead_provider:)
+      end
+
       before do
         allow(participant_profile).to receive(:eligible_to_change_cohort_and_continue_training?)
-                                        .with(cohort: school_cohort_2.cohort)
+                                        .with(cohort: Cohort.next)
                                         .and_return(true)
+        create(:ecf_extended_schedule, cohort: Cohort.next)
         service_call
       end
 
       it "flags the participant as changed for that reason" do
         expect(participant_profile).to be_cohort_changed_after_payments_frozen
+      end
+
+      it "sets 'ecf-extended-september' schedule" do
+        expect(participant_profile.schedule.schedule_identifier).to eq("ecf-extended-september")
+        expect(participant_profile.reload.latest_induction_record.schedule).to eq(participant_profile.schedule)
       end
     end
 


### PR DESCRIPTION
…in extended schedules

### Context

  Unfinished 2021 participants moved out of their frozen cohort needs to be set `ecf-extended-september` schedule in the landing cohort.

- [Ticket](https://dfedigital.atlassian.net/browse/CST-2622): 

### Changes proposed in this pull request

- Code changes to put unfinished 21 participants in `ecf-extended-september` schedule when moved to 2024
- Rake task to fix those already in the database since last week

### Guidance to review

