### PR TITLE
[CPDLP-3514] Scope `participant_declaration_finder` to completed declaration

### DIFF
--- a/app/models/npq_application.rb
+++ b/app/models/npq_application.rb
@@ -110,8 +110,8 @@ class NPQApplication < ApplicationRecord
     UK_CATCHMENT_AREA.include?(teacher_catchment)
   end
 
-  def self.participant_declaration_finder(participant_identity_id)
-    ParticipantDeclaration::NPQ.find_by_participant_profile_id(ParticipantProfile.find_by_participant_identity_id(participant_identity_id)&.id)
+  def self.completed_participant_declaration_finder(participant_identity_id)
+    ParticipantDeclaration::NPQ.find_by(declaration_type: "completed", participant_profile_id: ParticipantProfile.find_by_participant_identity_id(participant_identity_id)&.id)
   end
 
   def declared_as_billable?

--- a/app/models/npq_application.rb
+++ b/app/models/npq_application.rb
@@ -111,7 +111,7 @@ class NPQApplication < ApplicationRecord
   end
 
   def self.completed_participant_declaration_finder(participant_identity_id)
-    ParticipantDeclaration::NPQ.find_by(declaration_type: "completed", participant_profile_id: ParticipantProfile.find_by_participant_identity_id(participant_identity_id)&.id)
+    ParticipantDeclaration::NPQ.billable_or_changeable.for_declaration("completed").find_by(participant_profile_id: ParticipantProfile.find_by_participant_identity_id(participant_identity_id)&.id)
   end
 
   def declared_as_billable?

--- a/app/models/npq_application.rb
+++ b/app/models/npq_application.rb
@@ -110,8 +110,10 @@ class NPQApplication < ApplicationRecord
     UK_CATCHMENT_AREA.include?(teacher_catchment)
   end
 
-  def self.completed_participant_declaration_finder(participant_identity_id)
-    ParticipantDeclaration::NPQ.billable_or_changeable.for_declaration("completed").find_by(participant_profile_id: ParticipantProfile.find_by_participant_identity_id(participant_identity_id)&.id)
+  def latest_completed_participant_declaration
+    return unless profile
+
+    profile.participant_declarations.npq.for_declaration("completed").billable_or_changeable.order(created_at: :desc).first
   end
 
   def declared_as_billable?

--- a/app/services/api/v1/npq/application_status_query.rb
+++ b/app/services/api/v1/npq/application_status_query.rb
@@ -4,29 +4,22 @@ module Api
   module V1
     module NPQ
       class ApplicationStatusQuery
+        attr_reader :npq_application
+
         def initialize(npq_application)
           @npq_application = npq_application
         end
 
         def call
-          declaration = get_participant_declaration(@npq_application.participant_identity_id)
-          return_participant_outcome_state(get_latest_participant_outcome, declaration)
+          return unless completed_participant_declaration
+
+          completed_participant_declaration.outcomes.latest&.state
         end
 
       private
 
-        def get_participant_declaration(participant_identity_id)
-          NPQApplication.completed_participant_declaration_finder(participant_identity_id)
-        end
-
-        def get_latest_participant_outcome
-          ParticipantOutcome::NPQ.latest_per_declaration
-        end
-
-        def return_participant_outcome_state(participant_outcomes, declaration)
-          return participant_outcomes&.find_by_participant_declaration_id(declaration&.id)&.state if participant_outcomes.is_a?(Array)
-
-          ParticipantOutcome::NPQ.find_by_participant_declaration_id(declaration&.id)&.state
+        def completed_participant_declaration
+          @completed_participant_declaration ||= npq_application.latest_completed_participant_declaration
         end
       end
     end

--- a/app/services/api/v1/npq/application_status_query.rb
+++ b/app/services/api/v1/npq/application_status_query.rb
@@ -16,7 +16,7 @@ module Api
       private
 
         def get_participant_declaration(participant_identity_id)
