### PR TITLE
[CPDLP-2764] Introduce 422 errors on NPQ accept application endpoint when there are errors with GAI ID/Conflict

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "identity/transfer"
+
 module Api
   class ApiController < ActionController::API
     include ActionController::MimeResponds
@@ -18,6 +20,7 @@ module Api
     rescue_from Api::Errors::InvalidDatetimeError, with: :invalid_updated_since_response
     rescue_from Api::Errors::InvalidTrainingStatusError, with: :invalid_training_status_response
     rescue_from Pagy::VariableError, with: :invalid_pagination_response
+    rescue_from Identity::TransferError, with: :identity_transfer_error_response
 
     def append_info_to_payload(payload)
       super
@@ -66,6 +69,10 @@ module Api
 
     def invalid_pagination_response(_exception)
       render json: { errors: Api::ParamErrorFactory.new(error: I18n.t(:bad_request), params: I18n.t(:invalid_page_parameters)).call }, status: :bad_request
+    end
+
+    def identity_transfer_error_response(_exception)
+      render json: { errors: Api::ParamErrorFactory.new(error: I18n.t(:bad_request), params: I18n.t(:contact_us_to_resolve_issue)).call }, status: :unprocessable_entity
     end
   end
 end

--- a/app/controllers/api/v1/npq_applications_controller.rb
+++ b/app/controllers/api/v1/npq_applications_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "csv"
-require "identity/transfer"
 
 module Api
   module V1
@@ -10,8 +9,6 @@ module Api
       include ApiPagination
       include ApiFilter
       include ApiFilterValidation
-
-      rescue_from Identity::TransferError, with: :identity_transfer_error_response
 
       def index
         respond_to do |format|
@@ -98,10 +95,6 @@ module Api
         raise ActionController::BadRequest, I18n.t(:invalid_data_structure)
       rescue ActionController::ParameterMissing
         {}
-      end
-
-      def identity_transfer_error_response(_exception)
-        render json: { errors: Api::ParamErrorFactory.new(error: I18n.t(:application_not_accepted), params: I18n.t(:contact_us_to_resolve_issue)).call }, status: :unprocessable_entity
       end
     end
   end

--- a/app/controllers/api/v1/npq_applications_controller.rb
+++ b/app/controllers/api/v1/npq_applications_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "csv"
+require "identity/transfer"
 
 module Api
   module V1
@@ -9,6 +10,8 @@ module Api
       include ApiPagination
       include ApiFilter
       include ApiFilterValidation
+
+      rescue_from Identity::TransferError, with: :identity_transfer_error_response
 
       def index
         respond_to do |format|
@@ -95,6 +98,10 @@ module Api
         raise ActionController::BadRequest, I18n.t(:invalid_data_structure)
       rescue ActionController::ParameterMissing
         {}
+      end
+
+      def identity_transfer_error_response(_exception)
+        render json: { errors: Api::ParamErrorFactory.new(error: I18n.t(:application_not_accepted), params: I18n.t(:contact_us_to_resolve_issue)).call }, status: :unprocessable_entity
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,7 +40,6 @@ en:
   bad_request: "Bad request"
   bad_parameter: "Bad parameter"
   invalid_transition: "Invalid action"
-  application_not_accepted: "Application not accepted"
   contact_us_to_resolve_issue: "Contact us so we can help you resolve the issue"
   no_output_fee_statements_for_cohort: "You cannot submit or void declarations for the %{cohort} cohort. The funding contract for this cohort has ended. Get in touch if you need to discuss this with us"
   invalid_page_parameters: "The '#/page[page]' and '#/page[per_page]' parameter values must be a valid number (equal and more than 1)"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,8 @@ en:
   bad_request: "Bad request"
   bad_parameter: "Bad parameter"
   invalid_transition: "Invalid action"
+  application_not_accepted: "Application not accepted"
+  contact_us_to_resolve_issue: "Contact us so we can help you resolve the issue"
   no_output_fee_statements_for_cohort: "You cannot submit or void declarations for the %{cohort} cohort. The funding contract for this cohort has ended. Get in touch if you need to discuss this with us"
   invalid_page_parameters: "The '#/page[page]' and '#/page[per_page]' parameter values must be a valid number (equal and more than 1)"
   cannot_change_cohort: "You cannot change the '#/cohort' field"

