### PR TITLE
[CST-2766] Add nomination_link param to sit pre term comms mailer

### DIFF
--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -553,6 +553,7 @@ class SchoolMailer < ApplicationMailer
 
   def sit_pre_term_reminder_to_report_any_changes
     induction_coordinator = params[:induction_coordinator]
+    nomination_url = params[:nomination_url]
     sit_name = induction_coordinator.user.full_name
     email_address = induction_coordinator.user.email
 
@@ -564,6 +565,7 @@ class SchoolMailer < ApplicationMailer
       personalisation: {
         name: sit_name,
         email_address:,
+        nomination_link: nomination_url,
       },
     ).tag(:sit_pre_term_reminder_to_report_any_changes).associate_with(induction_coordinator, as: :induction_coordinator_profile)
   end

--- a/app/services/bulk_mailers/school_reminder_comms.rb
+++ b/app/services/bulk_mailers/school_reminder_comms.rb
@@ -229,8 +229,9 @@ module BulkMailers
         .find_each do |school|
         school.induction_coordinator_profiles.each do |induction_coordinator|
           email_count += 1
+          nomination_url = nomination_url(email: induction_coordinator.user.email, school:)
 
-          SchoolMailer.with(induction_coordinator:).sit_pre_term_reminder_to_report_any_changes.deliver_later(wait: get_waiting_time(email_count))
+          SchoolMailer.with(induction_coordinator:, nomination_url:).sit_pre_term_reminder_to_report_any_changes.deliver_later(wait: get_waiting_time(email_count))
         end
       end
 

--- a/spec/mailers/school_mailer_spec.rb
+++ b/spec/mailers/school_mailer_spec.rb
@@ -551,10 +551,12 @@ RSpec.describe SchoolMailer, type: :mailer do
   describe "#sit_pre_term_reminder_to_report_any_changes" do
     let(:induction_coordinator) { create(:seed_induction_coordinator_profile, :with_user) }
     let(:email_address) { induction_coordinator.user.email }
+    let(:nomination_link) { "https://ecf-dev.london.cloudapps/nominations/start?token=123" }
 
     let(:sit_pre_term_reminder_to_report_any_changes) do
       SchoolMailer.with(
         induction_coordinator:,
+        nomination_link:,
       ).sit_pre_term_reminder_to_report_any_changes.deliver_now
     end
 

--- a/spec/services/bulk_mailers/school_reminder_comms_spec.rb
+++ b/spec/services/bulk_mailers/school_reminder_comms_spec.rb
@@ -381,11 +381,17 @@ RSpec.describe BulkMailers::SchoolReminderComms, type: :mailer do
 
   describe "#contact_sits_pre_term_to_report_any_changes" do
     context "when a school rans FIP or CIP and has not opted out of updates" do
+      let(:nomination_url) { "http://nomination.example.com" }
+
+      before do
+        allow(service).to receive(:nomination_url).with(email: sit_profile.user.email, school:).and_return(nomination_url)
+      end
+
       it "mails the induction coordinator" do
         expect {
           service.contact_sits_pre_term_to_report_any_changes
         }.to have_enqueued_mail(SchoolMailer, :sit_pre_term_reminder_to_report_any_changes)
-          .with(params: { induction_coordinator: sit_profile }, args: [])
+          .with(params: { induction_coordinator: sit_profile, nomination_url: }, args: [])
       end
     end
 


### PR DESCRIPTION
### Context

- Ticket: CST-2766

The Notify template was updated to include the SIT nomination link

### Changes proposed in this pull request

- Add nomination_link as a new parameter to the mailer
- Update the bulk mailer to pass the nomination_link when calling the mailer

### Guidance to review

