### PR TITLE
Support filtering by declaration type in migration environment

### DIFF
--- a/app/controllers/api/v1/participant_declarations_controller.rb
+++ b/app/controllers/api/v1/participant_declarations_controller.rb
@@ -51,6 +51,7 @@ module Api
           cpd_lead_provider:,
           updated_since:,
           participant_id: participant_id_filter,
+          type: type_filter,
         ).scope
       end
 
@@ -60,6 +61,10 @@ module Api
 
       def participant_id_filter
         filter[:participant_id]
+      end
+
+      def type_filter
+        filter[:type]
       end
 
       def cpd_lead_provider

--- a/app/controllers/api/v3/participant_declarations_controller.rb
+++ b/app/controllers/api/v3/participant_declarations_controller.rb
@@ -66,7 +66,7 @@ module Api
       end
 
       def query_params
-        params.permit(:id, filter: %i[cohort participant_id updated_since delivery_partner_id])
+        params.permit(:id, filter: %i[cohort participant_id updated_since delivery_partner_id type])
       end
 
       def permitted_params

--- a/app/services/api/v3/participant_declarations_query.rb
+++ b/app/services/api/v3/participant_declarations_query.rb
@@ -113,7 +113,20 @@ module Api
         filter[:delivery_partner_id]&.split(",")
       end
 
+      def type
+        return nil unless Rails.env.migration?
+
+        case filter[:type]&.downcase&.to_sym
+        when :npq
+          ParticipantDeclaration::NPQ
+        when :ecf
+          ParticipantDeclaration::ECF
+        end
+      end
+
       def declaration_class
+        return type if type.present?
+
         if NpqApiEndpoint.disabled?
           ParticipantDeclaration::ECF
         else

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -779,6 +779,33 @@ RSpec.describe "participant-declarations endpoint spec", type: :request, mid_coh
         end
       end
 
+      context "when a type filter used" do
+        let(:environment) { "migration" }
+        before { allow(Rails).to receive(:env).and_return(environment.inquiry) }
+
+        it "returns NPQ declarations when filtering by NPQ" do
+          get "/api/v1/participant-declarations", params: { filter: { type: :npq } }
+          expect(response.status).to eq 200
+          expect(parsed_response["data"].size).to eq 0
+        end
+
+        it "returns ECF declarations when filtering by ECF" do
+          get "/api/v1/participant-declarations", params: { filter: { type: :ecf } }
+          expect(response.status).to eq 200
+          expect(parsed_response["data"].size).to eq 1
+        end
+
+        context "when the environment is not migration" do
+          let(:environment) { "production" }
+
+          it "ignores the type filter" do
+            get "/api/v1/participant-declarations", params: { filter: { type: :npq } }
+            expect(response.status).to eq 200
+            expect(parsed_response["data"].size).to eq 1
+          end
+        end
+      end
+
       context "when a participant id filter used" do
         let(:second_participant_profile) { create(:ect, school_cohort:) }
         let!(:second_participant_declaration) { create(:ect_participant_declaration, participant_profile: second_participant_profile, cpd_lead_provider:) }

--- a/spec/requests/api/v2/participant_declarations_spec.rb
+++ b/spec/requests/api/v2/participant_declarations_spec.rb
@@ -506,6 +506,37 @@ RSpec.describe "participant-declarations endpoint spec", type: :request, mid_coh
         end
       end
 