-          NPQApplication.participant_declaration_finder(participant_identity_id)
+          NPQApplication.completed_participant_declaration_finder(participant_identity_id)
         end
 
         def get_latest_participant_outcome

--- a/spec/models/npq_application_spec.rb
+++ b/spec/models/npq_application_spec.rb
@@ -731,24 +731,24 @@ RSpec.describe NPQApplication, type: :model do
     end
   end
 
-  describe "#self.completed_participant_declaration_finder" do
+  describe "#latest_completed_participant_declaration" do
     context "when participant_declaration not exist" do
       let(:npq_application) { create(:npq_application) }
 
       it "returns nil" do
-        result = described_class.completed_participant_declaration_finder(npq_application.participant_identity_id)
+        result = npq_application.latest_completed_participant_declaration
         expect(result).to eq(nil)
       end
     end
 
     context "when participant_declaration exist" do
-      let(:participant_declaration) { create(:npq_participant_declaration) }
-      let(:participant_profile) { participant_declaration.participant_profile }
-      let(:npq_application) { create(:npq_application, :accepted, npq_course: participant_profile.npq_course, npq_lead_provider: participant_declaration.cpd_lead_provider.npq_lead_provider, participant_identity_id: participant_profile.participant_identity_id) }
+      let(:npq_application) { create(:npq_application, :accepted) }
+      let(:participant_profile) { npq_application.profile }
+      let!(:participant_declaration) { create(:npq_participant_declaration, cpd_lead_provider: npq_application.npq_lead_provider.cpd_lead_provider, participant_profile:) }
 
       context "when declaration is not completed" do
         it "returns nil" do
-          result = described_class.completed_participant_declaration_finder(npq_application.participant_identity_id)
+          result = npq_application.latest_completed_participant_declaration
           expect(result).to eq(nil)
         end
       end
@@ -757,7 +757,7 @@ RSpec.describe NPQApplication, type: :model do
         before { participant_declaration.update!(declaration_type: "completed") }
 
         it "returns participant_declaration" do
-          result = described_class.completed_participant_declaration_finder(npq_application.participant_identity_id)
+          result = npq_application.latest_completed_participant_declaration
           expect(result).to eq(participant_declaration)
         end
       end

--- a/spec/models/npq_application_spec.rb
+++ b/spec/models/npq_application_spec.rb
@@ -731,22 +731,35 @@ RSpec.describe NPQApplication, type: :model do
     end
   end
 
-  describe "#self.participant_declaration_finder" do
+  describe "#self.completed_participant_declaration_finder" do
     context "when participant_declaration not exist" do
       let(:npq_application) { create(:npq_application) }
 
       it "returns nil" do
-        result = described_class.participant_declaration_finder(npq_application.participant_identity_id)
+        result = described_class.completed_participant_declaration_finder(npq_application.participant_identity_id)
         expect(result).to eq(nil)
       end
     end
 
     context "when participant_declaration exist" do
       let(:participant_declaration) { create(:npq_participant_declaration) }
-      let(:npq_application) { create(:npq_application, participant_identity_id: participant_declaration.participant_profile.participant_identity.id) }
-      it "returns participant_declaration" do
-        result = described_class.participant_declaration_finder(npq_application.participant_identity_id)
-        expect(result).to eq(participant_declaration)
+      let(:participant_profile) { participant_declaration.participant_profile }
+      let(:npq_application) { create(:npq_application, :accepted, npq_course: participant_profile.npq_course, npq_lead_provider: participant_declaration.cpd_lead_provider.npq_lead_provider, participant_identity_id: participant_profile.participant_identity_id) }
+
+      context "when declaration is not completed" do
+        it "returns nil" do
+          result = described_class.completed_participant_declaration_finder(npq_application.participant_identity_id)
+          expect(result).to eq(nil)
+        end
+      end
+
+      context "when declaration is completed" do
+        before { participant_declaration.update!(declaration_type: "completed") }
+
+        it "returns participant_declaration" do
+          result = described_class.completed_participant_declaration_finder(npq_application.participant_identity_id)
+          expect(result).to eq(participant_declaration)
+        end
       end
     end
   end

