### PR TITLE
Add validation to ensure NPQContract/Statement is present

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -73,11 +73,11 @@ module Api
     end
 
     def identity_transfer_error_response(_exception)
-      render json: { errors: Api::ParamErrorFactory.new(error: I18n.t(:bad_request), params: I18n.t(:contact_us_to_resolve_issue)).call }, status: :unprocessable_entity
+      render json: { errors: Api::ParamErrorFactory.new(error: I18n.t(:unprocessable_request), params: I18n.t(:contact_us_to_resolve_issue)).call }, status: :unprocessable_entity
     end
 
     def missing_npq_contract_or_statement_response(_exception)
-      render json: { errors: Api::ParamErrorFactory.new(error: I18n.t(:bad_request), params: I18n.t(:missing_npq_contract_or_statement)).call }, status: :bad_request
+      render json: { errors: Api::ParamErrorFactory.new(error: I18n.t(:unprocessable_request), params: I18n.t(:missing_npq_contract_or_statement)).call }, status: :unprocessable_entity
     end
   end
 end

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -19,6 +19,7 @@ module Api
     rescue_from Api::Errors::InvalidParticipantOutcomeError, with: :invalid_transition
     rescue_from Api::Errors::InvalidDatetimeError, with: :invalid_updated_since_response
     rescue_from Api::Errors::InvalidTrainingStatusError, with: :invalid_training_status_response
+    rescue_from Api::Errors::MissingNPQContractOrStatementError, with: :missing_npq_contract_or_statement_response
     rescue_from Pagy::VariableError, with: :invalid_pagination_response
     rescue_from Identity::TransferError, with: :identity_transfer_error_response
 
@@ -73,6 +74,10 @@ module Api
 
     def identity_transfer_error_response(_exception)
       render json: { errors: Api::ParamErrorFactory.new(error: I18n.t(:bad_request), params: I18n.t(:contact_us_to_resolve_issue)).call }, status: :unprocessable_entity
+    end
+
+    def missing_npq_contract_or_statement_response(_exception)
+      render json: { errors: Api::ParamErrorFactory.new(error: I18n.t(:bad_request), params: I18n.t(:missing_npq_contract_or_statement)).call }, status: :bad_request
     end
   end
 end

--- a/app/controllers/api/errors/missing_npq_contract_or_statement_error.rb
+++ b/app/controllers/api/errors/missing_npq_contract_or_statement_error.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Api
+  module Errors
+    class MissingNPQContractOrStatementError < StandardError; end
+  end
+end

--- a/app/services/npq/application/accept.rb
+++ b/app/services/npq/application/accept.rb
@@ -195,7 +195,7 @@ module NPQ
         return unless FeatureFlag.active?("npq_capping")
         return if errors.any?
 
-        raise Api::Errors::MissingNPQContractOrStatementError unless npq_contract && statement
+        raise Api::Errors::MissingNPQContractOrStatementError unless statement && npq_contract
       end
 
       def statement

--- a/app/services/npq/application/accept.rb
+++ b/app/services/npq/application/accept.rb
@@ -10,6 +10,7 @@ module NPQ
       attribute :schedule_identifier
       attribute :funded_place
 
+      validate :npq_contract_and_statement_exist
       validates :funded_place,
                 inclusion: {
                   in: [true, false],
@@ -179,13 +180,22 @@ module NPQ
       end
 
       def npq_contract
+        return unless statement
+
         @npq_contract ||=
-          NPQContract.where(
+          NPQContract.find_by(
             cohort_id: cohort.id,
             npq_lead_provider_id: npq_application.npq_lead_provider_id,
             course_identifier: npq_application.npq_course.identifier,
             version: statement.contract_version,
-          ).first
+          )
+      end
+
+      def npq_contract_and_statement_exist
+        return unless FeatureFlag.active?("npq_capping")
+        return if errors.any?
+
+        raise Api::Errors::MissingNPQContractOrStatementError unless npq_contract && statement
       end
 
       def statement

--- a/app/services/npq/application/change_funded_place.rb
+++ b/app/services/npq/application/change_funded_place.rb
@@ -19,6 +19,7 @@ module NPQ
       validate :accepted_application
       validate :eligible_for_funding
       validate :eligible_for_removing_funding_place
+      validate :npq_contract_exists
       validate :cohort_has_funding_cap
 
       def call
@@ -77,6 +78,13 @@ module NPQ
           npq_course: npq_application.npq_course,
           cohort: npq_application.cohort,
         )
