### PR TITLE
[CPDLP-3367] Add missing page titles

### DIFF
--- a/app/views/appropriate_bodies/participants/index.html.erb
+++ b/app/views/appropriate_bodies/participants/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, "Appropriate body participants" %>
+
 <span class="govuk-caption-l">Appropriate body</span>
 <h1 class="govuk-heading-l"><%= @appropriate_body.name %> Participants</h1>
 

--- a/app/views/delivery_partners/delivery_partners/index.html.erb
+++ b/app/views/delivery_partners/delivery_partners/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, "Delivery partner participants" %>
 <% content_for :before_content, govuk_back_link(text: "Back", href: choose_role_path) %>
 
 <div class="govuk-grid-row">


### PR DESCRIPTION
### Context 

- Ticket:[CPDLP-3367]( https://dfedigital.atlassian.net/browse/CPDLP-3367)

We would like to investigate and where we are able to address accessibility issues flagged by the accessibility testing done on ECF.

### Changes proposed in this pull request

Add missing page titles.

Other pages quoted in the ticket have been already fixed on https://github.com/DFE-Digital/early-careers-framework/commit/1a1a376b3d9326b4ba04a9d9158f66a28f208d54

### Guidance to review

Login using delivery partner and appropriate body logins and browse to the participants and show a participant pages to see the updated titles on the page.



[CPDLP-3367]: https://dfedigital.atlassian.net/browse/CPDLP-3367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