### PR TITLE
Add BigQuery maintenance window for DfE Analytics

### DIFF
--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -57,4 +57,7 @@ DfE::Analytics.configure do |config|
   # users that don't use the id field.
   #
   config.user_identifier = proc { |user| user&.id if user.respond_to?(:id) }
+
+  # FIXME: remove this line once the window has passed
+  config.bigquery_maintenance_window = "07-08-2024 18:00..07-08-2024 18:30"
 end


### PR DESCRIPTION
The analytics team are adding some encryption to to tables in BigQuery so we need to stop sending events for a few minutes and have arranged this Wednesday between 18:00 and 18:30 UTC.

You can check this is correctly set by running:

```ruby
DfE::Analytics.parse_maintenance_window

#=> [Wed, 07 Aug 2024 18:00:00.000000000 UTC +00:00, Wed, 07 Aug 2024 18:30:00.000000000 UTC +00:00]
```