+      end
+
+      def npq_contract_exists
+        return unless FeatureFlag.active?("npq_capping")
+        return if errors.any?
+
+        raise Api::Errors::MissingNPQContractOrStatementError unless npq_contract
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,6 +41,7 @@ en:
   bad_parameter: "Bad parameter"
   invalid_transition: "Invalid action"
   contact_us_to_resolve_issue: "Contact us so we can help you resolve the issue"
+  missing_npq_contract_or_statement: "There’s an issue with your contract data. Contact us so we can rectify this for you"
   no_output_fee_statements_for_cohort: "You cannot submit or void declarations for the %{cohort} cohort. The funding contract for this cohort has ended. Get in touch if you need to discuss this with us"
   invalid_page_parameters: "The '#/page[page]' and '#/page[per_page]' parameter values must be a valid number (equal and more than 1)"
   cannot_change_cohort: "You cannot change the '#/cohort' field"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,7 @@ en:
   bad_request: "Bad request"
   bad_parameter: "Bad parameter"
   invalid_transition: "Invalid action"
+  unprocessable_request: "Unprocessable request"
   contact_us_to_resolve_issue: "Contact us so we can help you resolve the issue"
   missing_npq_contract_or_statement: "There’s an issue with your contract data. Contact us so we can rectify this for you"
   no_output_fee_statements_for_cohort: "You cannot submit or void declarations for the %{cohort} cohort. The funding contract for this cohort has ended. Get in touch if you need to discuss this with us"

--- a/spec/requests/api/v1/npq_applications_spec.rb
+++ b/spec/requests/api/v1/npq_applications_spec.rb
@@ -354,14 +354,7 @@ RSpec.describe "NPQ Applications API", type: :request do
 
     describe "NPQ capping" do
       let(:params) { { data: { type: "npq-application-accept", attributes: { funded_place: true } } } }
-
-      before do
-        statement = create(
-          :npq_statement,
-          :next_output_fee,
-          cpd_lead_provider:,
-          cohort: default_npq_application.cohort,
-        )
+      let!(:npq_contract) do
         create(
           :npq_contract,
           npq_lead_provider:,
@@ -370,9 +363,17 @@ RSpec.describe "NPQ Applications API", type: :request do
           version: statement.contract_version,
           funding_cap: 10,
         )
-
-        default_npq_application.update!(eligible_for_funding: true)
       end
+      let(:statement) do
+        create(
+          :npq_statement,
+          :next_output_fee,
+          cpd_lead_provider:,
+          cohort: default_npq_application.cohort,
+        )
+      end
+
+      before { default_npq_application.update!(eligible_for_funding: true) }
 
       context "when feature flag `npq_capping` is disabled" do
         before { FeatureFlag.deactivate(:npq_capping) }
@@ -404,6 +405,17 @@ RSpec.describe "NPQ Applications API", type: :request do
           post("/api/v1/npq-applications/#{default_npq_application.id}/accept", params:, as: :json)
 
           expect(response).to be_successful
+        end
+
+        context "when the NPQContract does not exist" do
+          let(:npq_contract) {}
+
+          it "returns 400" do
+            post("/api/v3/npq-applications/#{default_npq_application.id}/accept", params:, as: :json)
+
+            expect(response).to be_bad_request
+            expect(response.body).to include("There’s an issue with your contract data. Contact us so we can rectify this for you")
+          end
         end
       end
     end
@@ -526,6 +538,15 @@ RSpec.describe "NPQ Applications API", type: :request do
 
         it "returns jsonapi content type header" do
           expect(response.headers["Content-Type"]).to eql("application/vnd.api+json")
+        end
+
+        it "returns 400 when the NPQContract does not exist" do
+          npq_contract.destroy!
+
+          put "/api/v1/npq-applications/#{accepted_application.id}/change-funded-place", params: params.to_json
+
+          expect(response).to be_bad_request
+          expect(response.body).to include("There’s an issue with your contract data. Contact us so we can rectify this for you")
         end
       end
 