--- a/spec/requests/api/v1/npq/application_synchronization/index_spec.rb
+++ b/spec/requests/api/v1/npq/application_synchronization/index_spec.rb
@@ -14,10 +14,6 @@ RSpec.describe "NPQ Application Status API", type: :request do
     let(:pick_application) { NPQApplication.where(id: npq_application.id).pick(:lead_provider_approval_status, :id, :participant_identity_id) }
     let(:participant_declaration) { create(:npq_participant_declaration, cpd_lead_provider: npq_application.npq_lead_provider.cpd_lead_provider, participant_profile: npq_application.profile) }
     let!(:participant_outcome) { create(:participant_outcome, participant_declaration:) }
-    let(:state) do
-      participant_declaration_id = NPQApplication.completed_participant_declaration_finder(pick_application.last).id
-      ParticipantOutcome::NPQ.latest_per_declaration.find_by_participant_declaration_id(participant_declaration_id).state
-    end
 
     before { participant_declaration.update!(declaration_type: "completed") }
 

--- a/spec/requests/api/v1/npq/application_synchronization/index_spec.rb
+++ b/spec/requests/api/v1/npq/application_synchronization/index_spec.rb
@@ -5,28 +5,34 @@ RSpec.describe "NPQ Application Status API", type: :request do
   let(:cpd_lead_provider) { create(:cpd_lead_provider) }
   let(:token)             { NPQRegistrationApiToken.create_with_random_token!(cpd_lead_provider_id: cpd_lead_provider.id) }
   let(:bearer_token)      { "Bearer #{token}" }
-  let(:parsed_response) { JSON.parse(response.body)["data"]&.first }
+  let(:parsed_response) { JSON.parse(response.body)["data"].first }
 
   before { default_headers[:Authorization] = bearer_token }
 
   describe "GET /api/v1/npq/application_synchronizations" do
-    let(:npq_application) { create(:npq_application) }
+    let(:npq_application) { create(:npq_application, :accepted) }
     let(:pick_application) { NPQApplication.where(id: npq_application.id).pick(:lead_provider_approval_status, :id, :participant_identity_id) }
+    let(:participant_declaration) { create(:npq_participant_declaration, cpd_lead_provider: npq_application.npq_lead_provider.cpd_lead_provider, participant_profile: npq_application.profile) }
+    let!(:participant_outcome) { create(:participant_outcome, participant_declaration:) }
     let(:state) do
-      participant_declaration_id = NPQApplication.participant_declaration_finder(pick_application.last)&.id
-      ParticipantOutcome::NPQ.latest_per_declaration&.find_by_participant_declaration_id(participant_declaration_id)&.state
+      participant_declaration_id = NPQApplication.completed_participant_declaration_finder(pick_application.last).id
+      ParticipantOutcome::NPQ.latest_per_declaration.find_by_participant_declaration_id(participant_declaration_id).state
     end
+
+    before { participant_declaration.update!(declaration_type: "completed") }
 
     it_behaves_like "Feature enabled NPQ API endpoint", "GET", "/api/v1/npq/application_synchronizations"
 
     it "returns correct jsonapi content" do
       @controller = Api::V1::NPQ::ApplicationSynchronizationsController.new
       @controller.params = { "@npq_applications": npq_application }
+
       get "/api/v1/npq/application_synchronizations"
+
       expect(parsed_response).to be_a(Hash)
       expect(parsed_response["attributes"]["id"]).to eq(npq_application.id.to_s)
-      expect(parsed_response["attributes"]["lead_provider_approval_status"]).to eq(npq_application.lead_provider_approval_status)
-      expect(parsed_response["attributes"]["participant_outcome_state"]).to eq(state)
+      expect(parsed_response["attributes"]["lead_provider_approval_status"]).to eq("accepted")
+      expect(parsed_response["attributes"]["participant_outcome_state"]).to eq("passed")
     end
   end
 end

