### PR TITLE
Change appropriate body view to show active registration cohort

### DIFF
--- a/app/services/appropriate_bodies/participants_filter.rb
+++ b/app/services/appropriate_bodies/participants_filter.rb
@@ -13,7 +13,7 @@ module AppropriateBodies
     def scope
       scoped = collection.includes(
         :cohort,
-      ).where(cohort: { start_year: Cohort.current.start_year })
+      ).where(cohort: { start_year: Cohort.active_registration_cohort.start_year })
 
       if params[:query].present?
         scoped = filter_query(scoped, params[:query])

--- a/app/views/appropriate_bodies/participants/index.html.erb
+++ b/app/views/appropriate_bodies/participants/index.html.erb
@@ -1,7 +1,7 @@
 <span class="govuk-caption-l">Appropriate body</span>
 <h1 class="govuk-heading-l"><%= @appropriate_body.name %> Participants</h1>
 
-<span class="govuk-caption-l"><%= Cohort.current.academic_year %> academic year</span>
+<span class="govuk-caption-l"><%= Cohort.active_registration_cohort.academic_year %> academic year</span>
 
 <p class="govuk-body govuk-!-text-align-right">
   <%= govuk_link_to "Download (csv)", appropriate_body_participants_path(params.permit(:query, :role, :academic_year, :status).merge({format: :csv})) %>

--- a/spec/features/appropriate_bodies/participants_spec.rb
+++ b/spec/features/appropriate_bodies/participants_spec.rb
@@ -3,15 +3,16 @@
 require "rails_helper"
 
 RSpec.feature "Appropriate body users participants", type: :feature do
+  let(:cohort) { Cohort.active_registration_cohort }
   let(:appropriate_body_user) { create(:user, :appropriate_body) }
   let(:appropriate_body) { appropriate_body_user.appropriate_bodies.first }
 
-  let(:participant_profile) { create :ect_participant_profile, training_status: "withdrawn" }
-  let(:mentor_profile) { create :mentor_participant_profile, training_status: "withdrawn" }
+  let(:participant_profile) { create :ect_participant_profile, training_status: "withdrawn", cohort: }
+  let(:mentor_profile) { create :mentor_participant_profile, training_status: "withdrawn", cohort: }
   let(:lead_provider) { create(:lead_provider) }
   let(:delivery_partner) { create(:delivery_partner) }
   let(:school) { create(:school) }
-  let(:school_cohort) { create(:school_cohort, school:) }
+  let(:school_cohort) { create(:school_cohort, school:, cohort:) }
   let(:partnership) do
     create(
       :partnership,
@@ -20,6 +21,7 @@ RSpec.feature "Appropriate body users participants", type: :feature do
       challenged_at: nil,
       challenge_reason: nil,
       pending: false,
+      cohort:,
     )
   end
   let(:induction_programme) { create(:induction_programme, :fip, partnership:, school_cohort:) }

--- a/spec/services/appropriate_bodies/participants_filter_spec.rb
+++ b/spec/services/appropriate_bodies/participants_filter_spec.rb
@@ -3,16 +3,26 @@
 require "rails_helper"
 
 RSpec.describe AppropriateBodies::ParticipantsFilter do
+  let(:cohort) { Cohort.active_registration_cohort }
   let(:appropriate_body_user) { create(:user, :appropriate_body) }
   let(:appropriate_body) { appropriate_body_user.appropriate_bodies.first }
 
-  let(:participant_profile1) { create(:ect_participant_profile) }
+  let(:participant_profile1) { create(:ect_participant_profile, cohort:) }
+  let(:school_cohort1) { create(:school_cohort, cohort:) }
   let(:induction_programme1) { create(:induction_programme, :fip) }
-  let!(:induction_record1) { create(:induction_record, participant_profile: participant_profile1, appropriate_body:, induction_programme: induction_programme1) }
+  let!(:induction_record1) { create(:induction_record, participant_profile: participant_profile1, appropriate_body:, induction_programme: induction_programme1, school_cohort: school_cohort1) }
 
   let(:participant_profile2) { create(:ect_participant_profile, training_status: "deferred") }
+  let(:school_cohort2) { create(:school_cohort, cohort:) }
   let(:induction_programme2) { create(:induction_programme, :cip) }
-  let!(:induction_record2) { create(:induction_record, participant_profile: participant_profile2, appropriate_body:, induction_programme: induction_programme2, training_status: "deferred") }
+  let!(:induction_record2) { create(:induction_record, participant_profile: participant_profile2, appropriate_body:, induction_programme: induction_programme2, training_status: "deferred", school_cohort: school_cohort2) }
+
+  # participant to be ignored
+  let(:older_cohort) { Cohort.find_by(start_year: 2021) }
+  let(:another_participant_profile) { create(:ect_participant_profile, cohort: older_cohort) }
+  let(:another_school_cohort) { create(:school_cohort, cohort: older_cohort) }
+  let(:another_induction_programme) { create(:induction_programme, :fip) }
+  let!(:another_induction_record) { create(:induction_record, participant_profile: another_participant_profile, appropriate_body:, induction_programme: another_induction_programme, school_cohort: another_school_cohort) }
 
   let(:collection) { AppropriateBodies::InductionRecordsQuery.new(appropriate_body:).induction_records }
   let(:params) { {} }


### PR DESCRIPTION
### Context

Currently we show the current cohort which is calculated from the `academic_year_start_date` which is in September. We would like to change that to be from the `active_registration_cohort ` which is in June instead.

- Ticket: https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-3214

### Changes proposed in this pull request
Amend the Appropriate bodies filter as well as view to read from the Cohort `active_registration_cohort`

### Guidance to review
Tests setup for the filter isn't great but amending it to always pass to avoid using time freezing, and setting an extra cohort in the past rather than next
