### PR TITLE
Move `analytics_appropriate_bodies` to the analytics blocklist

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -404,13 +404,6 @@
   - pupil_premium
   - schedule_identifier
   - external_id
-  :analytics_appropriate_bodies:
-  - id
-  - appropriate_body_id
-  - name
-  - body_type
-  - created_at
-  - updated_at
   :analytics_schools:
   - id
   - name

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -520,3 +520,10 @@
     - message
     - created_at
     - updated_at
+  :analytics_appropriate_bodies:
+  - id
+  - appropriate_body_id
+  - name
+  - body_type
+  - created_at
+  - updated_at


### PR DESCRIPTION
This is no longer wanted in BigQuery by the CPD data team.
