### PR TITLE
CST-2579: weekly retry of 2021 -> 2024 cohort changes that failed in the daily DQT checks

### DIFF
--- a/app/jobs/retry_continue_training_participants_that_failed_cohort_change_job.rb
+++ b/app/jobs/retry_continue_training_participants_that_failed_cohort_change_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class RetryContinueTrainingParticipantsThatFailedCohortChangeJob < ApplicationJob
+  def perform
+    errors.find_each do |error|
+      Participants::RetryContinueTraining.call(participant_profile: error.participant_profile)
+    end
+  end
+
+private
+
+  def errors
+    ContinueTrainingCohortChangeError.includes(participant_profile: { schedule: :cohort })
+  end
+end

--- a/app/services/participants/retry_continue_training.rb
+++ b/app/services/participants/retry_continue_training.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Participants
+  class RetryContinueTraining < BaseService
+    def call
+      clear_participant_continue_training_errors
+      return true unless unfinished_participant_continue_training?
+
+      amend_cohort.save || save_error(amend_cohort.errors.full_messages.first)
+    end
+
+  private
+
+    attr_reader :participant_profile
+
+    def initialize(participant_profile:)
+      @participant_profile = participant_profile
+    end
+
+    def amend_cohort
+      @amend_cohort ||= Induction::AmendParticipantCohort.new(participant_profile:,
+                                                              source_cohort_start_year:,
+                                                              target_cohort_start_year:)
+    end
+
+    def clear_participant_continue_training_errors
+      ContinueTrainingCohortChangeError.where(participant_profile:).destroy_all
+    end
+
+    def participant_cohort
+      @participant_cohort ||= (participant_profile.schedule || participant_profile.latest_induction_record)&.cohort
+    end
+
+    def source_cohort_start_year
+      participant_cohort&.start_year
+    end
+
+    def save_error(message)
+      ContinueTrainingCohortChangeError.find_or_create_by!(participant_profile:, message:)
+
+      false
+    end
+
+    def target_cohort
+      @target_cohort ||= Cohort.active_registration_cohort
+    end
+
+    def target_cohort_start_year
+      target_cohort.start_year
+    end
+
+    def unfinished_participant_continue_training?
+      participant_profile.eligible_to_change_cohort_and_continue_training?(cohort: target_cohort)
+    end
+  end
+end

--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -22,6 +22,10 @@ check_eligible_ects_that_failed_permanent_cohort_setup:
   cron: "0 11 * * 1"
   class: "CheckEligibleEctsThatFailedPermanentCohortSetupJob"
   queue: default
+retry_continue_training_participants_that_failed_cohort_change:
+  cron: "0 13 * * 1"
+  class: "RetryContinueTrainingParticipantsThatFailedCohortChangeJob"
+  queue: default
 enrol_school_cohorts:
   cron: "0 3 * * *"
   class: "EnrolSchoolCohortsJob"

--- a/spec/jobs/retry_continue_training_participants_that_failed_cohort_change_job_spec.rb
+++ b/spec/jobs/retry_continue_training_participants_that_failed_cohort_change_job_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RetryContinueTrainingParticipantsThatFailedCohortChangeJob do
+  let(:participant_profiles) { create_list(:ect, 2) }
+
+  before do
+    participant_profiles.each do |participant_profile|
+      ContinueTrainingCohortChangeError.create!(participant_profile:, message: "Can't change cohort")
+    end
+  end
+
+  describe "#perform" do
+    context "when there are continue training errors" do
+      before do
+        participant_profiles.each do |participant_profile|
+          allow(Participants::RetryContinueTraining).to receive(:new).with(participant_profile:).and_call_original
+        end
+        described_class.perform_now
+      end
+
+      it "retry all of them" do
+        participant_profiles.each do |participant_profile|
+          expect(Participants::RetryContinueTraining).to have_received(:new).with(participant_profile:)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/participants/retry_continue_training_spec.rb
+++ b/spec/services/participants/retry_continue_training_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Participants::RetryContinueTraining do
+  let(:cohort) { Cohort.find_by_start_year(2021) || create(:cohort, start_year: 2021) }
+  let(:participant_profile) { create(:ect, cohort:) }
+  let(:target_cohort_start_year) { Cohort.active_registration_cohort.start_year }
+  let(:old_error_message) { "Can't change cohort" }
+  let(:service) { described_class.new(participant_profile:) }
+
+  before do
+    ContinueTrainingCohortChangeError.create!(participant_profile:, message: old_error_message)
+  end
+
+  describe "#call" do
+    context "when the participant is no longer eligible to continue training" do
+      before do
+        allow(participant_profile).to receive(:eligible_to_change_cohort_and_continue_training?).and_return(false)
+      end
+
+      it "does not persist an error for the participant" do
+        expect { service.call }.to change(ContinueTrainingCohortChangeError, :count).from(1).to(0)
+      end
+    end
+
+    context "when the retry fails" do
+      let(:new_error_message) { "Cohort change failed" }
+      let(:errors) { double(full_messages: [new_error_message]) }
+
+      before do
+        allow(participant_profile).to receive(:eligible_to_change_cohort_and_continue_training?).and_return(true)
+        allow(Induction::AmendParticipantCohort).to receive(:new).with(participant_profile:,
+                                                                       source_cohort_start_year: 2021,
+                                                                       target_cohort_start_year:)
+                                                                 .and_return(double(save: false, errors:))
+      end
+
+      it "persist a new error for the participant" do
+        expect { service.call }.to change { ContinueTrainingCohortChangeError.pluck(:message) }
+                                     .from([old_error_message])
+                                     .to([new_error_message])
+      end
+    end
+
+    context "when the retry succeeds" do
+      before do
+        allow(Induction::AmendParticipantCohort).to receive(:new).with(participant_profile:,
+                                                                       source_cohort_start_year: 2021,
+                                                                       target_cohort_start_year:)
+                                                                 .and_return(double(save: true))
+      end
+
+      it "does not persist an error for the participant" do
+        expect { service.call }.to change(ContinueTrainingCohortChangeError, :count).from(1).to(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## TO BE MERGED ONLY AFTER [CST-2577](https://dfedigital.atlassian.net/browse/CST-2577) AND THE WEEK STARTING ON SEPT, 23rd 2024!!!


### Context

Every day we check DQT to get updates of induction dates (start and completion) for all the participants resulting in updates in their induction start dates or induction completion dates or even participants placed in a cohort different to their current one.

From mid September’24 (when we expect that DQT has finished receiving induction completion dates for all the participants that completed induction in 2023/24 or earlier) we need to extend the logic that amends participant cohorts as part of this daily check to move to 2024/25 cohort incomplete participants that according to their existing/updated induction start date are/should be put in 21/22 cohort but have an induction status of “In Progress”.

This PR is to retry those cohort changes that failed in the daily attempts: [Required ticket: CST-2577](https://dfedigital.atlassian.net/browse/CST-2577)

- [This ticket: CST-2579](https://dfedigital.atlassian.net/browse/CST-2579): 

### Changes proposed in this pull request

 - Schedule a job to weekly retry all entries in `ContinueTrainingCohortChangeError`


### Guidance to review



[CST-2577]: https://dfedigital.atlassian.net/browse/CST-2577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CST-2579]: https://dfedigital.atlassian.net/browse/CST-2579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