### PR TITLE
Amend accept and change funding service to only accept funded place booleans only

### DIFF
--- a/app/services/npq/application/change_funded_place.rb
+++ b/app/services/npq/application/change_funded_place.rb
@@ -11,6 +11,11 @@ module NPQ
 
       validates :npq_application, presence: { message: I18n.t("npq_application.missing_npq_application") }
       validate :funded_place_not_nil
+      validates :funded_place,
+                inclusion: {
+                  in: [true, false],
+                  message: I18n.t("npq_application.funded_place_required"),
+                }
       validate :accepted_application
       validate :eligible_for_funding
       validate :eligible_for_removing_funding_place

--- a/spec/requests/api/v1/npq_applications_spec.rb
+++ b/spec/requests/api/v1/npq_applications_spec.rb
@@ -369,13 +369,13 @@ RSpec.describe "NPQ Applications API", type: :request do
         before { FeatureFlag.deactivate(:npq_capping) }
 
         it "does not update funded place attribute" do
-          post("/api/v1/npq-applications/#{default_npq_application.id}/accept", params:)
+          post("/api/v1/npq-applications/#{default_npq_application.id}/accept", params:, as: :json)
 
           expect(default_npq_application.reload.funded_place).to be_nil
         end
 
         it "does not raise error if funded_place param is not sent" do
-          post("/api/v1/npq-applications/#{default_npq_application.id}/accept", params: {})
+          post("/api/v1/npq-applications/#{default_npq_application.id}/accept", params: {}, as: :json)
 
           expect(response).to be_successful
           expect(parsed_response.dig("data", "attributes", "status")).to eql("accepted")
@@ -386,13 +386,13 @@ RSpec.describe "NPQ Applications API", type: :request do
         before { FeatureFlag.activate(:npq_capping) }
 
         it "updates funded place attribute" do
-          post("/api/v1/npq-applications/#{default_npq_application.id}/accept", params:)
+          post("/api/v1/npq-applications/#{default_npq_application.id}/accept", params:, as: :json)
 
           expect(default_npq_application.reload.funded_place).to be_truthy
         end
 
         it "returns 200" do
-          post("/api/v1/npq-applications/#{default_npq_application.id}/accept", params:)
+          post("/api/v1/npq-applications/#{default_npq_application.id}/accept", params:, as: :json)
 
           expect(response).to be_successful
         end

--- a/spec/requests/api/v2/npq_applications_spec.rb
+++ b/spec/requests/api/v2/npq_applications_spec.rb
@@ -353,13 +353,13 @@ RSpec.describe "NPQ Applications API", type: :request do
         before { FeatureFlag.deactivate(:npq_capping) }
 
         it "does not update funded place attribute" do
-          post("/api/v2/npq-applications/#{default_npq_application.id}/accept", params:)
+          post("/api/v2/npq-applications/#{default_npq_application.id}/accept", params:, as: :json)
 
           expect(default_npq_application.reload.funded_place).to be_nil
         end
 
         it "does not raise error if funded_place param is not sent" do
-          post("/api/v2/npq-applications/#{default_npq_application.id}/accept", params: {})
+          post("/api/v2/npq-applications/#{default_npq_application.id}/accept", params: {}, as: :json)
 
           expect(response).to be_successful
           expect(parsed_response.dig("data", "attributes", "status")).to eql("accepted")
@@ -370,13 +370,13 @@ RSpec.describe "NPQ Applications API", type: :request do
         before { FeatureFlag.activate(:npq_capping) }
 
         it "updates funded place attribute" do
-          post("/api/v2/npq-applications/#{default_npq_application.id}/accept", params:)
+          post("/api/v2/npq-applications/#{default_npq_application.id}/accept", params:, as: :json)
 
           expect(default_npq_application.reload.funded_place).to be_truthy
         end
 
         it "returns 200" do
-          post("/api/v2/npq-applications/#{default_npq_application.id}/accept", params:)
+          post("/api/v2/npq-applications/#{default_npq_application.id}/accept", params:, as: :json)
 
           expect(response).to be_successful
         end

