### PR TITLE
Set the DQT record to inside the registration period

### DIFF
--- a/spec/services/participants/check_and_set_completion_date_spec.rb
+++ b/spec/services/participants/check_and_set_completion_date_spec.rb
@@ -30,7 +30,9 @@ RSpec.describe Participants::CheckAndSetCompletionDate do
 
   describe "#call" do
     before do
-      allow(DQT::GetInductionRecord).to receive(:call).with(trn:).and_return(dqt_induction_record)
+      inside_registration_window do
+        allow(DQT::GetInductionRecord).to receive(:call).with(trn:).and_return(dqt_induction_record)
+      end
     end
 
     context "when the participant already have a completion date" do


### PR DESCRIPTION

### Context

- Ticket: n/a

### Changes proposed in this pull request
To avoid dates and cohorts shifting, set the DQT record to always be inside the registration period.


### Guidance to review
will this fail again later?
