### PR TITLE
Add rake task to bulk mark applications as pending

### DIFF
--- a/app/services/oneoffs/npq/bulk_change_applications_to_pending.rb
+++ b/app/services/oneoffs/npq/bulk_change_applications_to_pending.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Oneoffs::NPQ
+  class BulkChangeApplicationsToPending
+    attr_reader :npq_application_ids
+
+    def initialize(npq_application_ids:)
+      @npq_application_ids = npq_application_ids
+    end
+
+    def run!(dry_run: true)
+      result = {}
+
+      ActiveRecord::Base.transaction do
+        result = npq_application_ids.each_with_object({}) do |npq_application_id, hash|
+          npq_application = NPQApplication.find_by(id: npq_application_id)
+          success = npq_application && NPQ::ChangeToPending.call(npq_application:)
+          hash[npq_application_id] = outcome(success, npq_application)
+        end
+
+        raise ActiveRecord::Rollback if dry_run
+      end
+
+      result
+    end
+
+  private
+
+    def outcome(success, npq_application)
+      return "Not found" if npq_application.nil?
+      return "Already pending" if success && !npq_application.saved_change_to_lead_provider_approval_status?
+      return "Changed to pending" if success
+
+      npq_application.errors.map(&:type).join(", ")
+    end
+  end
+end

--- a/lib/tasks/npq/bulk_change_applications_to_pending.rake
+++ b/lib/tasks/npq/bulk_change_applications_to_pending.rake
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rake"
+
+namespace :npq_applications do
+  # Bulk change NPQ applications to pending.
+  # Accepts a CSV of application IDs (without a header row) and a dry run
+  # flag. If the dry run flag is true, the changes will not be performed
+  # but the changes that would be made will be logged. Set dry run to false
+  # to commit the changes.
+  #
+  # Example usage (dry run):
+  # bundle exec rake 'npq_applications:bulk_change_to_pending[applications.csv,true]'
+  #
+  # Example usage (perform change):
+  # bundle exec rake 'npq_applications:bulk_change_to_pending[applications.csv,false]'
+  desc "Change NPQ applications to pending"
+  task :bulk_change_to_pending, %i[file dry_run] => :environment do |_task, args|
+    logger = Logger.new($stdout)
+    csv_file_path = args[:file]
+    dry_run = args[:dry_run] != "false"
+
+    unless File.exist?(csv_file_path)
+      logger.error "File not found: #{csv_file_path}"
+      return
+    end
+
+    npq_application_ids = CSV.read(csv_file_path, headers: false).flatten
+
+    logger.info "Bulk changing #{npq_application_ids.size} NPQ applications to pending#{' (dry run)' if dry_run}..."
+
+    result = Oneoffs::NPQ::BulkChangeApplicationsToPending.new(npq_application_ids:).run!(dry_run:)
+
+    logger.info JSON.pretty_generate(result)
+  end
+end

--- a/spec/services/oneoffs/npq/bulk_change_applications_to_pending_spec.rb
+++ b/spec/services/oneoffs/npq/bulk_change_applications_to_pending_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+describe Oneoffs::NPQ::BulkChangeApplicationsToPending do
+  let(:npq_application_ids) { [application.id] }
+  let(:instance) { described_class.new(npq_application_ids:) }
+
+  describe "#run!" do
+    let(:dry_run) { false }
+
+    subject(:run) { instance.run!(dry_run:) }
+
+    shared_context "changes to pending" do |initial_state|
+      it { expect { run }.to change { application.reload.lead_provider_approval_status }.from(initial_state).to("pending") }
+      it { expect(run[application.id]).to eq("Changed to pending") }
+    end
+
+    shared_context "does not change to pending" do |result|
+      it { expect { run }.not_to change { application.reload.lead_provider_approval_status } }
+      it { expect(run[application.id]).to match(result) }
+    end
+
+    context "when there is an accepted application" do
+      let(:application) { create(:npq_application, :accepted) }
+
+      it_behaves_like "changes to pending", "accepted"
+    end
+
+    context "when there is an rejected application" do
+      let(:application) { create(:npq_application, :rejected) }
+
+      it_behaves_like "changes to pending", "rejected"
+    end
+
+    %i[submitted voided ineligible].each do |state|
+      context "when the application has #{state} declarations" do
+        let(:participant_declaration) { create(:npq_participant_declaration, state) }
+
+        context "when the application is accepted" do
+          let(:application) { participant_declaration.participant_profile.npq_application }
+
+          it_behaves_like "changes to pending", "accepted"
+        end
+
+        context "when the application is rejected" do
+          let(:application) do
+            participant_declaration.participant_profile.npq_application.tap do |application|
+              application.update!(lead_provider_approval_status: "rejected")
+            end
+          end
+
+          it_behaves_like "changes to pending", "rejected"
+        end
+      end
+    end
+
+    context "when the application is already pending" do
+      let(:application) { create(:npq_application, :pending) }
+
+      it_behaves_like "does not change to pending", "Already pending"
+    end
+
+    context "when the application doesn't exist" do
+      let(:application_id) { SecureRandom.uuid }
+      let(:npq_application_ids) { [application_id] }
+
+      it { expect(run[application_id]).to eq("Not found") }
+    end
+
+    ParticipantDeclaration.states.keys.excluding("submitted", "voided", "ineligible").each do |state|
+      context "when the application has #{state} declarations" do
+        let(:participant_declaration) { create(:npq_participant_declaration, state) }
+        let(:application) { participant_declaration.participant_profile.npq_application }
+
+        it_behaves_like "does not change to pending", /declarations_exist/
+      end
+    end
+
+    context "when dry_run is true" do
+      let(:dry_run) { true }
+
+      let(:application) { create(:npq_application, :accepted) }
+
+      it { expect { run }.not_to change { application.reload.lead_provider_approval_status } }
+      it { expect(run[application.id]).to eq("Changed to pending") }
+    end
+  end
+end


### PR DESCRIPTION
[Jira-3274](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3274)

### Context

We want to add a rake task that will take a CSV of application IDs as an input and move all the applications to a `pending` state.

### Changes proposed in this pull request

- Add rake task to bulk mark applications as pending

Add a new one off service to make a group of applications `pending`. Add rake task so that we can call the service with a CSV of application ids and log out the updates (changed to pending, already pending or an error preventing it from moving to a pending state).

### Guidance to review

```
bundle exec rake 'npq_applications:bulk_change_to_pending[applications.csv,true]'

INFO -- : Bulk changing 4 NPQ applications to pending (dry run)...
INFO -- : {
  "fff73ce7-eebe-4089-9f21-19e4d58c8f04": "Changed to pending",
  "fffc50f4-1252-4518-ae56-f6d1e1100ba5": "Already pending",
  "000000-0000-0000-0000-000000000000": "Not found"
  "ffffe52f-8e36-4093-91e0-d6155f36774c": "declarations_exist"
}
```

Example CSV (IDs only, no header - taken from snapshot to give one of each result):

```
fffc50f4-1252-4518-ae56-f6d1e1100ba5
ffffe52f-8e36-4093-91e0-d6155f36774c
000000-0000-0000-0000-000000000000
fff73ce7-eebe-4089-9f21-19e4d58c8f04
```
