### PR TITLE
[CPDLP-3185] Legacy school mailer - Not looking up partnerships correctly

### DIFF
--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -345,7 +345,7 @@ class SchoolMailer < ApplicationMailer
   def fip_provider_has_withdrawn_a_participant
     withdrawn_participant = params[:withdrawn_participant]
     induction_coordinator = params[:induction_coordinator]
-    partnership = Partnership.find_by(school: withdrawn_participant.school, cohort: withdrawn_participant.cohort)
+    partnership = params[:partnership]
 
     email = template_mail(
       PARTICIPANT_WITHDRAWN_BY_PROVIDER,

--- a/app/services/withdraw_participant.rb
+++ b/app/services/withdraw_participant.rb
@@ -36,8 +36,11 @@ class WithdrawParticipant
     unless participant_profile.npq?
       induction_coordinator = participant_profile.school.induction_coordinator_profiles.first
       if induction_coordinator.present?
-        SchoolMailer.with(withdrawn_participant: participant_profile, induction_coordinator:)
-                    .fip_provider_has_withdrawn_a_participant.deliver_later
+        SchoolMailer.with(
+          withdrawn_participant: participant_profile,
+          induction_coordinator:,
+          partnership: relevant_induction_record.partnership,
+        ).fip_provider_has_withdrawn_a_participant.deliver_later
       end
     end
 

--- a/spec/mailers/school_mailer_spec.rb
+++ b/spec/mailers/school_mailer_spec.rb
@@ -313,11 +313,17 @@ RSpec.describe SchoolMailer, type: :mailer do
     let(:school_cohort) { create(:school_cohort, induction_programme_choice: "full_induction_programme") }
     let(:participant_profile) { create(:ect_participant_profile, training_status: "withdrawn", school_cohort:, user: create(:user, email: "john.clemence@example.com")) }
     let(:sit_profile) { create(:induction_coordinator_profile, schools: [school_cohort.school]) }
+    let(:partnership) { create(:partnership) }
+
+    before do
+      create(:induction_record, participant_profile:, partnership:)
+    end
 
     let(:email) do
       SchoolMailer.with(
         withdrawn_participant: participant_profile,
         induction_coordinator: sit_profile,
+        partnership:,
       ).fip_provider_has_withdrawn_a_participant
     end
 

--- a/spec/services/withdraw_participant_spec.rb
+++ b/spec/services/withdraw_participant_spec.rb
@@ -115,6 +115,7 @@ RSpec.shared_examples "withdrawing an ECF participant" do
         params: {
           withdrawn_participant: participant_profile,
           induction_coordinator:,
+          partnership: induction_record.partnership,
         },
         args: [],
       ).once


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-3185

### Changes proposed in this pull request

* Updated `SchoolMailer.fip_provider_has_withdrawn_a_participant` to include `partnership` params.
* Updated `WithdrawParticipant` to pass in `partnership`

### Guidance to review

