### PR TITLE
CST-2577: daily DQT checks. Move unfinished ECTs in progress to the reg-active cohort.

### DIFF
--- a/app/models/continue_training_cohort_change_error.rb
+++ b/app/models/continue_training_cohort_change_error.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ContinueTrainingCohortChangeError < ApplicationRecord
+  belongs_to :participant_profile
+
+  validates :participant_profile, presence: true
+  validates :message, presence: true
+end

--- a/app/services/induction/amend_participant_cohort.rb
+++ b/app/services/induction/amend_participant_cohort.rb
@@ -173,8 +173,7 @@ module Induction
         partnership = Partnership.find_or_create_by!(school_id: school_cohort.school_id,
                                                      cohort_id: school_cohort.cohort_id,
                                                      lead_provider_id:,
-                                                     delivery_partner_id:,
-                                                     relationship: false)
+                                                     delivery_partner_id:)
       end
 
       InductionProgramme.full_induction_programme.create!(school_cohort:, partnership:)

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -514,3 +514,9 @@
   - participant_type
   - induction_record_created_at
   - partnership_id
+  :continue_training_cohort_change_errors:
+    - id
+    - participant_profile_id
+    - message
+    - created_at
+    - updated_at

--- a/db/migrate/20240718153716_create_continue_training_cohort_change_errors.rb
+++ b/db/migrate/20240718153716_create_continue_training_cohort_change_errors.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateContinueTrainingCohortChangeErrors < ActiveRecord::Migration[7.1]
+  def change
+    create_table :continue_training_cohort_change_errors, if_not_exists: true do |t|
+      t.belongs_to :participant_profile, null: false, foreign_key: true, type: :uuid, index: { name: "continue_training_error_participant_profile_id" }
+      t.text :message
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_17_111257) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_18_153716) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -277,6 +277,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_17_111257) do
   create_table "completion_candidates", id: false, force: :cascade do |t|
     t.uuid "participant_profile_id"
     t.index ["participant_profile_id"], name: "index_completion_candidates_on_participant_profile_id", unique: true
+  end
+
+  create_table "continue_training_cohort_change_errors", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "participant_profile_id", null: false
+    t.text "message"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["participant_profile_id"], name: "continue_training_error_participant_profile_id"
   end
 
   create_table "core_induction_programmes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1294,6 +1302,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_17_111257) do
   add_foreign_key "cohorts_lead_providers", "cohorts"
   add_foreign_key "cohorts_lead_providers", "lead_providers"
   add_foreign_key "completion_candidates", "participant_profiles", on_delete: :cascade
+  add_foreign_key "continue_training_cohort_change_errors", "participant_profiles"
   add_foreign_key "data_stage_school_changes", "data_stage_schools"
   add_foreign_key "data_stage_school_links", "data_stage_schools"
   add_foreign_key "deleted_duplicates", "participant_profiles", column: "primary_participant_profile_id"


### PR DESCRIPTION
## TO BE MERGED ONLY THE WEEK STARTING ON SEPT, 23rd 2024!!!


### Context

Every day we check DQT to get updates of induction dates (start and completion) for all the participants resulting in updates in their induction start dates or induction completion dates or even participants placed in a cohort different to their current one.

From mid September’24 (when we expect that DQT has finished receiving induction completion dates for all the participants that completed induction in 2023/24 or earlier) we need to extend the logic that amends participant cohorts as part of this daily check to move to 2024/25 cohort incomplete participants that according to their existing/updated induction start date are/should be put in 21/22 cohort but have an induction status of “In Progress”.

- [Ticket](https://dfedigital.atlassian.net/browse/CST-2577): 

### Changes proposed in this pull request

 - Move eligible participants to 2024 after syncing induction start date and cohort with DQT.
 - Record an error entry if that cohort change fails for some reason (for retrying purposes).
 

### Guidance to review

