### PR TITLE
[CPDLP-3589] Disable NPQ in admin

### DIFF
--- a/app/controllers/concerns/admin/participants/retrieve_profile.rb
+++ b/app/controllers/concerns/admin/participants/retrieve_profile.rb
@@ -10,9 +10,17 @@ module Admin
       end
 
       def retrieve_participant_profile
-        @participant_profile = policy_scope(ParticipantProfile).find(params[:participant_id]).tap do |participant_profile|
+        @participant_profile = policy_scope(scope).find(params[:participant_id]).tap do |participant_profile|
           authorize participant_profile, :show?, policy_class: participant_profile.policy_class
         end
+      end
+
+    private
+
+      def scope
+        return ParticipantProfile unless NpqApiEndpoint.disabled?
+
+        ParticipantProfile.ecf
       end
     end
   end

--- a/app/services/admin/participants/search.rb
+++ b/app/services/admin/participants/search.rb
@@ -40,11 +40,8 @@ private
   end
 
   def type_conditions
-    if type.present?
-      ParticipantProfile.where(type:)
-    else
-      ParticipantProfile.all
-    end
+    scope = NpqApiEndpoint.disabled? ? ParticipantProfile.ecf : ParticipantProfile.all
+    type.present? ? scope.where(type:) : scope
   end
 
   def left_outer_joins

--- a/app/views/admin/participants/index.html.erb
+++ b/app/views/admin/participants/index.html.erb
@@ -12,8 +12,9 @@
         OpenStruct.new(id: "", name: ""),
         OpenStruct.new(id: "ParticipantProfile::ECT", name: "ECT"),
         OpenStruct.new(id: "ParticipantProfile::Mentor", name: "Mentor"),
-        OpenStruct.new(id: "ParticipantProfile::NPQ", name: "NPQ"),
-      ],
+      ].tap do |options|
+        options << OpenStruct.new(id: "ParticipantProfile::NPQ", name: "NPQ") unless NpqApiEndpoint.disabled?
+      end
     },
   ],
 ) %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -15,8 +15,10 @@
     <%= component.with_nav_item(path: "/admin/administrators") do %>
       Admin users
     <% end %>
-    <%= component.with_nav_item(path: admin_npq_applications_applications_path, selected: on_admin_npq_application_page?) do %>
-      NPQ
+    <% unless NpqApiEndpoint.disabled? %>
+      <%= component.with_nav_item(path: admin_npq_applications_applications_path, selected: on_admin_npq_application_page?) do %>
+        NPQ
+      <% end %>
     <% end %>
     <%= component.with_nav_item(path: admin_delivery_partners_users_path) do %>
       Delivery partners

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -259,7 +259,7 @@ Rails.application.routes.draw do
     # Keeping the urls to old guidance urls, but they need to lead to new api-reference ones
     get "/guidance/home", to: redirect("/api-reference")
     get "/guidance/ecf-usage", to: redirect("/api-reference/ecf-usage")
-    get "/guidance/npq-usage", to: redirect("/api-reference/npq-usage")
+    get "/guidance/npq-usage", to: redirect("/api-reference/npq-usage"), constraints: NpqApiEndpoint
     get "/guidance/reference", to: redirect("/api-reference/reference")
     get "/guidance/release-notes", to: redirect("/api-reference/release-notes")
     get "/guidance/help", to: redirect("/api-reference/help")
@@ -374,8 +374,8 @@ Rails.application.routes.draw do
 
       resource :add_to_school_mentor_pool, only: %i[new create], controller: "participants/add_to_school_mentor_pool"
 
-      resource :npq_change_full_name, only: %i[edit update], controller: "participants/npq/change_full_name"
-      resource :npq_change_email, only: %i[edit update], controller: "participants/npq/change_email"
+      resource :npq_change_full_name, only: %i[edit update], controller: "participants/npq/change_full_name", constraints: NpqApiEndpoint
+      resource :npq_change_email, only: %i[edit update], controller: "participants/npq/change_email", constraints: NpqApiEndpoint
 
       resource :change_induction_start_date, only: %i[edit update], controller: "participants/change_induction_start_date"
       resource :change_induction_status, only: %i[edit], controller: "participants/change_induction_status" do
@@ -503,7 +503,7 @@ Rails.application.routes.draw do
 
     resources :induction_coordinators, only: %i[index edit update], path: "induction-coordinators"
 
-    namespace :npq do
+    namespace :npq, constraints: NpqApiEndpoint do
       resource :applications, only: [] do
         get "/eligibility_imports/example", to: "applications/eligibility_imports#example", as: :example_csv_file
         get "/analysis", to: "applications/analysis#invalid_payments_analysis", as: :analysis

