### PR TITLE
Focus on continue button after selecting file

### DIFF
--- a/app/views/lead_providers/report_schools/csv/show.html.erb
+++ b/app/views/lead_providers/report_schools/csv/show.html.erb
@@ -35,7 +35,7 @@
         </div>
       <% end %>
 
-      <%= f.govuk_file_field :csv, label: { text: 'CSV file' }, accept: 'text/csv' %>
+      <%= f.govuk_file_field :csv, label: { text: 'CSV file' }, accept: 'text/csv', onchange: "document.querySelector('form button').focus();" %>
       <%= f.govuk_submit "Continue" %>
     <% end %>
   </div>


### PR DESCRIPTION
[Jira-3369](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3369)

### Context

On iOS using VoiceOver when selecting a file on the school report CSV upload page the focus resets to the first item on the page (skip to main content).

I can't find anything specific to our web app that would cause this, so I think its default iOS behaviour after a file picker modal appears and then Safari re-gains focus.

To make it more intuitive for the user I've added an `onchange` that will focus on the form submit button once a file has been selected (I tried to refocus on the file input but this doesn't work for some reason).

A side-effect is that this will change for all users; so on desktop the file input would retain focus by default but now it will move to the continue button. Short of adding a voice over/mobile detection library to make this more specific there's not much we can do here.

### Changes proposed in this pull request

- Focus on continue button after selecting file

### Guidance to review

| Before    | After |
| -------- | ------- |
| https://github.com/user-attachments/assets/e8e4d908-afca-4eac-9c25-fb3a99574c52  | https://github.com/user-attachments/assets/b64482d3-f8e1-4b9f-8c37-a356aacb108d   |




