### PR TITLE
Move Senco to leadership course as it is not specialist

### DIFF
--- a/app/models/finance/schedule/npq_leadership.rb
+++ b/app/models/finance/schedule/npq_leadership.rb
@@ -6,6 +6,7 @@ class Finance::Schedule::NPQLeadership < Finance::Schedule::NPQ
     npq-headship
     npq-executive-leadership
     npq-early-years-leadership
+    npq-senco
   ].freeze
 
   PERMITTED_COURSE_IDENTIFIERS = IDENTIFIERS

--- a/app/models/finance/schedule/npq_specialist.rb
+++ b/app/models/finance/schedule/npq_specialist.rb
@@ -7,7 +7,6 @@ class Finance::Schedule::NPQSpecialist < Finance::Schedule::NPQ
     npq-leading-teaching-development
     npq-leading-literacy
     npq-leading-primary-mathematics
-    npq-senco
   ].freeze
 
   PERMITTED_COURSE_IDENTIFIERS = IDENTIFIERS


### PR DESCRIPTION
### Context

Senco is not a specialist course but a leadership course

- Ticket: https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-3276
### Changes proposed in this pull request
Move course identifier to Leadership. 

### Guidance to review
Since this is already in production there is another ticket to cleanup the existing data for schedules, which will come after this
