### PR TITLE
Add postgres maintenance window

### DIFF
--- a/terraform/application/databases.tf
+++ b/terraform/application/databases.tf
@@ -59,6 +59,7 @@ module "postgres" {
   use_azure                      = var.deploy_azure_backing_services
   azure_enable_monitoring        = var.enable_monitoring
   azure_extensions               = ["citext", "fuzzystrmatch", "pg_stat_statements", "pgcrypto", "plpgsql", "uuid-ossp"]
+  azure_maintenance_window       = var.azure_maintenance_window
 }
 
 module "postgres-snapshot" {

--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -25,6 +25,15 @@ variable "deploy_snapshot_database" {
   default = false
 }
 
+variable "azure_maintenance_window" {
+  type = object({
+    day_of_week  = number
+    start_hour   = number
+    start_minute = number
+  })
+  default = null
+}
+
 variable "azure_sp_credentials_json" {
   type    = string
   default = null

--- a/terraform/application/workspace_variables/production.tfvars.json
+++ b/terraform/application/workspace_variables/production.tfvars.json
@@ -19,5 +19,10 @@
   "worker_memory_max": "2Gi",
   "azure_storage_mb": "65536",
   "azure_cpu_threshold": 70,
+  "azure_maintenance_window": {
+    "day_of_week": 0,
+    "start_hour": 4,
+    "start_minute": 0
+  },
   "enable_logit": true
 }


### PR DESCRIPTION
### Context

ECF postgres database don’t have a maintenance window set, so they are upgraded alongside nonprod at a random time

- Ticket: https://trello.com/c/4NPqv8MF/1903-add-prod-postgres-maintenance-window

### Changes proposed in this pull request

Add maintenance window to terraform

### Guidance to review

Maintenance window set in terraform

