### PR TITLE
Bug fix: do not archive participants in a closing cohort with archiva…

### DIFF
--- a/app/models/participant_declaration.rb
+++ b/app/models/participant_declaration.rb
@@ -3,6 +3,8 @@
 class ParticipantDeclaration < ApplicationRecord
   self.ignored_columns = %w[statement_type statement_id voided_at]
 
+  ARCHIVABLE_STATES = %w[ineligible voided submitted].freeze
+
   belongs_to :cpd_lead_provider
   belongs_to :user
   belongs_to :cohort
@@ -111,6 +113,10 @@ class ParticipantDeclaration < ApplicationRecord
   scope :billable_or_changeable, -> { billable.or(changeable) }
 
   before_create :build_initial_declaration_state
+
+  def self.non_archivable_states
+    states.keys.excluding(ARCHIVABLE_STATES)
+  end
 
   def voidable?
     %w[submitted eligible payable ineligible].include?(state)

--- a/app/models/participant_profile/ect.rb
+++ b/app/models/participant_profile/ect.rb
@@ -11,9 +11,37 @@ class ParticipantProfile::ECT < ParticipantProfile::ECF
   }
 
   def self.archivable_from_frozen_cohort(restrict_to_participant_ids: [])
-    super(restrict_to_participant_ids:)
-      .where(induction_completion_date: nil)
-      .where("induction_start_date IS NULL OR induction_start_date < make_date(cohorts.start_year, 9, 1)")
+    archivable_states = %i[ineligible voided submitted].freeze
+
+    # ECTs that have no FIP induction records
+    not_fip = InductionRecord.joins(:induction_programme, participant_profile: { schedule: :cohort })
+                             .where.not(cohorts: { payments_frozen_at: nil })
+                             .where(participant_profiles: { induction_completion_date: nil })
+                             .where(participant_profiles: { type: "ParticipantProfile::ECT" })
+                             .where("participant_profiles.induction_start_date IS NULL OR participant_profiles.induction_start_date < make_date(cohorts.start_year, 9, 1)")
+                             .where.not(induction_programme: { training_programme: :full_induction_programme })
+    not_fip = not_fip.where(participant_profile_id: restrict_to_participant_ids) if restrict_to_participant_ids.any?
+    not_fip_ids = not_fip.pluck(:participant_profile_id).uniq
+
+    # ECTs that have at least one non-archivable declaration
+    with_unarchivable_declaration = joins(:participant_declarations, schedule: :cohort)
+                                      .where.not(cohorts: { payments_frozen_at: nil })
+                                      .where(induction_completion_date: nil)
+                                      .where("induction_start_date IS NULL OR induction_start_date < make_date(cohorts.start_year, 9, 1)")
+                                      .where.not(id: not_fip_ids)
+                                      .where.not(participant_declarations: { state: archivable_states })
+                                      .distinct
+    with_unarchivable_declaration = with_unarchivable_declaration.where(id: restrict_to_participant_ids) if restrict_to_participant_ids.any?
+    with_unarchivable_declaration_ids = with_unarchivable_declaration.pluck(:id)
+
+    query = joins(schedule: :cohort)
+              .where.not(cohorts: { payments_frozen_at: nil })
+              .where(induction_completion_date: nil)
+              .where("induction_start_date IS NULL OR induction_start_date < make_date(cohorts.start_year, 9, 1)")
+              .where.not(id: not_fip_ids + with_unarchivable_declaration_ids)
+    query = query.where(id: restrict_to_participant_ids) if restrict_to_participant_ids.any?
+
+    query
   end
 
   def completed_training?

--- a/app/models/participant_profile/ect.rb
+++ b/app/models/participant_profile/ect.rb
@@ -34,6 +34,7 @@ class ParticipantProfile::ECT < ParticipantProfile::ECF
     with_unarchivable_declaration = with_unarchivable_declaration.where(id: restrict_to_participant_ids) if restrict_to_participant_ids.any?
     with_unarchivable_declaration_ids = with_unarchivable_declaration.pluck(:id)
 