--- a/spec/requests/api/v1/npq_applications_spec.rb
+++ b/spec/requests/api/v1/npq_applications_spec.rb
@@ -410,10 +410,10 @@ RSpec.describe "NPQ Applications API", type: :request do
         context "when the NPQContract does not exist" do
           let(:npq_contract) {}
 
-          it "returns 400" do
+          it "returns 422" do
             post("/api/v3/npq-applications/#{default_npq_application.id}/accept", params:, as: :json)
 
-            expect(response).to be_bad_request
+            expect(response.status).to be(422)
             expect(response.body).to include("There’s an issue with your contract data. Contact us so we can rectify this for you")
           end
         end
@@ -472,7 +472,7 @@ RSpec.describe "NPQ Applications API", type: :request do
         post "/api/v1/npq-applications/#{default_npq_application.id}/accept"
 
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(parsed_response.dig("errors", 0, "title")).to eql("Bad request")
+        expect(parsed_response.dig("errors", 0, "title")).to eql("Unprocessable request")
         expect(parsed_response.dig("errors", 0, "detail")).to eql("Contact us so we can help you resolve the issue")
       end
     end
@@ -540,12 +540,12 @@ RSpec.describe "NPQ Applications API", type: :request do
           expect(response.headers["Content-Type"]).to eql("application/vnd.api+json")
         end
 
-        it "returns 400 when the NPQContract does not exist" do
+        it "returns 422 when the NPQContract does not exist" do
           npq_contract.destroy!
 
           put "/api/v1/npq-applications/#{accepted_application.id}/change-funded-place", params: params.to_json
 
-          expect(response).to be_bad_request
+          expect(response.status).to be(422)
           expect(response.body).to include("There’s an issue with your contract data. Contact us so we can rectify this for you")
         end
       end

--- a/spec/requests/api/v1/npq_participants_spec.rb
+++ b/spec/requests/api/v1/npq_participants_spec.rb
@@ -274,13 +274,13 @@ RSpec.describe "NPQ Participants API", type: :request do
       expect(npq_application.profile.reload.schedule).to eq(new_schedule)
     end
 
-    it "returns 400 when the npq_capping feature is enabled and the NPQContract does not exist" do
+    it "returns 422 when the npq_capping feature is enabled and the NPQContract does not exist" do
       contract.destroy!
       FeatureFlag.activate(:npq_capping)
 
       put("/api/v2/participants/npq/#{npq_application.profile.user_id}/change-schedule", params:)
 
-      expect(response).to be_bad_request
+      expect(response.status).to be(422)
       expect(response.body).to include("There’s an issue with your contract data. Contact us so we can rectify this for you")
     end
   end

--- a/spec/requests/api/v1/npq_participants_spec.rb
+++ b/spec/requests/api/v1/npq_participants_spec.rb
@@ -254,9 +254,8 @@ RSpec.describe "NPQ Participants API", type: :request do
       end
     end
     let!(:contract) { create(:npq_contract, npq_course: npq_application.npq_course, npq_lead_provider: npq_application.npq_lead_provider) }