--- a/spec/serializers/api/v1/npq/application_synchronization_serializer_spec.rb
+++ b/spec/serializers/api/v1/npq/application_synchronization_serializer_spec.rb
@@ -3,27 +3,33 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::NPQ::ApplicationSynchronizationSerializer do
-  let(:npq_application) { create(:npq_application) }
+  let(:npq_application) { create(:npq_application, :accepted) }
   let(:pick_application) { NPQApplication.where(id: npq_application.id).pick(:lead_provider_approval_status, :id, :participant_identity_id) }
+  let(:participant_declaration) { create(:npq_participant_declaration, cpd_lead_provider: npq_application.npq_lead_provider.cpd_lead_provider, participant_profile: npq_application.profile) }
+  let!(:participant_outcome) { create(:participant_outcome, participant_declaration:) }
   let(:state) do
-    participant_declaration_id = NPQApplication.participant_declaration_finder(pick_application.last)&.id
-    ParticipantOutcome::NPQ.latest_per_declaration&.find_by_participant_declaration_id(participant_declaration_id)&.state
+    participant_declaration_id = NPQApplication.completed_participant_declaration_finder(pick_application.last).id
+    ParticipantOutcome::NPQ.latest_per_declaration.find_by_participant_declaration_id(participant_declaration_id).state
   end
+
+  before { participant_declaration.update!(declaration_type: "completed") }
 
   describe "#serializable_hash" do
     it "serialises to the correct structure" do
       result = described_class.new(npq_application).serializable_hash
+
       expected = {
         data: {
           id: npq_application.id,
           type: :application_synchronization,
           attributes: {
             id: npq_application.id,
-            lead_provider_approval_status: npq_application.lead_provider_approval_status,
-            participant_outcome_state: state,
+            lead_provider_approval_status: "accepted",
+            participant_outcome_state: "passed",
           },
         },
       }
+
       expect(result).to eql(expected)
     end
   end

--- a/spec/serializers/api/v1/npq/application_synchronization_serializer_spec.rb
+++ b/spec/serializers/api/v1/npq/application_synchronization_serializer_spec.rb
@@ -7,10 +7,6 @@ RSpec.describe Api::V1::NPQ::ApplicationSynchronizationSerializer do
   let(:pick_application) { NPQApplication.where(id: npq_application.id).pick(:lead_provider_approval_status, :id, :participant_identity_id) }
   let(:participant_declaration) { create(:npq_participant_declaration, cpd_lead_provider: npq_application.npq_lead_provider.cpd_lead_provider, participant_profile: npq_application.profile) }
   let!(:participant_outcome) { create(:participant_outcome, participant_declaration:) }
-  let(:state) do
-    participant_declaration_id = NPQApplication.completed_participant_declaration_finder(pick_application.last).id
-    ParticipantOutcome::NPQ.latest_per_declaration.find_by_participant_declaration_id(participant_declaration_id).state
-  end
 
   before { participant_declaration.update!(declaration_type: "completed") }
 

--- a/spec/services/api/v1/npq/application_status_query_spec.rb
+++ b/spec/services/api/v1/npq/application_status_query_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::NPQ::ApplicationStatusQuery do
-  let(:participant_declaration) { create(:npq_participant_declaration) }
-  let(:participant_profile) { participant_declaration.participant_profile }
-  let(:npq_application) { create(:npq_application, :accepted, npq_course: participant_profile.npq_course, npq_lead_provider: participant_declaration.cpd_lead_provider.npq_lead_provider, participant_identity_id: participant_profile.participant_identity_id) }
+  let(:npq_application) { create(:npq_application, :accepted) }
+  let(:participant_profile) { npq_application.profile }
+  let(:participant_declaration) { create(:npq_participant_declaration, cpd_lead_provider: npq_application.npq_lead_provider.cpd_lead_provider, participant_profile:) }
   let!(:participant_outcome) { create(:participant_outcome, participant_declaration:) }
   let(:service) { described_class.new(npq_application) }
 

