### PR TITLE
Change Sidekiq log level to `WARN`

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -3,23 +3,13 @@
 require "sidekiq/web"
 require "sidekiq/cron/web"
 
-if ENV.key?("REDIS_URI")
+if (redis_url = ENV["REDIS_URL"] || ENV["REDIS_URI"])
   Sidekiq.configure_server do |config|
-    config.redis = { url: ENV.fetch("REDIS_URI") }
+    config.redis = { url: redis_url }
   end
 
   Sidekiq.configure_client do |config|
-    config.redis = { url: ENV.fetch("REDIS_URI") }
-  end
-end
-
-if ENV.key?("REDIS_URL")
-  Sidekiq.configure_server do |config|
-    config.redis = { url: ENV.fetch("REDIS_URL") }
-  end
-
-  Sidekiq.configure_client do |config|
-    config.redis = { url: ENV.fetch("REDIS_URL") }
+    config.redis = { url: redis_url }
   end
 end
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -5,6 +5,7 @@ require "sidekiq/cron/web"
 
 if (redis_url = ENV["REDIS_URL"] || ENV["REDIS_URI"])
   Sidekiq.configure_server do |config|
+    config.logger.level = Logger::WARN
     config.redis = { url: redis_url }
   end
 


### PR DESCRIPTION
### Context

This was highlighted as a possible cause for our over-logging DfE-Analytics messages to Logit.io.

### Changes proposed in this pull request

- **Simpilfy and deduplicate Redis initialization**
- **Set Redis's server logger level to WARN**
