### PR TITLE
Fix spec failures after Cohort rollover

### DIFF
--- a/spec/components/finance/statements/npq_details_table_spec.rb
+++ b/spec/components/finance/statements/npq_details_table_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Finance::Statements::NPQDetailsTable, type: :component do
+RSpec.describe Finance::Statements::NPQDetailsTable, type: :component, mid_cohort: true do
   let(:cohort)              { Cohort.current || create(:cohort, :current) }
   let(:cpd_lead_provider)   { create(:cpd_lead_provider, :with_npq_lead_provider) }
   let(:npq_lead_provider)   { cpd_lead_provider.npq_lead_provider }

--- a/spec/factories/cohorts.rb
+++ b/spec/factories/cohorts.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
   factory :cohort do
     start_year { Faker::Number.unique.between(from: 2022, to: 2100) }
     registration_start_date { Date.new(start_year.to_i, 6, 5) }
-    academic_year_start_date { Date.new(start_year.to_i, 10, 1) }
+    academic_year_start_date { Date.new(start_year.to_i, 9, 1) }
     automatic_assignment_period_end_date { Date.new(start_year.to_i + 1, 3, 31) }
 
     initialize_with do
@@ -16,15 +16,15 @@ FactoryBot.define do
     end
 
     trait :previous do
-      start_year { Date.current.year - (Date.current.month < 10 ? 2 : 1) }
+      start_year { Date.current.year - (Date.current.month < 9 ? 2 : 1) }
     end
 
     trait :current do
-      start_year { Date.current.year - (Date.current.month < 10 ? 1 : 0) }
+      start_year { Date.current.year - (Date.current.month < 9 ? 1 : 0) }
     end
 
     trait :next do
-      start_year { Date.current.year + (Date.current.month < 10 ? 0 : 1) }
+      start_year { Date.current.year + (Date.current.month < 9 ? 0 : 1) }
     end
 
     trait :payments_frozen do

--- a/spec/features/lead_providers/dashboard_page_spec.rb
+++ b/spec/features/lead_providers/dashboard_page_spec.rb
@@ -148,7 +148,7 @@ RSpec.feature "Lead Provider Dashboard", type: :feature, js: true, rutabaga: fal
     when_i_visit_the_schools_page
     and_i_click_on "Big School"
     then_i_should_see "Big School"
-    and_i_should_see "2023 participants"
+    and_i_should_see "#{Cohort.current.start_year} participants"
     and_i_should_see "700001"
     and_i_should_see "Ace Delivery Partner"
     and_i_should_see "Pupil premium above 40%"
@@ -158,7 +158,7 @@ RSpec.feature "Lead Provider Dashboard", type: :feature, js: true, rutabaga: fal
     when_i_visit_the_schools_page
     and_i_click_on "Middle School"
     then_i_should_see "Middle School"
-    and_i_should_see "2023 participants"
+    and_i_should_see "#{Cohort.current.start_year} participants"
     and_i_should_see "700002"
     and_i_should_see "Ace Delivery Partner"
     and_i_should_see "Remote school"
@@ -167,7 +167,7 @@ RSpec.feature "Lead Provider Dashboard", type: :feature, js: true, rutabaga: fal
     when_i_visit_the_schools_page
     and_i_click_on "Small School"
     then_i_should_see "Small School"
-    and_i_should_see "2023 participants"
+    and_i_should_see "#{Cohort.current.start_year} participants"
     and_i_should_see "700003"
     and_i_should_see "Ace Delivery Partner"
     and_i_should_see "Pupil premium above 40% and Remote school"

--- a/spec/features/nominations/choose_how_to_continue_spec.rb
+++ b/spec/features/nominations/choose_how_to_continue_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "./nominate_induction_tutor_steps"
 
-RSpec.feature "School contact making cohort choice journey", type: :feature, js: true, mid_cohort: true do
+RSpec.feature "School contact making cohort choice journey", type: :feature, js: true, early_in_cohort: true do
   include NominateInductionTutorSteps
 
   shared_context "School choosing how to setup their cohort", shared_context: :metadata do

--- a/spec/features/nominations/nominate_induction_tutor_journey_spec.rb
+++ b/spec/features/nominations/nominate_induction_tutor_journey_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "./nominate_induction_tutor_steps"
 
-RSpec.feature "ECT nominate SIT journey", type: :feature, js: true, mid_cohort: true do
+RSpec.feature "ECT nominate SIT journey", type: :feature, js: true, early_in_cohort: true do
   include NominateInductionTutorSteps
 
   let(:academic_year_text) { Cohort.current.description }

--- a/spec/features/scenarios/participants/ect_doing_cip/no_validation_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_cip/no_validation_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "ECT doing CIP: no validation", type: :feature, early_in_cohort: t
   let(:schedule_identifier) { "ecf-standard-september" }
   let(:cip_material_provider) { "Education Development Trust" }
   let(:cip_materials) { "edt" }
-  let(:start_year) { 2023 }
+  let(:start_year) { Cohort.current.start_year }
   let(:registration_completed) { false }
   let(:participant_status) { "active" }
   let(:training_status) { "active" }

--- a/spec/features/scenarios/participants/ect_doing_cip/no_validation_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_cip/no_validation_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "ECT doing CIP: no validation", type: :feature, mid_cohort: true do
+RSpec.feature "ECT doing CIP: no validation", type: :feature, early_in_cohort: true do
   let!(:participant_details) do
     NewSeeds::Scenarios::Participants::Ects::EctNoValidation
       .new(school_cohort:, full_name: participant_full_name)

--- a/spec/features/schools/change_request_support_query/sit_requests_delivery_partner_change_for_academic_year_spec.rb
+++ b/spec/features/schools/change_request_support_query/sit_requests_delivery_partner_change_for_academic_year_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../training_dashboard/manage_training_steps"
 
-RSpec.describe "Induction coordinator requests delivery partner change for academic year", js: true, mid_cohort: true do
+RSpec.describe "Induction coordinator requests delivery partner change for academic year", js: true, early_in_cohort: true do
   include ManageTrainingSteps
 
   scenario "SIT makes support query to change delivery partner" do

--- a/spec/features/schools/change_request_support_query/sit_requests_lead_provider_change_for_a_mentor_spec.rb
+++ b/spec/features/schools/change_request_support_query/sit_requests_lead_provider_change_for_a_mentor_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../training_dashboard/manage_training_steps"
 
-RSpec.describe "Induction coordinator requests lead provider change for a mentor", js: true, mid_cohort: true do
+RSpec.describe "Induction coordinator requests lead provider change for a mentor", js: true, early_in_cohort: true do
   include ManageTrainingSteps
 
   scenario "SIT makes support query to change lead provider" do

--- a/spec/features/schools/change_request_support_query/sit_requests_lead_provider_change_for_a_participant_spec.rb
+++ b/spec/features/schools/change_request_support_query/sit_requests_lead_provider_change_for_a_participant_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../training_dashboard/manage_training_steps"
 
-RSpec.describe "Induction coordinator requests lead provider change for a participant", js: true, mid_cohort: true do
+RSpec.describe "Induction coordinator requests lead provider change for a participant", js: true, early_in_cohort: true do
   include ManageTrainingSteps
 
   scenario "SIT makes support query to change lead provider" do

