### PR TITLE
Clean up the specs output

### DIFF
--- a/app/services/npq/ehco/targeted_delivery_funding_eligibility_updater.rb
+++ b/app/services/npq/ehco/targeted_delivery_funding_eligibility_updater.rb
@@ -10,7 +10,7 @@ module NPQ
       end
 
       def run
-        logger = Logger.new($stdout)
+        logger = Logger.new(Rails.env.test? ? nil : $stdout)
         logger.info "Updating EHCO NPQ Applications, this may take a couple of minutes..."
 
         ehco_npq_course = NPQCourse.find_by(identifier: "npq-early-headship-coaching-offer")

--- a/app/services/support/base_service.rb
+++ b/app/services/support/base_service.rb
@@ -14,7 +14,7 @@ module Support
     end
 
     def logger
-      @logger = Logger.new($stdout)
+      @logger = Logger.new(Rails.env.test? ? nil : $stdout)
     end
   end
 end

--- a/lib/rails_semantic_logger/extensions/action_dispatch/debug_exceptions.rb
+++ b/lib/rails_semantic_logger/extensions/action_dispatch/debug_exceptions.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Log actual exceptions, not a string representation
+require "action_dispatch"
+
+module ActionDispatch
+  class DebugExceptions
+  private
+
+    undef_method :log_error
+    def log_error(_request, wrapper)
+      Rails.application.deprecators.silence do
+        ActionController::Base.logger.fatal(wrapper.exception)
+      end
+    end
+  end
+end

--- a/lib/tasks/oneoff/cleanup_itt_providers_npq_06_02_2023.rake
+++ b/lib/tasks/oneoff/cleanup_itt_providers_npq_06_02_2023.rake
@@ -20,7 +20,7 @@ namespace :npq_applications do
     require "csv"
     require "logger"
 
-    logger = Logger.new($stdout)
+    logger = Logger.new(Rails.env.test? ? nil : $stdout)
     file_path = args[:file_path]
 
     unless file_path && File.exist?(file_path)

--- a/spec/features/scenarios/participants/ect_doing_cip/after_cohort_transfer_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_cip/after_cohort_transfer_spec.rb
@@ -146,7 +146,6 @@ RSpec.feature "ECT doing CIP: after cohort transfer", type: :feature do
     expect(participant_detail).to have_full_name participant_full_name
     expect(participant_detail).to have_email_address participant_email
     expect(participant_detail).to have_trn teacher_reference_number
-    participant_detail.show_main_content
     expect(participant_detail).to have_cohort previous_start_year
     expect(participant_detail).to have_training_record_state training_record_state
     expect(participant_detail).to have_user_id participant_id
@@ -155,7 +154,6 @@ RSpec.feature "ECT doing CIP: after cohort transfer", type: :feature do
     participant_detail.open_training_tab
 
     participant_training = Pages::AdminSupportParticipantTraining.loaded(participant_id: training_record_id)
-    participant_training.show_main_content
     expect(participant_training).to have_cohort previous_start_year
     expect(participant_training).to have_school_name school.name
     expect(participant_training).to have_schedule_identifier schedule_identifier

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -474,7 +474,6 @@ module ManageTrainingSteps
   end
 
   def and_the_participant_is_displayed_mentored_by(name)
-    puts page.html
     expect(page).to have_summary_row("Mentor", name)
   end
 

--- a/spec/serializers/api/v3/npq_participant_serializer_spec.rb
+++ b/spec/serializers/api/v3/npq_participant_serializer_spec.rb
@@ -50,7 +50,6 @@ module Api
             it "does not include the `funded_place` attribute" do
               result = subject.serializable_hash
 
-              puts result
               expect(result[:data][0][:attributes][:npq_enrolments][0].keys).not_to include(:funded_place)
             end
           end

--- a/spec/support/features/pages/base_page.rb
+++ b/spec/support/features/pages/base_page.rb
@@ -112,39 +112,6 @@ module Pages
       click_on "Back"
     end
 
