### PR TITLE
Amend test data to generate random `created_at`

### DIFF
--- a/lib/tasks/valid_test_data_generator.rb
+++ b/lib/tasks/valid_test_data_generator.rb
@@ -102,7 +102,7 @@ module ValidTestDataGenerator
 
         return unless profile.active_record?
 
-        started_declaration = travel_to profile.schedule.milestones.first.start_date + 2.days do
+        started_declaration = travel_to profile.schedule.milestones.first.start_date + rand(5.days).seconds do
           RecordDeclaration.new(
             participant_id: user.tap(&:reload).id,
             course_identifier: "ecf-induction",
@@ -151,7 +151,7 @@ module ValidTestDataGenerator
 
         return profile unless profile.active_record?
 
-        started_declaration = travel_to profile.schedule.milestones.first.start_date + 2.days do
+        started_declaration = travel_to profile.schedule.milestones.first.start_date + rand(5.days).seconds do
           RecordDeclaration.new(
             participant_id: profile.user.tap(&:reload).id,
             course_identifier: "ecf-mentor",

--- a/lib/tasks/valid_test_data_generator/completed_mentor_generator.rb
+++ b/lib/tasks/valid_test_data_generator/completed_mentor_generator.rb
@@ -87,7 +87,7 @@ module ValidTestDataGenerator
 
         return profile unless profile.active_record?
 
-        started_declaration = travel_to profile.schedule.milestones.first.start_date + 2.days do
+        started_declaration = travel_to profile.schedule.milestones.first.start_date + rand(5.days).seconds do
           RecordDeclaration.new(
             participant_id: user.tap(&:reload).id,
             course_identifier: "ecf-induction",
@@ -135,7 +135,7 @@ module ValidTestDataGenerator
 
         return profile unless profile.active_record?
 
-        started_declaration = travel_to profile.schedule.milestones.first.start_date + 2.days do
+        started_declaration = travel_to profile.schedule.milestones.first.start_date + rand(5.days).seconds do
           RecordDeclaration.new(
             participant_id: profile.user.tap(&:reload).id,
             course_identifier: "ecf-mentor",


### PR DESCRIPTION
### Context
We were getting duplicates in pagination due to data having similar `created_at` timestamps across all test data. This makes the test data more random

- Ticket: https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-3609

### Changes proposed in this pull request

Add a random time to the schedule time selected

### Guidance to review
-