--- a/spec/features/schools/change_request_support_query/sit_requests_lead_provider_change_for_academic_year_spec.rb
+++ b/spec/features/schools/change_request_support_query/sit_requests_lead_provider_change_for_academic_year_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../training_dashboard/manage_training_steps"
 
-RSpec.describe "Induction coordinator requests lead provider change for academic year", js: true, mid_cohort: true do
+RSpec.describe "Induction coordinator requests lead provider change for academic year", js: true, early_in_cohort: true do
   include ManageTrainingSteps
 
   scenario "SIT makes support query to change lead provider" do

--- a/spec/features/schools/participant_dashboard/completed_induction_participants_spec.rb
+++ b/spec/features/schools/participant_dashboard/completed_induction_participants_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../training_dashboard/manage_training_steps"
 
-RSpec.describe "Manage currently training participants", js: true, mid_cohort: true do
+RSpec.describe "Manage currently training participants", js: true, early_in_cohort: true do
   include ManageTrainingSteps
 
   before do

--- a/spec/features/schools/participant_dashboard/currently_mentoring_mentors_spec.rb
+++ b/spec/features/schools/participant_dashboard/currently_mentoring_mentors_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../training_dashboard/manage_training_steps"
 
-RSpec.describe "Manage currently training participants", js: true, mid_cohort: true do
+RSpec.describe "Manage currently training participants", js: true, early_in_cohort: true do
   include ManageTrainingSteps
 
   before do

--- a/spec/features/schools/participant_dashboard/manage_cip_participants_spec.rb
+++ b/spec/features/schools/participant_dashboard/manage_cip_participants_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../training_dashboard/manage_training_steps"
 
-RSpec.describe "Manage CIP participants", js: true, with_feature_flags: { eligibility_notifications: "active" }, mid_cohort: true do
+RSpec.describe "Manage CIP participants", js: true, with_feature_flags: { eligibility_notifications: "active" }, early_in_cohort: true do
   include ManageTrainingSteps
 
   before do

--- a/spec/features/schools/participant_dashboard/manage_fip_partnered_participants_spec.rb
+++ b/spec/features/schools/participant_dashboard/manage_fip_partnered_participants_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../training_dashboard/manage_training_steps"
 
-RSpec.describe "Manage FIP partnered participants with no change of circumstances", js: true, with_feature_flags: { eligibility_notifications: "active" }, mid_cohort: true do
+RSpec.describe "Manage FIP partnered participants with no change of circumstances", js: true, with_feature_flags: { eligibility_notifications: "active" }, early_in_cohort: true do
   include ManageTrainingSteps
 
   context "inactive change of circumstances flag" do
@@ -14,11 +14,11 @@ end
 RSpec.describe "Manage FIP partnered participants with change of circumstances", js: true, with_feature_flags: { eligibility_notifications: "active" } do
   include ManageTrainingSteps
 
-  context "active change of circumstances flag", mid_cohort: true do
+  context "active change of circumstances flag", early_in_cohort: true do
     it_behaves_like "manage fip participants example"
   end
 
-  context "transferring participants", mid_cohort: true do
+  context "transferring participants", early_in_cohort: true do
     before do
       given_there_is_a_school_that_has_chosen_fip_for_previous_cohort_and_partnered
       and_i_am_signed_in_as_an_induction_coordinator
@@ -53,7 +53,7 @@ RSpec.describe "Manage FIP partnered participants with change of circumstances",
     end
   end
 
-  context "participants that have transferred out", mid_cohort: true do
+  context "participants that have transferred out", early_in_cohort: true do
     before do
       given_there_is_a_school_that_has_chosen_fip_and_partnered
       and_i_have_a_transferred_out_participant
@@ -61,7 +61,7 @@ RSpec.describe "Manage FIP partnered participants with change of circumstances",
       and_i_click(Cohort.current.description)
     end
 
-    scenario "Induction coordinator can view participants that have completed their transfer out", mid_cohort: true do
+    scenario "Induction coordinator can view participants that have completed their transfer out", early_in_cohort: true do
       given_i_am_taken_to_fip_induction_dashboard
       when_i_navigate_to_ect_dashboard
       when_i_filter_by("No longer training (1)")

--- a/spec/features/schools/participant_dashboard/manage_fip_unpartnered_participants_spec.rb
+++ b/spec/features/schools/participant_dashboard/manage_fip_unpartnered_participants_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../training_dashboard/manage_training_steps"
 
-RSpec.describe "Manage FIP unpartnered participants", js: true, with_feature_flags: { eligibility_notifications: "active" }, mid_cohort: true do
+RSpec.describe "Manage FIP unpartnered participants", js: true, with_feature_flags: { eligibility_notifications: "active" }, early_in_cohort: true do
   include ManageTrainingSteps
 
   before do

--- a/spec/features/schools/participant_dashboard/mentor_training_spec.rb
+++ b/spec/features/schools/participant_dashboard/mentor_training_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../training_dashboard/manage_training_steps"
 
-RSpec.describe "Mentor training dashboard", js: true, mid_cohort: true do
+RSpec.describe "Mentor training dashboard", js: true, early_in_cohort: true do
   include ManageTrainingSteps
 
   before do

--- a/spec/features/schools/participant_dashboard/no_longer_training_participants_spec.rb
+++ b/spec/features/schools/participant_dashboard/no_longer_training_participants_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../training_dashboard/manage_training_steps"
 
-RSpec.describe "Manage currently training participants", js: true, mid_cohort: true do
+RSpec.describe "Manage currently training participants", js: true, early_in_cohort: true do
   include ManageTrainingSteps
 
   before do

--- a/spec/features/schools/participant_dashboard/not_mentoring_mentors_spec.rb
+++ b/spec/features/schools/participant_dashboard/not_mentoring_mentors_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../training_dashboard/manage_training_steps"
 
-RSpec.describe "Manage currently training participants", js: true, mid_cohort: true do
+RSpec.describe "Manage currently training participants", js: true, early_in_cohort: true do
   include ManageTrainingSteps
 
   before do

--- a/spec/features/schools/participants/add_participants/add_ect_as_mentor_spec.rb
+++ b/spec/features/schools/participants/add_participants/add_ect_as_mentor_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../../training_dashboard/manage_training_steps"
 
-RSpec.describe "Add ECT as mentor", js: true, mid_cohort: true do
+RSpec.describe "Add ECT as mentor", js: true, early_in_cohort: true do
   include ManageTrainingSteps
 
   before do

--- a/spec/features/schools/participants/add_participants/add_previously_withdrawn_ect_spec.rb
+++ b/spec/features/schools/participants/add_participants/add_previously_withdrawn_ect_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Adding previously withdrawn ECT", type: :feature, js: true, mid_cohort: true do
+RSpec.describe "Adding previously withdrawn ECT", type: :feature, js: true, early_in_cohort: true do
   let(:current_year) { Time.current.year }
   let!(:cohort) { Cohort.current || create(:cohort, start_year: current_year) }
   let(:previous_cohort) { create(:cohort, start_year: cohort.start_year - 1) }

--- a/spec/features/schools/participants/add_participants/payments_frozen/assign_ect_to_mentor_spec.rb
+++ b/spec/features/schools/participants/add_participants/payments_frozen/assign_ect_to_mentor_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 require_relative "../../../training_dashboard/manage_training_steps"
 require_relative "./common_steps"
 