+    # ECTs in a payments-frozen cohort with no induction start date or prior to Sept 2021 excluding the ones above
     query = joins(schedule: :cohort)
               .where.not(cohorts: { payments_frozen_at: nil })
               .where(induction_completion_date: nil)

--- a/app/models/participant_profile/ect.rb
+++ b/app/models/participant_profile/ect.rb
@@ -11,8 +11,6 @@ class ParticipantProfile::ECT < ParticipantProfile::ECF
   }
 
   def self.archivable_from_frozen_cohort(restrict_to_participant_ids: [])
-    archivable_states = %i[ineligible voided submitted].freeze
-
     # ECTs that have no FIP induction records
     not_fip = InductionRecord.joins(:induction_programme, participant_profile: { schedule: :cohort })
                              .where.not(cohorts: { payments_frozen_at: nil })
@@ -29,7 +27,7 @@ class ParticipantProfile::ECT < ParticipantProfile::ECF
                                       .where(induction_completion_date: nil)
                                       .where("induction_start_date IS NULL OR induction_start_date < make_date(cohorts.start_year, 9, 1)")
                                       .where.not(id: not_fip_ids)
-                                      .where.not(participant_declarations: { state: archivable_states })
+                                      .where(participant_declarations: { state: ParticipantDeclaration.non_archivable_states })
                                       .distinct
     with_unarchivable_declaration = with_unarchivable_declaration.where(id: restrict_to_participant_ids) if restrict_to_participant_ids.any?
     with_unarchivable_declaration_ids = with_unarchivable_declaration.pluck(:id)

--- a/app/models/participant_profile/mentor.rb
+++ b/app/models/participant_profile/mentor.rb
@@ -22,8 +22,6 @@ class ParticipantProfile::Mentor < ParticipantProfile::ECF
   }
 
   def self.archivable_from_frozen_cohort(restrict_to_participant_ids: [])
-    archivable_states = %i[ineligible voided submitted].freeze
-
     # Mentors that have no FIP induction records
     not_fip = InductionRecord.joins(:induction_programme, participant_profile: { schedule: :cohort })
                              .where.not(cohorts: { payments_frozen_at: nil })
@@ -38,7 +36,7 @@ class ParticipantProfile::Mentor < ParticipantProfile::ECF
                                       .where.not(cohorts: { payments_frozen_at: nil })
                                       .where(mentor_completion_date: nil)
                                       .where.not(id: not_fip_ids)
-                                      .where.not(participant_declarations: { state: archivable_states })
+                                      .where(participant_declarations: { state: ParticipantDeclaration.non_archivable_states })
                                       .distinct
     with_unarchivable_declaration = with_unarchivable_declaration.where(id: restrict_to_participant_ids) if restrict_to_participant_ids.any?
     with_unarchivable_declaration_ids = with_unarchivable_declaration.pluck(:id)

--- a/app/models/participant_profile/mentor.rb
+++ b/app/models/participant_profile/mentor.rb
@@ -44,10 +44,11 @@ class ParticipantProfile::Mentor < ParticipantProfile::ECF
     with_unarchivable_declaration_ids = with_unarchivable_declaration.pluck(:id)
 
     # Mentors ever assigned an ECT
-    with_mentee = InductionRecord.joins(:induction_programme, :participant_profile)
-                                 .where(participant_profiles: { type: "ParticipantProfile::ECT" })
+    with_mentee = InductionRecord.joins(:induction_programme, mentor_profile: { schedule: :cohort })
                                  .where.not(mentor_profile_id: nil)
                                  .where.not(mentor_profile_id: not_fip_ids + with_unarchivable_declaration_ids)
+                                 .where.not(cohorts: { payments_frozen_at: nil })
+                                 .where(participant_profiles: { mentor_completion_date: nil })
     with_mentee = with_mentee.where(mentor_profile_id: restrict_to_participant_ids) if restrict_to_participant_ids.any?
     with_mentee_ids = with_mentee.pluck(:mentor_profile_id).uniq
 

