### PR TITLE
Move analytics_pii config to analytics_hidden_pii

### DIFF
--- a/config/analytics_hidden_pii.yml
+++ b/config/analytics_hidden_pii.yml
@@ -1,0 +1,10 @@
+---
+:shared:
+  :schools:
+  - secondary_contact_email
+  - primary_contact_email
+  :nomination_emails:
+  - sent_to
+  :emails:
+  - to
+  - personalisation

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -1,10 +1,2 @@
 ---
-:shared:
-  :schools:
-  - secondary_contact_email
-  - primary_contact_email
-  :nomination_emails:
-  - sent_to
-  :emails:
-  - to
-  - personalisation
+:shared: {}


### PR DESCRIPTION
This config change allows us to restrict access to sensitive data in BigQuery.

Note, on the night this is merged, log in and kick off [this job](https://github.com/DFE-Digital/dfe-analytics?tab=readme-ov-file#7-import-existing-data) to resync everything.

```
$ bundle exec rails dfe:analytics:import_all_entities
```