-RSpec.describe "SIT assigns a mentor to an ECT", js: true, mid_cohort: true do
+RSpec.describe "SIT assigns a mentor to an ECT", js: true, early_in_cohort: true do
   include ManageTrainingSteps
 
   scenario "when payments are frozen for cohort" do

--- a/spec/features/schools/participants/add_participants/payments_frozen/sit_adds_ect_spec.rb
+++ b/spec/features/schools/participants/add_participants/payments_frozen/sit_adds_ect_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 require_relative "../../../training_dashboard/manage_training_steps"
 require_relative "./common_steps"
 
-RSpec.describe "SIT adding an ECT", js: true, mid_cohort: true do
+RSpec.describe "SIT adding an ECT", js: true, early_in_cohort: true do
   include ManageTrainingSteps
 
   scenario "when target cohort payments are frozen" do

--- a/spec/features/schools/participants/add_participants/payments_frozen/sit_adds_mentor_spec.rb
+++ b/spec/features/schools/participants/add_participants/payments_frozen/sit_adds_mentor_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 require_relative "../../../training_dashboard/manage_training_steps"
 require_relative "./common_steps"
 
-RSpec.describe "SIT adding mentor", js: true, mid_cohort: true do
+RSpec.describe "SIT adding mentor", js: true, early_in_cohort: true do
   include ManageTrainingSteps
 
   scenario "Induction tutor adds a new mentor when cohort is frozen" do

--- a/spec/features/schools/participants/add_participants/payments_frozen/sit_reregisters_as_mentor_spec.rb
+++ b/spec/features/schools/participants/add_participants/payments_frozen/sit_reregisters_as_mentor_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 require_relative "../../../training_dashboard/manage_training_steps"
 require_relative "./common_steps"
 
-RSpec.describe "SIT adding mentor", js: true, mid_cohort: true do
+RSpec.describe "SIT adding mentor", js: true, early_in_cohort: true do
   include ManageTrainingSteps
 
   scenario "Induction tutor adds themself as mentor using their own email address" do

--- a/spec/features/schools/participants/add_participants/payments_frozen/sit_reregisters_ect_as_mentor_spec.rb
+++ b/spec/features/schools/participants/add_participants/payments_frozen/sit_reregisters_ect_as_mentor_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 require_relative "../../../training_dashboard/manage_training_steps"
 require_relative "./common_steps"
 
-RSpec.describe "SIT adding mentor", js: true, mid_cohort: true do
+RSpec.describe "SIT adding mentor", js: true, early_in_cohort: true do
   include ManageTrainingSteps
 
   scenario "Induction tutor re-registers an ECT as mentor when cohort is frozen" do

--- a/spec/features/schools/participants/add_participants/payments_frozen/transfer_ect_to_another_school_spec.rb
+++ b/spec/features/schools/participants/add_participants/payments_frozen/transfer_ect_to_another_school_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 require_relative "../../../training_dashboard/manage_training_steps"
 require_relative "./common_steps"
 
-RSpec.describe "SIT transfers ECT to another school", js: true, mid_cohort: true do
+RSpec.describe "SIT transfers ECT to another school", js: true, early_in_cohort: true do
   include ManageTrainingSteps
 
   scenario "when target cohort payments are frozen" do

--- a/spec/features/schools/participants/add_participants/payments_frozen/transfer_mentor_to_another_school_spec.rb
+++ b/spec/features/schools/participants/add_participants/payments_frozen/transfer_mentor_to_another_school_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 require_relative "../../../training_dashboard/manage_training_steps"
 require_relative "./common_steps"
 
-RSpec.describe "SIT transfers mentor to another school", js: true, mid_cohort: true do
+RSpec.describe "SIT transfers mentor to another school", js: true, early_in_cohort: true do
   include ManageTrainingSteps
 
   scenario "when target cohort payments are frozen" do

--- a/spec/features/schools/participants/add_participants/reporting_participants_with_trn_spec.rb
+++ b/spec/features/schools/participants/add_participants/reporting_participants_with_trn_spec.rb
@@ -12,7 +12,7 @@ end
 
 require "rails_helper"
 
-RSpec.describe "Reporting participants with a known TRN", type: :feature, js: true, mid_cohort: true do
+RSpec.describe "Reporting participants with a known TRN", type: :feature, js: true, early_in_cohort: true do
   let!(:cohort) { Cohort.previous || create(:cohort, :previous) }
   let!(:next_cohort) { Cohort.current || create(:cohort, :current) }
   let!(:current_cohort) { Cohort.current || create(:cohort, :current) }

--- a/spec/features/schools/participants/add_participants/unhappy_path_already_on_ecf_training_spec.rb
+++ b/spec/features/schools/participants/add_participants/unhappy_path_already_on_ecf_training_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../../training_dashboard/manage_training_steps"
 
-RSpec.describe "Add participants", js: true, mid_cohort: true do
+RSpec.describe "Add participants", js: true, early_in_cohort: true do
   include ManageTrainingSteps
 
   before do

--- a/spec/features/schools/participants/add_participants/unhappy_path_can_validate_with_nino_spec.rb
+++ b/spec/features/schools/participants/add_participants/unhappy_path_can_validate_with_nino_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../../training_dashboard/manage_training_steps"
 
-RSpec.describe "Add participants", js: true, mid_cohort: true do
+RSpec.describe "Add participants", js: true, early_in_cohort: true do
   include ManageTrainingSteps
 
   before do

--- a/spec/features/schools/participants/add_participants/unhappy_path_cannot_validate_with_nino_spec.rb
+++ b/spec/features/schools/participants/add_participants/unhappy_path_cannot_validate_with_nino_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../../training_dashboard/manage_training_steps"
 
-RSpec.describe "Add participants", js: true, mid_cohort: true do
+RSpec.describe "Add participants", js: true, early_in_cohort: true do
   include ManageTrainingSteps
 
   before do

--- a/spec/features/schools/participants/add_participants/unhappy_path_email_taken_spec.rb
+++ b/spec/features/schools/participants/add_participants/unhappy_path_email_taken_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../../training_dashboard/manage_training_steps"
 
-RSpec.describe "Add participants", js: true, mid_cohort: true do
+RSpec.describe "Add participants", js: true, early_in_cohort: true do
   include ManageTrainingSteps
 
   before do

--- a/spec/features/schools/participants/add_participants/unhappy_path_sit_error_entering_validation_info_spec.rb
+++ b/spec/features/schools/participants/add_participants/unhappy_path_sit_error_entering_validation_info_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../../training_dashboard/manage_training_steps"
 
-RSpec.describe "Add participants", js: true, mid_cohort: true do
+RSpec.describe "Add participants", js: true, early_in_cohort: true do
   include ManageTrainingSteps
 
   before do

--- a/spec/features/schools/participants/transferring_participants/already_enrolled_at_school_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/already_enrolled_at_school_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Transferring participants", type: :feature, js: true, rutabaga: false, mid_cohort: true do
+RSpec.describe "Transferring participants", type: :feature, js: true, rutabaga: false, early_in_cohort: true do
   context "Participant is already enrolled at the school" do
     before do
       set_participant_data

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/allow_withdrawn_participant_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/allow_withdrawn_participant_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe "transferring a withdrawn participant", type: :feature, js: true 
   def when_i_add_a_valid_start_date
     legend = "When is #{@participant_data[:full_name]} moving to your school?"
 
