### PR TITLE
Spike 2: Remove references to NPQ from the swagger docs in separation environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,9 +17,11 @@ on:
   push:
     branches:
       - main
+      - 3226-remove-npq-from-swagger-docs 
   pull_request:
     branches:
       - main
+      - 3226-remove-npq-from-swagger-docs 
   merge_group:
 
 jobs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,80 +53,6 @@ jobs:
           docker-repository: ghcr.io/dfe-digital/early-careers-framework
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-  docker_without_npq_swagger:
-    name: Build and push Docker image (without NPQ swagger docs)
-    runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]' && github.event_name != 'merge_group'
-    outputs:
-      docker-image-without-npq-swagger: ${{ steps.set-image-output.outputs.image }}
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Ensure docker repository is lowercase
-        shell: pwsh
-        run: |
-          $DockerRepository = "ghcr.io/${{ github.repository }}".ToLower()
-          "DOCKER_REPOSITORY=$DockerRepository" | Out-File -FilePath $env:GITHUB_ENV -Append
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set environment variables (push)
-        if: github.event_name == 'push'
-        shell: bash
-        run: |
-          GIT_BRANCH=${GITHUB_REF##*/}
-          echo "BRANCH_TAG=$GIT_BRANCH" >> $GITHUB_ENV # GIT_BRANCH will be main for refs/heads/main
-          echo "IMAGE_TAG=${{ github.sha }}" >> $GITHUB_ENV
-
-      - name: Set environment variables (pull_request)
-        if: github.event_name == 'pull_request'
-        shell: bash
-        run: |
-          GIT_BRANCH=${GITHUB_HEAD_REF##*/}
-          echo "BRANCH_TAG=$GIT_BRANCH" >> $GITHUB_ENV
-          echo "IMAGE_TAG=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
-
-      - name: Set environment variables (default event)
-        if: github.event_name != 'push' && github.event_name != 'pull_request'
-        shell: bash
-        run: |
-          echo "BRANCH_TAG=main" >> $GITHUB_ENV
-          echo "IMAGE_TAG=$(date +%s)" >> $GITHUB_ENV
-
-      - name: Set image output
-        id: set-image-output
-        shell: bash
-        run: |
-          echo "image=${{ env.DOCKER_REPOSITORY }}:${{ env.IMAGE_TAG }}-without-npq-swagger" >> "$GITHUB_OUTPUT"
-
-      - uses: docker/build-push-action@v5
-        id: build-docker-image-without-npq-swagger
-        with:
-          context: .
-          load: true
-          push: false
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          tags: |
-            ${{ env.DOCKER_REPOSITORY }}:${{ env.IMAGE_TAG }}-without-npq-swagger
-            ${{ env.DOCKER_REPOSITORY }}:${{ env.BRANCH_TAG }}-without-npq-swagger
-          cache-to: type=inline
-          cache-from: |
-            type=registry,ref=${{ env.DOCKER_REPOSITORY }}:main
-            type=registry,ref=${{ env.DOCKER_REPOSITORY }}:${{ env.IMAGE_TAG }}-without-npq-swagger
-            type=registry,ref=${{ env.DOCKER_REPOSITORY }}:${{ env.BRANCH_TAG }}-without-npq-swagger
-          build-args: |
-            REMOVE_NPQ_REFERENCES=true
-            COMMIT_SHA=${{ env.IMAGE_TAG }}
-      
-      - name: Push ${{ env.DOCKER_REPOSITORY }}:${{ env.IMAGE_TAG }} image to registry
-        shell: bash
-        run: docker image push --all-tags ${{ env.DOCKER_REPOSITORY }}
-
   brakeman:
     name: Run Brakeman vulnerability scanner
     uses: ./.github/workflows/brakeman.yml
@@ -137,7 +63,7 @@ jobs:
     name: Deploy review
     concurrency: deploy_review_${{ github.event.pull_request.number }}
     if: github.actor != 'dependabot[bot]' && github.event_name == 'pull_request'
-    needs: [docker_without_npq_swagger, brakeman]
+    needs: [docker, brakeman]
     runs-on: ubuntu-latest
     environment:
       name: review
@@ -148,7 +74,7 @@ jobs:
         id: deploy
         with:
           environment: review
-          docker-image: ${{ needs.docker_without_npq_swagger.outputs.docker-image-without-npq-swagger }}
+          docker-image: ${{ needs.docker.outputs.docker-image }}
           azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
           pull-request-number: ${{ github.event.pull_request.number }}
           current-commit-sha: ${{ github.event.pull_request.head.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ tokens
 /spec/examples.txt
 
 /public/api-reference
+/public/api-reference-without-npq
 
 /app/assets/builds/*
 !/app/assets/builds/.keep

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,10 @@ COPY swagger /swagger
 
 WORKDIR docs
 
-ARG REMOVE_NPQ_REFERENCES=false
-ENV REMOVE_NPQ_REFERENCES=${REMOVE_NPQ_REFERENCES}
+ENV REMOVE_NPQ_REFERENCES="false"
 RUN bundle exec middleman build --build-dir=../public/api-reference
+ENV REMOVE_NPQ_REFERENCES="true"
+RUN bundle exec middleman build --build-dir=../public/api-reference-without-npq
 
 # Stage 1: Download gems and node modules.
 FROM ${BASE_RUBY_IMAGE} AS builder

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/integer/time"
+require "redirect_api_reference_middleware"
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -8,6 +9,7 @@ Rails.application.configure do
   # Used to handle HTTP_X_WITH_SERVER_DATE header for server side datetime overwrite
   config.middleware.use TimeTraveler
   config.middleware.use ApiRequestMiddleware
+  config.middleware.insert_before ActionDispatch::Static, RedirectApiReferenceMiddleware
 
   # In the development environment your application's code is reloaded any time
   # it changes. This slows down response time but is perfect for development

--- a/lib/redirect_api_reference_middleware.rb
+++ b/lib/redirect_api_reference_middleware.rb
@@ -8,7 +8,7 @@ class RedirectApiReferenceMiddleware
   def call(env)
     request = Rack::Request.new(env)
 
-    if request.path =~ /^\/api-reference(?:\/|$)/ && Rails.env.review?
+    if request.path =~ /^\/api-reference(?:\/|$)/
       new_location = "/api-reference-without-npq#{request.path.sub('/api-reference', '')}"
       return [301, { "Location" => new_location, "Content-Type" => "text/html" }, ["Redirecting..."]]
     end

--- a/lib/redirect_api_reference_middleware.rb
+++ b/lib/redirect_api_reference_middleware.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class RedirectApiReferenceMiddleware
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    request = Rack::Request.new(env)
+
+    if request.path =~ /^\/api-reference(?:\/|$)/ && Rails.env.review?
+      new_location = "/api-reference-without-npq#{request.path.sub('/api-reference', '')}"
+      return [301, { "Location" => new_location, "Content-Type" => "text/html" }, ["Redirecting..."]]
+    end
+
+    @app.call(env)
+  end
+end


### PR DESCRIPTION
### Context

Builds on #5011 but instead of compiling multiple docker images we build the API docs twice; one with NPQ references and one without. We then use middleware to intercept and redirect `/api-reference` to `/api-reference-without-npq` for a specific environment.

### Changes proposed in this pull request

- Compile a separate api-reference without NPQ

Update the docker image to compile a second version of the API docs without NPQ references.

Use middleware to intercept the `api-reference` requests on a specific environment so we can serve the version without NPQ references.

### Guidance to review

Avoids the complexity of multiple docker images. I think the internal links may be reloading the page/losing the left navigation state - needs looking into but generally speaking it seems to work fairly well.

This seems to work perfectly when ran locally, but in the review app the middleware isn't intercepting the public asset requests so `/api-reference` isn't being redirected to `/api-reference-without-npq`. I think there may be something in the infrastructure sitting in front of Rails causing this, but I'm not sure what.

To test it locally you can `cd docs` then `bundle exec middleman build --build-dir=../public/api-reference-without-npq` and `REMOVE_NPQ_REFERENCES=true bundle exec middleman build --build-dir=../public/api-reference-without-npq`. Then when you hit `/api-reference` you should be redirected (and for all other `/api-reference*` paths).