### PR TITLE
[CPDLP-3272] NPQ - Update cohort 2022 output from FALSE to TRUE and move declarations

### DIFF
--- a/app/services/oneoffs/npq/migrate_declarations_between_statements.rb
+++ b/app/services/oneoffs/npq/migrate_declarations_between_statements.rb
@@ -156,7 +156,6 @@ module Oneoffs::NPQ
       Finance::Statement::NPQ
         .includes(:cohort, :participant_declarations, cpd_lead_provider: :npq_lead_provider)
         .where(cohort:, name: statement_name, cpd_lead_provider: { npq_lead_provider: })
-        .output
         .group_by(&:npq_lead_provider)
         .transform_values(&:first)
     end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-3272

### Changes proposed in this pull request

* removed `output` to allow running command for this ticket.

### Guidance to review

Will run the following command:

```ruby
cohort = Cohort.where(start_year: 2022).first!

from_statement_name = "August 2024"
from_statement_updates = {
  output_fee: false,
}

to_statement_name = "September 2024"
to_statement_updates = {
  output_fee: true,
  deadline_date: "2024-08-25",
}

service = Oneoffs::NPQ::MigrateDeclarationsBetweenStatements.new(
  cohort:,
  from_statement_name:,
  to_statement_name:,
  from_statement_updates:,
  to_statement_updates:,
  restrict_to_lead_providers: nil,
  restrict_to_declaration_types: nil,
  restrict_to_declaration_states: nil,
)

service.migrate(dry_run: true)
```