-    fill_in_date(legend, with: "2023-10-24")
+    fill_in_date(legend, with: "#{Cohort.current.start_year}-10-24")
   end
 
   def when_i_assign_a_mentor

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_different_partner_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_different_partner_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Transferring ECT is with a different lead provider", type: :feature, js: true, mid_cohort: true do
+RSpec.describe "Transferring ECT is with a different lead provider", type: :feature, js: true, early_in_cohort: true do
   before do
     allow_participant_transfer_mailers
     set_participant_data

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_no_change_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_no_change_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "ECT has matching lead provider and delivery partner", type: :feature, js: true, mid_cohort: true do
+RSpec.describe "ECT has matching lead provider and delivery partner", type: :feature, js: true, early_in_cohort: true do
   before do
     allow_participant_transfer_mailers
     set_participant_data

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_no_change_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_no_change_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe "ECT has matching lead provider and delivery partner", type: :fea
   def when_i_add_an_invalid_start_date
     legend = "When is #{@participant_data[:full_name]} moving to your school?"
 
-    fill_in_date(legend, with: "25-10-25")
+    fill_in_date(legend, with: "25-10-32")
   end
 
   def when_i_add_a_valid_start_date

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_different_partner_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_different_partner_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Transferring a mentor with a different provider", type: :feature, js: true, mid_cohort: true do
+RSpec.describe "Transferring a mentor with a different provider", type: :feature, js: true, early_in_cohort: true do
   before do
     allow_participant_transfer_mailers
     set_participant_data

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_no_change_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_no_change_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Transferring a mentor weith matching lead provider and delivery partner", type: :feature, js: true, mid_cohort: true do
+RSpec.describe "Transferring a mentor weith matching lead provider and delivery partner", type: :feature, js: true, early_in_cohort: true do
   before do
     allow_participant_transfer_mailers
     set_participant_data

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_no_change_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_no_change_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe "Transferring a mentor weith matching lead provider and delivery 
   def when_i_add_a_valid_start_date
     legend = "When is #{@participant_data[:full_name]} moving to your school?"
 
-    fill_in_date(legend, with: "2023-10-24")
+    fill_in_date(legend, with: "#{Cohort.current.start_year}-10-24")
   end
 
   def when_i_select(option)

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/unhappy_path_cannot_validate_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/unhappy_path_cannot_validate_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "transferring participants", type: :feature, js: true, mid_cohort: true do
+RSpec.describe "transferring participants", type: :feature, js: true, early_in_cohort: true do
   context "Attempting to transfer an ECT to a school" do
     context "ECT cannot be validated" do
       before do

--- a/spec/features/schools/participants/update_participants_details_spec.rb
+++ b/spec/features/schools/participants/update_participants_details_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../training_dashboard/manage_training_steps"
 
-RSpec.describe "Changing participant details from check answers", type: :feature, js: true, mid_cohort: true do
+RSpec.describe "Changing participant details from check answers", type: :feature, js: true, early_in_cohort: true do
   include ManageTrainingSteps
 
   before do
@@ -87,7 +87,7 @@ RSpec.describe "Changing participant details from check answers", type: :feature
   end
 end
 
-RSpec.describe "Changing participant details from the dashboard", type: :feature, js: true, mid_cohort: true do
+RSpec.describe "Changing participant details from the dashboard", type: :feature, js: true, early_in_cohort: true do
   include ManageTrainingSteps
 
   before do

--- a/spec/features/schools/training_dashboard/manage_design_our_own_training_spec.rb
+++ b/spec/features/schools/training_dashboard/manage_design_our_own_training_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "./manage_training_steps"
 
-RSpec.describe "Manage Design Our Own training", js: true, mid_cohort: true do
+RSpec.describe "Manage Design Our Own training", js: true, early_in_cohort: true do
   include ManageTrainingSteps
 
   scenario "Design Our Own Induction Coordinator" do

--- a/spec/features/schools/training_dashboard/manage_no_ect_training_spec.rb
+++ b/spec/features/schools/training_dashboard/manage_no_ect_training_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "./manage_training_steps"
 
-RSpec.describe "Manage No ECT training", js: true, mid_cohort: true do
+RSpec.describe "Manage No ECT training", js: true, early_in_cohort: true do
   include ManageTrainingSteps
 
   scenario "Manage No ECT Induction Coordinator" do

--- a/spec/features/schools/training_dashboard/manage_schools_spec.rb
+++ b/spec/features/schools/training_dashboard/manage_schools_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "./manage_training_steps"
 
-RSpec.feature "School Tutors should be able to manage schools", type: :feature, js: true, rutabaga: false, mid_cohort: true do
+RSpec.feature "School Tutors should be able to manage schools", type: :feature, js: true, rutabaga: false, early_in_cohort: true do
   include ManageTrainingSteps
 
   scenario "Change school" do

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -1234,7 +1234,7 @@ module ManageTrainingSteps
   end
 
   def then_i_am_taken_to_the_support_form_for_changing_an_induction_programme
-    expect(page).to have_text("Complete this form to tell us that you want to use a different training programme option for ECTs and mentors who started their training in the 2022 to 2023 academic year.")
+    expect(page).to have_text("Complete this form to tell us that you want to use a different training programme option for ECTs and mentors who started their training in the #{Cohort.current.start_year} to #{Cohort.current.start_year + 1} academic year.")
   end
 
   def then_i_am_taken_to_sign_up_to_training_provider_page

--- a/spec/fixtures/files/importers/cohort_csv_data.csv
+++ b/spec/fixtures/files/importers/cohort_csv_data.csv
@@ -1,2 +1,2 @@
 start-year,registration-start-date,academic-year-start-date,npq-registration-start-date,automatic-assignment-period-end-date,payments-frozen-at
-2025,2025/05/10,2025/09/01,2026/03/31,
+2026,2026/05/10,2026/09/01,2027/03/31,

--- a/spec/fixtures/files/importers/cohort_csv_data.csv
+++ b/spec/fixtures/files/importers/cohort_csv_data.csv
@@ -1,2 +1,2 @@
 start-year,registration-start-date,academic-year-start-date,npq-registration-start-date,automatic-assignment-period-end-date,payments-frozen-at
-2026,2026/05/10,2026/10/01,2027/03/31,
+2025,2025/05/10,2025/09/01,2026/03/31,

--- a/spec/fixtures/files/importers/cohort_lead_provider_csv_data.csv
+++ b/spec/fixtures/files/importers/cohort_lead_provider_csv_data.csv
@@ -1,2 +1,2 @@
 lead-provider-name,cohort-start-year
-Ambition Institute,2025
+Ambition Institute,2026

--- a/spec/fixtures/files/importers/cohort_lead_provider_csv_data.csv
+++ b/spec/fixtures/files/importers/cohort_lead_provider_csv_data.csv
@@ -1,2 +1,2 @@
 lead-provider-name,cohort-start-year
-Ambition Institute,2026
+Ambition Institute,2025