--- a/db/data/schedules/schedules.csv
+++ b/db/data/schedules/schedules.csv
@@ -113,6 +113,12 @@ ecf_replacement,ecf-replacement-january,ECF Replacement January,2021,Output 3 - 
 ecf_replacement,ecf-replacement-january,ECF Replacement January,2021,Output 4 - Retention Point 3,retained-3,2022-01-01,,2022-01-01
 ecf_replacement,ecf-replacement-january,ECF Replacement January,2021,Output 5 - Retention Point 4,retained-4,2022-01-01,,2022-01-01
 ecf_replacement,ecf-replacement-january,ECF Replacement January,2021,Output 6 - Participant Completion,completed,2022-01-01,,2022-01-01
+ecf_standard,ecf-standard-april,ECF Standard April,2021,Output 1 - Participant Start,started,2022-04-01,2022-07-31,2022-08-31
+ecf_standard,ecf-standard-april,ECF Standard April,2021,Output 2 - Retention Point 1,retained-1,2022-08-01,2022-12-31,2023-01-31
+ecf_standard,ecf-standard-april,ECF Standard April,2021,Output 3 - Retention Point 2,retained-2,2023-01-01,2023-03-31,2023-04-30
+ecf_standard,ecf-standard-april,ECF Standard April,2021,Output 4 - Retention Point 3,retained-3,2023-04-01,2023-07-31,2023-08-31
+ecf_standard,ecf-standard-april,ECF Standard April,2021,Output 5 - Retention Point 4,retained-4,2023-08-01,2023-12-31,2024-01-31
+ecf_standard,ecf-standard-april,ECF Standard April,2021,Output 6 - Participant Completion,completed,2024-01-01,2024-03-31,2024-04-30
 ecf_standard,ecf-standard-april,ECF Standard April,2022,Output 1 - Participant Start,started,2023-04-01,2023-07-31,2023-08-31
 ecf_standard,ecf-standard-april,ECF Standard April,2022,Output 2 - Retention Point 1,retained-1,2023-08-01,2023-12-31,2024-01-31
 ecf_standard,ecf-standard-april,ECF Standard April,2022,Output 3 - Retention Point 2,retained-2,2024-01-01,2024-03-31,2024-04-30

--- a/spec/controllers/concerns/admin/participants/retrieve_profile_spec.rb
+++ b/spec/controllers/concerns/admin/participants/retrieve_profile_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-class TestsController < Admin::BaseController
+class RetrieveProfileTestsController < Admin::BaseController
   include Admin::Participants::RetrieveProfile
 end
 
@@ -12,7 +12,7 @@ describe Admin::Participants::RetrieveProfile, type: :controller do
   let!(:mentor_participant_profile) { create(:mentor_participant_profile) }
   let!(:npq_participant_profile) { create(:npq_participant_profile) }
 
-  controller TestsController do
+  controller RetrieveProfileTestsController do
     def index
       render body: @participant_profile.id
     end
@@ -22,7 +22,7 @@ describe Admin::Participants::RetrieveProfile, type: :controller do
     sign_in user
 
     routes.append do
-      get "index" => "tests#index"
+      get "index" => "retrieve_profile_tests#index"
     end
   end
 

