### PR TITLE
[CPDLP-3279] Add course identifier as a filter to MigrateDeclarationsBetweenStatements service

### DIFF
--- a/app/services/oneoffs/npq/migrate_declarations_between_statements.rb
+++ b/app/services/oneoffs/npq/migrate_declarations_between_statements.rb
@@ -17,7 +17,8 @@ module Oneoffs::NPQ
       to_statement_updates: {},
       restrict_to_lead_providers: nil,
       restrict_to_declaration_types: nil,
-      restrict_to_declaration_states: nil
+      restrict_to_declaration_states: nil,
+      restrict_to_course_identifiers: nil
     )
       @cohort = cohort
       @from_statement_name = from_statement_name
@@ -27,6 +28,7 @@ module Oneoffs::NPQ
       @restrict_to_lead_providers = restrict_to_lead_providers
       @restrict_to_declaration_types = restrict_to_declaration_types
       @restrict_to_declaration_states = restrict_to_declaration_states
+      @restrict_to_course_identifiers = restrict_to_course_identifiers
     end
 
     def migrate(dry_run: true)
@@ -52,7 +54,7 @@ module Oneoffs::NPQ
     attr_reader :cohort, :from_statement_name, :to_statement_name,
                 :to_statement_updates, :from_statement_updates,
                 :restrict_to_lead_providers, :restrict_to_declaration_types,
-                :restrict_to_declaration_states
+                :restrict_to_declaration_states, :restrict_to_course_identifiers
 
     def update_from_statement_attributes!
       return if from_statement_updates.blank?
@@ -110,6 +112,7 @@ module Oneoffs::NPQ
       scope = statement_line_items.includes(:participant_declaration)
       scope = scope.where(participant_declaration: { declaration_type: restrict_to_declaration_types }) if restrict_to_declaration_types
       scope = scope.where(participant_declaration: { state: restrict_to_declaration_states }) if restrict_to_declaration_states
+      scope = scope.where(participant_declaration: { course_identifier: restrict_to_course_identifiers }) if restrict_to_course_identifiers
 
       scope
     end

--- a/spec/services/oneoffs/npq/migrate_declarations_between_statements_spec.rb
+++ b/spec/services/oneoffs/npq/migrate_declarations_between_statements_spec.rb
@@ -13,6 +13,7 @@ describe Oneoffs::NPQ::MigrateDeclarationsBetweenStatements do
   let(:restrict_to_lead_providers) { nil }
   let(:restrict_to_declaration_types) { nil }
   let(:restrict_to_declaration_states) { nil }
+  let(:restrict_to_course_identifiers) { nil }
 
   let(:instance) do
     described_class.new(
@@ -24,6 +25,7 @@ describe Oneoffs::NPQ::MigrateDeclarationsBetweenStatements do
       restrict_to_lead_providers:,
       restrict_to_declaration_types:,
       restrict_to_declaration_states:,
+      restrict_to_course_identifiers:,
     )
   end
 
@@ -185,6 +187,27 @@ describe Oneoffs::NPQ::MigrateDeclarationsBetweenStatements do
             "~~~ DRY RUN ~~~",
             "Migrating declarations from #{from_statement_name} to #{to_statement_name} for 2 providers",
             "Migrating 1 declarations for #{npq_lead_provider.name}",
+            "Migrating 1 declarations for #{npq_lead_provider2.name}",
+          ])
+        end
+      end
+
+      context "when restrict_to_course_identifiers is provided" do
+        let(:restrict_to_course_identifiers) { [declaration2.course_identifier] }
+
+        it "migrates only the declarations with the given course identifier" do
+          migrate
+
+          expect(declaration.statement_line_items.map(&:statement)).to all(eq(from_statement))
+          expect(declaration2.statement_line_items.map(&:statement)).to all(eq(to_statement2))
+        end
+
+        it "records information" do
+          migrate
+
+          expect(instance).to have_recorded_info([
+            "Migrating declarations from #{from_statement_name} to #{to_statement_name} for 2 providers",
+            "Migrating 0 declarations for #{npq_lead_provider.name}",
             "Migrating 1 declarations for #{npq_lead_provider2.name}",
           ])
         end


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-3279](https://dfedigital.atlassian.net/browse/CPDLP-3279)

LLSE has put a request to move 5 declarations for a specific course to a different statement.

### Changes proposed in this pull request

Add course identifier as a filter to MigrateDeclarationsBetweenStatements service.

### Guidance to review

```
cohort = Cohort.find_by_start_year!(2023)
cpd_lead_provider = CpdLeadProvider.find_by!(name: "LLSE")
from_statement_name = Finance::Statement::NPQ.find_by!(cpd_lead_provider:, name: "July 2024", cohort:).name
to_statement_name = Finance::Statement::NPQ.find_by!(cpd_lead_provider:, name: "November 2024", cohort:).name
restrict_to_lead_providers = [cpd_lead_provider.npq_lead_provider]
restrict_to_course_identifiers = ["npq-early-headship-coaching-offer"]
Oneoffs::NPQ::MigrateDeclarationsBetweenStatements.new(cohort:, from_statement_name:, to_statement_name:, restrict_to_lead_providers:, restrict_to_course_identifiers:).migrate
```

```
["~~~ DRY RUN ~~~",
 "Migrating declarations from July 2024 to November 2024 for 1 providers",
 "Migrating 5 declarations for LLSE"] 
```



[CPDLP-3279]: https://dfedigital.atlassian.net/browse/CPDLP-3279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