### PR TITLE
Allow providers to migrate participants from 2021 to 2024

### DIFF
--- a/app/controllers/concerns/api/v1/participant_actions.rb
+++ b/app/controllers/concerns/api/v1/participant_actions.rb
@@ -22,7 +22,7 @@ module Api
       end
 
       def change_schedule
-        service = ChangeSchedule.new(action_params)
+        service = ChangeSchedule.new(action_params.merge!(allow_change_to_from_frozen_cohort: true))
 
         serialized_response_for(service)
       end

--- a/spec/support/shared_examples/participant_actions_change_schedule_support.rb
+++ b/spec/support/shared_examples/participant_actions_change_schedule_support.rb
@@ -50,6 +50,77 @@ RSpec.shared_examples "JSON Participant Change schedule endpoint" do
     end
   end
 
+  describe "/api/v1/participants/ID/change-schedule with declarations from payments frozen cohort" do
+    let(:parsed_response) { JSON.parse(response.body) }
+
+    let!(:schedule) { early_career_teacher_profile.schedule }
+    let(:new_cohort) { Cohort.active_registration_cohort }
+    let(:new_schedule) { create(:ecf_schedule, schedule_identifier: "new-schedule", name: "new schedule", cohort: new_cohort) }
+
+    before do
+      cohort.freeze_payments!
+      create(:partnership,
+             school: early_career_teacher_profile.school,
+             cohort: new_cohort,
+             lead_provider: early_career_teacher_profile.lead_provider)
+      create(:ect_participant_declaration,
+             participant_profile: early_career_teacher_profile,
+             user: early_career_teacher_profile.user,
+             cohort:,
+             state: :paid,
+             cpd_lead_provider: early_career_teacher_profile.lead_provider.cpd_lead_provider)
+      induction_programme = early_career_teacher_profile.latest_induction_record.induction_programme
+      create(:school_cohort, school: early_career_teacher_profile.school, cohort: new_cohort, default_induction_programme: induction_programme)
+    end
+
+    it "changes participant schedule" do
+      expect {
+        put "/api/v1/participants/#{early_career_teacher_profile.user.id}/change-schedule", params: {
+          data: {
+            attributes: {
+              course_identifier: "ecf-induction",
+              schedule_identifier: new_schedule.schedule_identifier,
+              cohort: new_cohort.start_year,
+            },
+          },
+        }
+      }.to change { early_career_teacher_profile.reload.cohort_changed_after_payments_frozen }.to(true)
+      .and change { early_career_teacher_profile.reload.schedule }.to(new_schedule)
+
+      expect(response).to be_successful
+      expect(parsed_response.dig("data", "attributes", "schedule_identifier")).to eql(new_schedule.schedule_identifier)
+    end
+
+    context "when they have changed schedule to a future cohort" do
+      before do
+        put "/api/v1/participants/#{early_career_teacher_profile.user.id}/change-schedule", params: {
+          data: {
+            attributes: {
+              course_identifier: "ecf-induction",
+              schedule_identifier: new_schedule.schedule_identifier,
+              cohort: new_cohort.start_year,
+            },
+          },
+        }
+      end
+
+      it "allows them to change back to their original cohort" do
+        expect {
+          put "/api/v1/participants/#{early_career_teacher_profile.user.id}/change-schedule", params: {
+            data: {
+              attributes: {
+                course_identifier: "ecf-induction",
+                schedule_identifier: schedule.schedule_identifier,
+                cohort: cohort.start_year,
+              },
+            },
+          }
+        }.to change { early_career_teacher_profile.reload.cohort_changed_after_payments_frozen }.to(false)
+        .and change { early_career_teacher_profile.reload.schedule }.to(schedule)
+      end
+    end
+  end
+
   describe "/api/v1/participants/ecf/ID/change-schedule" do
     let(:parsed_response) { JSON.parse(response.body) }
 


### PR DESCRIPTION
[Jira-3200](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-3200)

### Context

The `ChangeSchedule` service already has this functionality, however it was locked down so that providers could not perform the action. It has been decided we want to open up this functionality to LPs going forward, so we can do this by passing `allow_change_to_from_frozen_cohort: true` into the `ChangeSchedule` service.

### Changes proposed in this pull request

- Allow providers to migrate participants from 2021 to 2024

### Guidance to review