--- a/spec/requests/api/v1/npq_applications_spec.rb
+++ b/spec/requests/api/v1/npq_applications_spec.rb
@@ -451,7 +451,7 @@ RSpec.describe "NPQ Applications API", type: :request do
         post "/api/v1/npq-applications/#{default_npq_application.id}/accept"
 
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(parsed_response.dig("errors", 0, "title")).to eql("Application not accepted")
+        expect(parsed_response.dig("errors", 0, "title")).to eql("Bad request")
         expect(parsed_response.dig("errors", 0, "detail")).to eql("Contact us so we can help you resolve the issue")
       end
     end

--- a/spec/requests/api/v1/npq_applications_spec.rb
+++ b/spec/requests/api/v1/npq_applications_spec.rb
@@ -433,6 +433,28 @@ RSpec.describe "NPQ Applications API", type: :request do
         expect(parsed_response.dig("errors", 0, "detail")).to eql("Once rejected an application cannot change state")
       end
     end
+
+    context "when there is a dedupe transfer error" do
+      let(:user1) { user }
+      let(:user2) { create(:participant_identity).user }
+
+      let(:get_an_identity_id_1) { SecureRandom.uuid }
+      let(:get_an_identity_id_2) { SecureRandom.uuid }
+
+      before do
+        user1.update!(get_an_identity_id: get_an_identity_id_1)
+        user2.update!(get_an_identity_id: get_an_identity_id_2)
+        allow(Identity::PrimaryUser).to receive(:find_by).and_return(user2)
+      end
+
+      it "returns an error" do
+        post "/api/v1/npq-applications/#{default_npq_application.id}/accept"
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(parsed_response.dig("errors", 0, "title")).to eql("Application not accepted")
+        expect(parsed_response.dig("errors", 0, "detail")).to eql("Contact us so we can help you resolve the issue")
+      end
+    end
   end
 
   describe "PUT /api/v1/npq-applications/:id/change-funded-place" do

--- a/spec/requests/api/v2/npq_applications_spec.rb
+++ b/spec/requests/api/v2/npq_applications_spec.rb
@@ -417,6 +417,28 @@ RSpec.describe "NPQ Applications API", type: :request do
         expect(parsed_response.dig("errors", 0, "detail")).to eql("Once rejected an application cannot change state")
       end
     end
+
+    context "when there is a dedupe transfer error" do
+      let(:user1) { user }
+      let(:user2) { create(:participant_identity).user }
+
+      let(:get_an_identity_id_1) { SecureRandom.uuid }
+      let(:get_an_identity_id_2) { SecureRandom.uuid }
+
+      before do
+        user1.update!(get_an_identity_id: get_an_identity_id_1)
+        user2.update!(get_an_identity_id: get_an_identity_id_2)
+        allow(Identity::PrimaryUser).to receive(:find_by).and_return(user2)
+      end
+
+      it "returns an error" do
+        post "/api/v2/npq-applications/#{default_npq_application.id}/accept"
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(parsed_response.dig("errors", 0, "title")).to eql("Application not accepted")
+        expect(parsed_response.dig("errors", 0, "detail")).to eql("Contact us so we can help you resolve the issue")
+      end
+    end
   end
 
   describe "PUT /api/v2/npq-applications/:id/change-funded-place" do

--- a/spec/requests/api/v2/npq_applications_spec.rb
+++ b/spec/requests/api/v2/npq_applications_spec.rb
@@ -435,7 +435,7 @@ RSpec.describe "NPQ Applications API", type: :request do
         post "/api/v2/npq-applications/#{default_npq_application.id}/accept"
 
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(parsed_response.dig("errors", 0, "title")).to eql("Application not accepted")
+        expect(parsed_response.dig("errors", 0, "title")).to eql("Bad request")
         expect(parsed_response.dig("errors", 0, "detail")).to eql("Contact us so we can help you resolve the issue")
       end
     end

--- a/spec/requests/api/v3/npq_applications_spec.rb
+++ b/spec/requests/api/v3/npq_applications_spec.rb
@@ -532,7 +532,7 @@ RSpec.describe "NPQ Applications API", type: :request do
         post "/api/v3/npq-applications/#{default_npq_application.id}/accept"
 
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(parsed_response.dig("errors", 0, "title")).to eql("Application not accepted")
+        expect(parsed_response.dig("errors", 0, "title")).to eql("Bad request")
         expect(parsed_response.dig("errors", 0, "detail")).to eql("Contact us so we can help you resolve the issue")
       end
     end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-2764

### Changes proposed in this pull request

* Added `rescue_from Identity::TransferError` to npq_applications controllers to return errors

### Guidance to review