-    # helpers that can show what capybara sees
-
-    def show_html
-      puts page.html
-    end
-
-    def show_all_content
-      puts page.text
-    end
-
-    def show_main_content
-      puts page.find("main").text
-    end
-
-    # helper whilst debugging scenarios with --fail-fast
-
-    def full_stop(html: false)
-      links = page.all("main a").map { |link| "  -  #{link.text} href: #{link['href']}" }
-
-      puts "==="
-      puts page.current_url
-      puts "---"
-      if html
-        puts page.html
-      else
-        puts page.find("main").text
-      end
-      puts "---\nLinks:"
-      puts links
-      puts "==="
-      raise
-    end
-
   private
 
     def primary_heading

--- a/spec/support/features/pages/finance/finance_portal.rb
+++ b/spec/support/features/pages/finance/finance_portal.rb
@@ -15,8 +15,6 @@ module Pages
 
     def view_schedules
       click_on "View payment schedules"
-
-      full_stop
     end
 
     def view_participant_drilldown

--- a/spec/support/features/steps/changes_of_circumstance_steps.rb
+++ b/spec/support/features/steps/changes_of_circumstance_steps.rb
@@ -642,24 +642,5 @@ module Steps
 
       lead_provider
     end
-
-    # helper whilst debugging scenarios with --fail-fast
-
-    def full_stop(html: false)
-      links = page.all("main a").map { |link| "  -  #{link.text} href: #{link['href']}" }
-
-      puts "==="
-      puts page.current_url
-      puts "---"
-      if html
-        puts page.html
-      else
-        puts page.find("main").text
-      end
-      puts "---\nLinks:"
-      puts links
-      puts "==="
-      raise
-    end
   end
 end

--- a/spec/support/matchers/lead_provider_api/make_duplicate_training_declaration.rb
+++ b/spec/support/matchers/lead_provider_api/make_duplicate_training_declaration.rb
@@ -37,15 +37,11 @@ module Support
           timestamp = participant_profile.schedule.milestones.first.start_date + 10.days
         when :retained_1
           timestamp = participant_profile.schedule.milestones.second.start_date + 10.days
-        else
-          puts "Unexpected declaration type \"#{declaration_type}\""
         end
 
         course_identifier = participant_type == "ECT" ? "ecf-induction" : "ecf-mentor"
 
         travel_to(timestamp) do
-          puts timestamp
-
           declarations_endpoint = APIs::PostParticipantDeclarationsEndpoint.new tokens[lead_provider_name]
           declarations_endpoint.post_training_declaration participant_profile.user.id, course_identifier, declaration_type, timestamp - 8.days
 

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -12,11 +12,11 @@ RSpec.configure do |config|
   # Specify a root folder where Swagger JSON files are generated
   # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
   # to ensure that it's configured to serve Swagger from the same folder
-  config.swagger_root = Rails.root.join("swagger").to_s
+  config.openapi_root = Rails.root.join("swagger").to_s
 
   # Define one or more Swagger documents and provide global metadata for each one
   # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will
-  # be generated at the provided relative path under swagger_root
+  # be generated at the provided relative path under openapi_root
   # By default, the operations defined in spec files are added to the first
   # document below. You can override this behavior by adding a swagger_doc tag to the
   # the root example_group in your specs, e.g. describe '...', swagger_doc: 'v2/swagger.json'
@@ -59,7 +59,7 @@ RSpec.configure do |config|
 
   ###
 
-  config.swagger_docs = {
+  config.openapi_specs = {
     "v1/api_spec.json" => swagger_v1_template.with_indifferent_access,
     "v2/api_spec.json" => swagger_v2_template.with_indifferent_access,
     "v3/api_spec.json" => swagger_v3_template.with_indifferent_access,


### PR DESCRIPTION
### Context

- Ticket: N/A

The specs output is polluted with various debugging messages from puts statements or the logger.

This PR is an attempt to clean up the output.

### Changes proposed in this pull request
- Remove puts from specs
- Fix deprecation messages
- Change the logger in test env to nil

### Guidance to review

