### PR TITLE
[1839] Pin terraform kubernetes provider to 2.32.0

### DIFF
--- a/terraform/application/terraform.tf
+++ b/terraform/application/terraform.tf
@@ -8,9 +8,13 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "3.116.0"
     }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+      version = "2.32.0"
+    }
     statuscake = {
       source  = "StatusCakeDev/statuscake"
-      version = ">= 2.0.5"
+      version = "2.2.2"
     }
   }
 }


### PR DESCRIPTION
### Context
Avoid unexpected provider updates. In https://github.com/DFE-Digital/early-careers-framework/pull/5132 we notived the kubernetes provider definition was missing.

- Ticket: https://trello.com/c/moH45K2M

### Changes proposed in this pull request
Pin terraform kubernetes provider to 2.32.0

### Guidance to review
Run: make production terraform-plan