### PR TITLE
[CST-2519] Make the steps explicit in the cookies policy specs

### DIFF
--- a/spec/features/cookies_policy_page_spec.rb
+++ b/spec/features/cookies_policy_page_spec.rb
@@ -3,6 +3,7 @@
 require "rails_helper"
 
 RSpec.feature "Cookie policy page", type: :feature, js: true do
+  include Steps::CookiesPolicySteps
   # All ECF users need to be able to set and modify their cookie preferences
 
   scenario "Cookie policy is accessible" do
@@ -20,6 +21,7 @@ RSpec.feature "Cookie policy page", type: :feature, js: true do
   scenario "Returning from the cookie policy" do
     given_i_am_on_the_start_page
     when_i_view_cookie_policy_from_the_start_page
+    then_i_am_on_the_cookie_policy_page
     when_i_go_back_from_the_cookie_policy_page
     then_i_am_on_the_start_page
   end
@@ -27,7 +29,8 @@ RSpec.feature "Cookie policy page", type: :feature, js: true do
   scenario "Default cookie preferences" do
     given_i_am_on_the_start_page
     when_i_view_cookie_policy_from_the_start_page
-    then_i_confirm_cookie_consent_is_given_on_the_cookie_policy_page
+    then_i_am_on_the_cookie_policy_page
+    and_i_confirm_cookie_consent_is_given_on_the_cookie_policy_page
   end
 
   scenario "Consenting to the cookie policy" do
@@ -60,6 +63,8 @@ RSpec.feature "Cookie policy page", type: :feature, js: true do
 end
 
 RSpec.feature "Cookie banner without JavaScript", type: :feature, js: false do
+  include Steps::CookiesPolicySteps
+
   scenario "Cookie banner is visible" do
     given_i_am_on_the_start_page
 
@@ -104,6 +109,8 @@ RSpec.feature "Cookie banner without JavaScript", type: :feature, js: false do
 end
 
 RSpec.feature "Cookie banner with JavaScript", type: :feature, js: true do
+  include Steps::CookiesPolicySteps
+
   scenario "Cookie banner is visible" do
     given_i_am_on_the_start_page
 

--- a/spec/support/features/steps/cookies_policy_steps.rb
+++ b/spec/support/features/steps/cookies_policy_steps.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module Steps
+  module CookiesPolicySteps
+    include RSpec::Matchers
+
+    def given_i_am_on_the_start_page
+      @start_page = Pages::StartPage.load
+    end
+
+    def when_i_view_cookie_policy_from_the_start_page
+      @start_page.view_cookie_policy
+    end
+
+    def when_i_go_back_from_the_cookie_policy_page
+      @cookies_policy_page.go_back
+    end
+
+    def when_i_give_cookie_consent_on_the_cookie_policy_page
+      @cookies_policy_page.give_cookie_consent
+    end
+    alias_method :and_i_give_cookie_consent_on_the_cookie_policy_page, :when_i_give_cookie_consent_on_the_cookie_policy_page
+
+    def when_i_revoke_cookie_consent_on_the_cookie_policy_page
+      @cookies_policy_page.revoke_cookie_consent
+    end
+    alias_method :and_i_revoke_cookie_consent_on_the_cookie_policy_page, :when_i_revoke_cookie_consent_on_the_cookie_policy_page
+
+    def when_i_reject_cookies_on_the_start_page
+      @start_page.reject_cookies
+    end
+    alias_method :and_i_reject_cookies_on_the_start_page, :when_i_reject_cookies_on_the_start_page
+
+    def when_i_hide_success_message_on_the_start_page
+      @start_page.hide_success_message
+    end
+
+    def when_i_accept_cookies_on_the_start_page
+      @start_page.accept_cookies
+    end
+    alias_method :and_i_accept_cookies_on_the_start_page, :when_i_accept_cookies_on_the_start_page
+
+    def and_i_confirm_cookie_preferences_rejected_on_the_start_page
+      @start_page.confirm_cookie_preferences_rejected
+    end
+
+    def and_i_confirm_cookie_preferences_accepted_on_the_start_page
+      @start_page.confirm_cookie_preferences_accepted
+    end
+
+    def then_i_am_on_the_cookie_policy_page
+      @cookies_policy_page = Pages::CookiePolicyPage.load
+      @cookies_policy_page.loaded
+    end
+    alias_method :given_i_am_on_the_cookie_policy_page, :then_i_am_on_the_cookie_policy_page
+    alias_method :and_i_am_on_the_cookie_policy_page, :then_i_am_on_the_cookie_policy_page
+    alias_method :when_i_am_on_the_cookie_policy_page, :then_i_am_on_the_cookie_policy_page
+
+    def then_i_am_on_the_start_page
+      @start_page.loaded
+    end
+
+    def then_i_confirm_cookie_consent_is_given_on_the_cookie_policy_page
+      @cookies_policy_page.confirm_cookie_consent_is_given
+    end
+    alias_method :and_i_confirm_cookie_consent_is_given_on_the_cookie_policy_page, :then_i_confirm_cookie_consent_is_given_on_the_cookie_policy_page
+
+    def then_i_confirm_cookie_consent_is_not_given_on_the_cookie_policy_page
+      @cookies_policy_page.confirm_cookie_consent_is_not_given
+    end
+    alias_method :and_i_confirm_cookie_consent_is_not_given_on_the_cookie_policy_page, :then_i_confirm_cookie_consent_is_not_given_on_the_cookie_policy_page
+
+    def then_i_confirm_cookie_banner_displayed_on_the_start_page
+      @start_page.confirm_cookie_banner_displayed
+    end
+
+    def then_i_confirm_cookie_banner_not_displayed_on_the_start_page
+      @start_page.confirm_cookie_banner_not_displayed
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: CST-2519

This is part of the effort to move away from the GenericPageObjectSteps.

### Changes proposed in this pull request
- Create explicit methods for each magic step in the cookies policy specs

### Guidance to review

