### PR TITLE
[CST-2765] Cross-Check 2024 ECT Appropriate Body Records Against DQT

### DIFF
--- a/app/jobs/update_participant_appropriate_body_dqt_check_job.rb
+++ b/app/jobs/update_participant_appropriate_body_dqt_check_job.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class UpdateParticipantAppropriateBodyDQTCheckJob < ApplicationJob
+  queue_as :default
+
+  def perform(participant_profile_id)
+    # Participant profiles sometimes are getting deleted (when dedupped for example).
+    # Ensure they exist before updating the DQT AB check record.
+    if ParticipantAppropriateBodyDQTCheck.exists?(participant_profile_id:)
+      check_record = ParticipantAppropriateBodyDQTCheck.find_by(participant_profile_id:)
+
+      # Get the appropriate body name from DQT's latest period
+      dqt_response = DQT::V3::Client.new.get_record(trn: check_record.participant_profile.trn)
+      dqt_latest_period = dqt_response["induction"]["periods"].max_by { |period| period["startDate"] }
+      dqt_ab_name = dqt_latest_period["appropriateBody"]["name"]
+
+      check_record.update!(dqt_appropriate_body_name: dqt_ab_name)
+    else
+      Rails.logger.info "Couldn't find the participant profile with id #{participant_profile_id}"
+    end
+  end
+end

--- a/app/models/participant_appropriate_body_dqt_check.rb
+++ b/app/models/participant_appropriate_body_dqt_check.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ParticipantAppropriateBodyDQTCheck < ApplicationRecord
+  belongs_to :participant_profile
+
+  # Prioritise the leading school of the AB, then the AB name and finaly nil if the participant doesn't have any AB.
+  # That's because for some reasone DQT returns the leading school as the Appropriate Body name if available.
+  def normalised_appropriate_body_name
+    appropriate_body_name&.match(/\(([^)]+)\)/)&.captures&.first || appropriate_body_name
+  end
+end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -527,3 +527,10 @@
   - body_type
   - created_at
   - updated_at
+  :participant_appropriate_body_dqt_checks:
+  - id
+  - participant_profile_id
+  - appropriate_body_name
+  - dqt_appropriate_body_name
+  - created_at
+  - updated_at

--- a/db/migrate/20241021071942_create_participant_appropriate_body_dqt_checks.rb
+++ b/db/migrate/20241021071942_create_participant_appropriate_body_dqt_checks.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateParticipantAppropriateBodyDQTChecks < ActiveRecord::Migration[7.1]
+  def change
+    create_table :participant_appropriate_body_dqt_checks do |t|
+      t.uuid :participant_profile_id, null: false
+      t.string :appropriate_body_name
+      t.string :dqt_appropriate_body_name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_18_153716) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_21_071942) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -784,6 +784,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_18_153716) do
     t.uuid "cpd_lead_provider_id"
     t.boolean "vat_chargeable", default: true
     t.index ["cpd_lead_provider_id"], name: "index_npq_lead_providers_on_cpd_lead_provider_id"