--- a/spec/services/api/v1/npq/application_status_query_spec.rb
+++ b/spec/services/api/v1/npq/application_status_query_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Api::V1::NPQ::ApplicationStatusQuery do
     end
 
     context "when no participant declaration exists" do
-      before { npq_application.destroy }
+      before { participant_declaration.update!(participant_profile: create(:npq_participant_profile)) }
 
       it "returns nil" do
         expect(service.call).to be_nil

--- a/spec/services/api/v1/npq/application_status_query_spec.rb
+++ b/spec/services/api/v1/npq/application_status_query_spec.rb
@@ -4,35 +4,39 @@ require "rails_helper"
 
 RSpec.describe Api::V1::NPQ::ApplicationStatusQuery do
   let(:participant_declaration) { create(:npq_participant_declaration) }
-  let(:npq_application) { create(:npq_application, participant_identity_id: participant_declaration.participant_profile.participant_identity.id) }
-  let(:participant_outcome) { create(:participant_outcome, participant_declaration:) }
+  let(:participant_profile) { participant_declaration.participant_profile }
+  let(:npq_application) { create(:npq_application, :accepted, npq_course: participant_profile.npq_course, npq_lead_provider: participant_declaration.cpd_lead_provider.npq_lead_provider, participant_identity_id: participant_profile.participant_identity_id) }
+  let!(:participant_outcome) { create(:participant_outcome, participant_declaration:) }
   let(:service) { described_class.new(npq_application) }
+
   describe "#call" do
-    context "when a participant declaration exists" do
-      before do
-        allow(NPQApplication).to receive(:participant_declaration_finder).and_return(participant_declaration)
+    context "when a non completed participant declaration exists" do
+      it "returns nil" do
+        expect(service.call).to be_nil
       end
+    end
+
+    context "when a completed participant declaration exists" do
+      before { participant_declaration.update!(declaration_type: "completed") }
+
       context "when a participant outcome exists" do
-        before do
-          allow(ParticipantOutcome::NPQ).to receive(:latest_per_declaration).and_return(participant_outcome)
-        end
         it "returns the latest state of the participant outcome which is only one created" do
-          expect(service.call).to eq(participant_outcome.state)
+          expect(service.call).to eq("passed")
         end
       end
+
       context "when no participant outcome exists" do
-        before do
-          allow(ParticipantOutcome::NPQ).to receive(:latest_per_declaration).and_return(nil)
-        end
+        before { participant_outcome.update!(participant_declaration: create(:npq_participant_declaration)) }
+
         it "returns nil" do
           expect(service.call).to be_nil
         end
       end
     end
+
     context "when no participant declaration exists" do
-      before do
-        allow(NPQApplication).to receive(:participant_declaration_finder).and_return(nil)
-      end
+      before { npq_application.destroy }
+
       it "returns nil" do
         expect(service.call).to be_nil
       end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-3514

`NPQApplication` `participant_declaration_finder` is not scoped by completed declarations. It should be as the outcomes belongs to only completed declarations, not to started declarations, which are the first type of declaration for a participant profile, and it's the one that's being fetched using `find_by_participant_profile_id`.

### Changes proposed in this pull request

Scope `participant_declaration_finder` by completed declarations as well, so we make sure we select the correct and completed declaration for the participant profile, and then after that the possible outcomes linked to those completed declarations.

### Guidance to review

Before: 
```
Api::V1::NPQ::ApplicationStatusQuery.new(NPQApplication.find("06787ded-3102-4647-ad15-d0d56b70139b").call
-> nil
```

After:
```
Api::V1::NPQ::ApplicationStatusQuery.new(NPQApplication.find("06787ded-3102-4647-ad15-d0d56b70139b").call
-> "passed"

