### PR TITLE
Move API Requests in DFE Analytics to custom events

### DIFF
--- a/app/jobs/api_request_job.rb
+++ b/app/jobs/api_request_job.rb
@@ -28,14 +28,7 @@ class ApiRequestJob
     }
 
     ApiRequest.create!(data)
-
-    event = DfE::Analytics::Event.new
-                                 .with_type(:persist_api_request)
-                                 .with_request_uuid(uuid)
-                                 .with_entity_table_name(:api_requests)
-                                 .with_data(data)
-
-    DfE::Analytics::SendEvents.do(Array.wrap(event.as_json))
+    send_analytics_event(cpd_lead_provider:, data:, uuid:)
   end
 
 private
@@ -66,5 +59,17 @@ private
     end
   rescue JSON::ParserError
     { error: "request data did not contain valid JSON" }
+  end
+
+  def send_analytics_event(cpd_lead_provider:, data:, uuid:)
+    return if cpd_lead_provider.blank?
+
+    event = DfE::Analytics::Event.new
+                                 .with_type(:persist_api_request)
+                                 .with_request_uuid(uuid)
+                                 .with_entity_table_name(:api_requests)
+                                 .with_data(data:)
+
+    DfE::Analytics::SendEvents.do(Array.wrap(event.as_json))
   end
 end

--- a/app/jobs/api_request_job.rb
+++ b/app/jobs/api_request_job.rb
@@ -16,7 +16,7 @@ class ApiRequestJob
     response_headers = response_data[:headers]
     response_body = response_data[:body]
 
-    ApiRequest.create!(
+    data = {
       request_path: request_data[:path],
       request_headers:,
       request_body: request_body(request_data),
@@ -27,7 +27,16 @@ class ApiRequestJob
       user_description: token&.owner_description,
       cpd_lead_provider:,
       created_at:,
-    )
+    }
+
+    ApiRequest.create!(data)
+
+    event = DfE::Analytics::Event.new
+                                 .with_type(:persist_api_request)
+                                 .with_entity_table_name(:api_requests)
+                                 .with_data(data)
+
+    DfE::Analytics::SendEvents.do(Array.wrap(event.as_json))
   end
 
 private

--- a/app/jobs/api_request_job.rb
+++ b/app/jobs/api_request_job.rb
@@ -33,6 +33,7 @@ class ApiRequestJob
 
     event = DfE::Analytics::Event.new
                                  .with_type(:persist_api_request)
+                                 .with_request_uuid(uuid)
                                  .with_entity_table_name(:api_requests)
                                  .with_data(data)
 

--- a/app/jobs/api_request_job.rb
+++ b/app/jobs/api_request_job.rb
@@ -69,6 +69,7 @@ private
                                  .with_request_uuid(uuid)
                                  .with_entity_table_name(:api_requests)
                                  .with_data(data:)
+                                 .with_user(cpd_lead_provider)
 
     DfE::Analytics::SendEvents.do(Array.wrap(event.as_json))
   end

--- a/app/jobs/api_request_job.rb
+++ b/app/jobs/api_request_job.rb
@@ -5,8 +5,6 @@ class ApiRequestJob
   include ActionController::HttpAuthentication::Token
 
   def perform(request_data, response_data, status_code, created_at, uuid)
-    RequestLocals.store[:dfe_analytics_request_id] = uuid
-
     request_data = request_data.with_indifferent_access
     response_data = response_data.with_indifferent_access
     request_headers = request_data.fetch(:headers, {})

--- a/app/models/api_request.rb
+++ b/app/models/api_request.rb
@@ -5,10 +5,4 @@ class ApiRequest < ApplicationRecord
   scope :unprocessable_entities, -> { where(status_code: 422) }
   scope :errors, -> { where.not(status_code: [200, 302, 301]) }
   scope :successful, -> { where(status_code: [200]) }
-
-  def send_event(type, data)
-    return if cpd_lead_provider.blank?
-
-    super
-  end
 end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -358,19 +358,6 @@
   - type
   - cohort_id
   - identifier_alias
-  :api_requests:
-  - id
-  - request_path
-  - status_code
-  - request_headers
-  - request_body
-  - response_body
-  - request_method
-  - response_headers
-  - cpd_lead_provider_id
-  - user_description
-  - created_at
-  - updated_at
   :support_queries:
   - id
   - user_id

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -534,3 +534,16 @@
   - dqt_appropriate_body_name
   - created_at
   - updated_at
+  :api_requests:
+  - id
+  - request_path
+  - status_code
+  - request_headers
+  - request_body
+  - response_body
+  - request_method
+  - response_headers
+  - cpd_lead_provider_id
+  - user_description
+  - created_at
+  - updated_at

--- a/config/analytics_custom_events.yml
+++ b/config/analytics_custom_events.yml
@@ -1,0 +1,3 @@
+---
+shared:
+  - persist_api_request

--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -45,7 +45,7 @@ DfE::Analytics.configure do |config|
   # enable analytics. You might want to hook this up to a feature flag or
   # environment variable.
 
