### PR TITLE
Add release note for multi-cohort schedules changes

### DIFF
--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -7,6 +7,25 @@ weight: 8
 
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
 
+## 28 June 2024
+
+We’ve added some new features to help providers ahead of the closure of the funding contract for the 2021 cohort on 31 July.
+
+The main impact will be ECTs and mentors with partial declarations currently assigned to the 2021 cohort being moved to the 2024 cohort.
+
+Because these ECTs and mentors are automatically shifted from a standard to an extended schedule, we’re allowing providers to change their schedules if necessary, using the existing [change-schedule](/api-reference/reference-v3.html#api-v3-participants-ecf-id-change-schedule-put) endpoint.
+
+Providers can also temporarily move participants back to the 2021 cohort if they need to make any final declarations before it closes. They must be returned to the 2024 cohort to start making submissions against that year.
+
+Note that the schedule and cohort cannot be changed when a migrated participant is in the 2024 cohort if there are existing declarations in any of the following states:
+
+- submitted
+- eligible
+- payable
+- paid
+
+However, you can make changes in the 2021 cohort where participants already have declarations in these statuses.
+
 ## 25 June 2024
 
 Registration is now open for the 2024/25 intake of early career teachers and mentors, so we’ve added the schedules and contract data for this academic year to the production environment.


### PR DESCRIPTION
### Context

We are releasing changes to change schedule endpoint to allow providers to move participants across regardless of declarations in 2021. This is explains all the things

- Ticket: 

### Changes proposed in this pull request

Amend release notes to include change schedule message

### Guidance to review
Content innit