--- a/app/models/participant_profile/mentor.rb
+++ b/app/models/participant_profile/mentor.rb
@@ -24,7 +24,7 @@ class ParticipantProfile::Mentor < ParticipantProfile::ECF
   def self.archivable_from_frozen_cohort(restrict_to_participant_ids: [])
     archivable_states = %i[ineligible voided submitted].freeze
 
-    # ECTs that have no FIP induction records
+    # Mentors that have no FIP induction records
     not_fip = InductionRecord.joins(:induction_programme, participant_profile: { schedule: :cohort })
                              .where.not(cohorts: { payments_frozen_at: nil })
                              .where(participant_profiles: { mentor_completion_date: nil })

--- a/app/models/participant_profile/mentor.rb
+++ b/app/models/participant_profile/mentor.rb
@@ -51,7 +51,7 @@ class ParticipantProfile::Mentor < ParticipantProfile::ECF
     with_mentee = with_mentee.where(mentor_profile_id: restrict_to_participant_ids) if restrict_to_participant_ids.any?
     with_mentee_ids = with_mentee.pluck(:mentor_profile_id).uniq
 
-    # Mentors in a payments frozen cohort with no completion date
+    # Mentors in a payments frozen cohort with no completion date excluding the ones above
     query = joins(schedule: :cohort)
               .where.not(cohorts: { payments_frozen_at: nil })
               .where(mentor_completion_date: nil)

--- a/app/models/participant_profile/mentor.rb
+++ b/app/models/participant_profile/mentor.rb
@@ -22,9 +22,43 @@ class ParticipantProfile::Mentor < ParticipantProfile::ECF
   }
 
   def self.archivable_from_frozen_cohort(restrict_to_participant_ids: [])
-    super(restrict_to_participant_ids:)
-      .where(mentor_completion_date: nil)
-      .where.not(id: InductionRecord.where.not(mentor_profile_id: nil).select(:mentor_profile_id).distinct)
+    archivable_states = %i[ineligible voided submitted].freeze
+
+    # ECTs that have no FIP induction records
+    not_fip = InductionRecord.joins(:induction_programme, participant_profile: { schedule: :cohort })
+                             .where.not(cohorts: { payments_frozen_at: nil })
+                             .where(participant_profiles: { mentor_completion_date: nil })
+                             .where(participant_profiles: { type: "ParticipantProfile::Mentor" })
+                             .where.not(induction_programme: { training_programme: :full_induction_programme })
+    not_fip = not_fip.where(participant_profile_id: restrict_to_participant_ids) if restrict_to_participant_ids.any?
+    not_fip_ids = not_fip.pluck(:participant_profile_id).uniq
+
+    # Mentors that have at least one non-archivable declaration
+    with_unarchivable_declaration = joins(:participant_declarations, schedule: :cohort)
+                                      .where.not(cohorts: { payments_frozen_at: nil })
+                                      .where(mentor_completion_date: nil)
+                                      .where.not(id: not_fip_ids)
+                                      .where.not(participant_declarations: { state: archivable_states })
+                                      .distinct
+    with_unarchivable_declaration = with_unarchivable_declaration.where(id: restrict_to_participant_ids) if restrict_to_participant_ids.any?
+    with_unarchivable_declaration_ids = with_unarchivable_declaration.pluck(:id)
+
+    # Mentors ever assigned an ECT
+    with_mentee = InductionRecord.joins(:induction_programme, :participant_profile)
+                                 .where(participant_profiles: { type: "ParticipantProfile::ECT" })
+                                 .where.not(mentor_profile_id: nil)
+                                 .where.not(mentor_profile_id: not_fip_ids + with_unarchivable_declaration_ids)
+    with_mentee = with_mentee.where(mentor_profile_id: restrict_to_participant_ids) if restrict_to_participant_ids.any?
+    with_mentee_ids = with_mentee.pluck(:mentor_profile_id).uniq
+
+    # Mentors in a payments frozen cohort with no completion date
+    query = joins(schedule: :cohort)
+              .where.not(cohorts: { payments_frozen_at: nil })
+              .where(mentor_completion_date: nil)
+              .where.not(id: not_fip_ids + with_unarchivable_declaration_ids + with_mentee_ids)
+    query = query.where(id: restrict_to_participant_ids) if restrict_to_participant_ids.any?
+
+    query
   end
 
   def complete_training!(completion_date:, completion_reason:)