--- a/spec/requests/api/v3/npq_applications_spec.rb
+++ b/spec/requests/api/v3/npq_applications_spec.rb
@@ -342,13 +342,13 @@ RSpec.describe "NPQ Applications API", type: :request do
         before { FeatureFlag.deactivate(:npq_capping) }
 
         it "does not update funded place attribute" do
-          post("/api/v3/npq-applications/#{default_npq_application.id}/accept", params:)
+          post("/api/v3/npq-applications/#{default_npq_application.id}/accept", params:, as: :json)
 
           expect(default_npq_application.reload.funded_place).to be_nil
         end
 
         it "does not raise error if funded_place param is not sent" do
-          post("/api/v3/npq-applications/#{default_npq_application.id}/accept", params: {})
+          post("/api/v3/npq-applications/#{default_npq_application.id}/accept", params: {}, as: :json)
 
           expect(response).to be_successful
           expect(parsed_response.dig("data", "attributes", "status")).to eql("accepted")
@@ -359,13 +359,13 @@ RSpec.describe "NPQ Applications API", type: :request do
         before { FeatureFlag.activate(:npq_capping) }
 
         it "updates funded place attribute" do
-          post("/api/v3/npq-applications/#{default_npq_application.id}/accept", params:)
+          post("/api/v3/npq-applications/#{default_npq_application.id}/accept", params:, as: :json)
 
           expect(default_npq_application.reload.funded_place).to be_truthy
         end
 
         it "returns 200" do
-          post("/api/v3/npq-applications/#{default_npq_application.id}/accept", params:)
+          post("/api/v3/npq-applications/#{default_npq_application.id}/accept", params:, as: :json)
 
           expect(response).to be_successful
         end
@@ -413,12 +413,12 @@ RSpec.describe "NPQ Applications API", type: :request do
       end
 
       it "update status to accepted" do
-        expect { post("/api/v3/npq-applications/#{default_npq_application.id}/accept", params:) }
+        expect { post("/api/v3/npq-applications/#{default_npq_application.id}/accept", params:, as: :json) }
           .to change { default_npq_application.reload.lead_provider_approval_status }.from("pending").to("accepted")
       end
 
       it "responds with 200 and representation of the resource" do
-        post("/api/v3/npq-applications/#{default_npq_application.id}/accept", params:)
+        post("/api/v3/npq-applications/#{default_npq_application.id}/accept", params:, as: :json)
 
         expect(response).to be_successful
 
@@ -426,7 +426,7 @@ RSpec.describe "NPQ Applications API", type: :request do
       end
 
       it "updates npq profile schedule identifier" do
-        post("/api/v3/npq-applications/#{default_npq_application.id}/accept", params:)
+        post("/api/v3/npq-applications/#{default_npq_application.id}/accept", params:, as: :json)
 
         expect(response).to be_successful
         expect(default_npq_application.profile.schedule.schedule_identifier).to eql("npq-leadership-spring")
@@ -438,12 +438,12 @@ RSpec.describe "NPQ Applications API", type: :request do
         end
 
         it "update status to accepted" do
-          expect { post("/api/v3/npq-applications/#{default_npq_application.id}/accept", params:) }
+          expect { post("/api/v3/npq-applications/#{default_npq_application.id}/accept", params:, as: :json) }
             .to change { default_npq_application.reload.lead_provider_approval_status }.from("pending").to("accepted")
         end
 
         it "responds with 200 and representation of the resource" do
-          post("/api/v3/npq-applications/#{default_npq_application.id}/accept", params:)
+          post("/api/v3/npq-applications/#{default_npq_application.id}/accept", params:, as: :json)
 
           expect(response).to be_successful
 
@@ -457,13 +457,13 @@ RSpec.describe "NPQ Applications API", type: :request do
         end
 
         it "return 422" do
-          post("/api/v3/npq-applications/#{default_npq_application.id}/accept", params:)
+          post("/api/v3/npq-applications/#{default_npq_application.id}/accept", params:, as: :json)
 
           expect(response).to have_http_status(:unprocessable_entity)
         end
 
         it "returns error in response" do
