### PR TITLE
Don't make `awaiting_clawback` line items `payable` on migrating declarations

### DIFF
--- a/app/services/oneoffs/npq/migrate_declarations_between_statements.rb
+++ b/app/services/oneoffs/npq/migrate_declarations_between_statements.rb
@@ -97,15 +97,18 @@ module Oneoffs::NPQ
     end
 
     def change_declaration_states_for_to_statement(to_statement, statement_line_items)
+      declarations = statement_line_items.map(&:participant_declaration).uniq
+      eligible_declarations = declarations.select(&:eligible?)
+
+      return unless eligible_declarations.any?
       return unless to_statement.payable?
 
-      declarations = statement_line_items.map(&:participant_declaration).uniq
       service = ParticipantDeclarations::MarkAsPayable.new(to_statement)
       action = service.class.to_s.underscore.humanize.split.last
 
-      record_info("Marking #{declarations.size} declarations as #{action} for #{to_statement.name} statement")
+      record_info("Marking #{eligible_declarations.size} eligible declarations as #{action} for #{to_statement.name} statement")
 
-      declarations.each { |declaration| service.call(declaration) }
+      eligible_declarations.each { |declaration| service.call(declaration) }
     end
 
     def filter_statement_line_items(statement_line_items)

--- a/app/services/oneoffs/npq/migrate_declarations_between_statements.rb
+++ b/app/services/oneoffs/npq/migrate_declarations_between_statements.rb
@@ -100,8 +100,8 @@ module Oneoffs::NPQ
       declarations = statement_line_items.map(&:participant_declaration).uniq
       eligible_declarations = declarations.select(&:eligible?)
 
-      return unless eligible_declarations.any?
       return unless to_statement.payable?
+      return unless eligible_declarations.any?
 
       service = ParticipantDeclarations::MarkAsPayable.new(to_statement)
       action = service.class.to_s.underscore.humanize.split.last

--- a/spec/services/oneoffs/npq/migrate_declarations_between_statements_spec.rb
+++ b/spec/services/oneoffs/npq/migrate_declarations_between_statements_spec.rb
@@ -242,7 +242,13 @@ describe Oneoffs::NPQ::MigrateDeclarationsBetweenStatements do
 
       context "when there are declarations awaiting_clawback" do
         let(:declaration) { create(:npq_participant_declaration, :awaiting_clawback, cohort:, cpd_lead_provider:) }
-        let(:from_statement) { declaration.statement_line_items.find(&:awaiting_clawback?).statement }
+        let(:awaiting_clawback_line_item) { declaration.statement_line_items.find(&:awaiting_clawback?) }
+        let(:from_statement) { awaiting_clawback_line_item.statement }
+
+        # Fixes flakey test where the paid statement and awaiting clawback statement can
+        # end up with the same name, resulting in an exception from the migration operation
+        # as we don't allow migrating from paid statements.
+        before { from_statement.update!(name: "#{from_statement.name} - Clawback") }
 
         it "migrates them, but does not make them payable" do
           migrate

--- a/spec/services/oneoffs/npq/migrate_declarations_between_statements_spec.rb
+++ b/spec/services/oneoffs/npq/migrate_declarations_between_statements_spec.rb
@@ -221,7 +221,7 @@ describe Oneoffs::NPQ::MigrateDeclarationsBetweenStatements do
       let(:declaration) { create(:npq_participant_declaration, :eligible, cohort:, cpd_lead_provider:) }
       let(:from_statement) { declaration.statements.first }
 
-      it "migrates them to the new statement and makes payable" do
+      it "migrates eligible declarations to the new statement and makes them payable" do
         migrate
 
         declaration.reload
@@ -236,8 +236,39 @@ describe Oneoffs::NPQ::MigrateDeclarationsBetweenStatements do
         expect(instance).to have_recorded_info([
           "Migrating declarations from #{from_statement_name} to #{to_statement_name} for 1 providers",
           "Migrating 1 declarations for #{npq_lead_provider.name}",
-          "Marking 1 declarations as payable for #{to_statement_name} statement",
+          "Marking 1 eligible declarations as payable for #{to_statement_name} statement",
         ])
+      end
+
+      context "when there are declarations awaiting_clawback" do
+        let(:declaration) { create(:npq_participant_declaration, :awaiting_clawback, cohort:, cpd_lead_provider:) }
+        let(:from_statement) { declaration.statement_line_items.find(&:awaiting_clawback?).statement }
+
+        it "migrates them, but does not make them payable" do
+          migrate
+
+          declaration.reload
+
+          migrated_statement_line_item = declaration.statement_line_items.find(&:awaiting_clawback?)
+          expect(migrated_statement_line_item.statement).to eq(to_statement)
+          expect(declaration).to be_awaiting_clawback
+          expect(instance.recorded_info).not_to include(/eligible declarations as payable/)
+        end
+      end
+
+      context "when there are declarations are already payable" do
+        let(:declaration) { create(:npq_participant_declaration, :payable, cohort:, cpd_lead_provider:) }
+        let(:from_statement) { declaration.statement_line_items.first.statement }
+
+        it "migrates them, but does not attempt to make them payable" do
+          migrate
+
+          declaration.reload
+
+          expect(declaration.statement_line_items.map(&:statement)).to all(eq(to_statement))
+          expect(declaration).to be_payable
+          expect(instance.recorded_info).not_to include(/eligible declarations as payable/)
+        end
       end
     end
 


### PR DESCRIPTION
[Jira-3600](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-3600)

### Context

We have a bug when migrating declarations to a `Payable` statement whereby we will put the declaration through the `MarkAsPayable` service regardless of its current state. This results in `awaiting_clawback` declarations being made `payable`.

Instead, we want to follow the logic in the rest of the service and only make `eligible` declarations `payable` when moving to a `Payable` statement.

### Changes proposed in this pull request

- Don't make `awaiting_clawback` line items `payable` on migrating declarations

As it stands, the following behaviour will apply for declarations moving to a `Payable` statement:

- eligible -> payable
- awaiting_clawback -> awaiting clawback
- payable -> payable
- submitted/voided/ineligible (ignored - no line items)
- paid/clawed_back (raise error, can't migrate from paid statement)
