### PR TITLE
DQT synced participants cannot be placed in 2021 cohort in daily checks

### DIFF
--- a/app/models/participant_profile_start_date_inconsistency.rb
+++ b/app/models/participant_profile_start_date_inconsistency.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-class ParticipantProfileStartDateInconsistency < ApplicationRecord
-  belongs_to :participant_profile
-end

--- a/app/services/admin/participants/change_induction_start_date.rb
+++ b/app/services/admin/participants/change_induction_start_date.rb
@@ -10,7 +10,7 @@ module Admin::Participants
     end
 
     def call
-      participant_profile.update!(induction_start_date:)
+      Participants::SyncDQTInductionStartDate.call(induction_start_date, participant_profile)
     end
   end
 end

--- a/app/services/participants/check_and_set_completion_date.rb
+++ b/app/services/participants/check_and_set_completion_date.rb
@@ -4,9 +4,9 @@ module Participants
   class CheckAndSetCompletionDate < BaseService
     def call
       return unless participant_profile.ect?
+      return Induction::Complete.call(participant_profile:, completion_date:) if complete_induction?
 
-      Induction::Complete.call(participant_profile:, completion_date:) if complete_induction?
-      record_start_date_inconsistency if start_date_inconsistent?
+      Participants::SyncDQTInductionStartDate.call(start_date, participant_profile)
       record_completion_date_inconsistency if completion_date_inconsistent?
     end
 
@@ -45,10 +45,6 @@ module Participants
       participant_profile.induction_completion_date
     end
 
-    def participant_start_date
-      participant_profile.induction_start_date
-    end
-
     def record_completion_date_inconsistency
       ParticipantProfileCompletionDateInconsistency.upsert(
         {
@@ -60,24 +56,9 @@ module Participants
       )
     end
 
-    def record_start_date_inconsistency
-      ParticipantProfileStartDateInconsistency.upsert(
-        {
-          participant_profile_id: participant_profile.id,
-          dqt_value: start_date,
-          participant_value: participant_start_date,
-        },
-        unique_by: :participant_profile_id,
-      )
-    end
-
     # returns the minimum start date of all the induction periods
     def start_date
       @start_date ||= induction_periods.map { |period| period["startDate"] }.compact.min
-    end
-
-    def start_date_inconsistent?
-      start_date != participant_start_date
     end
   end
 end

--- a/app/services/participants/check_and_set_completion_date.rb
+++ b/app/services/participants/check_and_set_completion_date.rb
@@ -4,8 +4,8 @@ module Participants
   class CheckAndSetCompletionDate < BaseService
     def call
       return unless participant_profile.ect?
-      return Induction::Complete.call(participant_profile:, completion_date:) if complete_induction?
 
+      Induction::Complete.call(participant_profile:, completion_date:) if complete_induction?
       Participants::SyncDQTInductionStartDate.call(start_date, participant_profile)
       record_completion_date_inconsistency if completion_date_inconsistent?
     end

--- a/db/migrate/20240717111257_remove_participant_profile_start_date_inconsistencies_table.rb
+++ b/db/migrate/20240717111257_remove_participant_profile_start_date_inconsistencies_table.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveParticipantProfileStartDateInconsistenciesTable < ActiveRecord::Migration[7.1]
+  def change
+    drop_table :participant_profile_start_date_inconsistencies
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_20_093655) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_17_111257) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -899,15 +899,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_20_093655) do
     t.index ["schedule_id"], name: "index_participant_profile_schedules_on_schedule_id"
   end
 
-  create_table "participant_profile_start_date_inconsistencies", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "participant_profile_id", null: false
-    t.date "dqt_value"
-    t.date "participant_value"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["participant_profile_id"], name: "idx_on_participant_profile_id_77e3f2fe02", unique: true
-  end
-
   create_table "participant_profile_states", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "participant_profile_id", null: false
     t.text "state", default: "active"
@@ -1349,7 +1340,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_20_093655) do
   add_foreign_key "participant_profile_completion_date_inconsistencies", "participant_profiles"
   add_foreign_key "participant_profile_schedules", "participant_profiles"
   add_foreign_key "participant_profile_schedules", "schedules"
-  add_foreign_key "participant_profile_start_date_inconsistencies", "participant_profiles"
   add_foreign_key "participant_profile_states", "participant_profiles"
   add_foreign_key "participant_profiles", "cohorts"
   add_foreign_key "participant_profiles", "core_induction_programmes"

--- a/spec/services/admin/participants/change_induction_start_date_spec.rb
+++ b/spec/services/admin/participants/change_induction_start_date_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Admin::Participants::ChangeInductionStartDate do
-  let(:participant_profile) { double(ParticipantProfile, update!: true) }
+  let(:participant_profile) { ParticipantProfile.new }
   let(:induction_start_date) { 3.weeks.from_now }
 
   subject { described_class.new(participant_profile, induction_start_date:) }
@@ -19,9 +19,11 @@ RSpec.describe Admin::Participants::ChangeInductionStartDate do
 
   describe "#call" do
     it "updates the participant profile's induction_start_date field with the supplied date when called" do
+      allow(Participants::SyncDQTInductionStartDate).to receive(:call)
+
       subject.call
 
-      expect(participant_profile).to have_received(:update!).with(induction_start_date:)
+      expect(Participants::SyncDQTInductionStartDate).to have_received(:call).with(induction_start_date, participant_profile)
     end
   end
 end


### PR DESCRIPTION
### Context

Automatically put participants in their permanent cohort on Daily DQT date checks.

- [Ticket](https://dfedigital.atlassian.net/browse/CST-2629)

### Changes proposed in this pull request

### Guidance to review

