### PR TITLE
Add spacing on API doc bullet links

### DIFF
--- a/docs/source/api-reference/stylesheets/screen.css.scss
+++ b/docs/source/api-reference/stylesheets/screen.css.scss
@@ -10,6 +10,10 @@ $govuk-assets-path: "/api-reference/assets/govuk/assets/";
   font-size: 14px;
 }
 
+.technical-documentation table ul li {
+  padding: 3px 0;
+}
+
 @include govuk-media-query(desktop) {
   .flexbox {
     .app-pane__toc {


### PR DESCRIPTION
[Jira-3368](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3368)

### Context

In order to improve accessibility, we are adding spacing around bulleted links in the API documentation.

### Changes proposed in this pull request

- Add spacing on API doc bullet links

### Guidance to review

| Before    | After |
| -------- | ------- |
| ![before](https://github.com/user-attachments/assets/27369506-f2c1-4c06-950c-b6bdd9759e34)  | ![after](https://github.com/user-attachments/assets/b6283549-2784-42d5-8df3-6e12664acd12)    |


