### PR TITLE
Minor updates to `ChangeServiceFees` script

### DIFF
--- a/app/services/oneoffs/ecf/change_service_fees.rb
+++ b/app/services/oneoffs/ecf/change_service_fees.rb
@@ -23,8 +23,8 @@ module Oneoffs::ECF
       ActiveRecord::Base.transaction do
         contract = create_contract(monthly_service_fee)
 
-        record_info("Current contract version: #{call_off_contract.version}, fee: #{call_off_contract.monthly_service_fee}")
-        record_info("New contract version: #{contract.version}, fee: #{contract.monthly_service_fee}")
+        record_info("Latest contract version: #{latest_call_off_contract.version}, fee: #{format_fee(latest_call_off_contract)}")
+        record_info("New contract version: #{contract.version}, fee: #{format_fee(contract)}")
 
         create_participant_bands(contract)
         update_statement_contract_versions(payment_date_range, contract.version)
@@ -39,16 +39,16 @@ module Oneoffs::ECF
 
     attr_reader :cpd_lead_provider, :cohort
 
-    def call_off_contract
-      @call_off_contract ||= CallOffContract
+    def latest_call_off_contract
+      @latest_call_off_contract ||= CallOffContract
         .where(lead_provider:, cohort:)
         .max_by { |c| Finance::ECF::ContractVersion.new(c.version).numerical_value }
     end
 
     def create_contract(monthly_service_fee)
-      raise CallOffContractNotFoundError unless call_off_contract
+      raise CallOffContractNotFoundError unless latest_call_off_contract
 
-      call_off_contract.dup.tap do |c|
+      latest_call_off_contract.dup.tap do |c|
         c.version = Finance::ECF::ContractVersion.new(c.version).increment!
         c.monthly_service_fee = monthly_service_fee
         c.save!
@@ -56,14 +56,14 @@ module Oneoffs::ECF
     end
 
     def create_participant_bands(contract)
-      call_off_contract.participant_bands.each do |band|
+      latest_call_off_contract.participant_bands.each do |band|
         band.dup.tap { |b| b.call_off_contract = contract }.save!
       end
     end
 
     def update_statement_contract_versions(payment_date_range, contract_version)
       statements(payment_date_range).each do |s|
-        record_info("Updating statement dated: #{s.payment_date}")
+        record_info("Updating statement (#{s.id}) dated: #{s.payment_date} (version: #{s.contract.version}, fee: #{format_fee(s.contract)})")
         s.update!(contract_version:)
       end
     end
@@ -71,6 +71,11 @@ module Oneoffs::ECF
     def statements(payment_date_range)
       @statements ||= Finance::Statement::ECF
         .where(cohort:, cpd_lead_provider:, payment_date: payment_date_range)
+        .order(:payment_date)
+    end
+
+    def format_fee(contract)
+      contract.monthly_service_fee.nil? ? "nil" : contract.monthly_service_fee
     end
   end
 end

--- a/spec/services/oneoffs/ecf/change_service_fees_spec.rb
+++ b/spec/services/oneoffs/ecf/change_service_fees_spec.rb
@@ -59,9 +59,9 @@ describe Oneoffs::ECF::ChangeServiceFees do
       perform_change
 
       expect(instance).to have_recorded_info([
-        "Current contract version: 0.0.2, fee: 10.0",
+        "Latest contract version: 0.0.2, fee: 10.0",
         "New contract version: 0.0.3, fee: 20.0",
-        "Updating statement dated: 2023-10-25",
+        "Updating statement (#{ecf_statement.id}) dated: 2023-10-25 (version: 0.0.2, fee: 10.0)",
       ])
     end
 
@@ -124,6 +124,18 @@ describe Oneoffs::ECF::ChangeServiceFees do
       it { expect { perform_change }.to raise_error(described_class::CallOffContractNotFoundError) }
     end
 
+    context "when the service fees are `nil`" do
+      before { call_off_contract.update!(monthly_service_fee: nil) }
+
+      it "logs out the `nil` value explicitly" do
+        perform_change
+
+        expect(instance).to have_recorded_info([
+          "Latest contract version: 0.0.2, fee: nil",
+        ])
+      end
+    end
+
     context "when dry_run is true" do
       let(:dry_run) { true }
 
@@ -132,9 +144,9 @@ describe Oneoffs::ECF::ChangeServiceFees do
 
         expect(instance).to have_recorded_info([
           "~~~ DRY RUN ~~~",
-          "Current contract version: 0.0.2, fee: 10.0",
+          "Latest contract version: 0.0.2, fee: 10.0",
           "New contract version: 0.0.3, fee: 20.0",
-          "Updating statement dated: 2023-10-25",
+          "Updating statement (#{ecf_statement.id}) dated: 2023-10-25 (version: 0.0.2, fee: 10.0)",
         ])
       end
     end


### PR DESCRIPTION
[Jira-3346](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3346)

### Context

Improve the logging so we can see the statement ids being changed and their current contract versions/service fees. Call out `nil` explicitly as this is different to `0.0` (when `nil` it will fallback to a calculated service fee determined by the bandings).

### Changes proposed in this pull request

- Minor updates to `ChangeServiceFees` script

### Guidance to review

