### PR TITLE
Re-enable change LP/DP links on schools dashboard

### DIFF
--- a/app/views/schools/dashboard/_school_cohort_details.html.erb
+++ b/app/views/schools/dashboard/_school_cohort_details.html.erb
@@ -48,17 +48,15 @@
       <% else %>
         <% row.with_value(text: school_cohort_lead_provider_name(school_cohort)) %>
       <% end %>
-      <% if school_cohort.start_year != Cohort.active_registration_cohort.start_year %>
-        <% row.with_action(
-          text: 'Change',
-          visually_hidden_text: "lead provider",
-          href: schools_change_request_support_query_intro_path(
-            start_year: school_cohort.start_year,
-            school_id: @school.id,
-            change_request_type: "change-lead-provider",
-          )
-        ) %>
-      <% end %>
+      <% row.with_action(
+        text: 'Change',
+        visually_hidden_text: "lead provider",
+        href: schools_change_request_support_query_intro_path(
+          start_year: school_cohort.start_year,
+          school_id: @school.id,
+          change_request_type: "change-lead-provider",
+        )
+      ) %>
     <% end %>
 
     <% list.with_row do |row| %>
@@ -68,17 +66,15 @@
       <% else %>
         <% row.with_value(text: school_cohort_delivery_partner_name(school_cohort)) %>
       <% end %>
-      <% if school_cohort.start_year != Cohort.active_registration_cohort.start_year %>
-        <% row.with_action(
-          text: 'Change',
-          visually_hidden_text: "delivery partner",
-          href: schools_change_request_support_query_intro_path(
-            start_year: school_cohort.start_year,
-            school_id: @school.id,
-            change_request_type: "change-delivery-partner",
-          )
-        ) %>
-      <% end %>
+      <% row.with_action(
+        text: 'Change',
+        visually_hidden_text: "delivery partner",
+        href: schools_change_request_support_query_intro_path(
+          start_year: school_cohort.start_year,
+          school_id: @school.id,
+          change_request_type: "change-delivery-partner",
+        )
+      ) %>
     <% end %>
   <% end %>
 <% end %>

--- a/spec/features/schools/change_request_support_query/sit_requests_delivery_partner_change_for_academic_year_spec.rb
+++ b/spec/features/schools/change_request_support_query/sit_requests_delivery_partner_change_for_academic_year_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Induction coordinator requests delivery partner change for acade
     and_there_is_a_choice_of_delivery_partners
     when_i_visit_manage_training_dashboard
     click_on(Cohort.previous.start_year)
-    click_on("Change delivery partner", visible: false)
+    and_i_click_change_delivery_partner
     then_i_see_the_intro_step
     then_i_choose_yes_on_the_start_step
     then_i_choose_a_new_delivery_partner
@@ -33,6 +33,10 @@ RSpec.describe "Induction coordinator requests delivery partner change for acade
            cohort: @school_cohort.cohort,
            lead_provider: @lead_provider,
            delivery_partner: create(:delivery_partner, name: "Delivery Partner 2"))
+  end
+
+  def and_i_click_change_delivery_partner
+    all("a", text: "Change delivery partner", visible: false).last.click
   end
 
   def then_i_see_the_intro_step

--- a/spec/features/schools/change_request_support_query/sit_requests_lead_provider_change_for_academic_year_spec.rb
+++ b/spec/features/schools/change_request_support_query/sit_requests_lead_provider_change_for_academic_year_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Induction coordinator requests lead provider change for academic
     and_there_is_a_choice_of_lead_providers
     when_i_visit_manage_training_dashboard
     click_on(Cohort.previous.start_year)
-    click_on("Change lead provider", visible: false)
+    and_i_click_change_lead_provider
     then_i_see_the_intro_step
     then_i_choose_yes_on_the_start_step
     then_i_choose_a_new_lead_provider
@@ -27,6 +27,10 @@ RSpec.describe "Induction coordinator requests lead provider change for academic
   def and_there_is_a_choice_of_lead_providers
     create(:lead_provider, name: "Lead Provider 1")
     create(:lead_provider, name: "Lead Provider 2")
+  end
+
+  def and_i_click_change_lead_provider
+    all("a", text: "Change lead provider", visible: false).last.click
   end
 
   def then_i_see_the_intro_step


### PR DESCRIPTION
### Context

Undo this https://github.com/DFE-Digital/early-careers-framework/pull/4986 as we want these links for the active registration cohort now.

- Ticket: https://dfedigital.atlassian.net.mcas.ms/browse/CST-2698

### Changes proposed in this pull request

Re-enable change LP/DP links for active registration cohort

![image](https://github.com/user-attachments/assets/52b711c5-07d5-41f8-8c5a-22ee21ad9f1d)


### Guidance to review

