### PR TITLE
Remove email to field from DfE-Analytics data

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -467,7 +467,6 @@
   :emails:
   - id
   - from
-  - to
   - template_id
   - template_version
   - uri


### PR DESCRIPTION
This contains peoles' email addresses and we don't really want them leaking into BQ or logs.
