### PR TITLE
[CPDNPQ-1980] add one-off script to update contracts and statements f…

### DIFF
--- a/app/services/oneoffs/npq/create_new_contract_and_update_existing_statements.rb
+++ b/app/services/oneoffs/npq/create_new_contract_and_update_existing_statements.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+module Oneoffs::NPQ
+  class CreateNewContractAndUpdateExistingStatements
+    def initialize(path_to_csv:, cohort_year:, payment_date_range:)
+      @path_to_csv = path_to_csv
+      @cohort_year = cohort_year
+      @payment_date_range = payment_date_range
+    end
+
+    def call
+      ActiveRecord::Base.transaction do
+        rows_by_provider.each do |provider_name, rows|
+          cpd_lead_provider = CpdLeadProvider.find_by!(name: provider_name)
+          npq_lead_provider = cpd_lead_provider.npq_lead_provider
+
+          rows.each.with_index(1) do |row, index|
+            cohort = Cohort.find_by!(start_year: row["cohort_year"])
+            course = NPQCourse.find_by!(identifier: row["course_identifier"])
+
+            current_version = Finance::Statement::NPQ.where(cohort:, cpd_lead_provider:).pluck(:contract_version).max
+            new_version = Finance::ECF::ContractVersion.new(current_version).increment!
+
+            new_contract = NPQContract.find_or_initialize_by(
+              cohort:,
+              version: new_version,
+              npq_lead_provider:,
+              course_identifier: course.identifier,
+            )
+
+            new_contract.update!(
+              monthly_service_fee: row["monthly_service_fee"] || 0.0,
+              recruitment_target: row["recruitment_target"].to_i,
+              per_participant: row["per_participant"],
+              service_fee_installments: row["service_fee_installments"].to_i,
+              number_of_payment_periods: number_of_payment_periods_for(course:),
+              service_fee_percentage: service_fee_percentage_for(course:),
+              output_payment_percentage: output_payment_percentage_for(course:),
+              special_course: (row["special_course"].to_s.upcase == "TRUE"),
+              funding_cap: row["funding_cap"],
+            )
+
+            next unless index == rows.size
+
+            statements = Finance::Statement::NPQ.where(cohort:, payment_date: payment_date_range, cpd_lead_provider:)
+            statements.find_each do |statement|
+              statement.update!(contract_version: new_version)
+            end
+          end
+        end
+      end
+    end
+
+  private
+
+    attr_reader :path_to_csv, :cohort_year, :payment_date_range
+
+    def number_of_payment_periods_for(course:)
+      case course.identifier
+      when *Finance::Schedule::NPQLeadership::IDENTIFIERS
+        4
+      when *Finance::Schedule::NPQSpecialist::IDENTIFIERS
+        3
+      when *Finance::Schedule::NPQSupport::IDENTIFIERS
+        4
+      when *Finance::Schedule::NPQEhco::IDENTIFIERS
+        4
+      else
+        raise ArgumentError, "Invalid course identifier"
+      end
+    end
+
+    def service_fee_percentage_for(course:)
+      case course.identifier
+      when *Finance::Schedule::NPQSupport::IDENTIFIERS
+        0
+      when *Finance::Schedule::NPQEhco::IDENTIFIERS
+        0
+      else
+        40
+      end
+    end
+
+    def output_payment_percentage_for(course:)
+      case course.identifier
+      when *Finance::Schedule::NPQSupport::IDENTIFIERS
+        100
+      when *Finance::Schedule::NPQEhco::IDENTIFIERS
+        100
+      else
+        60
+      end
+    end
+
+    def rows_by_provider
+      rows.group_by { |row| row["provider_name"] }
+    end
+
+    def rows
+      @rows ||= CSV.read(path_to_csv, headers: true, skip_blanks: true)
+    end
+  end
+end

--- a/spec/services/oneoffs/npq/create_new_contact_and_update_existing_statements_spec.rb
+++ b/spec/services/oneoffs/npq/create_new_contact_and_update_existing_statements_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Oneoffs::NPQ::CreateNewContractAndUpdateExistingStatements do
       csv.close
     end
 
-    it "creates a contracts with correct values" do
+    it "creates contracts with correct values" do
       expect { subject.call }.to change { NPQContract.count }.by(4)
 
       lead_provider_data.each do |lead_provider_name, course_identifier_data|