--- a/spec/support/shared_examples/archivable_support.rb
+++ b/spec/support/shared_examples/archivable_support.rb
@@ -70,18 +70,20 @@ RSpec.shared_examples "can archive participant profile" do |other_participant_ty
       expect(participant_profile).not_to be_archivable_from_frozen_cohort
     end
 
-    it "returns false if the participant has not archivable declarations" do
-      paid_declaration = build_declaration(state: :paid, cohort: eligible_cohort)
-      participant_profile = paid_declaration.participant_profile
-      declaration_date = participant_profile.schedule.milestones.find_by(declaration_type: "retained-2").milestone_date - 1.day
-      travel_to declaration_date do
-        build_declaration(state: :voided,
-                          cohort: eligible_cohort,
-                          participant_profile:,
-                          cpd_lead_provider: paid_declaration.cpd_lead_provider,
-                          declaration_date:,
-                          declaration_type: "retained-2")
-        expect(participant_profile).not_to be_archivable_from_frozen_cohort
+    ParticipantDeclaration.non_archivable_states.each do |declaration_state|
+      it "returns false if the participant has #{declaration_state} declarations" do
+        paid_declaration = build_declaration(state: declaration_state, cohort: eligible_cohort)
+        participant_profile = paid_declaration.participant_profile
+        declaration_date = participant_profile.schedule.milestones.find_by(declaration_type: "retained-2").milestone_date - 1.day
+        travel_to declaration_date do
+          build_declaration(state: :voided,
+                            cohort: eligible_cohort,
+                            participant_profile:,
+                            cpd_lead_provider: paid_declaration.cpd_lead_provider,
+                            declaration_date:,
+                            declaration_type: "retained-2")
+          expect(participant_profile).not_to be_archivable_from_frozen_cohort
+        end
       end
     end
 

--- a/spec/support/shared_examples/archivable_support.rb
+++ b/spec/support/shared_examples/archivable_support.rb
@@ -70,9 +70,19 @@ RSpec.shared_examples "can archive participant profile" do |other_participant_ty
       expect(participant_profile).not_to be_archivable_from_frozen_cohort
     end
 
-    it "returns false if the participant has billable declarations" do
-      participant_profile = build_declaration(state: :paid, cohort: eligible_cohort).participant_profile
-      expect(participant_profile).not_to be_archivable_from_frozen_cohort
+    it "returns false if the participant has not archivable declarations" do
+      paid_declaration = build_declaration(state: :paid, cohort: eligible_cohort)
+      participant_profile = paid_declaration.participant_profile
+      declaration_date = participant_profile.schedule.milestones.find_by(declaration_type: "retained-2").milestone_date - 1.day
+      travel_to declaration_date do
+        build_declaration(state: :voided,
+                          cohort: eligible_cohort,
+                          participant_profile:,
+                          cpd_lead_provider: paid_declaration.cpd_lead_provider,
+                          declaration_date:,
+                          declaration_type: "retained-2")
+        expect(participant_profile).not_to be_archivable_from_frozen_cohort
+      end
     end
 
     it "returns false if the participant has a CIP induction record" do


### PR DESCRIPTION
…ble and non-archivable declarations

### Context

  The code to archive participants in a closing cohort is including participants who has both "archivable" and "non-archivable" declarations. 

  This fix amends that to only include participants with no "non-archivable" declarations at all.

- Included as part of [Closing 2021: Archive 2021 participants that didn't start training](https://dfedigital.atlassian.net/browse/CST-2578): 

### Changes proposed in this pull request

Redefinition of the class method in `ParticipantProfile::ECF` class to archive closing cohort participants.
Instead a specific version has been written for the 2 subclasses: `ParticipantProfile::ECT` and `ParticipantProfile::Mentor`.

### Guidance to review

