### PR TITLE
Fix API docs removing response text

### DIFF
--- a/docs/lib/govuk_tech_docs/open_api/renderer.rb
+++ b/docs/lib/govuk_tech_docs/open_api/renderer.rb
@@ -187,7 +187,9 @@ module GovukTechDocs
       end
 
       def remove_npq_references_from_text(text)
-        text.gsub(/ecf or npq/i, "ecf") if remove_npq_references?
+        return text unless remove_npq_references?
+
+        text.gsub(/ecf or npq/i, "ecf")
       end
 
       def filter_possible_values(enum)


### PR DESCRIPTION
The method was returning `nil` instead of the original text when the flag to remove NPQ references was `false`.

These methods don't have test coverage as they're `private` and called directly from the view. It's not a great solution but the code is to be short-lived, so I haven't tried to improve it.