### PR TITLE
Fix flakey test

### DIFF
--- a/spec/services/valid_test_data_generators/npq_lead_provider_populater_spec.rb
+++ b/spec/services/valid_test_data_generators/npq_lead_provider_populater_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ValidTestDataGenerators::NPQLeadProviderPopulater do
   let(:npq_lead_provider) { create(:npq_lead_provider) }
   let(:cohort) { create(:cohort, :current) }
   let!(:school) { create(:school) }
-  let!(:npq_course) { create(:npq_specialist_course) }
+  let!(:npq_course) { create(:npq_course, identifier: "npq-headship") }
 
   before do
     allow(Rails).to receive(:env) { environment.inquiry }


### PR DESCRIPTION
### Context

- Ticket: N/A

A spec is flakey because the populater skips creating declarations for some type of npq courses.

https://github.com/DFE-Digital/early-careers-framework/blob/main/app/services/valid_test_data_generators/npq_lead_provider_populater.rb#L44

### Changes proposed in this pull request

Fix `spec/services/valid_test_data_generators/npq_lead_provider_populater_spec.rb:80` flakey test.