### PR TITLE
Change string to boolean for funded type in API spec

### DIFF
--- a/swagger/v3/api_spec.json
+++ b/swagger/v3/api_spec.json
@@ -5211,7 +5211,7 @@
             "type": "npq-application-accept",
             "attributes": {
               "schedule_identifier": "npq-leadership-spring",
-              "funded_place": "true"
+              "funded_place": true
             }
           }
         }


### PR DESCRIPTION
### Context
Providers got confused by this in v3, and used strings instead. Another fix for the types coming in shortly

- Ticket: n/a

### Changes proposed in this pull request

### Guidance to review

