### PR TITLE
Set log level to `:warn` when Sidekiq running in server mode

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,3 +61,9 @@ Rails/SaveBang:
 Style/RedundantFetchBlock:
   Exclude:
     - 'app/middlewares/api_request_middleware.rb'
+
+Style/TernaryParentheses:
+  Enabled: false
+
+Style/RedundantParentheses:
+  Enabled: false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -120,7 +120,7 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new "app-name")
 
   # Logging
-  config.log_level = :info
+  config.log_level = (Sidekiq.server?) ? :warn : :info
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
     config.rails_semantic_logger.add_file_appender = false


### PR DESCRIPTION
This should reduce the number of entries we're sending on to Logit.io and stop us from going over the limit!

Approach lifted from [this PR](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/pull/2283/files).

- **When Sidekiq running in prod set log level to warn**
- **Disable incorrect Rubocop rules**
