### PR TITLE
Add `mentor_ineligible_for_funding_reason` to v3 participant serializer

### DIFF
--- a/app/serializers/api/v3/ecf/participant_serializer.rb
+++ b/app/serializers/api/v3/ecf/participant_serializer.rb
@@ -141,7 +141,9 @@ module Api
               induction_end_date: profile.induction_completion_date&.strftime("%Y-%m-%d"),
               mentor_funding_end_date: profile.mentor_completion_date&.strftime("%Y-%m-%d"),
               cohort_changed_after_payments_frozen: profile.cohort_changed_after_payments_frozen,
-            }
+            }.tap do |hash|
+              hash.merge!(mentor_ineligible_for_funding_reason: profile.mentor? ? profile.mentor_completion_reason : nil) unless Rails.env.production?
+            end
           }.compact
         end
 

--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -7,7 +7,7 @@ weight: 8
 
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
 
-## 16 August 2024 
+## 20 August 2024 
 
 We’ve added a field in the API sandbox environment’s participant response bodies to show why funding for a mentor’s training has ended.  
 

--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -7,6 +7,20 @@ weight: 8
 
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
 
+## 16 August 2024 
+
+We’ve added a field in the API sandbox environment’s participant response bodies to show why funding for a mentor’s training has ended.  
+
+This follows feedback from providers who want this information for record keeping.  
+
+The new field is called <code>mentor_funding_end_date_reason</code>. It’ll display 3 possible values:  
+
+- <code>completed_declaration_received</code>. Providers will see this if the mentor has completed their mentor training 
+- <code>completed_during-early_roll_out</code>. This means the mentor completed their training during the pilot period of the ECF (Early Career Framework) programme, so is no longer eligible for funding 
+- <code>started_not_completed</code>. We’ll display this if 2 years has elapsed since a full-time mentor started training. After 2 years, they’re no longer eligible 
+
+We’d welcome feedback on this sandbox update before it goes into production. Providers can contact us via the usual Slack channel if they’ve got any suggestions or concerns.
+
 ## 13 August 2024 
 
 We’ve launched standalone API test environments so providers can manage ECF and NPQ data separately.  

--- a/spec/docs/v3/ecf_participants_spec.rb
+++ b/spec/docs/v3/ecf_participants_spec.rb
@@ -198,6 +198,7 @@ describe "API", type: :request, swagger_doc: "v3/api_spec.json" do
                             induction_end_date: "2022-01-12",
                             mentor_funding_end_date: "2021-04-19",
                             cohort_changed_after_payments_frozen: true,
+                            mentor_ineligible_for_funding_reason: nil,
                           },
                         ],
                         participant_id_changes: [
@@ -362,6 +363,7 @@ describe "API", type: :request, swagger_doc: "v3/api_spec.json" do
                             induction_end_date: "2022-01-12",
                             mentor_funding_end_date: "2021-04-19",
                             cohort_changed_after_payments_frozen: false,
+                            mentor_ineligible_for_funding_reason: nil,
                           },
                         ],
                         participant_id_changes: [

--- a/spec/fixtures/files/api_reference/api_spec.json
+++ b/spec/fixtures/files/api_reference/api_spec.json
@@ -2524,7 +2524,8 @@
                               "created_at": "2021-05-31T02:22:32.000Z",
                               "induction_end_date": "2022-01-12",
                               "mentor_funding_end_date": "2021-04-19",
-                              "cohort_changed_after_payments_frozen": true
+                              "cohort_changed_after_payments_frozen": true,
+                              "mentor_ineligible_for_funding_reason": null
                             }
                           ],
                           "participant_id_changes": [
@@ -2671,7 +2672,8 @@
                               "created_at": "2021-05-31T02:22:32.000Z",
                               "induction_end_date": "2022-01-12",
                               "mentor_funding_end_date": "2021-04-19",
-                              "cohort_changed_after_payments_frozen": false
+                              "cohort_changed_after_payments_frozen": false,
+                              "mentor_ineligible_for_funding_reason": null
                             }
                           ],
                           "participant_id_changes": [
@@ -3427,6 +3429,17 @@
             "type": "boolean",
             "nullable": false,
             "example": true
+          },
+          "mentor_ineligible_for_funding_reason": {
+            "description": "The reason why funding for a mentor's training has ended",
+            "type": "string",
+            "enum": [
+              "completed_declaration_received",
+              "completed_during_early_roll_out",
+              "started_not_completed"
+            ],
+            "nullable": true,
+            "example": "completed_declaration_received"
           }
         }
       },

