### PR TITLE
Fix case-insensitive name matching in nominate SIT form

### DIFF
--- a/app/forms/nominate_induction_tutor_form.rb
+++ b/app/forms/nominate_induction_tutor_form.rb
@@ -39,7 +39,7 @@ private
   end
 
   def different_name?
-    user.full_name != full_name
+    user.full_name&.downcase != full_name&.downcase
   end
 
   def ensure_user_persisted

--- a/spec/forms/nominate_induction_tutor_form_spec.rb
+++ b/spec/forms/nominate_induction_tutor_form_spec.rb
@@ -23,16 +23,28 @@ RSpec.describe NominateInductionTutorForm, type: :model do
       end
     end
 
-    context "when the name provided doesn't match the intended new SIT's name" do
-      let(:form) { described_class.new(full_name: "Another name", email:, school:) }
+    describe "#name_matches" do
+      let(:form) { described_class.new(full_name: new_full_name, email:, school:) }
 
       before do
         create(:ect, user: create(:user, email:, full_name:))
       end
 
-      it "an error is added" do
-        expect(form.valid?(:email)).to be_falsey
-        expect(form.errors[:full_name].first).to eq("A user with a different name (#{full_name}) has already been registered with this email address. Change the name or email address you entered.")
+      context "when the name provided doesn't match the intended new SIT's name" do
+        let(:new_full_name) { "Another name" }
+
+        it "an error is added" do
+          expect(form.valid?(:email)).to be_falsey
+          expect(form.errors[:full_name].first).to eq("A user with a different name (#{full_name}) has already been registered with this email address. Change the name or email address you entered.")
+        end
+      end
+
+      context "when the name is the same but in different case" do
+        let(:new_full_name) { full_name.upcase }
+
+        it "an error is added" do
+          expect(form.valid?(:email)).to be_truthy
+        end
       end
     end
 


### PR DESCRIPTION
### Context

- Ticket: N/A

This PR fixes the case-insensitive name matching validation in the Nominate SIT form that prevents adding SITs.

### Changes proposed in this pull request
- Downcase the names before comparing them

### Guidance to review

