### PR TITLE
Add 'to' to filter filter_parameter_logging

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -20,4 +20,5 @@ Rails.application.config.filter_parameters += %i[
   trn
   teacher_reference_number
   email
+  to
 ]


### PR DESCRIPTION
This should hopefully stop DfE Analytics including email addresses in the logs.
