### PR TITLE
Provide correct additional information to Support Query when changing LP/DP

### DIFF
--- a/app/services/create_change_request_support_query.rb
+++ b/app/services/create_change_request_support_query.rb
@@ -32,12 +32,11 @@ private
   end
 
   def additional_information
-    I18n.t(
-      "schools.change_request_support_query.#{relation_i18n_key}.additional_information",
-      academic_year:,
-      school: school.name,
-      urn: school.urn,
-    )
+    {
+      school_id: school&.id,
+      participant_profile_id: participant&.id,
+      cohort_year: academic_year&.split&.first,
+    }.reject { |_k, v| v.blank? }
   end
 
   def message
@@ -54,7 +53,10 @@ private
       induction_coordinator: induction_coordinator.full_name,
     }
 
-    kwargs[:participant] = participant.full_name if participant_change_request?
+    if participant_change_request?
+      kwargs[:participant] = participant.full_name
+      kwargs[:participant_id] = participant.id
+    end
 
     I18n.t(key, **kwargs)
   end

--- a/config/locales/schools/change_request_support_query.yml
+++ b/config/locales/schools/change_request_support_query.yml
@@ -48,11 +48,6 @@ en:
           title: You need to contact the current and new lead provider
 
       delivery_partner:
-        additional_information: |
-          Academic year: %{academic_year}
-          School name: %{school}
-          School URN: %{urn}
-
         message:
           cohort: |
             %{current_user} has requested to change the delivery partner for the academic year %{academic_year}.
@@ -63,11 +58,6 @@ en:
             New delivery partner: %{new_relation}
 
       lead_provider:
-        additional_information: |
-          Academic year: %{academic_year}
-          School name: %{school}
-          School URN: %{urn}
-
         message:
           cohort: |
             %{current_user} has requested to change the lead provider for the academic year %{academic_year}.


### PR DESCRIPTION
### Context

We've recently changed how change LP/DP support forms are submitted. The additional information provided in the footer of the Zendesk ticket has also changed, we'd like to retain the same information as we submitted previously

- Ticket: https://dfedigital.atlassian.net/browse/CST-2706

### Changes proposed in this pull request

Provides a hash of additional information in the same format as before, this will be used by [`SupportQuery#sync_to_support_queue`](https://github.com/DFE-Digital/early-careers-framework/blob/main/app/models/support_query.rb#L31) to format the footer information as we did previously.

### Guidance to review

This will need deployment to test from test/staging.