### PR TITLE
Remove NPQ references from swagger docs on separation env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ tokens
 /spec/examples.txt
 
 /public/api-reference
+/public/api-reference-without-npq
 
 /app/assets/builds/*
 !/app/assets/builds/.keep

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,10 @@ COPY public /public
 COPY swagger /swagger
 
 WORKDIR docs
+ENV REMOVE_NPQ_REFERENCES="false"
 RUN bundle exec middleman build --build-dir=../public/api-reference
+ENV REMOVE_NPQ_REFERENCES="true"
+RUN bundle exec middleman build --build-dir=../public/api-reference-without-npq
 
 # Stage 1: Download gems and node modules.
 FROM ${BASE_RUBY_IMAGE} AS builder

--- a/config/initializers/api_reference.rb
+++ b/config/initializers/api_reference.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# TODO: change to separation before merging!
+return unless Rails.env.review?
+
+api_reference_path = Rails.root.join("public/api-reference")
+api_reference_without_npq_path = Rails.root.join("public/api-reference-without-npq")
+
+if [api_reference_path, api_reference_without_npq_path].all? { |d| Dir.exist?(d) }
+  # Remove the existing 'api-reference' directory
+  FileUtils.rm_rf(api_reference_path)
+
+  # Move 'api-reference-without-npq' to 'api-reference'
+  FileUtils.mv(api_reference_without_npq_path, api_reference_path) if Dir.exist?(api_reference_without_npq_path)
+end

--- a/config/initializers/api_reference.rb
+++ b/config/initializers/api_reference.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# TODO: change to separation before merging!
-return unless Rails.env.review?
+return unless Rails.env.separation?
 
 api_reference_path = Rails.root.join("public/api-reference")
 api_reference_without_npq_path = Rails.root.join("public/api-reference-without-npq")

--- a/docs/config.rb
+++ b/docs/config.rb
@@ -17,3 +17,8 @@ set :js_dir, "api-reference/javascripts"
 set :images_dir, "api-reference/javascripts"
 
 set :relative_links, true
+
+if ENV["REMOVE_NPQ_REFERENCES"].to_s == "true"
+  ignore "/npq.html"
+  ignore "/npq/**.*"
+end

--- a/docs/lib/govuk_tech_docs/open_api/renderer.rb
+++ b/docs/lib/govuk_tech_docs/open_api/renderer.rb
@@ -186,8 +186,18 @@ module GovukTechDocs
         ENV["REMOVE_NPQ_REFERENCES"].to_s == "true"
       end
 
+      def remove_npq_references_from_text(text)
+        text.gsub(/ecf or npq/i, "ecf") if remove_npq_references?
+      end
+
       def filter_possible_values(enum)
         enum.reject { |v| remove_npq_references? && v.downcase.include?("npq") }
+      end
+
+      def filter_examples(examples)
+        examples&.reject do |_, example|
+          remove_npq_references? && example["value"].to_s.downcase.include?("npq")
+        end
       end
 
       def filter_schemas(schemas)

--- a/docs/lib/govuk_tech_docs/open_api/templates/responses.html.erb
+++ b/docs/lib/govuk_tech_docs/open_api/templates/responses.html.erb
@@ -15,7 +15,7 @@
           <td><%= key %></td>
 
           <td>
-            <%= markdown(response.description) %>
+            <%= markdown(remove_npq_references_from_text(response.description)) %>
 
             <% if response.content['application/json'] %>
               <p>
@@ -38,7 +38,7 @@
     <details class="govuk-details" data-module="govuk-details">
       <summary class="govuk-details__summary">
         <span class="govuk-details__summary-text">
-          <%= key %> - <%= response.description %>
+          <%= key %> - <%= remove_npq_references_from_text(response.description) %>
         </span>
       </summary>
 
@@ -64,8 +64,8 @@
         <% example_done = false %>
 
         <% if response.content['application/json'] %>
-          <% if response.content['application/json']["examples"] %>
-            <% response.content['application/json']["examples"].each do |name, hash| %>
+          <% if filter_examples(response.content['application/json']["examples"]) %>
+            <% filter_examples(response.content['application/json']["examples"]).each do |name, hash| %>
               <% body = json_prettyprint(hash["value"]) %>
 
               <%

--- a/docs/lib/govuk_tech_docs/open_api/templates/schema.html.erb
+++ b/docs/lib/govuk_tech_docs/open_api/templates/schema.html.erb
@@ -29,11 +29,11 @@
             <% if property[1].type == 'array' %>
               <% nested_schema = property[1]['items'] %>
 
-              <% if nested_schema["anyOf"] %>
+              <% if filter_schemas(nested_schema["anyOf"]) %>
                 <p>This conforms to any of the following schemas:</p>
 
                 <ul>
-                  <% nested_schema["anyOf"].each do |node| %>
+                  <% filter_schemas(nested_schema["anyOf"]).each do |node| %>
                     <li><%= get_schema_link node %></li>
                   <% end %>
                 </ul>
@@ -48,11 +48,11 @@
               <%= "It conforms to #{get_schema_link_data(nested_schema)} schema." %>
             <% end %>
 
-            <% if property[1].node_data["anyOf"].node.present? %>
+            <% if filter_schemas(property[1].node_data["anyOf"].node).present? %>
               <p>This conforms to any of the following schemas:</p>
 
               <ul>
-                <% property[1].node_data["anyOf"].node.each do |node| %>
+                <% filter_schemas(property[1].node_data["anyOf"].node).each do |node| %>
                   <li><%= get_schema_link node %></li>
                 <% end %>
               </ul>
@@ -62,7 +62,7 @@
               <p>Possible values:</p>
 
               <ul>
-                <% enum.each do |possible_value| %>
+                <% filter_possible_values(enum).each do |possible_value| %>
                   <li><%= format_possible_value(possible_value) %></li>
                 <% end %>
               </ul>

--- a/docs/spec/govuk_tech_docs/open_api/renderer_spec.rb
+++ b/docs/spec/govuk_tech_docs/open_api/renderer_spec.rb
@@ -17,11 +17,27 @@ RSpec.describe GovukTechDocs::OpenApi::Renderer do
           get: {
             responses: {
               "200": {
-                description: "description goes here",
+                description: "widgets description goes here",
                 content: {
                   "application/json": {
                     schema: {
                       "$ref": "#/components/schemas/widgets",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "/npq-widgets": {
+          get: {
+            responses: {
+              "200": {
+                description: "npq widgets description goes here",
+                content: {
+                  "application/json": {
+                    schema: {
+                      "$ref": "#/components/schemas/npqWidgets",
                     },
                   },
                 },
@@ -42,10 +58,26 @@ RSpec.describe GovukTechDocs::OpenApi::Renderer do
               },
             },
           },
+          npqWidgets: {
+            properties: {
+              data: {
+                type: "array",
+                items: {
+                  "$ref": "#/components/schemas/npqWidget",
+                },
+              },
+            },
+          },
           widget: {
             anyOf: [
               { "$ref": "#/components/schemas/widgetInteger" },
               { "$ref": "#/components/schemas/widgetString" },
+            ],
+          },
+          npqWidget: {
+            anyOf: [
+              { "$ref": "#/components/schemas/npqWidgetInteger" },
+              { "$ref": "#/components/schemas/npqWidgetString" },
             ],
           },
           widgetInteger: {
@@ -60,14 +92,54 @@ RSpec.describe GovukTechDocs::OpenApi::Renderer do
               id: { type: "string", example: "abcde" },
             },
           },
+          npqWidgetInteger: {
+            type: "object",
+            properties: {
+              id: { type: "integer", example: 12_345 },
+            },
+          },
+          npqWidgetString: {
+            type: "object",
+            properties: {
+              id: { type: "string", example: "abcde" },
+            },
+          },
+          otherWidget: {
+            type: "object",
+            description: "an NPQ widget without npq in the schema name",
+          },
+          enumWidget: {
+            type: "object",
+            properties: {
+              enum_attr: {
+                type: "string",
+                enum: %w[
+                  value
+                  NPQ-value
+                ],
+              },
+              various: {
+                anyOf: [
+                  {
+                    "$ref": "#/components/schemas/npqWidget",
+                  },
+                ],
+              },
+            },
+          },
         },
       },
     }
   end
 
-  let(:document) { Openapi3Parser.load(spec) }
-
   describe "#api_full" do
+    let(:remove_npq_references) { false }
+
+    before do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("REMOVE_NPQ_REFERENCES").and_return(remove_npq_references)
+    end
+
     it "renders a server with no description" do
       spec["servers"] = [
         { url: "https://example.com" },
@@ -75,9 +147,8 @@ RSpec.describe GovukTechDocs::OpenApi::Renderer do
       document = Openapi3Parser.load(spec)
 
       render = described_class.new(nil, document)
-      rendered = render.api_full
+      rendered = Capybara::Node::Simple.new(render.api_full)
 
-      rendered = Capybara::Node::Simple.new(rendered)
       expect(rendered).to have_css("h2#servers")
       expect(rendered).to have_css("div#server-list>a", text: "https://example.com")
       expect(rendered).not_to have_css("div#server-list>p")
@@ -91,14 +162,83 @@ RSpec.describe GovukTechDocs::OpenApi::Renderer do
       document = Openapi3Parser.load(spec)
 
       render = described_class.new(nil, document)
-      rendered = render.api_full
+      rendered = Capybara::Node::Simple.new(render.api_full)
 
-      rendered = Capybara::Node::Simple.new(rendered)
       expect(rendered).to have_css("h2#servers")
       expect(rendered).to have_css("div#server-list>a", text: "https://example.com")
       expect(rendered).to have_css("div#server-list>p>strong", text: "Production")
       expect(rendered).to have_css("div#server-list>a", text: "https://dev.example.com")
       expect(rendered).to have_css("div#server-list>p>strong", text: "Development")
+    end
+
+    describe "rendering API content" do
+      subject(:rendered) do
+        spec["servers"] = [
+          { url: "https://example.com" },
+        ]
+        document = Openapi3Parser.load(spec)
+
+        render = described_class.new(nil, document)
+        Capybara::Node::Simple.new(render.api_full)
+      end
+
+      it "renders a list of paths" do
+        expect(rendered).to have_css(".govuk-heading-l", text: "/widgets")
+        expect(rendered).to have_css("#widgets-get-responses")
+        expect(rendered).to have_css("#widgets-get-responses-examples")
+        expect(rendered).to have_css("span.govuk-details__summary-text", text: "200 - widgets description goes here")
+
+        expect(rendered).to have_css(".govuk-heading-l", text: "/npq-widgets")
+        expect(rendered).to have_css("#npq-widgets-get-responses")
+        expect(rendered).to have_css("#npq-widgets-get-responses-examples")
+        expect(rendered).to have_css("span.govuk-details__summary-text", text: "200 - npq widgets description goes here")
+      end
+
+      it "renders schemas" do
+        expect(rendered).to have_css("#schema-widget", text: "widget")
+        expect(rendered).to have_link("widgetInteger", href: "#schema-widgetinteger")
+        expect(rendered).to have_link("widgetString", href: "#schema-widgetstring")
+
+        expect(rendered).to have_css("#schema-npqwidget", text: "npqWidget")
+        expect(rendered).to have_link("npqWidgetInteger", href: "#schema-npqwidgetinteger")
+        expect(rendered).to have_link("npqWidgetString", href: "#schema-npqwidgetstring")
+
+        expect(rendered).to have_css("#schema-otherwidget", text: "otherWidget")
+        expect(rendered).to have_link("npqWidget", href: "#schema-npqwidget")
+
+        expect(rendered).to have_css("li", text: "NPQ-value")
+      end
+
+      context "whem removing NPQ references" do
+        let(:remove_npq_references) { true }
+
+        it "renders a list of paths, excluding any that contain 'npq'" do
+          expect(rendered).to have_css(".govuk-heading-l", text: "/widgets")
+          expect(rendered).to have_css("#widgets-get-responses")
+          expect(rendered).to have_css("#widgets-get-responses-examples")
+          expect(rendered).to have_css("span.govuk-details__summary-text", text: "200 - widgets description goes here")
+
+          expect(rendered).not_to have_css(".govuk-heading-l", text: "/npq-widgets")
+          expect(rendered).not_to have_css("#npq-widgets-get-responses")
+          expect(rendered).not_to have_css("#npq-widgets-get-responses-examples")
+          expect(rendered).not_to have_css("span.govuk-details__summary-text", text: "200 - npq widgets description goes here")
+        end
+
+        it "renders schemas, excluding any that contain 'npq'" do
+          expect(rendered).to have_css("#schema-widget", text: "widget")
+          expect(rendered).to have_link("widgetInteger", href: "#schema-widgetinteger")
+          expect(rendered).to have_link("widgetString", href: "#schema-widgetstring")
+
+          expect(rendered).not_to have_css("#schema-npqwidget", text: "npqWidget")
+          expect(rendered).not_to have_link("npqWidgetInteger", href: "#schema-npqwidgetinteger")
+          expect(rendered).not_to have_link("npqWidgetString", href: "#schema-npqwidgetstring")
+
+          expect(rendered).not_to have_css("#schema-otherwidget", text: "otherWidget")
+          expect(rendered).not_to have_link("npqWidget", href: "#schema-npqwidget")
+
+          expect(rendered).not_to have_css("li", text: "NPQ-value")
+        end
+      end
     end
   end
 end

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -2134,7 +2134,7 @@
             ]
           },
           "teacher_reference_number": {
-            "description": "The Teacher Reference Number (TRN) for this NPQ participant",
+            "description": "The Teacher Reference Number (TRN) for this ECF participant",
             "type": "string",
             "example": "1234567"
           },
@@ -2518,7 +2518,7 @@
             ]
           },
           "teacher_reference_number": {
-            "description": "The Teacher Reference Number (TRN) for this NPQ participant",
+            "description": "The Teacher Reference Number (TRN) for this ECF participant",
             "type": "string",
             "example": "1234567"
           },
@@ -2754,7 +2754,7 @@
             ]
           },
           "teacher_reference_number": {
-            "description": "The Teacher Reference Number (TRN) for this NPQ participant",
+            "description": "The Teacher Reference Number (TRN) for this ECF participant",
             "type": "string",
             "example": "1234567"
           },
@@ -3139,7 +3139,7 @@
             ]
           },
           "teacher_reference_number": {
-            "description": "The Teacher Reference Number (TRN) for this NPQ participant",
+            "description": "The Teacher Reference Number (TRN) for this ECF participant",
             "type": "string",
             "example": "1234567"
           },

--- a/swagger/v2/api_spec.json
+++ b/swagger/v2/api_spec.json
@@ -1985,7 +1985,7 @@
             ]
           },
           "teacher_reference_number": {
-            "description": "The Teacher Reference Number (TRN) for this NPQ participant",
+            "description": "The Teacher Reference Number (TRN) for this ECF participant",
             "type": "string",
             "example": "1234567"
           },
@@ -2368,7 +2368,7 @@
             ]
           },
           "teacher_reference_number": {
-            "description": "The Teacher Reference Number (TRN) for this NPQ participant",
+            "description": "The Teacher Reference Number (TRN) for this ECF participant",
             "type": "string",
             "example": "1234567",
             "required": false,
@@ -2607,7 +2607,7 @@
             ]
           },
           "teacher_reference_number": {
-            "description": "The Teacher Reference Number (TRN) for this NPQ participant",
+            "description": "The Teacher Reference Number (TRN) for this ECF participant",
             "type": "string",
             "example": "1234567"
           },
@@ -2992,7 +2992,7 @@
             ]
           },
           "teacher_reference_number": {
-            "description": "The Teacher Reference Number (TRN) for this NPQ participant",
+            "description": "The Teacher Reference Number (TRN) for this ECF participant",
             "type": "string",
             "example": "1234567",
             "required": false,

--- a/swagger/v3/api_spec.json
+++ b/swagger/v3/api_spec.json
@@ -1816,7 +1816,7 @@
                             "participant_id": "bf3c6251-f2a0-4690-a859-0fbecc6ed151",
                             "declaration_type": "started",
                             "declaration_date": "2020-11-13T11:21:55Z",
-                            "course_identifier": "npq-leading-teaching",
+                            "course_identifier": "ecf-mentor",
                             "state": "eligible",
                             "updated_at": "2020-11-13T11:21:55Z",
                             "created_at": "2020-11-13T11:21:55Z",


### PR DESCRIPTION
[Jira-3275](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3275)

### Context

We want to remove all references to the NPQ endpoints from the swagger docs in the `separation` environment for providers to test.

### Changes proposed in this pull request

- Fix references to NPQ in ECF

These references to NPQ participants should be ECF participants as they are in the context of an ECF path/schema.

- Conditionally remove NPQ references from swagger docs

We want to be able to conditionally remove the references to NPQ from the swagger docs. This includes stripping out paths, schemas and links to schemas as well as NPQ-specific pages.

- Dynamically replace API reference on boot

We want to serve two versions of the API reference depending on the environment we are running. In order to do this we are generating a second version in the `public/api-reference-without-npq` directory and then on boot we will replace `public/api-reference` with this version if applicable.

### Guidance to review

> ⚠️ Environment needs to change from `review` to `separation` prior to merging!