-
-    it "changes the schedules of the specified profile", :aggregate_failures do
-      put "/api/v1/participants/npq/#{npq_application.profile.user_id}/change-schedule", params: {
+    let(:params) do
+      {
         data: {
           type: "participant-change-schedule",
           attributes: {
@@ -266,9 +265,23 @@ RSpec.describe "NPQ Participants API", type: :request do
           },
         },
       }
+    end
+
+    it "changes the schedules of the specified profile", :aggregate_failures do
+      put("/api/v1/participants/npq/#{npq_application.profile.user_id}/change-schedule", params:)
 
       expect(response).to be_successful
       expect(npq_application.profile.reload.schedule).to eq(new_schedule)
+    end
+
+    it "returns 400 when the npq_capping feature is enabled and the NPQContract does not exist" do
+      contract.destroy!
+      FeatureFlag.activate(:npq_capping)
+
+      put("/api/v2/participants/npq/#{npq_application.profile.user_id}/change-schedule", params:)
+
+      expect(response).to be_bad_request
+      expect(response.body).to include("There’s an issue with your contract data. Contact us so we can rectify this for you")
     end
   end
 end

--- a/spec/requests/api/v2/npq_applications_spec.rb
+++ b/spec/requests/api/v2/npq_applications_spec.rb
@@ -394,10 +394,10 @@ RSpec.describe "NPQ Applications API", type: :request do
         context "when the NPQContract does not exist" do
           let(:npq_contract) {}
 
-          it "returns 400" do
+          it "returns 422" do
             post("/api/v2/npq-applications/#{default_npq_application.id}/accept", params:, as: :json)
 
-            expect(response).to be_bad_request
+            expect(response.status).to be(422)
             expect(response.body).to include("There’s an issue with your contract data. Contact us so we can rectify this for you")
           end
         end
@@ -456,7 +456,7 @@ RSpec.describe "NPQ Applications API", type: :request do
         post "/api/v2/npq-applications/#{default_npq_application.id}/accept"
 
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(parsed_response.dig("errors", 0, "title")).to eql("Bad request")
+        expect(parsed_response.dig("errors", 0, "title")).to eql("Unprocessable request")
         expect(parsed_response.dig("errors", 0, "detail")).to eql("Contact us so we can help you resolve the issue")
       end
     end
@@ -524,12 +524,12 @@ RSpec.describe "NPQ Applications API", type: :request do
           expect(response.headers["Content-Type"]).to eql("application/vnd.api+json")
         end
 
-        it "returns 400 when the NPQContract does not exist" do
+        it "returns 422 when the NPQContract does not exist" do
           npq_contract.destroy!
 
           put "/api/v2/npq-applications/#{accepted_application.id}/change-funded-place", params: params.to_json
 
-          expect(response).to be_bad_request
+          expect(response.status).to be(422)
           expect(response.body).to include("There’s an issue with your contract data. Contact us so we can rectify this for you")
         end
       end

--- a/spec/requests/api/v2/npq_participants_spec.rb
+++ b/spec/requests/api/v2/npq_participants_spec.rb
@@ -282,13 +282,13 @@ RSpec.describe "NPQ Participants API", type: :request do
       expect(npq_application.profile.reload.schedule).to eq(new_schedule)
     end
 
-    it "returns 400 when the npq_capping feature is enabled and the NPQContract does not exist" do
+    it "returns 422 when the npq_capping feature is enabled and the NPQContract does not exist" do
       contract.destroy!
       FeatureFlag.activate(:npq_capping)
 
       put("/api/v2/participants/npq/#{npq_application.profile.user_id}/change-schedule", params:)
 
-      expect(response).to be_bad_request
+      expect(response.status).to be(422)
       expect(response.body).to include("There’s an issue with your contract data. Contact us so we can rectify this for you")
     end
   end

--- a/spec/requests/api/v3/npq_applications_spec.rb
+++ b/spec/requests/api/v3/npq_applications_spec.rb
@@ -326,14 +326,7 @@ RSpec.describe "NPQ Applications API", type: :request do
 
     describe "NPQ capping" do
       let(:params) { { data: { type: "npq-application-accept", attributes: { funded_place: true } } } }
-
-      before do
-        statement = create(
-          :npq_statement,
-          :next_output_fee,
-          cpd_lead_provider:,
-          cohort: default_npq_application.cohort,
-        )
+      let!(:npq_contract) do
         create(
           :npq_contract,
           npq_lead_provider:,
@@ -342,9 +335,17 @@ RSpec.describe "NPQ Applications API", type: :request do
           version: statement.contract_version,
           funding_cap: 10,
         )
-
-        default_npq_application.update!(eligible_for_funding: true)
       end
+      let(:statement) do
+        create(
+          :npq_statement,
+          :next_output_fee,
+          cpd_lead_provider:,
+          cohort: default_npq_application.cohort,
+        )
+      end
+
+      before { default_npq_application.update!(eligible_for_funding: true) }
 
       context "when feature flag `npq_capping` is disabled" do
         before { FeatureFlag.deactivate(:npq_capping) }
@@ -376,6 +377,17 @@ RSpec.describe "NPQ Applications API", type: :request do
           post("/api/v3/npq-applications/#{default_npq_application.id}/accept", params:, as: :json)
 
           expect(response).to be_successful
+        end
+
+        context "when the NPQContract does not exist" do
+          let(:npq_contract) {}
+
+          it "returns 400" do
+            post("/api/v3/npq-applications/#{default_npq_application.id}/accept", params:, as: :json)
+
+            expect(response).to be_bad_request
+            expect(response.body).to include("There’s an issue with your contract data. Contact us so we can rectify this for you")
+          end
         end
       end
     end
@@ -606,6 +618,15 @@ RSpec.describe "NPQ Applications API", type: :request do
 
         it "returns jsonapi content type header" do
           expect(response.headers["Content-Type"]).to eql("application/vnd.api+json")
+        end
+
+        it "returns 400 when the NPQContract does not exist" do
+          npq_contract.destroy!
+
+          put "/api/v3/npq-applications/#{accepted_application.id}/change-funded-place", params: params.to_json
+
+          expect(response).to be_bad_request
+          expect(response.body).to include("There’s an issue with your contract data. Contact us so we can rectify this for you")
         end
       end
 

--- a/spec/requests/api/v3/npq_applications_spec.rb
+++ b/spec/requests/api/v3/npq_applications_spec.rb
@@ -382,10 +382,10 @@ RSpec.describe "NPQ Applications API", type: :request do
         context "when the NPQContract does not exist" do
           let(:npq_contract) {}
 
-          it "returns 400" do
+          it "returns 422" do
             post("/api/v3/npq-applications/#{default_npq_application.id}/accept", params:, as: :json)
 
-            expect(response).to be_bad_request
+            expect(response.status).to be(422)
             expect(response.body).to include("There’s an issue with your contract data. Contact us so we can rectify this for you")
           end
         end
@@ -552,7 +552,7 @@ RSpec.describe "NPQ Applications API", type: :request do
         post "/api/v3/npq-applications/#{default_npq_application.id}/accept"
 
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(parsed_response.dig("errors", 0, "title")).to eql("Bad request")
+        expect(parsed_response.dig("errors", 0, "title")).to eql("Unprocessable request")
         expect(parsed_response.dig("errors", 0, "detail")).to eql("Contact us so we can help you resolve the issue")
       end
     end
@@ -620,12 +620,12 @@ RSpec.describe "NPQ Applications API", type: :request do
           expect(response.headers["Content-Type"]).to eql("application/vnd.api+json")
         end
 
-        it "returns 400 when the NPQContract does not exist" do
+        it "returns 422 when the NPQContract does not exist" do
           npq_contract.destroy!
 
           put "/api/v3/npq-applications/#{accepted_application.id}/change-funded-place", params: params.to_json
 
-          expect(response).to be_bad_request
+          expect(response.status).to be(422)
           expect(response.body).to include("There’s an issue with your contract data. Contact us so we can rectify this for you")
         end
       end

--- a/spec/requests/api/v3/npq_participants_spec.rb
+++ b/spec/requests/api/v3/npq_participants_spec.rb
@@ -321,13 +321,13 @@ RSpec.describe "NPQ Participants API", type: :request do
       expect(npq_application.profile.reload.schedule).to eq(new_schedule)
     end
 
-    it "returns 400 when the npq_capping feature is enabled and the NPQContract does not exist" do
+    it "returns 422 when the npq_capping feature is enabled and the NPQContract does not exist" do
       contract.destroy!
       FeatureFlag.activate(:npq_capping)
 
       put("/api/v3/participants/npq/#{npq_application.profile.user_id}/change-schedule", params:)
 
-      expect(response).to be_bad_request
+      expect(response.status).to be(422)
       expect(response.body).to include("There’s an issue with your contract data. Contact us so we can rectify this for you")
     end
   end

--- a/spec/requests/api/v3/npq_participants_spec.rb
+++ b/spec/requests/api/v3/npq_participants_spec.rb
@@ -301,9 +301,8 @@ RSpec.describe "NPQ Participants API", type: :request do
       end
     end
     let!(:contract) { create(:npq_contract, npq_course: npq_application.npq_course, npq_lead_provider: npq_application.npq_lead_provider) }
-
-    it "changes the schedules of the specified profile", :aggregate_failures do
-      put "/api/v3/participants/npq/#{npq_application.profile.user_id}/change-schedule", params: {
+    let(:params) do
+      {
         data: {
           type: "participant-change-schedule",
           attributes: {
@@ -313,9 +312,23 @@ RSpec.describe "NPQ Participants API", type: :request do
           },
         },
       }
+    end
+
+    it "changes the schedules of the specified profile", :aggregate_failures do
+      put("/api/v3/participants/npq/#{npq_application.profile.user_id}/change-schedule", params:)
 
       expect(response).to be_successful
       expect(npq_application.profile.reload.schedule).to eq(new_schedule)
+    end
+
+    it "returns 400 when the npq_capping feature is enabled and the NPQContract does not exist" do
+      contract.destroy!
+      FeatureFlag.activate(:npq_capping)
+
+      put("/api/v3/participants/npq/#{npq_application.profile.user_id}/change-schedule", params:)
+
+      expect(response).to be_bad_request
+      expect(response.body).to include("There’s an issue with your contract data. Contact us so we can rectify this for you")
     end
   end
 

--- a/spec/services/change_schedule_spec.rb
+++ b/spec/services/change_schedule_spec.rb
@@ -721,6 +721,16 @@ RSpec.describe ChangeSchedule do
         let(:participant_profile) { create(:npq_participant_profile, :withdrawn, npq_lead_provider:, npq_course:) }
       end
 
+      context "when the NPQContract is missing" do
+        before { FeatureFlag.activate(:npq_capping) }
+
+        let(:npq_contract) {}
+
+        it "raises an error" do
+          expect { service.call }.to raise_error(::Api::Errors::MissingNPQContractOrStatementError)
+        end
+      end
+
       context "when the cohort is changing" do
         let!(:npq_contract_new_cohort) { create(:npq_contract, :npq_senior_leadership, cohort: new_cohort, npq_lead_provider:, npq_course:) }
         let(:new_schedule) { Finance::Schedule::NPQ.find_by(schedule_identifier: "npq-leadership-spring", cohort: new_cohort) }

--- a/spec/services/npq/application/accept_spec.rb
+++ b/spec/services/npq/application/accept_spec.rb
@@ -545,6 +545,22 @@ RSpec.describe NPQ::Application::Accept do
             expect(service.errors.messages_for(:funded_place)).to include("Set '#/funded_place' to true or false.")
           end
         end
+
+        context "when the NPQContract is missing" do
+          let(:npq_contract) {}
+
+          it "raises an error" do
+            expect { service.call }.to raise_error(::Api::Errors::MissingNPQContractOrStatementError)
+          end
+        end
+
+        context "when the statement is missing" do
+          before { statement.destroy! }
+
+          it "raises an error" do
+            expect { service.call }.to raise_error(::Api::Errors::MissingNPQContractOrStatementError)
+          end
+        end
       end
 
       context "when feature flag `npq_capping` is disabled" do

--- a/spec/services/npq/application/change_funded_place_spec.rb
+++ b/spec/services/npq/application/change_funded_place_spec.rb
@@ -83,6 +83,14 @@ RSpec.describe NPQ::Application::ChangeFundedPlace do
         params.merge!(funded_place: true)
       end
 
+      context "when the NPQContract is missing" do
+        let(:npq_contract) {}
+
+        it "raises an error" do
+          expect { service.call }.to raise_error(::Api::Errors::MissingNPQContractOrStatementError)
+        end
+      end
+
       context "when funded_place is present" do
         before { params.merge!(funded_place: true) }
 


### PR DESCRIPTION
[Jira-3223](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3223)

### Context

In the accept, change schedule and change funded place actions we want to ensure the NPQContract and (for some) the Statement is present when the `npq_capping` feature is enabled.

### Changes proposed in this pull request

- Add validation to ensure NPQContract/Statement is present

Add validation that raises a `Api::Errors::MissingNPQContractOrStatementError`, to be rescued in the API controller and an error message returned.


### Guidance to review

The error is raised so that it can be returned as a `400 bad request` instead of a `422 unprocessable entity`, which would happen if we performed the check as a validation rule in the model.
