### PR TITLE
Remove alt text from screenshots in API docs

### DIFF
--- a/app/views/lead_providers/content/index.html.erb
+++ b/app/views/lead_providers/content/index.html.erb
@@ -39,7 +39,7 @@
         ) %>
       </div>
       <div class="govuk-grid-column-one-half">
-        <img src="/lead-provider/schools.png" alt="A screenshot of the service showing a list of applications and their statuses.">
+        <img src="/lead-provider/schools.png" alt="">
       </div>
       <div class="govuk-grid-column-full">
         <h2 class="govuk-heading-m">Get support</h2>

--- a/app/views/lead_providers/content/partnership_guide.html.erb
+++ b/app/views/lead_providers/content/partnership_guide.html.erb
@@ -34,7 +34,7 @@
   <li>When you have login you will see this page (with your organisation’s name)</li>
 </ul>
 
-<p class="govuk-body-m"><img src="/lead-provider/start-page.png" alt="Example of a Lead Provider start page"></p>
+<p class="govuk-body-m"><img src="/lead-provider/start-page.png" alt=""></p>
 
 <ul class="govuk-list govuk-list--bullet">
   <li>Select ‘Confirm your schools’</li>
@@ -42,7 +42,7 @@
   <li>Choose the delivery partner that these schools will be working with and press ‘Continue’</li>
 </ul>
 
-<p class="govuk-body-m"><img src="/lead-provider/choose-delivery-partner-page.png" alt="Example of a Choose the delivery partner page"></p>
+<p class="govuk-body-m"><img src="/lead-provider/choose-delivery-partner-page.png" alt=""></p>
 
 <ul class="govuk-list govuk-list--bullet">
   <li>Upload a CSV list for each delivery partner of the schools they will be working with</li>
@@ -57,7 +57,7 @@
       <li>no other data</li>
     </ul>
 
-<p class="govuk-body-m"><img src="/lead-provider/example-csv.png" alt="Example CSV containing a list of school URNs"></p>
+<p class="govuk-body-m"><img src="/lead-provider/example-csv.png" alt=""></p>
 
 <h2 id="how-to-check-csv-upload-errors" class="govuk-heading-l">How to check CSV upload errors</h2>
 
@@ -131,19 +131,19 @@ end %>
   <li>Providers will see a notification when logged into the service, and will receive an email notification:</li></li>
 </ul>
 
-<p class="govuk-body-m"><img src="/lead-provider/email-notification.png" alt="Example email notification of a school rejecting a partnership"></p>
+<p class="govuk-body-m"><img src="/lead-provider/email-notification.png" alt=""></p>
 
 <ul class="govuk-list govuk-list--bullet">
   <li>Select ‘Check your schools’ to see a ‘Reported error’ label next to schools that have reported incorrect partnerships.</li>
 </ul>
 
-<p class="govuk-body-m"><img src="/lead-provider/schools-page-with-error.png" alt="Example school listing page showing a partnership error"></p>
+<p class="govuk-body-m"><img src="/lead-provider/schools-page-with-error.png" alt=""></p>
 
 <ul class="govuk-list govuk-list--bullet">
   <li>Click on that school to see a banner at the top of the page, including the reason they reported this as a mistake.</li>
 </ul>
 
-<p class="govuk-body-m"><img src="/lead-provider/reported-reason.png" alt="Example of a reson being reported"></p>
+<p class="govuk-body-m"><img src="/lead-provider/reported-reason.png" alt=""></p>
 
 <h3 class="govuk-heading-m">If you think the school made a mistake in reporting this</h3>
 
@@ -158,13 +158,13 @@ end %>
   <li>Login to the service to view schools you have confirmed partnership with, see their details and induction tutor contact information</li>
 </ul>
 
-<p class="govuk-body-m"><img src="/lead-provider/schools-page.png" alt="Example showing the page of your schools"></p>
+<p class="govuk-body-m"><img src="/lead-provider/schools-page.png" alt=""></p>
 
 <ul class="govuk-list govuk-list--bullet">
   <li>Click on any school to see more details. ECT and mentor numbers will be zero (0) until data is entered by schools. DfE will update providers before schools start adding them to the service</li>
 </ul>
 
-<p class="govuk-body-m"><img src="/lead-provider/school-page.png" alt="Example showing the details known about a school"></p>
+<p class="govuk-body-m"><img src="/lead-provider/school-page.png" alt=""></p>
 
 <%= render GovukComponent::WarningTextComponent.new(text: "ECT and mentor numbers will be zero (0) until we gather this data from schools. We will update all providers before schools start adding them to the service.") %>
 


### PR DESCRIPTION
### Context

It has been flagged that these images don't provide any additional information for visually impared users and should be set to `null`, which is `alt=""`.

### Changes proposed in this pull request

- Remove alt text from screenshots in API docs

### Guidance to review

