### PR TITLE
Add support and links to API docs footer

### DIFF
--- a/docs/config.rb
+++ b/docs/config.rb
@@ -18,6 +18,8 @@ set :images_dir, "api-reference/javascripts"
 
 set :relative_links, true
 
+set :layout, :custom
+
 if ENV["REMOVE_NPQ_REFERENCES"].to_s == "true"
   ignore "/npq.html"
   ignore "/npq/**.*"

--- a/docs/config/tech-docs.yml
+++ b/docs/config/tech-docs.yml
@@ -24,6 +24,11 @@ collapsible_nav: true
 # headings.
 max_toc_heading_level: 2
 
+footer_links:
+  Privacy: /privacy-policy
+  Cookies: /cookies
+  Accessibility: /accessibility-statement
+
 # Prevent robots from indexing (e.g. whilst in development)
 prevent_indexing: false
 

--- a/docs/source/layouts/_custom_footer.erb
+++ b/docs/source/layouts/_custom_footer.erb
@@ -1,0 +1,51 @@
+<footer class="govuk-footer app-footer" role="contentinfo">
+  <div class="govuk-footer__meta">
+    <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+
+      <h2 class="govuk-heading-m">Support and guidance</h2>
+      <p class="govuk-body-s">
+        If you have a question, or you’ve had a problem using this service, contact us at
+        <%= mail_to "continuing-professional-development@digital.education.gov.uk", "continuing-professional-development@digital.education.gov.uk", class: "govuk-footer__link govuk-link--no-visited-state" %>
+      </p>
+
+      <% if config[:tech_docs][:footer_links] %>
+        <ul class="govuk-footer__inline-list">
+          <% config[:tech_docs][:footer_links].each do |title, path| %>
+            <li class="govuk-footer__inline-list-item">
+              <a class="govuk-footer__link" href="<%= url_for path %>"><%= title %></a>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
+
+      <svg
+        aria-hidden="true"
+        focusable="false"
+        class="govuk-footer__licence-logo"
+        xmlns="http://www.w3.org/2000/svg"
+        viewbox="0 0 483.2 195.7"
+        height="17"
+        width="41"
+      >
+        <path
+          fill="currentColor"
+          d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
+        />
+      </svg>
+      <span class="govuk-footer__licence-description">
+        All content is available under the
+        <a
+          class="govuk-footer__link"
+          href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+          rel="license"
+        >Open Government Licence v3.0</a>, except where otherwise stated
+      </span>
+    </div>
+    <div class="govuk-footer__meta-item">
+      <a
+        class="govuk-footer__link govuk-footer__copyright-logo"
+        href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
+      >© Crown copyright</a>
+    </div>
+  </div>
+</footer>

--- a/docs/source/layouts/custom.erb
+++ b/docs/source/layouts/custom.erb
@@ -1,0 +1,20 @@
+<%
+wrap_layout :custom_core do
+  html = yield
+
+  content_for(:toc_module, "in-page-navigation")
+
+  use_multipage_nav = current_page.data.fetch(:multipage_nav, config[:tech_docs][:multipage_nav])
+
+  content_for :sidebar do
+    if use_multipage_nav %>
+      <%= multi_page_table_of_contents(sitemap.resources, current_page, config, html) %>
+    <% else %>
+      <%= single_page_table_of_contents(html, max_level: config[:tech_docs][:max_toc_heading_level]) %>
+    <% end %>
+  <%
+  end
+
+  html
+end
+%>

--- a/docs/source/layouts/custom_core.erb
+++ b/docs/source/layouts/custom_core.erb
@@ -1,0 +1,80 @@
+<!doctype html>
+<html lang="en" class="govuk-template no-js">
+  <head>
+    <meta content="IE=edge" http-equiv="X-UA-Compatible">
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+
+    <title><%= meta_tags.browser_title %></title>
+
+    <%= stylesheet_link_tag :manifest %>
+
+    <link rel="canonical" href="<%= meta_tags.canonical_url %>">
+
+    <% meta_tags.tags.each do |name, content| %>
+      <%= tag :meta, name: name, content: content %>
+    <% end %>
+
+    <% meta_tags.opengraph_tags.each do |property, content| %>
+      <%= tag :meta, property: property, content: content %>
+    <% end %>
+
+    <%= yield_content :head %>
+  </head>
+
+  <body class="govuk-template__body">
+    <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+
+    <div class="app-pane">
+      <div class="app-pane__header toc-open-disabled">
+        <a href="#content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+
+        <%= partial 'layouts/header' %>
+      </div>
+
+      <% if content_for? :sidebar %>
+        <div id="toc-heading" class="toc-show fixedsticky">
+          <button type="button" class="toc-show__label js-toc-show" aria-controls="toc">
+            Table of contents <span class="toc-show__icon"></span>
+          </button>
+        </div>
+      <% end %>
+
+      <div class="app-pane__body"<%= " data-module=\"#{yield_content(:toc_module)}\"" if content_for? :toc_module %>>
+        <% if content_for? :sidebar %>
+          <div class="app-pane__toc">
+            <div class="toc" data-module="table-of-contents" tabindex="-1" aria-label="Table of contents" role="dialog">
+              <%= partial "layouts/search" %>
+              <button type="button" class="toc__close js-toc-close" aria-controls="toc" aria-label="Hide table of contents"></button>
+              <nav id="toc" class="js-toc-list toc__list" aria-labelledby="toc-heading"<%= " data-module=\"collapsible-navigation\"" if config[:tech_docs][:collapsible_nav] %>>
+                <%= yield_content :sidebar %>
+              </nav>
+            </div>
+          </div>
+        <% end %>
+
+        <div class="app-pane__content toc-open-disabled" aria-label="Content" tabindex="0">
+          <main id="content" class="technical-documentation" data-module="anchored-headings">
+            <%= yield %>
+            <%= partial "layouts/page_review" %>
+          </main>
+
+          <aside>
+            <% if config[:tech_docs][:show_contribution_banner] %>
+              <ul class="contribution-banner">
+                <li><%= link_to "View source", source_urls.view_source_url %></li>
+                <li><%= link_to "Report problem", source_urls.report_issue_url %></li>
+                <li><%= link_to "GitHub Repo", source_urls.repo_url %></li>
+              </ul>
+            <% end %>
+          </aside>
+
+          <%= partial "layouts/custom_footer" %>
+        </div>
+      </div>
+    </div>
+
+    <%= partial 'layouts/analytics' %>
+    <%= javascript_include_tag :application %>
+  </body>
+</html>


### PR DESCRIPTION
[Jira-3365](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3365)

### Context

We want to make the footer on the API docs consistent with that on the rest of the website.

### Changes proposed in this pull request

- Add support and links to API docs footer

The links are supported by the tech docs gem, however the support paragraph required overriding the footer from the template. Usually in a Middleman template you can just specify a partial in the correct place and it will use it/override for you, however for some reason this doesn't work with the tech docs template. I think because of the way it builds/pulls from the tech docs gem. Instead, I've had to copy the layouts to our repository, rename them and update all pages to use them by default. We can then specify a custom footer.

### Guidance to review

| Before    | After |
| -------- | ------- |
| <img width="1236" alt="Screenshot 2024-08-02 at 11 17 09" src="https://github.com/user-attachments/assets/689fd85d-08f7-4ca9-9ac0-db3e60cad5b2">  | <img width="1236" alt="Screenshot 2024-08-02 at 11 16 49" src="https://github.com/user-attachments/assets/45fbf4e3-e82d-435c-9566-cae79e60241b">   |