+      context "when a type filter used" do
+        let(:environment) { "migration" }
+
+        before do
+          create(:ect_participant_declaration, cpd_lead_provider:, participant_profile: ect_profile)
+          allow(Rails).to receive(:env).and_return(environment.inquiry)
+        end
+
+        it "returns NPQ declarations when filtering by NPQ" do
+          get "/api/v2/participant-declarations", params: { filter: { type: :npq } }
+          expect(response.status).to eq 200
+          expect(parsed_response["data"].size).to eq 0
+        end
+
+        it "returns ECF declarations when filtering by ECF" do
+          get "/api/v2/participant-declarations", params: { filter: { type: :ecf } }
+          expect(response.status).to eq 200
+          expect(parsed_response["data"].size).to eq 1
+        end
+
+        context "when the environment is not migration" do
+          let(:environment) { "production" }
+
+          it "ignores the type filter" do
+            get "/api/v2/participant-declarations", params: { filter: { type: :npq } }
+            expect(response.status).to eq 200
+            expect(parsed_response["data"].size).to eq 1
+          end
+        end
+      end
+
       context "when a participant id filter used" do
         let!(:second_ect_profile) { create(:ect, lead_provider: cpd_lead_provider.lead_provider) }
         let!(:second_participant_declaration) do

--- a/spec/requests/api/v3/participant_declarations_spec.rb
+++ b/spec/requests/api/v3/participant_declarations_spec.rb
@@ -220,6 +220,33 @@ RSpec.describe "API Participant Declarations", type: :request, mid_cohort: true 
         end
       end
 
+      context "when a type filter used" do
+        let(:environment) { "migration" }
+        before { allow(Rails).to receive(:env).and_return(environment.inquiry) }
+
+        it "returns NPQ declarations when filtering by NPQ" do
+          get "/api/v3/participant-declarations", params: { filter: { type: :npq } }
+          expect(response.status).to eq 200
+          expect(parsed_response["data"].size).to eq 0
+        end
+
+        it "returns ECF declarations when filtering by ECF" do
+          get "/api/v3/participant-declarations", params: { filter: { type: :ecf } }
+          expect(response.status).to eq 200
+          expect(parsed_response["data"].size).to eq 3
+        end
+
+        context "when the environment is not migration" do
+          let(:environment) { "production" }
+
+          it "ignores the type filter" do
+            get "/api/v3/participant-declarations", params: { filter: { type: :npq } }
+            expect(response.status).to eq 200
+            expect(parsed_response["data"].size).to eq 3
+          end
+        end
+      end
+
       context "when filtering by updated_since" do
         before do
           participant_declaration1.update!(updated_at: 3.days.ago)

--- a/spec/services/api/participant_declarations/index_spec.rb
+++ b/spec/services/api/participant_declarations/index_spec.rb
@@ -97,6 +97,51 @@ RSpec.describe Api::ParticipantDeclarations::Index do
       end
     end
 
+    context "when filtering by type" do
+      let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider, :with_npq_lead_provider) }
+      let!(:npq_declaration) do
+        create(
+          :npq_participant_declaration,
+          declaration_type: "started",
+          cpd_lead_provider:,
+        )
+      end
+      let!(:ecf_declaration) do
+        create(
+          :ect_participant_declaration,
+          declaration_type: "started",
+          cpd_lead_provider:,
+        )
+      end
+      let(:environment) { "migration" }
+
+      before { allow(Rails).to receive(:env) { environment.inquiry } }
+
+      subject { described_class.new(cpd_lead_provider:, type:) }
+
+      context "when filtering by NPQ declarations" do
+        let(:type) { "npq" }
+
+        it { expect(subject.scope.to_a).to contain_exactly(npq_declaration) }
+      end
+
+      context "when filtering by ECF declarations" do
+        let(:type) { "ECF" }
+
+        it { expect(subject.scope.to_a).to contain_exactly(ecf_declaration) }
+      end
+
+      context "when environment is not migration" do
+        let(:environment) { "production" }
+
+        context "when filtering by type" do
+          let(:type) { "npq" }
+
+          it { expect(subject.scope.to_a).to contain_exactly(ecf_declaration, npq_declaration) }
+        end
+      end
+    end
+
     context "when using 'disable_npq' feature" do
       let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider, :with_npq_lead_provider) }
       let!(:npq_declaration) do


### PR DESCRIPTION
In the migration environment we are running a comparison between NPQ and ECF responses; in order to do this for the declarations endpoint we need to be able to return only NPQ declarations.

Add `type` filter support to declaration endpoints, only for the migration environment.