-  config.enable_analytics = proc { !Rails.env.review? && FeatureFlag.active?(:dfe_analytics) }
+  config.enable_analytics = proc { FeatureFlag.active?(:dfe_analytics) }
 
   # The environment we’re running in. This value will be attached
   # to all events we send to BigQuery.

--- a/spec/jobs/api_request_job_spec.rb
+++ b/spec/jobs/api_request_job_spec.rb
@@ -121,6 +121,7 @@ RSpec.describe ApiRequestJob do
             "event_type" => "persist_api_request",
             "request_uuid" => request_uuid,
             "entity_table_name" => "api_requests",
+            "user_id" => cpd_lead_provider.id,
             "data" => array_including({ "key" => "request_path", "value" => ["/api/v1/bar"] }),
           ),
         )

--- a/spec/jobs/api_request_job_spec.rb
+++ b/spec/jobs/api_request_job_spec.rb
@@ -114,15 +114,19 @@ RSpec.describe ApiRequestJob do
 
     context "when the dfe_analytics feature is enabled" do
       before { FeatureFlag.activate(:dfe_analytics) }
+
       let(:expected_job_data) do
-        {
-          "event_type" => "persist_api_request",
-          "request_uuid" => request_uuid,
-          "entity_table_name" => "api_requests",
-        }
+        array_including(
+          hash_including(
+            "event_type" => "persist_api_request",
+            "request_uuid" => request_uuid,
+            "entity_table_name" => "api_requests",
+            "data" => array_including({ "key" => "request_path", "value" => ["/api/v1/bar"] }),
+          ),
+        )
       end
 
-      it "saves the request_uuid on the big query event" do
+      it "sends event to analytics with API request data and uuid" do
         expect {
           described_class.new.perform({
             headers:,
@@ -130,7 +134,7 @@ RSpec.describe ApiRequestJob do
             path: "/api/v1/bar",
             method: "POST",
           }, {}, 500, Time.zone.now, request_uuid)
-        }.to have_enqueued_job(DfE::Analytics::SendEvents).with(array_including(hash_including(**expected_job_data))).on_queue("dfe_analytics")
+        }.to have_enqueued_job(DfE::Analytics::SendEvents).with(expected_job_data).on_queue("dfe_analytics")
       end
     end
 
@@ -151,6 +155,8 @@ RSpec.describe ApiRequestJob do
   end
 
   context "when the api request is not made by a lead provider" do
+    before { FeatureFlag.activate(:dfe_analytics) }
+
     it "does not send events to analytics" do
       expect {
         described_class.new.perform({

--- a/spec/jobs/api_request_job_spec.rb
+++ b/spec/jobs/api_request_job_spec.rb
@@ -114,6 +114,13 @@ RSpec.describe ApiRequestJob do
 
     context "when the dfe_analytics feature is enabled" do
       before { FeatureFlag.activate(:dfe_analytics) }
+      let(:expected_job_data) do
+        {
+          "event_type" => "persist_api_request",
+          "request_uuid" => request_uuid,
+          "entity_table_name" => "api_requests",
+        }
+      end
 
       it "saves the request_uuid on the big query event" do
         expect {
@@ -123,7 +130,7 @@ RSpec.describe ApiRequestJob do
             path: "/api/v1/bar",
             method: "POST",
           }, {}, 500, Time.zone.now, request_uuid)
-        }.to have_enqueued_job(DfE::Analytics::SendEvents).with(array_including(hash_including("request_uuid" => request_uuid))).on_queue("dfe_analytics")
+        }.to have_enqueued_job(DfE::Analytics::SendEvents).with(array_including(hash_including(**expected_job_data))).on_queue("dfe_analytics")
       end
     end
 

--- a/spec/models/api_request_spec.rb
+++ b/spec/models/api_request_spec.rb
@@ -37,32 +37,4 @@ RSpec.describe ApiRequest, type: :model do
       end
     end
   end
-
-  describe "#send_event" do
-    before do
-      FeatureFlag.activate(:dfe_analytics)
-      allow(DfE::Analytics::SendEvents).to receive(:perform_later)
-    end
-
-    it "sends analytics events with the request uuid" do
-      RequestLocals.store[:dfe_analytics_request_id] = "example-request-id"
-
-      subject.send_event("create_entity", {})
-
-      expect(DfE::Analytics::SendEvents).to have_received(:perform_later)
-        .with([a_hash_including({
-          "request_uuid" => "example-request-id",
-        })])
-    end
-
-    context "when api request is not from a lead provider" do
-      subject { create(:api_request, cpd_lead_provider: nil) }
-
-      it "does not send analytics events" do
-        subject.send_event("create_entity", {})
-
-        expect(DfE::Analytics::SendEvents).not_to have_received(:perform_later)
-      end
-    end
-  end
 end


### PR DESCRIPTION
### Context

- Ticket: n/a

API requests are huge and we need to stop sending them via BQ dfe analytics, but via a custom event

### Changes proposed in this pull request
- remove API request from BQ dfe analytics
- add custom event to send this data

### Guidance to review
commit by commit