--- a/spec/services/oneoffs/npq/create_new_contact_and_update_existing_statements_spec.rb
+++ b/spec/services/oneoffs/npq/create_new_contact_and_update_existing_statements_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+RSpec.describe Oneoffs::NPQ::CreateNewContractAndUpdateExistingStatements do
+  let(:csv) { Tempfile.new("data.csv") }
+  let(:cohort) { create(:cohort, start_year: 2024) }
+  let(:payment_date_range) { Date.new(2024, 1, 1)..Date.new(2024, 1, 31) }
+
+  let(:lead_provider_data) do
+    {
+      "Ambition Institute" => {
+        course_data: {
+          "npq-early-headship-coaching-offer" => {
+            contract_version: "0.0.2",
+            recruitment_target: 1,
+            per_participant: 10,
+          },
+          "npq-headship" => {
+            contract_version: "0.0.3",
+            recruitment_target: 2,
+            per_participant: 20,
+          },
+        },
+        new_contract_version: "0.0.4",
+      },
+      "Best Practice Network" => {
+        course_data: {
+          "npq-early-headship-coaching-offer" => {
+            contract_version: "0.0.4",
+            recruitment_target: 1,
+            per_participant: 10,
+          },
+          "npq-headship" => {
+            contract_version: "0.0.5",
+            recruitment_target: 2,
+            per_participant: 20,
+          },
+        },
+        new_contract_version: "0.0.6",
+      },
+    }
+  end
+
+  before do
+    lead_provider_data.each do |lead_provider_name, course_identifier_data|
+      cpd_lead_provider = create(:cpd_lead_provider, :with_npq_lead_provider, name: lead_provider_name)
+
+      course_identifier_data[:course_data].each do |course_identifier, data|
+        create(:npq_course, identifier: course_identifier)
+        create(:npq_contract, npq_lead_provider: cpd_lead_provider.npq_lead_provider, course_identifier:, cohort:, version: data[:contract_version])
+        create(:npq_statement, cohort:, cpd_lead_provider:, contract_version: data[:contract_version], payment_date: Date.new(2024, 1, 2))
+      end
+    end
+  end
+
+  subject { described_class.new(path_to_csv: csv.path, cohort_year: cohort.start_year, payment_date_range:) }
+
+  describe "#call" do
+    before do
+      csv.write "provider_name,cohort_year,course_identifier,recruitment_target,per_participant,service_fee_installments,special_course,monthly_service_fee,funding_cap"
+      csv.write "\n"
+      csv.write "Ambition Institute,2024,npq-early-headship-coaching-offer,33,800,0,FALSE,0,1"
+      csv.write "\n"
+      csv.write "Ambition Institute,2024,npq-headship,33,800,0,FALSE,0,1"
+      csv.write "\n"
+      csv.write "Best Practice Network,2024,npq-early-headship-coaching-offer,33,800,0,FALSE,0,1"
+      csv.write "\n"
+      csv.write "Best Practice Network,2024,npq-headship,33,800,0,FALSE,0,1"
+      csv.write "\n"
+      csv.close
+    end
+
+    it "creates a contracts with correct values" do
+      expect { subject.call }.to change { NPQContract.count }.by(4)
+
+      lead_provider_data.each do |lead_provider_name, course_identifier_data|
+        cpd_lead_provider = CpdLeadProvider.find_by(name: lead_provider_name)
+
+        course_identifier_data[:course_data].each_key do |course_identifier|
+          contract = NPQContract.where(
+            course_identifier:,
+            npq_lead_provider: cpd_lead_provider.npq_lead_provider,
+          ).order(:created_at).last
+
+          expect(contract.npq_lead_provider.name).to eql(cpd_lead_provider.npq_lead_provider.name)
+          expect(contract.recruitment_target).to eql(33)
+          expect(contract.course_identifier).to eql(course_identifier)
+          expect(contract.per_participant).to eql(800)
+          expect(contract.cohort).to eql(cohort)
+          expect(contract.version).to eql(lead_provider_data[lead_provider_name][:new_contract_version])
+        end
+      end
+    end
+
+    it "updates the statements with the new contract version" do
+      subject.call
+
+      lead_provider_data.each_key do |lead_provider_name|
+        cpd_lead_provider = CpdLeadProvider.find_by(name: lead_provider_name)
+        expect(Finance::Statement::NPQ.where(cpd_lead_provider:).pluck(:contract_version).uniq).to eql([lead_provider_data[lead_provider_name][:new_contract_version]])
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CPDNPQ-1960

Before launch on Jul 1st 2024, we ran the task to import cohort data
- https://dfedigital.atlassian.net/browse/CPDNPQ-1826
- https://dfedigital.atlassian.net/wiki/spaces/CPD/pages/3901947911/Create+new+NPQ+cohort

Due to a delay in contract data being finalised, as well as TDT, LLSE and UCL deciding to offer EHCO with no DfE funding, we need to upload a new version of the contract.csv for 2024.

To achieve this, we need to write a one-off script that imports the new contract data, as well as updates the existing data and associated statements.