### PR TITLE
Change the default NPQ admin page to the npq applications index page

### DIFF
--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -15,7 +15,7 @@
     <%= component.with_nav_item(path: "/admin/administrators") do %>
       Admin users
     <% end %>
-    <%= component.with_nav_item(path: admin_npq_applications_edge_cases_path, selected: on_admin_npq_application_page?) do %>
+    <%= component.with_nav_item(path: admin_npq_applications_applications_path, selected: on_admin_npq_application_page?) do %>
       NPQ
     <% end %>
     <%= component.with_nav_item(path: admin_delivery_partners_users_path) do %>


### PR DESCRIPTION
### Context

- Ticket: N/A

The NPQ link in the admin menu takes you to the NPQ Edge Case page, which causes confusions. Admins use the Edge Cases search bar to search for normal NPQ applications, which returns no results.

### Changes proposed in this pull request
- Update the link to the npq applications index page