--- a/spec/fixtures/files/importers/contract_csv_data.csv
+++ b/spec/fixtures/files/importers/contract_csv_data.csv
@@ -1,2 +1,2 @@
 lead-provider-name,cohort-start-year,uplift-target,uplift-amount,recruitment-target,revised-target,set-up-fee,monthly-service-fee,band-a-min,band-a-max,band-a-per-participant,band-b-min,band-b-max,band-b-per-participant,band-c-min,band-c-max,band-c-per-participant,band-d-min,band-d-max,band-d-per-participant
-Ambition Institute,2026,0.44,200,4600,4790,0,0,90,895,91,199,700,200,299,600,300,400,500
+Ambition Institute,2025,0.44,200,4600,4790,0,0,90,895,91,199,700,200,299,600,300,400,500

--- a/spec/fixtures/files/importers/contract_csv_data.csv
+++ b/spec/fixtures/files/importers/contract_csv_data.csv
@@ -1,2 +1,2 @@
 lead-provider-name,cohort-start-year,uplift-target,uplift-amount,recruitment-target,revised-target,set-up-fee,monthly-service-fee,band-a-min,band-a-max,band-a-per-participant,band-b-min,band-b-max,band-b-per-participant,band-c-min,band-c-max,band-c-per-participant,band-d-min,band-d-max,band-d-per-participant
-Ambition Institute,2025,0.44,200,4600,4790,0,0,90,895,91,199,700,200,299,600,300,400,500
+Ambition Institute,2026,0.44,200,4600,4790,0,0,90,895,91,199,700,200,299,600,300,400,500

--- a/spec/fixtures/files/importers/schedule_csv_data.csv
+++ b/spec/fixtures/files/importers/schedule_csv_data.csv
@@ -1,2 +1,2 @@
 type,schedule-identifier,schedule-name,schedule-cohort-year,milestone-name,milestone-declaration-type,milestone-start-date,milestone-date,milestone-payment-date
-ecf_standard,ecf-standard-september,ECF Standard September,2025,Output 1 - Participant Start,started,2024/09/01,2024/11/30,2024/11/30
+ecf_standard,ecf-standard-september,ECF Standard September,2026,Output 1 - Participant Start,started,2024/09/01,2024/11/30,2024/11/30

--- a/spec/fixtures/files/importers/schedule_csv_data.csv
+++ b/spec/fixtures/files/importers/schedule_csv_data.csv
@@ -1,2 +1,2 @@
 type,schedule-identifier,schedule-name,schedule-cohort-year,milestone-name,milestone-declaration-type,milestone-start-date,milestone-date,milestone-payment-date
-ecf_standard,ecf-standard-september,ECF Standard September,2026,Output 1 - Participant Start,started,2024/09/01,2024/11/30,2024/11/30
+ecf_standard,ecf-standard-september,ECF Standard September,2025,Output 1 - Participant Start,started,2024/09/01,2024/11/30,2024/11/30

--- a/spec/fixtures/files/importers/statement_csv_data.csv
+++ b/spec/fixtures/files/importers/statement_csv_data.csv
@@ -1,2 +1,2 @@
 type,name,cohort,deadline_date,payment_date,output_fee
-ecf,September 2026,2026,2026-09-01,2026-11-25,true
+ecf,September 2025,2025,2025-09-01,2025-11-25,true

--- a/spec/fixtures/files/importers/statement_csv_data.csv
+++ b/spec/fixtures/files/importers/statement_csv_data.csv
@@ -1,2 +1,2 @@
 type,name,cohort,deadline_date,payment_date,output_fee
-ecf,September 2025,2025,2025-09-01,2025-11-25,true
+ecf,September 2026,2026,2026-09-01,2026-11-25,true

--- a/spec/forms/schools/add_participants/transfer_wizard_spec.rb
+++ b/spec/forms/schools/add_participants/transfer_wizard_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Schools::AddParticipants::TransferWizard, type: :model, mid_cohort: true do
+RSpec.describe Schools::AddParticipants::TransferWizard, type: :model, early_in_cohort: true do
   let(:cohort) { Cohort.previous || create(:cohort, :previous) }
   let(:next_cohort) { Cohort.current || create(:cohort, :current) }
   let(:data_store) do

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Cohort, type: :model do
     describe ".ordered_by_start_year" do
       it "orders the cohorts by year ascending" do
         expect(Cohort.ordered_by_start_year.to_sql).to include(%(ORDER BY "cohorts"."start_year" ASC))
-        expect(Cohort.ordered_by_start_year.map(&:start_year)).to eql([2020, 2021, 2022, 2023, 2024, 2025])
+        expect(Cohort.ordered_by_start_year.map(&:start_year)).to eql([2020, 2021, 2022, 2023, 2024])
       end
     end
   end
@@ -40,7 +40,7 @@ RSpec.describe Cohort, type: :model do
   describe ".current" do
     describe "when the current date matches the academic year start date" do
       it "returns the cohort with start_year the current year" do
-        Timecop.freeze(Date.new(2021, 10, 1)) do
+        Timecop.freeze(Date.new(2021, 9, 1)) do
           expect(Cohort.current.start_year).to eq 2021
         end
       end
@@ -71,7 +71,7 @@ RSpec.describe Cohort, type: :model do
     end
 
     context "when the provided date is in 2021 since September" do
-      let(:induction_start_date) { Date.new(2021, 10, 1) }
+      let(:induction_start_date) { Date.new(2021, 9, 1) }
 
       it { is_expected.to eq(Cohort.find_by_start_year(2021)) }
     end
@@ -92,7 +92,7 @@ RSpec.describe Cohort, type: :model do
   describe ".next" do
     describe "when the current date matches the academic year start date" do
       it "returns the cohort with start_year the next year" do
-        Timecop.freeze(Date.new(2021, 10, 1)) do
+        Timecop.freeze(Date.new(2021, 9, 1)) do
           expect(Cohort.next.start_year).to eq 2022
         end
       end
@@ -110,7 +110,7 @@ RSpec.describe Cohort, type: :model do
   describe ".previous" do
     describe "when exactly 1 year ago matches the academic year start date" do
       it "returns the cohort with start_year the previous year" do
-        Timecop.freeze(Date.new(2021, 10, 10)) do
+        Timecop.freeze(Date.new(2021, 9, 10)) do
           expect(Cohort.previous.start_year).to eq 2020
         end
       end
@@ -127,14 +127,14 @@ RSpec.describe Cohort, type: :model do
 
   describe ".containing_date" do
     it "returns the cohort which contains the given date" do
-      expect(Cohort.containing_date(Date.new(2021, 10, 1)).start_year).to eq 2021
-      expect(Cohort.containing_date(Date.new(2022, 10, 10)).start_year).to eq 2022
+      expect(Cohort.containing_date(Date.new(2021, 9, 1)).start_year).to eq 2021
+      expect(Cohort.containing_date(Date.new(2022, 9, 10)).start_year).to eq 2022
       expect(Cohort.containing_date(Date.new(2023, 1, 10)).start_year).to eq 2022
       expect(Cohort.containing_date(Date.new(2024, 3, 22)).start_year).to eq 2023
     end
 
     context "when outside the currently added cohorts" do
-      let(:oob_date) { Date.new(Cohort.maximum(:start_year) + 1, 10, 1) }
+      let(:oob_date) { Date.new(Cohort.maximum(:start_year) + 1, 9, 1) }
 
       it "returns nil" do
         expect(Cohort.containing_date(oob_date)).to be_nil
