### PR TITLE
[CST-2656] Change links to correct guidance page

### DIFF
--- a/app/views/schools/cohort_setup/_change_lead_provider_confirmation.html.erb
+++ b/app/views/schools/cohort_setup/_change_lead_provider_confirmation.html.erb
@@ -6,7 +6,7 @@
 </p>
 <p class="govuk-body govuk-!-margin-bottom-7">
     <%= govuk_link_to "Find out more about partnering with a lead provider (opens in new tab).",
-                      "https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview",
+                      guidance_for_how_to_setup_training_url,
                       target: :_blank,
                       rel: "noopener noreferrer",
                       no_visited_state: true %>

--- a/app/views/schools/cohort_setup/what_changes.html.erb
+++ b/app/views/schools/cohort_setup/what_changes.html.erb
@@ -22,7 +22,7 @@
 
             <p class="govuk-body govuk-!-margin-top-4">If you’re not sure which option to choose, see
                 <%= govuk_link_to "delivery options for ECF-based training (opens in new tab)",
-                                  "https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview",
+                                  guidance_for_how_to_setup_training_url,
                                   target: :_blank,
                                   rel: "noopener noreferrer",
                                   no_visited_state: true %>


### PR DESCRIPTION
### Context

- Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-2656)
- It was noticed that 2 links to guidance pointed to the wrong information, this PR updates them to use the correct links.

### Changes proposed in this pull request

### Guidance to review

You need a school that was doing FIP last year and has not yet set up their latest cohort. The LP/DP pairing from the previous year should also not exist - in the test data "FIP School for Training Record States" is such a school.
Impersonate the SIT
Choose FIP
and go through

![image](https://github.com/DFE-Digital/early-careers-framework/assets/333931/23c9506e-bbff-46a9-ba40-31cca59c5907)

![image](https://github.com/DFE-Digital/early-careers-framework/assets/333931/bc2be6a5-a0b1-4880-81c0-0ff7295f2f5c)

![image](https://github.com/DFE-Digital/early-careers-framework/assets/333931/d2e34560-5c7a-4831-ac85-de829262bf48)

![image](https://github.com/DFE-Digital/early-careers-framework/assets/333931/c1247d9a-eccb-48dc-be60-673cdc905418)

The link "delivery options for ECF-based training (opens in new tab)" should link to https://www.gov.uk/guidance/how-to-set-up-training-for-early-career-teachers

![image](https://github.com/DFE-Digital/early-careers-framework/assets/333931/3d9ceab7-f83f-4b6d-92ed-53ac6e948d34)
The link "Find out more about partnering with a lead provider (opens in new tab)." should link to https://www.gov.uk/guidance/how-to-set-up-training-for-early-career-teachers