-          post("/api/v3/npq-applications/#{default_npq_application.id}/accept", params:)
+          post("/api/v3/npq-applications/#{default_npq_application.id}/accept", params:, as: :json)
 
           expect(parsed_response.key?("errors")).to be_truthy
           expect(parsed_response.dig("errors", 0, "detail")).to eql("Selected schedule is not valid for the course")
@@ -476,13 +476,13 @@ RSpec.describe "NPQ Applications API", type: :request do
         end
 
         it "return 422" do
-          post("/api/v3/npq-applications/#{default_npq_application.id}/accept", params:)
+          post("/api/v3/npq-applications/#{default_npq_application.id}/accept", params:, as: :json)
 
           expect(response).to have_http_status(:unprocessable_entity)
         end
 
         it "returns error in response" do
-          post("/api/v3/npq-applications/#{default_npq_application.id}/accept", params:)
+          post("/api/v3/npq-applications/#{default_npq_application.id}/accept", params:, as: :json)
 
           expect(parsed_response.key?("errors")).to be_truthy
           expect(parsed_response.dig("errors", 0, "detail")).to eql("Selected schedule is not valid for the course")
@@ -495,13 +495,13 @@ RSpec.describe "NPQ Applications API", type: :request do
         end
 
         it "return 400" do
-          post("/api/v3/npq-applications/#{default_npq_application.id}/accept", params:)
+          post("/api/v3/npq-applications/#{default_npq_application.id}/accept", params:, as: :json)
 
           expect(response).to be_bad_request
         end
 
         it "returns error in response" do
-          post("/api/v3/npq-applications/#{default_npq_application.id}/accept", params:)
+          post("/api/v3/npq-applications/#{default_npq_application.id}/accept", params:, as: :json)
 
           expect(parsed_response).to eql(HashWithIndifferentAccess.new({
             "errors": [

--- a/spec/services/npq/application/accept_spec.rb
+++ b/spec/services/npq/application/accept_spec.rb
@@ -523,8 +523,26 @@ RSpec.describe NPQ::Application::Accept do
 
             it "returns funding_place is required error" do
               service.call
-              expect(service.errors.messages_for(:npq_application)).to include("Set '#/funded_place' to true or false.")
+              expect(service.errors.messages_for(:funded_place)).to include("Set '#/funded_place' to true or false.")
             end
+          end
+        end
+
+        context "when funded_place is a string" do
+          let(:params) { { npq_application:, funded_place: "true" } }
+
+          it "returns funding_place is required error" do
+            service.call
+            expect(service.errors.messages_for(:funded_place)).to include("Set '#/funded_place' to true or false.")
+          end
+        end
+
+        context "when funded_place is an empty string" do
+          let(:params) { { npq_application:, funded_place: "" } }
+
+          it "returns funding_place is required error" do
+            service.call
+            expect(service.errors.messages_for(:funded_place)).to include("Set '#/funded_place' to true or false.")
           end
         end
       end

--- a/spec/services/npq/application/change_funded_place_spec.rb
+++ b/spec/services/npq/application/change_funded_place_spec.rb
@@ -178,6 +178,24 @@ RSpec.describe NPQ::Application::ChangeFundedPlace do
           expect(service.errors.messages_for(:npq_application)).to include("The entered '#/funded_place' is missing from your request. Check details and try again.")
         end
       end
+
+      context "when funded_place is set to a string" do
+        before { params.merge!(funded_place: "false") }
+
+        it "is invalid" do
+          service.call
+          expect(service.errors.messages_for(:funded_place)).to include("Set '#/funded_place' to true or false.")
+        end
+      end
+
+      context "when funded_place is set to an empty string" do
+        before { params.merge!(funded_place: "false") }
+
+        it "is invalid" do
+          service.call
+          expect(service.errors.messages_for(:funded_place)).to include("Set '#/funded_place' to true or false.")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

We currently validate against the funded place attribute regardless of type. So if a string is passed in we compute it as true.
This confused providers as they were passing values such as `"false"` and `"null"` and this was computed as `true`

- Ticket: https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-3205

### Changes proposed in this pull request

Amend the validations in both services to only accept boolean values otherwise returns a validation error, even if it's a string.

### Guidance to review
Maybe we should allow strings and compute those values, but felt better to lock it down to just booleans