@@ -144,7 +144,7 @@ RSpec.describe Cohort, type: :model do
 
   describe ".within_next_registration_period?" do
     before do
-      Cohort.find_by(start_year: 2023).update!(registration_start_date: Date.new(2023, 6, 1), academic_year_start_date: Date.new(2023, 10, 1))
+      Cohort.find_by(start_year: 2023).update!(registration_start_date: Date.new(2023, 6, 1), academic_year_start_date: Date.new(2023, 9, 1))
     end
 
     context "when the current time is after the registration start date for then next cohort" do
@@ -157,7 +157,7 @@ RSpec.describe Cohort, type: :model do
 
     context "when the active_registration_cohort and the current cohort are the same" do
       it "returns false" do
-        Timecop.freeze(Date.new(2023, 10, 1)) do
+        Timecop.freeze(Date.new(2023, 9, 1)) do
           expect(Cohort).not_to be_within_next_registration_period
         end
       end

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Cohort, type: :model do
     describe ".ordered_by_start_year" do
       it "orders the cohorts by year ascending" do
         expect(Cohort.ordered_by_start_year.to_sql).to include(%(ORDER BY "cohorts"."start_year" ASC))
-        expect(Cohort.ordered_by_start_year.map(&:start_year)).to eql([2020, 2021, 2022, 2023, 2024])
+        expect(Cohort.ordered_by_start_year.map(&:start_year)).to eql([2020, 2021, 2022, 2023, 2024, 2025])
       end
     end
   end

--- a/spec/models/participant_declaration/ecf_spec.rb
+++ b/spec/models/participant_declaration/ecf_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ParticipantDeclaration::ECF do
+RSpec.describe ParticipantDeclaration::ECF, mid_cohort: true do
   describe "#uplift_paid?" do
     %i[paid awaiting_clawback clawed_back].each do |declaration_state|
       context "started - ecf-induction - #{declaration_state} - sparsity_uplift" do

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "participant-declarations endpoint spec", type: :request do
+RSpec.describe "participant-declarations endpoint spec", type: :request, mid_cohort: true do
   let(:cpd_lead_provider)    { create(:cpd_lead_provider, :with_lead_provider) }
   let(:token)                { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider:) }
   let(:bearer_token)         { "Bearer #{token}" }

--- a/spec/requests/api/v2/participant_declarations_spec.rb
+++ b/spec/requests/api/v2/participant_declarations_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "participant-declarations endpoint spec", type: :request do
+RSpec.describe "participant-declarations endpoint spec", type: :request, mid_cohort: true do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
   let(:started_milestone) { ect_profile.schedule.milestones.find_by(declaration_type: "started") }
   let(:declaration_date)  { started_milestone.start_date }

--- a/spec/requests/api/v3/participant_declarations_spec.rb
+++ b/spec/requests/api/v3/participant_declarations_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "API Participant Declarations", type: :request do
+RSpec.describe "API Participant Declarations", type: :request, mid_cohort: true do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
 
   let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider:) }

--- a/spec/requests/finance/ecf/assurance_reports_spec.rb
+++ b/spec/requests/finance/ecf/assurance_reports_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Finance::ECF::AssuranceReportsController do
+RSpec.describe Finance::ECF::AssuranceReportsController, mid_cohort: true do
   let(:user)                    { create(:user, :finance) }
   let(:cpd_lead_provider)       { create(:cpd_lead_provider, :with_lead_provider) }
   let(:lead_provider)           { cpd_lead_provider.lead_provider }

--- a/spec/requests/finance/npq/assurance_reports_spec.rb
+++ b/spec/requests/finance/npq/assurance_reports_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Finance::NPQ::AssuranceReportsController do
+RSpec.describe Finance::NPQ::AssuranceReportsController, mid_cohort: true do
   let(:user)                    { create(:user, :finance) }
   let(:cpd_lead_provider)       { create(:cpd_lead_provider, :with_npq_lead_provider) }
   let(:npq_lead_provider)       { cpd_lead_provider.npq_lead_provider }

--- a/spec/requests/nominations/choose_how_to_continue_spec.rb
+++ b/spec/requests/nominations/choose_how_to_continue_spec.rb
@@ -24,7 +24,7 @@ RSpec.shared_examples "redirects to start nomination" do |how_to_continue|
   end
 end
 
-RSpec.describe "Choosing how to continue with nominations", type: :request, mid_cohort: true do
+RSpec.describe "Choosing how to continue with nominations", type: :request, early_in_cohort: true do
   let!(:cohort) { create(:cohort, :current) }
 
   describe "GET /nominations/start" do

--- a/spec/requests/schools/core_programme/materials_spec.rb
+++ b/spec/requests/schools/core_programme/materials_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Schools::CoreProgramme::Materials", type: :request, mid_cohort: true do
+RSpec.describe "Schools::CoreProgramme::Materials", type: :request, early_in_cohort: true do
   let(:user) { create(:user, :induction_coordinator) }
   let(:school) { user.induction_coordinator_profile.schools.first }
   let!(:cohort) { Cohort.current || create(:cohort, :current) }

--- a/spec/requests/schools/dashboard_spec.rb
+++ b/spec/requests/schools/dashboard_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Schools::Dashboard", type: :request do
   let(:school) { user.schools.first }
 
   before do
-    travel_to Date.new(2022, 10, 1)
+    travel_to Date.new(2022, 9, 1)
     sign_in user
   end
 

--- a/spec/requests/schools/early_career_teachers_request_spec.rb
+++ b/spec/requests/schools/early_career_teachers_request_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Schools::EarlyCareerTeachers", type: :request, js: true, with_feature_flags: { eligibility_notifications: "active" }, mid_cohort: true do
+RSpec.describe "Schools::EarlyCareerTeachers", type: :request, js: true, with_feature_flags: { eligibility_notifications: "active" }, early_in_cohort: true do
   let(:user) { create(:user, :induction_coordinator, school_ids: [school.id]) }
   let!(:lead_provider) { create(:cpd_lead_provider, :with_lead_provider, name: "Lead Provider").lead_provider }
 

--- a/spec/requests/schools/mentors_request_spec.rb
+++ b/spec/requests/schools/mentors_request_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Schools::Participants", type: :request, js: true, with_feature_flags: { eligibility_notifications: "active" }, mid_cohort: true do
+RSpec.describe "Schools::Participants", type: :request, js: true, with_feature_flags: { eligibility_notifications: "active" }, early_in_cohort: true do
   let(:user) { create(:user, :induction_coordinator, school_ids: [school.id]) }
   let!(:lead_provider) { create(:cpd_lead_provider, :with_lead_provider, name: "Lead Provider").lead_provider }
 

--- a/spec/requests/schools/participants_request_spec.rb
+++ b/spec/requests/schools/participants_request_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Schools::Participants", type: :request, js: true, with_feature_flags: { eligibility_notifications: "active" }, mid_cohort: true do
+RSpec.describe "Schools::Participants", type: :request, js: true, with_feature_flags: { eligibility_notifications: "active" }, early_in_cohort: true do
   let(:user) { create(:user, :induction_coordinator, school_ids: [school.id]) }
   let!(:lead_provider) { create(:cpd_lead_provider, :with_lead_provider, name: "Lead Provider").lead_provider }
 