+  end
+
+  create_table "participant_appropriate_body_dqt_checks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "participant_profile_id", null: false
+    t.string "appropriate_body_name"
+    t.string "dqt_appropriate_body_name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "participant_bands", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/lib/tasks/participant_appropriate_body_dqt_checks.rake
+++ b/lib/tasks/participant_appropriate_body_dqt_checks.rake
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+require "csv"
+
+namespace :participant_appropriate_body_dqt_checks do
+  desc "Pre-populate the participant_appropriate_body_dqt_checks with all the active 2024 ECT participants"
+  task prepopulate_records: :environment do
+    cohort_start_year = 2024
+
+    InductionRecord
+      .includes(:appropriate_body)
+      .joins(:cohort, :participant_profile)
+      .where(participant_profiles: { type: "ParticipantProfile::ECT" })
+      .where(cohorts: { start_year: cohort_start_year })
+      .where(end_date: nil, induction_status: :active, training_status: :active)
+      .find_each(batch_size: 1000) do |induction_record|
+      unless ParticipantAppropriateBodyDQTCheck.exists?(participant_profile_id: induction_record.participant_profile_id)
+        ParticipantAppropriateBodyDQTCheck.create!(
+          participant_profile_id: induction_record.participant_profile_id,
+          appropriate_body_name: induction_record.appropriate_body_name,
+        )
+      end
+    end
+  end
+
+  desc "Update the ParticipantAppropriateBodyDQTCheck records with the AB name from DQT"
+  task process_records: :environment do
+    batch_size = 300
+    delay_interval = 1.minute
+
+    # Limit processing to a maximum of 300 records per minute to ensure we stay within the DQT API’s 1000 requests per minute rate limit
+    ParticipantAppropriateBodyDQTCheck.where(dqt_appropriate_body_name: nil).find_in_batches(batch_size:).with_index do |batch, index|
+      batch.each do |record|
+        UpdateParticipantAppropriateBodyDQTCheckJob.set(wait: index * delay_interval).perform_later(record.participant_profile_id)
+      end
+    end
+  end
+
+  desc "Generate a CSV with the Participant's and DQT's appropriate body missmatches"
+  task export_mismatches: :environment do
+    csv_file_path = Rails.root.join("tmp/mismatched_records.csv")
+
+    CSV.open(csv_file_path, "w", headers: true) do |csv|
+      csv << ["TRN", "Appropriate Body Name", "DQT Appropriate Body Name"]
+
+      ParticipantAppropriateBodyDQTCheck.includes(:participant_profile).find_each do |record|
+        if record.normalised_appropriate_body_name != record.dqt_appropriate_body_name
+          csv << [record.participant_profile.trn, record.normalised_appropriate_body_name, record.dqt_appropriate_body_name]
+        end
+      end
+    end
+
+    puts "CSV file with mismatched records generated at #{csv_file_path}"
+  end
+end

--- a/lib/tasks/participant_appropriate_body_dqt_checks.rake
+++ b/lib/tasks/participant_appropriate_body_dqt_checks.rake
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "csv"
 
 namespace :participant_appropriate_body_dqt_checks do

--- a/spec/models/participant_appropriate_body_dqt_check_spec.rb
+++ b/spec/models/participant_appropriate_body_dqt_check_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ParticipantAppropriateBodyDQTCheck, type: :model do
+  describe "#normalised_appropriate_body_name" do
+    let(:record) { ParticipantAppropriateBodyDQTCheck.new(appropriate_body_name:) }
+
+    context "when appropriate_body_name contains a leading school name in parentheses" do
+      let(:appropriate_body_name) { "Some AB (Leading School Name)" }
+
+      it "returns the leading school name" do
+        expect(record.normalised_appropriate_body_name).to eq("Leading School Name")
+      end
+    end
+
+    context "when appropriate_body_name does not contain parentheses" do
+      let(:appropriate_body_name) { "Some AB" }
+
+      it "returns the full appropriate_body_name" do
+        expect(record.normalised_appropriate_body_name).to eq("Some AB")
+      end
+    end
+
+    context "when appropriate_body_name is nil" do
+      let(:appropriate_body_name) { nil }
+
+      it "returns nil" do
+        expect(record.normalised_appropriate_body_name).to be_nil
+      end
+    end
+
+    context "when appropriate_body_name has parentheses with extra characters" do
+      let(:appropriate_body_name) { "Some AB (Leading School - Extra Info)" }
+
+      it "returns what is inside the parentheses" do
+        expect(record.normalised_appropriate_body_name).to eq("Leading School - Extra Info")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: CST-2765

This PR enables cross-checking our records for 20,000 active 2024 ECTs against DQT records to identify any participants whose Appropriate Body does not match the DQT record.

Since the DQT API has a rate limit of 1000 requests per minute, it’s crucial to ensure we don't exceed this quota and cause bottlenecks to the service.

We’ve also noticed that the DQT returns the name of the leading school for the Appropriate Bodies, whereas in our records, we typically include it in parentheses as part of the Appropriate Body name. For example, for an Appropriate Body named `London TSH` with a leading school `Astro Primary School`, our records show it as `London TSH (Astro Primary School)`, while the DQT response simply lists `Astro Primary School`.

### Changes proposed in this pull request
- Add a temporary table to store all the active 2024 participants to enable batch processing
- Add a Model for the temp records, including a method that formats the Appropriate Body name for correct comparison with the DQT one
- Add task to pre-populate the data required from our records
- Add task to process the records in 300 batches per min, fetch the DQT record and update the temporary table
- Add task to compare the participant's appropriate body name against the dqt one and export the mismatches for manual review


### Guidance to review

1. Queries efficiency
2. Processing 300 records per minute will take ~67 minutes to process all the records
