### PR TITLE
[CPDNPQ-1980] rollbacks in Identity::Transfer rollback outer transactions

### DIFF
--- a/app/services/identity/transfer.rb
+++ b/app/services/identity/transfer.rb
@@ -13,6 +13,8 @@ module Identity
         transfer_induction_coordinator_profile!
         transfer_get_an_identity_id!
         create_participant_id_change!
+      rescue ActiveRecord::Rollback
+        raise TransferError, "Transfer failed"
       end
     end
 


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CPDNPQ-1980

There is an issue with "Ghost" applications appearing in BigQuery. These are applications which are found there but not in ECF or NPQ dbs.

They correspond with applications that have had syncing errors between NPQ & ECF.

Upon investigation, it seems that a nested transaction in ECF which deduplicates applications before publishing them _could_ be the cause.

```
#models/npq_application.rb

def save_and_dedupe_participant
  ActiveRecord::Base.transaction do
    result = save
    NPQ::DedupeParticipant.new(npq_application: self, trn: teacher_reference_number).call if result
    result
  end
end
```

Nested transactions are often troublesome and should be avoided where possible as they often have unintended consequences. The main issue is that when a`ActiveRecord::Rollback` error happens inside a nested transaction, it does not rollback commits for the inner or outer transaction - See https://api.rubyonrails.org/classes/ActiveRecord/Transactions/ClassMethods.html

We can solve this by rescuing the `ActiveRecord::Rollback` error and raising a `StandardError`. This will then behave as expected and rollback both the inner and outer commits.

---------

It's important to say that it's quite hard to identify the exact cause of the ghost applications. It may end up being caused by another issue. We need to deploy this change and continue to monitor to see if the problem keeps happening. Either way, this change is still a benefit as if any Rollback errors do occur, this is the desired behaviour.