### PR TITLE
[CST-2666] [A11y Fixes] Add nav element to menu and add menuitem roles to links

### DIFF
--- a/app/components/primary_nav_component.html.erb
+++ b/app/components/primary_nav_component.html.erb
@@ -1,9 +1,9 @@
 <div class="primary-nav-container <%= "primary-nav-container--reversed" if reversed %>">
   <div class="govuk-width-container <%= "govuk-width-container__wide" if wide %>">
-    <div class="primary-nav">
+    <nav class="primary-nav" aria-label="Manage your training">
       <% nav_items.each do |item| %>
         <%= item %>
       <% end %>
-    </div>
+    </nav>
   </div>
 </div>

--- a/app/components/primary_nav_component/nav_item_component.html.erb
+++ b/app/components/primary_nav_component/nav_item_component.html.erb
@@ -1,5 +1,5 @@
 <div class="nav-item <%= "nav-item__selected" if current_section?(path) %>">
-  <%= govuk_link_to path, no_visited_state: true do %>
+  <%= govuk_link_to path, no_visited_state: true, role: "menuitem" do %>
     <%= content %> <%= "<span class='govuk-visually-hidden'>Current page</span>".html_safe if current_section?(path) %>
   <% end %>
 </div>


### PR DESCRIPTION
### Context

- Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-2666)
- Adding fix for accessibility review

### Changes proposed in this pull request
On the schools dashboard there is a menu with "Home", "Early career teachers" and "Mentors" links. This was not contained in a `<nav>` element.  Also I have added `role="menuitem"` to the navitem `<a>` elements.

### Guidance to review