--- a/spec/controllers/concerns/admin/participants/retrieve_profile_spec.rb
+++ b/spec/controllers/concerns/admin/participants/retrieve_profile_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+class TestsController < Admin::BaseController
+  include Admin::Participants::RetrieveProfile
+end
+
+describe Admin::Participants::RetrieveProfile, type: :controller do
+  let(:user) { create(:user, :admin) }
+  let!(:ect_participant_profile) { create(:ect_participant_profile) }
+  let!(:mentor_participant_profile) { create(:mentor_participant_profile) }
+  let!(:npq_participant_profile) { create(:npq_participant_profile) }
+
+  controller TestsController do
+    def index
+      render body: @participant_profile.id
+    end
+  end
+
+  before do
+    sign_in user
+
+    routes.append do
+      get "index" => "tests#index"
+    end
+  end
+
+  it "returns correct data" do
+    params = { participant_id: ect_participant_profile.id }
+    response = get("index", params:)
+
+    expect(response.body).to eq(ect_participant_profile.id)
+  end
+
+  context "when participant id is not in the params" do
+    it "raises an error" do
+      params = { any: "1" }
+
+      expect { get("index", params:) }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  context "when participant is an ECT participant" do
+    it "returns correct data" do
+      params = { participant_id: ect_participant_profile.id }
+      response = get("index", params:)
+
+      expect(response.body).to eq(ect_participant_profile.id)
+    end
+  end
+
+  context "when participant is a Mentor participant" do
+    it "returns correct data" do
+      params = { participant_id: mentor_participant_profile.id }
+      response = get("index", params:)
+
+      expect(response.body).to eq(mentor_participant_profile.id)
+    end
+  end
+
+  context "when participant is a NPQ participant" do
+    it "returns correct data" do
+      params = { participant_id: npq_participant_profile.id }
+      response = get("index", params:)
+
+      expect(response.body).to eq(npq_participant_profile.id)
+    end
+  end
+
+  context "when 'disable_npq' feature is active" do
+    before { FeatureFlag.activate(:disable_npq) }
+
+    context "when participant is an ECT participant" do
+      it "returns correct data" do
+        params = { participant_id: ect_participant_profile.id }
+        response = get("index", params:)
+
+        expect(response.body).to eq(ect_participant_profile.id)
+      end
+    end
+
+    context "when participant is a Mentor participant" do
+      it "returns correct data" do
+        params = { participant_id: mentor_participant_profile.id }
+        response = get("index", params:)
+
+        expect(response.body).to eq(mentor_participant_profile.id)
+      end
+    end
+
+    context "when participant is a NPQ participant" do
+      it "raises an error" do
+        params = { participant_id: npq_participant_profile.id }
+
+        expect { get("index", params:) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end

--- a/spec/controllers/concerns/api_filter_spec.rb
+++ b/spec/controllers/concerns/api_filter_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-class TestsController < Api::ApiController
+class ApiFilterTestsController < Api::ApiController
   include ApiFilter
 end
 
@@ -11,14 +11,14 @@ class Test < ApplicationRecord; end
 describe "ApiFilter", type: :controller do
   before do
     routes.append do
-      get "index" => "tests#index"
+      get "index" => "api_filter_tests#index"
     end
   end
 
   describe "updated_since" do
     let(:now) { Time.zone.local(2023, 3, 29, 10, 10, 0) }
 
-    controller TestsController do
+    controller ApiFilterTestsController do
       def index
         render json: { updated_since_param: updated_since }
       end

--- a/spec/controllers/concerns/api_filter_validation_spec.rb
+++ b/spec/controllers/concerns/api_filter_validation_spec.rb
@@ -2,12 +2,12 @@
 
 require "rails_helper"
 
-class TestsController < Api::ApiController
+class ApiFilterValidationTestsController < Api::ApiController
   include ApiFilterValidation
 end
 
 describe ApiFilterValidation, type: :controller do
-  controller TestsController do
+  controller ApiFilterValidationTestsController do
     filter_validation required_filters: %i[cohort]
 
     def index
@@ -17,7 +17,7 @@ describe ApiFilterValidation, type: :controller do
 
   before do
     routes.append do
-      get "index" => "tests#index"
+      get "index" => "api_filter_validation_tests#index"
     end
   end
 

--- a/spec/controllers/concerns/api_pagination_spec.rb
+++ b/spec/controllers/concerns/api_pagination_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-class TestsController < Api::ApiController
+class ApiPaginationTestsController < Api::ApiController
   include ApiPagination
 end
 
@@ -11,14 +11,14 @@ class Test < ApplicationRecord; end
 describe "ApiPagination", type: :controller do
   before do
     routes.append do
-      get "index" => "tests#index"
+      get "index" => "api_pagination_tests#index"
     end
   end
 
   describe "pagination" do
     let!(:first_school)  { create(:school) }
     let!(:second_school) { create(:school) }
-    controller TestsController do
+    controller ApiPaginationTestsController do
       def index
         render json: { data: paginate(School.order(created_at: :asc)) }
       end

--- a/spec/features/admin/notes/participant_note_spec.rb
+++ b/spec/features/admin/notes/participant_note_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Admin can add notes to a participants record in the admin console
     and_i_am_signed_in_as_an_admin
     and_i_have_added_an_ect
     and_i_have_added_a_mentor
-    and_i_have_added_a_npq
+    and_i_have_added_an_npq_profile
     when_i_visit_admin_participants_dashboard
     then_i_should_see_a_list_of_participants
   end

--- a/spec/features/admin/notes/participant_note_spec.rb
+++ b/spec/features/admin/notes/participant_note_spec.rb
@@ -11,6 +11,7 @@ RSpec.feature "Admin can add notes to a participants record in the admin console
     and_i_am_signed_in_as_an_admin
     and_i_have_added_an_ect
     and_i_have_added_a_mentor
+    and_i_have_added_a_npq
     when_i_visit_admin_participants_dashboard
     then_i_should_see_a_list_of_participants
   end

--- a/spec/features/admin/npq_applications/npq_applications_spec.rb
+++ b/spec/features/admin/npq_applications/npq_applications_spec.rb
@@ -16,11 +16,15 @@ RSpec.feature "Admin NPQ application details", js: true, rutabaga: false do
     create :npq_application, :edge_case, funded_place: true
 
     and_i_am_signed_in_as_an_admin
-
     when_i_visit_the_npq_applications_section
     when_i_display_an_npq_application
-
     then_i_can_see_the_application_details
+  end
+
+  scenario "Hide NPQ when :disable_npq feature is active" do
+    and_disable_npq_feature_is_active
+    and_i_am_signed_in_as_an_admin
+    then_i_should_not_see_the_npq_section
   end
 
 private
@@ -36,5 +40,13 @@ private
 
   def then_i_can_see_the_application_details
     expect(page).to have_selector(".govuk-summary-list__row--no-actions", text: /Funded place.*?Yes/)
+  end
+
+  def and_disable_npq_feature_is_active
+    FeatureFlag.activate(:disable_npq)
+  end
+
+  def then_i_should_not_see_the_npq_section
+    expect(page).not_to have_selector(".govuk-link", text: /NPQ/)
   end
 end

--- a/spec/features/admin/npq_applications/participant_details_spec.rb
+++ b/spec/features/admin/npq_applications/participant_details_spec.rb
@@ -26,6 +26,12 @@ RSpec.feature "Admin NPQ participant details", js: true, rutabaga: false do
     then_i_can_see_the_participant_funded_place_attribute
   end
 
+  scenario "Hide NPQ option when :disable_npq feature is active" do
+    and_disable_npq_feature_is_active
+    and_i_am_signed_in_as_an_admin
+    then_i_should_not_see_npq_as_an_option
+  end
+
 private
 
   def when_i_visit_the_npq_applications_participants
@@ -48,5 +54,16 @@ private
 
   def then_i_can_see_the_participant_funded_place_attribute
     expect(page).to have_selector(".govuk-summary-list__row--no-actions", text: /Funded place.*?No/)
+  end
+
+  def and_disable_npq_feature_is_active
+    FeatureFlag.activate(:disable_npq)
+  end
+
+  def then_i_should_not_see_npq_as_an_option
+    click_on "Participants"
+    within(:xpath, "//select[@id = 'type-field']") do
+      expect(page).to have_no_content("NPQ")
+    end
   end
 end

--- a/spec/features/admin/participants/participant_induction_records_spec.rb
+++ b/spec/features/admin/participants/participant_induction_records_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Admin should be able to see the participant's induction records",
     and_i_am_signed_in_as_an_admin
     and_i_have_added_an_ect
     and_i_have_added_a_mentor
-    and_i_have_added_a_npq
+    and_i_have_added_an_npq_profile
     when_i_visit_admin_participants_dashboard
     then_i_should_see_a_list_of_participants
 

--- a/spec/features/admin/participants/participant_induction_records_spec.rb
+++ b/spec/features/admin/participants/participant_induction_records_spec.rb
@@ -11,6 +11,7 @@ RSpec.feature "Admin should be able to see the participant's induction records",
     and_i_am_signed_in_as_an_admin
     and_i_have_added_an_ect
     and_i_have_added_a_mentor
+    and_i_have_added_a_npq
     when_i_visit_admin_participants_dashboard
     then_i_should_see_a_list_of_participants
 

--- a/spec/features/admin/participants/participant_steps.rb
+++ b/spec/features/admin/participants/participant_steps.rb
@@ -29,7 +29,7 @@ module ParticipantSteps
     and_i_am_signed_in_as_an_admin
     and_i_have_added_an_ect
     and_i_have_added_a_mentor
-
+    and_i_have_added_a_npq
     when_i_visit_admin_participants_dashboard
     then_i_should_see_a_list_of_participants
   end

--- a/spec/features/admin/participants/participant_steps.rb
+++ b/spec/features/admin/participants/participant_steps.rb
@@ -114,8 +114,20 @@ module ParticipantSteps
     expect(page).to have_text("Fip School")
     expect(page).to have_text("Sally Teacher")
     expect(page).to have_text("Billy Mentor")
+    expect(page).to have_text("Bart NPQ")
     expect(page).to have_text("Early career teacher")
     expect(page).to have_text("Mentor")
+    expect(page).to have_text("NPQ")
+  end
+
+  def then_i_should_see_a_list_of_participants_without_npq
+    expect(page).to have_text("Fip School")
+    expect(page).to have_text("Sally Teacher")
+    expect(page).to have_text("Billy Mentor")
+    expect(page).not_to have_text("Bart NPQ")
+    expect(page).to have_text("Early career teacher")
+    expect(page).to have_text("Mentor")
+    expect(page).not_to have_text("NPQ")
   end
 
   def then_i_should_be_in_the_admin_participants_dashboard
@@ -189,6 +201,10 @@ module ParticipantSteps
     @participant_profile_mentor = create(:mentor_participant_profile, user: create(:user, full_name: "Billy Mentor", email: "billy-mentor@example.com"), school_cohort: @school_cohort)
     Induction::Enrol.call(participant_profile: @participant_profile_mentor, induction_programme: @induction_programme)
     Mentors::AddToSchool.call(school: @school, mentor_profile: @participant_profile_mentor)
+  end
+
+  def and_i_have_added_a_npq
+    @participant_profile_npq = create(:npq_participant_profile, user: create(:user, full_name: "Bart NPQ", email: "bart-npq@example.com"))
   end
 
   def and_the_mentor_is_mentoring_the_ect

--- a/spec/features/admin/participants/participant_steps.rb
+++ b/spec/features/admin/participants/participant_steps.rb
@@ -29,7 +29,7 @@ module ParticipantSteps
     and_i_am_signed_in_as_an_admin
     and_i_have_added_an_ect
     and_i_have_added_a_mentor
-    and_i_have_added_a_npq
+    and_i_have_added_an_npq_profile
     when_i_visit_admin_participants_dashboard
     then_i_should_see_a_list_of_participants
   end
@@ -203,7 +203,7 @@ module ParticipantSteps
     Mentors::AddToSchool.call(school: @school, mentor_profile: @participant_profile_mentor)
   end
 
-  def and_i_have_added_a_npq
+  def and_i_have_added_an_npq_profile
     @participant_profile_npq = create(:npq_participant_profile, user: create(:user, full_name: "Bart NPQ", email: "bart-npq@example.com"))
   end
 

--- a/spec/features/admin/participants/participants_details_spec.rb
+++ b/spec/features/admin/participants/participants_details_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Admin should be able to manage participants details", js: true, r
     and_i_am_signed_in_as_an_admin
     and_i_have_added_an_ect
     and_i_have_added_a_mentor
-    and_i_have_added_a_npq
+    and_i_have_added_an_npq_profile
     when_i_visit_admin_participants_dashboard
     then_i_should_see_a_list_of_participants
   end

--- a/spec/features/admin/participants/participants_details_spec.rb
+++ b/spec/features/admin/participants/participants_details_spec.rb
@@ -11,6 +11,7 @@ RSpec.feature "Admin should be able to manage participants details", js: true, r
     and_i_am_signed_in_as_an_admin
     and_i_have_added_an_ect
     and_i_have_added_a_mentor
+    and_i_have_added_a_npq
     when_i_visit_admin_participants_dashboard
     then_i_should_see_a_list_of_participants
   end

--- a/spec/features/admin/participants/participants_spec.rb
+++ b/spec/features/admin/participants/participants_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Admin finding participants", js: true, rutabaga: false do
     and_i_am_signed_in_as_an_admin
     and_i_have_added_an_ect
     and_i_have_added_a_mentor
-    and_i_have_added_a_npq
+    and_i_have_added_an_npq_profile
     when_i_visit_admin_participants_dashboard
   end
 

--- a/spec/features/admin/participants/participants_spec.rb
+++ b/spec/features/admin/participants/participants_spec.rb
@@ -11,6 +11,7 @@ RSpec.feature "Admin finding participants", js: true, rutabaga: false do
     and_i_am_signed_in_as_an_admin
     and_i_have_added_an_ect
     and_i_have_added_a_mentor
+    and_i_have_added_a_npq
     when_i_visit_admin_participants_dashboard
   end
 
@@ -32,6 +33,40 @@ RSpec.feature "Admin finding participants", js: true, rutabaga: false do
     then_the_search_results_are_empty
   end
 
+  scenario "Searching NPQ participants" do
+    @page = Pages::AdminSupportParticipantList.load
+
+    then_i_see_the_search_bar
+
+    when_i_search_for_participant "Bart NPQ"
+    then_the_search_npq_results_are_displayed
+
+    when_i_search_for_participant "random keyword"
+    then_the_search_results_are_empty
+  end
+
+  scenario "when :disable_npq feature is active" do
+    given_disable_npq_feature_is_active
+
+    @page = Pages::AdminSupportParticipantList.load
+    then_i_should_see_a_list_of_participants_without_npq
+
+    then_i_see_the_search_bar
+
+    when_i_search_for_participant "Sally Teacher"
+    then_the_search_results_are_displayed
+
+    when_i_search_for_participant "random keyword"
+    then_the_search_results_are_empty
+
+    when_i_search_for_participant "Bart NPQ"
+    then_the_search_results_are_empty
+  end
+
+  def given_disable_npq_feature_is_active
+    FeatureFlag.activate(:disable_npq)
+  end
+
   def when_i_search_for_participant(keyword)
     @page.search_field.send_keys(keyword)
     @page.search_button.click
@@ -49,5 +84,10 @@ RSpec.feature "Admin finding participants", js: true, rutabaga: false do
 
   def then_the_search_results_are_empty
     expect(@page).to_not have_search_results
+  end
+
+  def then_the_search_npq_results_are_displayed
+    expect(@page).to have_search_results
+    expect(@page.search_results.first.full_name.text).to eq("Bart NPQ")
   end
 end

--- a/spec/models/finance/schedule/ecf_spec.rb
+++ b/spec/models/finance/schedule/ecf_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Finance::Schedule::ECF, type: :model do
     end
   end
 
-  Cohort.where(start_year: 2021..Cohort.current.start_year).find_each do |cohort|
+  Cohort.where(start_year: 2021..).find_each do |cohort|
     context "for #{cohort.start_year} cohort" do
       let(:cohort) { Cohort.find_by(start_year: cohort.start_year) }
 

--- a/spec/models/finance/schedule/ecf_spec.rb
+++ b/spec/models/finance/schedule/ecf_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Finance::Schedule::ECF, type: :model do
     end
   end
 
-  Cohort.where.not(start_year: 2020).find_each do |cohort|
+  Cohort.where(start_year: 2021..Cohort.current.start_year).find_each do |cohort|
     context "for #{cohort.start_year} cohort" do
       let(:cohort) { Cohort.find_by(start_year: cohort.start_year) }
 

--- a/spec/requests/admin/npq_admin_routes_spec.rb
+++ b/spec/requests/admin/npq_admin_routes_spec.rb
@@ -1,0 +1,343 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "NPQ admin dashboard routes" do
+  let(:user) { create(:user, :admin) }
+  let(:participant_profile) { create(:npq_participant_profile) }
+  let(:npq_application) { create(:npq_application, :accepted) }
+
+  before do
+    sign_in user
+  end
+
+  describe "GET /admin/participants/:participant_id/npq_change_full_name/edit" do
+    context "when :disable_npq feature is active" do
+      before { FeatureFlag.activate(:disable_npq) }
+
+      it "does not exist" do
+        expect {
+          get("/admin/participants/#{participant_profile.id}/npq_change_full_name/edit")
+        }.to raise_error(ActionController::RoutingError, /No route matches/)
+      end
+    end
+
+    context "when :disable_npq feature is not active" do
+      before { FeatureFlag.deactivate(:disable_npq) }
+
+      it "exists" do
+        get("/admin/participants/#{participant_profile.id}/npq_change_full_name/edit")
+
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+
+  describe "PUT /admin/participants/:participant_id/npq_change_full_name" do
+    context "when :disable_npq feature is active" do
+      before { FeatureFlag.activate(:disable_npq) }
+
+      it "does not exist" do
+        expect {
+          put("/admin/participants/#{participant_profile.id}/npq_change_full_name", params: {})
+        }.to raise_error(ActionController::RoutingError, /No route matches/)
+      end
+    end
+
+    context "when :disable_npq feature is not active" do
+      before { FeatureFlag.deactivate(:disable_npq) }
+
+      it "exists" do
+        put("/admin/participants/#{participant_profile.id}/npq_change_full_name", params: { admin_participants_npq_change_full_name_form: { full_name: "test" } })
+
+        expect(response).to have_http_status(:found)
+      end
+    end
+  end
+
+  describe "GET /admin/participants/:participant_id/npq_change_email/edit" do
+    context "when :disable_npq feature is active" do
+      before { FeatureFlag.activate(:disable_npq) }
+
+      it "does not exist" do
+        expect {
+          get("/admin/participants/#{participant_profile.id}/npq_change_email/edit")
+        }.to raise_error(ActionController::RoutingError, /No route matches/)
+      end
+    end
+
+    context "when :disable_npq feature is not active" do
+      before { FeatureFlag.deactivate(:disable_npq) }
+
+      it "exists" do
+        get("/admin/participants/#{participant_profile.id}/npq_change_email/edit")
+
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+
+  describe "PUT /admin/participants/:participant_id/npq_change_email" do
+    context "when :disable_npq feature is active" do
+      before { FeatureFlag.activate(:disable_npq) }
+
+      it "does not exist" do
+        expect {
+          put("/admin/participants/#{participant_profile.id}/npq_change_email", params: {})
+        }.to raise_error(ActionController::RoutingError, /No route matches/)
+      end
+    end
+
+    context "when :disable_npq feature is not active" do
+      before { FeatureFlag.deactivate(:disable_npq) }
+
+      it "exists" do
+        put("/admin/participants/#{participant_profile.id}/npq_change_email", params: { admin_participants_npq_change_email_form: { email: "test" } })
+
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+
+  describe "GET /admin/npq/applications/applications/:application_id/change_logs" do
+    context "when :disable_npq feature is active" do
+      before { FeatureFlag.activate(:disable_npq) }
+
+      it "does not exist" do
+        expect {
+          get("/admin/npq/applications/applications/#{npq_application.id}/change_logs")
+        }.to raise_error(ActionController::RoutingError, /No route matches/)
+      end
+    end
+
+    context "when :disable_npq feature is not active" do
+      before { FeatureFlag.deactivate(:disable_npq) }
+
+      it "exists" do
+        get("/admin/npq/applications/applications/#{npq_application.id}/change_logs")
+
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+
+  describe "GET /admin/npq/applications/analysis" do
+    context "when :disable_npq feature is active" do
+      before { FeatureFlag.activate(:disable_npq) }
+
+      it "does not exist" do
+        expect {
+          get("/admin/npq/applications/analysis")
+        }.to raise_error(ActionController::RoutingError, /No route matches/)
+      end
+    end
+
+    context "when :disable_npq feature is not active" do
+      before { FeatureFlag.deactivate(:disable_npq) }
+
+      it "exists" do
+        get("/admin/npq/applications/analysis")
+
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+
+  describe "GET /admin/npq/applications/change_name/:id/edit" do
+    context "when :disable_npq feature is active" do
+      before { FeatureFlag.activate(:disable_npq) }
+
+      it "does not exist" do
+        expect {
+          get("/admin/npq/applications/change_name/#{npq_application.id}/edit")
+        }.to raise_error(ActionController::RoutingError, /No route matches/)
+      end
+    end
+
+    context "when :disable_npq feature is not active" do
+      before { FeatureFlag.deactivate(:disable_npq) }
+
+      it "exists" do
+        get("/admin/npq/applications/change_name/#{npq_application.id}/edit")
+
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+
+  describe "PUT /admin/npq/applications/change_name/:id" do
+    context "when :disable_npq feature is active" do
+      before { FeatureFlag.activate(:disable_npq) }
+
+      it "does not exist" do
+        expect {
+          put("/admin/npq/applications/change_name/#{npq_application.id}", params: {})
+        }.to raise_error(ActionController::RoutingError, /No route matches/)
+      end
+    end
+
+    context "when :disable_npq feature is not active" do
+      before { FeatureFlag.deactivate(:disable_npq) }
+
+      it "exists" do
+        put("/admin/npq/applications/change_name/#{npq_application.id}", params: { user: { name: "test" } })
+
+        expect(response).to have_http_status(:found)
+      end
+    end
+  end
+
+  describe "GET /admin/npq/applications/change_email/:id/edit" do
+    context "when :disable_npq feature is active" do
+      before { FeatureFlag.activate(:disable_npq) }
+
+      it "does not exist" do
+        expect {
+          get("/admin/npq/applications/change_email/#{npq_application.id}/edit")
+        }.to raise_error(ActionController::RoutingError, /No route matches/)
+      end
+    end
+
+    context "when :disable_npq feature is not active" do
+      before { FeatureFlag.deactivate(:disable_npq) }
+
+      it "exists" do
+        get("/admin/npq/applications/change_email/#{npq_application.id}/edit")
+
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+
+  describe "PUT /admin/npq/applications/change_email/:id" do
+    context "when :disable_npq feature is active" do
+      before { FeatureFlag.activate(:disable_npq) }
+
+      it "does not exist" do
+        expect {
+          put("/admin/npq/applications/change_email/#{npq_application.id}", params: {})
+        }.to raise_error(ActionController::RoutingError, /No route matches/)
+      end
+    end
+
+    context "when :disable_npq feature is not active" do
+      before { FeatureFlag.deactivate(:disable_npq) }
+
+      it "exists" do
+        put("/admin/npq/applications/change_email/#{npq_application.id}", params: { user: { email: "test" } })
+
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+
+  describe "GET /admin/npq/applications/edge_cases" do
+    context "when :disable_npq feature is active" do
+      before { FeatureFlag.activate(:disable_npq) }
+
+      it "does not exist" do
+        expect {
+          get("/admin/npq/applications/edge_cases")
+        }.to raise_error(ActionController::RoutingError, /No route matches/)
+      end
+    end
+
+    context "when :disable_npq feature is not active" do
+      before { FeatureFlag.deactivate(:disable_npq) }
+
+      it "exists" do
+        get("/admin/npq/applications/edge_cases")
+
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+
+  describe "GET /admin/npq/applications/eligible_for_funding/:id/edit" do
+    context "when :disable_npq feature is active" do
+      before { FeatureFlag.activate(:disable_npq) }
+
+      it "does not exist" do
+        expect {
+          get("/admin/npq/applications/eligible_for_funding/#{npq_application.id}/edit")
+        }.to raise_error(ActionController::RoutingError, /No route matches/)
+      end
+    end
+
+    context "when :disable_npq feature is not active" do
+      before { FeatureFlag.deactivate(:disable_npq) }
+
+      it "exists" do
+        get("/admin/npq/applications/eligible_for_funding/#{npq_application.id}/edit")
+
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+
+  describe "GET /admin/npq/applications/eligibility_status/:id/edit" do
+    context "when :disable_npq feature is active" do
+      before { FeatureFlag.activate(:disable_npq) }
+
+      it "does not exist" do
+        expect {
+          get("/admin/npq/applications/eligibility_status/#{npq_application.id}/edit")
+        }.to raise_error(ActionController::RoutingError, /No route matches/)
+      end
+    end
+
+    context "when :disable_npq feature is not active" do
+      before { FeatureFlag.deactivate(:disable_npq) }
+
+      it "exists" do
+        get("/admin/npq/applications/eligibility_status/#{npq_application.id}/edit")
+
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+
+  describe "GET /admin/npq/applications/notes/:id/edit" do
+    context "when :disable_npq feature is active" do
+      before { FeatureFlag.activate(:disable_npq) }
+
+      it "does not exist" do
+        expect {
+          get("/admin/npq/applications/notes/#{npq_application.id}/edit")
+        }.to raise_error(ActionController::RoutingError, /No route matches/)
+      end
+    end
+
+    context "when :disable_npq feature is not active" do
+      before { FeatureFlag.deactivate(:disable_npq) }
+
+      it "exists" do
+        get("/admin/npq/applications/notes/#{npq_application.id}/edit")
+
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+
+  describe "GET /lead-providers/guidance/npq-usage" do
+    context "when :disable_npq feature is active" do
+      before { FeatureFlag.activate(:disable_npq) }
+
+      it "does not exist" do
+        expect {
+          get("/lead-providers/guidance/npq-usage")
+        }.to raise_error(ActionController::RoutingError, /No route matches/)
+      end
+    end
+
+    context "when :disable_npq feature is not active" do
+      before { FeatureFlag.deactivate(:disable_npq) }
+
+      it "exists" do
+        get("/lead-providers/guidance/npq-usage")
+
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+  end
+end

--- a/spec/services/admin/participants/search_spec.rb
+++ b/spec/services/admin/participants/search_spec.rb
@@ -64,6 +64,14 @@ RSpec.describe Admin::Participants::Search do
         end
       end
 
+      describe "partly matching by participant identity email (case insensitively)" do
+        let(:results) { search.call(ParticipantProfile, search_term: "@Example.com") }
+
+        it "returns matching participants" do
+          expect(results).to include(pp_1, pp_2, pp_3)
+        end
+      end
+
       describe "matching by TRN" do
         before { pp_3.teacher_profile.update(trn: "123456") }
 
@@ -145,6 +153,17 @@ RSpec.describe Admin::Participants::Search do
 
         it "doesn't return non-matching participants" do
           expect(results).not_to include(pp_2, pp_3)
+        end
+      end
+
+      context "when 'disable_npq' feature is active" do
+        let(:results) { search.call(ParticipantProfile, search_term: "example.com") }
+
+        before { FeatureFlag.activate(:disable_npq) }
+
+        it "does not return NPQ participants" do
+          expect(results).to include(pp_1, pp_2)
+          expect(results).not_to include(pp_3)
         end
       end
     end


### PR DESCRIPTION
### Context

We need to disable any NPQ logic and services in the admin interface.

- Ticket: [CPDLP-3589](https://dfedigital.atlassian.net/browse/CPDLP-3589)

### Changes proposed in this pull request

- Disable any NPQ tools in the admin interface
- Disable any tabs/routes that show NPQ data
- Add the feature flag to any services that show both, so when disabled will only show ECF

[CPDLP-3589]: https://dfedigital.atlassian.net/browse/CPDLP-3589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