--- a/spec/requests/schools/partnerships_spec.rb
+++ b/spec/requests/schools/partnerships_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Schools::Partnerships", type: :request, mid_cohort: true do
+RSpec.describe "Schools::Partnerships", type: :request, early_in_cohort: true do
   let(:user) { create(:user, :induction_coordinator) }
   let!(:school) { user.induction_coordinator_profile.schools.first }
   let(:cohort) { Cohort.current || create(:cohort, :current) }

--- a/spec/serializers/finance/ecf/duplicate_serializer_spec.rb
+++ b/spec/serializers/finance/ecf/duplicate_serializer_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Finance::ECF::DuplicateSerializer do
         cohort: Cohort.current.display_name,
         training_status: "active",
         induction_status: "active",
-        start_date: participant_declaration.declaration_date.rfc3339,
+        start_date: Cohort.current.academic_year_start_date.rfc3339,
         end_date: nil,
         school_transfer: false,
       )
@@ -53,7 +53,7 @@ RSpec.describe Finance::ECF::DuplicateSerializer do
       result = subject.serializable_hash
       expect(result[:data][:attributes][:participant_declarations][0]).to include(
         declaration_type: "started",
-        declaration_date: participant_declaration.declaration_date.rfc3339,
+        declaration_date: Cohort.current.academic_year_start_date.rfc3339,
         course_identifier: "ecf-induction",
       )
     end

--- a/spec/services/change_schedule_spec.rb
+++ b/spec/services/change_schedule_spec.rb
@@ -135,7 +135,11 @@ RSpec.shared_examples "changing schedule after migrating from a payments frozen 
       it { expect { service.call }.to change { participant_profile.reload.schedule_id }.to(new_schedule.id) }
 
       context "when they have declarations in a non-frozen cohort" do
-        before { create(:participant_declaration, participant_profile:, declaration_type: "retained-1", cohort: new_cohort, state:, course_identifier:, cpd_lead_provider:) }
+        before do
+          travel_to(participant_profile.schedule.milestones.find_by(declaration_type: "retained-1").start_date) do
+            create(:participant_declaration, participant_profile:, declaration_type: "retained-1", cohort: new_cohort, state:, course_identifier:, cpd_lead_provider:)
+          end
+        end
 
         it { is_expected.to be_invalid }
       end

--- a/spec/services/finance/ecf/assurance_report/query_spec.rb
+++ b/spec/services/finance/ecf/assurance_report/query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Finance::ECF::AssuranceReport::Query do
+RSpec.describe Finance::ECF::AssuranceReport::Query, mid_cohort: true do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
   let(:statement) { create(:ecf_statement, cpd_lead_provider:) }
 

--- a/spec/services/finance/ecf/output_calculator_spec.rb
+++ b/spec/services/finance/ecf/output_calculator_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Finance::ECF::OutputCalculator do
+RSpec.describe Finance::ECF::OutputCalculator, mid_cohort: true do
   let(:first_statement) { create(:ecf_statement, cpd_lead_provider:, payment_date: 6.months.ago) }
   let(:second_statement) { create(:ecf_statement, cpd_lead_provider:, payment_date: 4.months.ago) }
   let(:third_statement) { create(:ecf_statement, cpd_lead_provider:, payment_date: 2.months.ago) }

--- a/spec/services/finance/ecf/statement_calculator_spec.rb
+++ b/spec/services/finance/ecf/statement_calculator_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Finance::ECF::StatementCalculator do
+RSpec.describe Finance::ECF::StatementCalculator, mid_cohort: true do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
   let(:lead_provider) { cpd_lead_provider.lead_provider }
 

--- a/spec/services/finance/npq/assurance_report/query_spec.rb
+++ b/spec/services/finance/npq/assurance_report/query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Finance::NPQ::AssuranceReport::Query do
+RSpec.describe Finance::NPQ::AssuranceReport::Query, mid_cohort: true do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_npq_lead_provider) }
   let(:statement)         { create(:npq_statement, cpd_lead_provider:) }
 

--- a/spec/services/finance/npq/statement_calculator_spec.rb
+++ b/spec/services/finance/npq/statement_calculator_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Finance::NPQ::StatementCalculator do
+RSpec.describe Finance::NPQ::StatementCalculator, mid_cohort: true do
   let(:cohort)              { Cohort.current || create(:cohort, :current) }
   let(:cpd_lead_provider)   { create(:cpd_lead_provider, :with_npq_lead_provider) }
   let(:npq_lead_provider)   { cpd_lead_provider.npq_lead_provider }

--- a/spec/services/importers/create_new_ecf_cohort_spec.rb
+++ b/spec/services/importers/create_new_ecf_cohort_spec.rb
@@ -5,7 +5,7 @@ require "tempfile"
 RSpec.describe Importers::CreateNewECFCohort do
   describe "#call" do
     # TODO: hard coding year for now here and in csvs due to flaky tests but those need to be dynamic
-    let(:start_year) { "2026" }
+    let(:start_year) { "2025" }
 
     let(:cohort_csv) { "spec/fixtures/files/importers/cohort_csv_data.csv" }
     let(:cohort_lead_provider_csv) { "spec/fixtures/files/importers/cohort_lead_provider_csv_data.csv" }

--- a/spec/services/importers/create_new_ecf_cohort_spec.rb
+++ b/spec/services/importers/create_new_ecf_cohort_spec.rb
@@ -5,7 +5,7 @@ require "tempfile"
 RSpec.describe Importers::CreateNewECFCohort do
   describe "#call" do
     # TODO: hard coding year for now here and in csvs due to flaky tests but those need to be dynamic
-    let(:start_year) { "2025" }
+    let(:start_year) { "2026" }
 
     let(:cohort_csv) { "spec/fixtures/files/importers/cohort_csv_data.csv" }
     let(:cohort_lead_provider_csv) { "spec/fixtures/files/importers/cohort_lead_provider_csv_data.csv" }

--- a/spec/services/induction/amend_participant_cohort_spec.rb
+++ b/spec/services/induction/amend_participant_cohort_spec.rb
@@ -391,7 +391,7 @@ RSpec.describe Induction::AmendParticipantCohort do
           end
         end
 
-        describe "declaration states", mid_cohort: true do
+        describe "declaration states", early_in_cohort: true do
           %i[voided ineligible awaiting_clawback clawed_back].each do |declaration_state|
             context "when the participant has #{declaration_state} declarations and no billable or changeable declarations" do
               before do

--- a/spec/services/oneoffs/npq/migrate_declarations_between_statements_spec.rb
+++ b/spec/services/oneoffs/npq/migrate_declarations_between_statements_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Oneoffs::NPQ::MigrateDeclarationsBetweenStatements do
+describe Oneoffs::NPQ::MigrateDeclarationsBetweenStatements, mid_cohort: true do
   let(:from_statement_updates) { {} }
   let(:to_statement_updates) { {} }
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_npq_lead_provider) }

--- a/spec/services/participants/check_and_set_completion_date_spec.rb
+++ b/spec/services/participants/check_and_set_completion_date_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Participants::CheckAndSetCompletionDate do
 
   describe "#call" do
     before do
-      inside_registration_window do
+      inside_registration_window(cohort: Cohort.current) do
         allow(DQT::GetInductionRecord).to receive(:call).with(trn:).and_return(dqt_induction_record)
       end
     end
