### PR TITLE
Generate known tokens for parity check on migration DB restore

### DIFF
--- a/.github/workflows/refresh_migration_database.yml
+++ b/.github/workflows/refresh_migration_database.yml
@@ -25,3 +25,25 @@ jobs:
         with:
           environment: production
           azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
+          
+      - name: Login
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
+        with:
+          azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Install kubectl
+        uses: DFE-Digital/github-actions/set-kubectl@master
+
+      - name: Set AKS credentials (migration)
+        shell: bash
+        run: make ci migration get-cluster-credentials
+
+      - name: Generate known keys
+        shell: bash
+        run: |
+          kubectl -n cpd-production exec -ti --tty deployment/npq-registration-migration-web -- /bin/sh -c "cd /app && bundle exec rails runner \"Migration::ParityCheck::TokenProvider.new.generate!\""
+          

--- a/app/services/migration/parity_check/token_provider.rb
+++ b/app/services/migration/parity_check/token_provider.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Migration
+  class ParityCheck::TokenProvider
+    class UnsupportedEnvironmentError < RuntimeError; end
+
+    def generate!
+      raise UnsupportedEnvironmentError, "The parity check functionality is disabled for this environment" unless enabled?
+
+      known_tokens_by_lead_provider_ecf_id.each do |id, token|
+        cpd_lead_provider = NPQLeadProvider.find_by!(id:).cpd_lead_provider
+        create_with_known_token!(token:, cpd_lead_provider:) if cpd_lead_provider
+      end
+    end
+
+  private
+
+    def known_tokens_by_lead_provider_ecf_id
+      JSON.parse(ENV["PARITY-CHECK-KEYS"].to_s)
+    rescue JSON::ParserError
+      {}
+    end
+
+    def create_with_known_token!(token:, cpd_lead_provider:)
+      LeadProviderApiToken.create_with_known_token!(token, cpd_lead_provider:)
+    end
+
+    def enabled?
+      Rails.env.migration?
+    end
+  end
+end

--- a/app/services/migration/parity_check/token_provider.rb
+++ b/app/services/migration/parity_check/token_provider.rb
@@ -16,7 +16,7 @@ module Migration
   private
 
     def known_tokens_by_lead_provider_ecf_id
-      JSON.parse(ENV["PARITY-CHECK-KEYS"].to_s)
+      JSON.parse(ENV["PARITY_CHECK_KEYS"].to_s)
     rescue JSON::ParserError
       {}
     end

--- a/spec/services/migration/parity_check/token_provider_spec.rb
+++ b/spec/services/migration/parity_check/token_provider_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Migration::ParityCheck::TokenProvider do
+  before do
+    create_list(:npq_lead_provider, 3)
+
+    allow(Rails).to receive(:env) { environment.inquiry }
+
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with("PARITY-CHECK-KEYS").and_return(keys.to_json) if keys
+  end
+
+  let(:instance) { described_class.new }
+
+  describe "#generate!" do
+    subject(:generate) { instance.generate! }
+
+    context "when running in migration" do
+      let(:environment) { "migration" }
+
+      context "when the keys are not present" do
+        let(:keys) { nil }
+
+        it { expect { generate }.not_to change(ApiToken, :count) }
+      end
+
+      context "when the keys are present" do
+        let(:keys) do
+          NPQLeadProvider.all.each_with_object({}) do |lead_provider, hash|
+            hash[lead_provider.id] = SecureRandom.uuid
+          end
+        end
+
+        it { expect { generate }.to change(ApiToken, :count).by(NPQLeadProvider.count) }
+
+        it "generates valid tokens for each lead provider" do
+          generate
+
+          NPQLeadProvider.find_each do |lead_provider|
+            cpd_lead_provider = lead_provider.cpd_lead_provider
+            token = keys[lead_provider.id]
+            expect(ApiToken.find_by_unhashed_token(token).cpd_lead_provider).to eq(cpd_lead_provider)
+          end
+        end
+      end
+    end
+
+    context "when not running in migration" do
+      let(:environment) { "production" }
+      let(:keys) { {} }
+
+      it { expect { generate }.to raise_error(described_class::UnsupportedEnvironmentError, "The parity check functionality is disabled for this environment") }
+    end
+  end
+end

--- a/spec/services/migration/parity_check/token_provider_spec.rb
+++ b/spec/services/migration/parity_check/token_provider_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Migration::ParityCheck::TokenProvider do
     allow(Rails).to receive(:env) { environment.inquiry }
 
     allow(ENV).to receive(:[]).and_call_original
-    allow(ENV).to receive(:[]).with("PARITY-CHECK-KEYS").and_return(keys.to_json) if keys
+    allow(ENV).to receive(:[]).with("PARITY_CHECK_KEYS").and_return(keys.to_json) if keys
   end
 
   let(:instance) { described_class.new }


### PR DESCRIPTION
[Jira-3650](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345%2Cunassigned&selectedIssue=CPDLP-3650)

### Context

We hit an issue when running the original token provider whereby the keys would generate but not work in the migration environment. This was due to the keys being generated using the NPQ reg migration environment secret_key_base but verified in ECF using a different secret_key_base.

To get around this, we are going to use known tokens; each migration keyvault has the same set of tokens indexed by the lead provider `ecf_id`. After restoring the migration database we will create the known-tokens for the parity check service to use.

### Changes proposed in this pull request

- Generate known tokens for parity check on migration DB restore

### Guidance for review

The keyvaults have been updated with a `PARITY-CHECK-KEYS` secret, which is in the format:

```
LeadProvider.all.each_with_object({}) do |lead_provider, hash|
  hash[lead_provider.ecf_id] = SecureRandom.uuid
end.to_json
```