### PR TITLE
add trigger to transfer-ect-journey when an unfinished 2021 mentor is…

### DIFF
--- a/spec/features/schools/participants/add_participants/payments_frozen/transfer_ect_to_another_school_spec.rb
+++ b/spec/features/schools/participants/add_participants/payments_frozen/transfer_ect_to_another_school_spec.rb
@@ -48,6 +48,65 @@ RSpec.describe "SIT transfers ECT to another school", js: true, mid_cohort: true
     and_the_participant_has_been_added_to_the_active_registration_cohort
   end
 
+  scenario "when an unfinished mentor is assigned" do
+    given_there_is_a_school_that_has_chosen_fip_for_four_cohorts_and_partnered
+    and_there_is_another_school_that_has_chosen_fip_in_the_payments_frozen_cohort_and_partnered
+    and_the_earliest_cohort_has_payments_frozen
+    and_i_am_signed_in_as_an_induction_coordinator_for_the_transfer_school
+
+    and_i_have_added_a_mentor_in_cohort(earliest_cohort, school: target_school)
+    and_i_am_transfering_an_ect_in_a_cohort_with_payments_frozen_between_schools
+    and_i_click_on(Cohort.current.description)
+
+    when_i_navigate_to_ect_dashboard
+    when_i_click_to_add_a_new_ect
+    then_i_should_be_on_the_who_to_add_page
+
+    when_i_select_to_add_a "ECT"
+    when_i_click_on_continue
+
+    then_i_am_taken_to_the_what_we_need_from_you_page
+
+    when_i_click_on_continue
+    then_i_am_taken_to_add_ect_name_page
+
+    when_i_add_ect_name
+    when_i_click_on_continue
+    then_i_am_taken_to_add_teachers_trn_page
+
+    when_i_add_the_trn
+    when_i_click_on_continue
+    then_i_am_taken_to_add_date_of_birth_page
+
+    when_i_add_a_date_of_birth
+    when_i_click_on_continue
+
+    then_i_should_be_on_the_confirm_transfer_page
+    when_i_click_on_confirm
+    then_i_should_be_on_the_teacher_start_date_page
+
+    when_i_add_a_valid_start_date
+    when_i_click_on_continue
+    then_i_am_taken_to_add_ect_or_mentor_email_page
+
+    when_i_add_ect_or_mentor_email(email: @participant_data[:email])
+    when_i_click_on_continue
+    then_i_am_taken_to_choose_mentor_page
+
+    when_i_select("Cohort Mentor")
+    when_i_click_on_continue
+    when_i_choose_yes
+    when_i_click_on_continue
+    then_i_am_taken_to_check_details_page
+
+    when_i_click_confirm_and_add
+    then_i_see_confirmation_that_the_participant_has_been_added
+
+    and_the_participant_has_been_transfered_to_another_school
+    and_the_participant_has_been_added_to_the_active_registration_cohort
+    and_the_mentor_has_been_added_to_the_active_registration_cohort
+  end
+
   def and_i_am_transfering_an_ect_in_a_cohort_with_payments_frozen_between_schools
     # Setup here is for a participant at Fip School to be transferred to Target Fip School
     # They are currently in the earliest cohort, which has payments frozen.
@@ -109,6 +168,6 @@ RSpec.describe "SIT transfers ECT to another school", js: true, mid_cohort: true
   end
 
   def school_transfer_induction_record
-    ParticipantProfile::ECT.last.induction_records.find_by(school_transfer: true)
+    InductionRecord.find_by(school_transfer: true)
   end
 end

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -278,9 +278,9 @@ module ManageTrainingSteps
     Mentors::AddToSchool.call(mentor_profile: @participant_profile_mentor, school: @school)
   end
 
-  def and_i_have_added_a_mentor_in_cohort(cohort)
-    @mentor_school_cohort = @school.school_cohorts.for_year(cohort.start_year).first ||
-      create(:school_cohort, school: @school, cohort:, induction_programme_choice: "full_induction_programme")
+  def and_i_have_added_a_mentor_in_cohort(cohort, school: @school)
+    @mentor_school_cohort = school.school_cohorts.for_year(cohort.start_year).first ||
+      create(:school_cohort, school:, cohort:, induction_programme_choice: "full_induction_programme")
     @mentor_profile_in_cohort = create(:mentor_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, user: create(:user, full_name: "Cohort Mentor"), school_cohort: @mentor_school_cohort)
     if cohort.payments_frozen?
       @mentor_profile_in_cohort.participant_declarations.create!(declaration_date: Date.new(cohort.start_year, 10, 10),
@@ -292,7 +292,7 @@ module ManageTrainingSteps
                                                                  cohort:)
     end
     Induction::Enrol.call(participant_profile: @mentor_profile_in_cohort, induction_programme: @induction_programme)
-    Mentors::AddToSchool.call(mentor_profile: @mentor_profile_in_cohort, school: @school)
+    Mentors::AddToSchool.call(mentor_profile: @mentor_profile_in_cohort, school:)
   end
 
   def and_i_have_added_a_mentor_who_completed_training


### PR DESCRIPTION
…gned to an ECT being transferred schools.

### Context
Since 2024/25 academic year, 2021-unfinished-training-mentors assigned to any non-2021 ECT should be automatically moved to 2024 cohort by the service.

This trigger was added in June'24 to the school dashboard to all the events where a mentor-ECT takes place.


### Changes proposed in this pull request
This PR adds the trigger to the transfer-ECT journey when a new ECT is transferred schools and a mentor is assigned as part of it.

### Guidance to review



