### PR TITLE
Select correct contract version for statement importer

### DIFF
--- a/app/services/importers/create_statement.rb
+++ b/app/services/importers/create_statement.rb
@@ -47,7 +47,7 @@ module Importers
 
           next if statement
 
-          contract_version = Finance::Statement::ECF.order(payment_date: :desc).first&.contract_version
+          contract_version = Finance::Statement::ECF.where(cpd_lead_provider:, cohort: statement_data.cohort).order(payment_date: :desc).first&.contract_version
           contract_version ||= "0.0.1"
 
           Finance::Statement::ECF.create!(
@@ -81,7 +81,7 @@ module Importers
 
           next if statement
 
-          contract_version = Finance::Statement::NPQ.order(payment_date: :desc).first&.contract_version
+          contract_version = Finance::Statement::NPQ.where(cpd_lead_provider:, cohort: statement_data.cohort).order(payment_date: :desc).first&.contract_version
           contract_version ||= "0.0.1"
 
           Finance::Statement::NPQ.create!(


### PR DESCRIPTION
[Jira-3395](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-3395)

### Context

Currently, when we import statements we take the latest contract version across all other statements. Instead, we should be selecting the latest (by `payment_date`) scoped to cohort and lead provider.

### Changes proposed in this pull request

- Select correct contract version for statement importer

### Guidance to review