@@ -103,9 +103,13 @@ RSpec.describe Participants::CheckAndSetCompletionDate do
         end
 
         it "try to change the cohort of the participant" do
-          expect(Induction::AmendParticipantCohort).to have_received(:new).with(participant_profile:,
-                                                                                source_cohort_start_year:,
-                                                                                target_cohort_start_year:)
+          expect(Induction::AmendParticipantCohort)
+            .to have_received(:new)
+            .with(
+              participant_profile:,
+              source_cohort_start_year:,
+              target_cohort_start_year:,
+            )
         end
       end
     end

--- a/spec/services/partnerships/report_spec.rb
+++ b/spec/services/partnerships/report_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe Partnerships::Report do
   end
 
   context "challenge deadline to 31st October from 2023" do
-    let(:cohort) { create(:cohort, start_year: 2023, academic_year_start_date: Date.new(2023, 9, 1)) }
+    let(:cohort) { create(:cohort, start_year: 2023) }
 
     it "sets the challenge deadline to 31st October when the partnership is created before the 17th October", travel_to: Date.new(2023, 5, 1) do
       expect(result.challenge_deadline).to eq(Date.new(2023, 10, 31))

--- a/spec/services/partnerships/report_spec.rb
+++ b/spec/services/partnerships/report_spec.rb
@@ -20,17 +20,18 @@ RSpec.describe Partnerships::Report do
   before { freeze_time }
 
   it "creates a new partnership with expected attributes" do
-    expect { result }.to change(Partnership, :count).by 1
-    expect(result).to be_an_instance_of(Partnership)
-
-    expect(result).to have_attributes(
-      school_id: school.id,
-      cohort_id: cohort.id,
-      lead_provider_id: lead_provider.id,
-      delivery_partner_id: delivery_partner.id,
-      pending: false,
-      challenge_deadline: described_class::DEFAULT_CHALLENGE_WINDOW.from_now,
-    )
+    outside_auto_assignment_window do
+      expect { result }.to change(Partnership, :count).by 1
+      expect(result).to be_an_instance_of(Partnership)
+      expect(result).to have_attributes(
+        school_id: school.id,
+        cohort_id: cohort.id,
+        lead_provider_id: lead_provider.id,
+        delivery_partner_id: delivery_partner.id,
+        pending: false,
+        challenge_deadline: described_class::DEFAULT_CHALLENGE_WINDOW.from_now,
+      )
+    end
   end
 
   it "schedules partnership notifications" do
@@ -118,16 +119,18 @@ RSpec.describe Partnerships::Report do
     end
 
     it "updates the existing partnership" do
-      result
+      outside_auto_assignment_window do
+        result
 
-      expect(partnership.reload).to have_attributes(
-        school_id: school.id,
-        cohort_id: cohort.id,
-        lead_provider_id: lead_provider.id,
-        delivery_partner_id: delivery_partner.id,
-        pending: false,
-        challenge_deadline: described_class::DEFAULT_CHALLENGE_WINDOW.from_now,
-      )
+        expect(partnership.reload).to have_attributes(
+          school_id: school.id,
+          cohort_id: cohort.id,
+          lead_provider_id: lead_provider.id,
+          delivery_partner_id: delivery_partner.id,
+          pending: false,
+          challenge_deadline: described_class::DEFAULT_CHALLENGE_WINDOW.from_now,
+        )
+      end
     end
 
     it "updates partnership's report_id" do

--- a/spec/services/record_declaration_spec.rb
+++ b/spec/services/record_declaration_spec.rb
@@ -76,7 +76,7 @@ RSpec.shared_examples "validates the declaration for a withdrawn participant" do
     end
 
     context "when the declaration is backdated before the participant has been withdrawn" do
-      let(:withdrawal_time) { declaration_date + 1.second + 1.month } # Temp fix until we revert cohort start date to September
+      let(:withdrawal_time) { declaration_date + 1.second }
 
       it { is_expected.to be_valid }
     end

--- a/spec/services/record_declaration_spec.rb
+++ b/spec/services/record_declaration_spec.rb
@@ -438,7 +438,9 @@ RSpec.describe RecordDeclaration do
       let(:declaration_type) { "retained-1" }
 
       it "creates a declaration, no need to pass evidence_held" do
-        expect(service).to be_valid
+        travel_to(declaration_date) do
+          expect(service).to be_valid
+        end
       end
     end
 

--- a/spec/support/cohort_periods.rb
+++ b/spec/support/cohort_periods.rb
@@ -21,3 +21,9 @@ RSpec.configure do |config|
     travel_to(Cohort.current.academic_year_start_date + 2.days)
   end
 end
+
+RSpec.configure do |config|
+  config.before(mid_cohort: true) do
+    travel_to(Cohort.current.academic_year_start_date + 6.months)
+  end
+end

--- a/spec/support/cohort_periods.rb
+++ b/spec/support/cohort_periods.rb
@@ -17,7 +17,7 @@ end
 
 # time travel to after the current cohort opens
 RSpec.configure do |config|
-  config.before(mid_cohort: true) do
+  config.before(early_in_cohort: true) do
     travel_to(Cohort.current.academic_year_start_date + 2.days)
   end
 end

--- a/spec/support/shared_examples/change_cohort_and_continue_training_support.rb
+++ b/spec/support/shared_examples/change_cohort_and_continue_training_support.rb
@@ -139,7 +139,12 @@ RSpec.shared_examples "can change cohort and continue training" do |participant_
 
     %i[paid payable eligible submitted].each do |billable_or_changeable_declaration_type|
       context "when the participant has a #{billable_or_changeable_declaration_type} declaration for the current cohort" do
-        before { create(declaration_type, :payable, declaration_type: "retained-1", participant_profile:, cpd_lead_provider: participant_profile.lead_provider.cpd_lead_provider) }
+        before do
+          milestone_date = participant_profile.schedule.milestones.find_by(declaration_type: "retained-1").start_date
+          travel_to(milestone_date) do
+            create(declaration_type, :payable, declaration_type: "retained-1", participant_profile:, cpd_lead_provider: participant_profile.lead_provider.cpd_lead_provider)
+          end
+        end
 
         it { is_expected.not_to be_eligible_to_change_cohort_back_to_their_payments_frozen_original(cohort:, current_cohort:) }
       end


### PR DESCRIPTION
### Context

Every Year when we roll into the next Cohort (after September) we get a lot of failures in the specs. We pushed the times to make sure we get time to fix the failures in https://github.com/DFE-Digital/early-careers-framework/pull/5158

This pr reverts that work, and introduces a proper fix for the failures rather than push the start time of the cohort.

### Changes proposed in this pull request

We've introduced helpers to wrap around tests to travel to different times in the cohort. To avoid half the test suite failing tomorrow:

- Rename the `mid_cohort` rspec flag to `early_in_cohort` so we can create a new `mid_cohort` flag which is 6 months into a cohort.
- Add the new flag to everywhere we care being in the middle of the cohort which throws all calculations otherwise especially on declarations
- Unfortunately csv data is hardcoded so we need to change those dates. When we have more time those need to become dynamic
- Remove hard coded dates in other specs where we can
- Fix remaining tests with wrapping them with correct timeframe they need to be in, and travelling to declaration milestones

### Guidance to review
Commit by commit is easier