--- a/spec/fixtures/files/api_reference/api_spec_no_npq.json
+++ b/spec/fixtures/files/api_reference/api_spec_no_npq.json
@@ -1330,7 +1330,8 @@
                               "created_at": "2021-05-31T02:22:32.000Z",
                               "induction_end_date": "2022-01-12",
                               "mentor_funding_end_date": "2021-04-19",
-                              "cohort_changed_after_payments_frozen": true
+                              "cohort_changed_after_payments_frozen": true,
+                              "mentor_ineligible_for_funding_reason": null
                             }
                           ],
                           "participant_id_changes": [
@@ -1477,7 +1478,8 @@
                               "created_at": "2021-05-31T02:22:32.000Z",
                               "induction_end_date": "2022-01-12",
                               "mentor_funding_end_date": "2021-04-19",
-                              "cohort_changed_after_payments_frozen": false
+                              "cohort_changed_after_payments_frozen": false,
+                              "mentor_ineligible_for_funding_reason": null
                             }
                           ],
                           "participant_id_changes": [
@@ -2191,6 +2193,17 @@
             "type": "boolean",
             "nullable": false,
             "example": true
+          },
+          "mentor_ineligible_for_funding_reason": {
+            "description": "The reason why funding for a mentor's training has ended",
+            "type": "string",
+            "enum": [
+              "completed_declaration_received",
+              "completed_during_early_roll_out",
+              "started_not_completed"
+            ],
+            "nullable": true,
+            "example": "completed_declaration_received"
           }
         }
       },

--- a/spec/requests/api/v3/ecf/participants_spec.rb
+++ b/spec/requests/api/v3/ecf/participants_spec.rb
@@ -335,6 +335,7 @@ RSpec.describe "API ECF Participants", type: :request do
                 "induction_end_date": "2022-01-12",
                 "mentor_funding_end_date": nil,
                 "cohort_changed_after_payments_frozen": false,
+                "mentor_ineligible_for_funding_reason": nil,
               }],
               "participant_id_changes": [],
             },

--- a/swagger/v3/api_spec.json
+++ b/swagger/v3/api_spec.json
@@ -2524,7 +2524,8 @@
                               "created_at": "2021-05-31T02:22:32.000Z",
                               "induction_end_date": "2022-01-12",
                               "mentor_funding_end_date": "2021-04-19",
-                              "cohort_changed_after_payments_frozen": true
+                              "cohort_changed_after_payments_frozen": true,
+                              "mentor_ineligible_for_funding_reason": null
                             }
                           ],
                           "participant_id_changes": [
@@ -2671,7 +2672,8 @@
                               "created_at": "2021-05-31T02:22:32.000Z",
                               "induction_end_date": "2022-01-12",
                               "mentor_funding_end_date": "2021-04-19",
-                              "cohort_changed_after_payments_frozen": false
+                              "cohort_changed_after_payments_frozen": false,
+                              "mentor_ineligible_for_funding_reason": null
                             }
                           ],
                           "participant_id_changes": [
@@ -3427,6 +3429,17 @@
             "type": "boolean",
             "nullable": false,
             "example": true
+          },
+          "mentor_ineligible_for_funding_reason": {
+            "description": "The reason why funding for a mentor's training has ended",
+            "type": "string",
+            "enum": [
+              "completed_declaration_received",
+              "completed_during_early_roll_out",
+              "started_not_completed"
+            ],
+            "nullable": true,
+            "example": "completed_declaration_received"
           }
         }
       },

--- a/swagger/v3/component_schemas/ECFEnrolment.yml
+++ b/swagger/v3/component_schemas/ECFEnrolment.yml
@@ -132,3 +132,12 @@ properties:
     description: Identify participants that migrated to a new cohort as payments were frozen on their original cohort
     type: boolean
     example: true
+  mentor_ineligible_for_funding_reason:
+    description: The reason why funding for a mentor's training has ended
+    type: string
+    nullable: true
+    enum:
+      - completed_declaration_received
+      - completed_during_early_roll_out
+      - started_not_completed
+    example: completed_declaration_received


### PR DESCRIPTION
[Jira-2971](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-2971)

### Context

We want to add a new field `mentor_ineligible_for_funding_reason` to the v3 participant serializer, which is populated using the mentor `mentor_completion_reason` attribute. We only want to populate this in non-production environments to begin with.

Add release note describing the change.

### Changes proposed in this pull request

- Add `mentor_ineligible_for_funding_reason` to v3 participant serializer


