### PR TITLE
[CPDLP-3517] Add NPQ feature flag to turn off ECF jobs

### DIFF
--- a/app/jobs/create_new_fake_sandbox_data_job.rb
+++ b/app/jobs/create_new_fake_sandbox_data_job.rb
@@ -20,7 +20,7 @@ class CreateNewFakeSandboxDataJob < ApplicationJob
       end
     end
 
-    if npq_lead_provider.present? && random_school.present?
+    if !NpqApiEndpoint.disabled? && npq_lead_provider.present? && random_school.present?
       10.times do
         name = Faker::Name.name
         user = User.create!(full_name: name, email: Faker::Internet.email(name:))

--- a/app/jobs/npq/stream_big_query_enrollment_job.rb
+++ b/app/jobs/npq/stream_big_query_enrollment_job.rb
@@ -5,6 +5,8 @@ module NPQ
     queue_as :big_query
 
     def perform(npq_application_id:)
+      return if NpqApiEndpoint.disabled?
+
       bigquery = Google::Cloud::Bigquery.new
       dataset = bigquery.dataset "npq_registration", skip_lookup: true
       table = dataset.table "enrollments_#{Rails.env.downcase}"

--- a/app/jobs/npq/stream_big_query_profile_job.rb
+++ b/app/jobs/npq/stream_big_query_profile_job.rb
@@ -5,6 +5,8 @@ module NPQ
     queue_as :big_query
 
     def perform(profile_id:)
+      return if NpqApiEndpoint.disabled?
+
       bigquery = Google::Cloud::Bigquery.new
       dataset = bigquery.dataset "npq_registration", skip_lookup: true
       table = dataset.table "profiles_#{Rails.env.downcase}"

--- a/app/jobs/participant_outcomes/batch_send_latest_outcomes_job.rb
+++ b/app/jobs/participant_outcomes/batch_send_latest_outcomes_job.rb
@@ -8,6 +8,8 @@ module ParticipantOutcomes
     DEFAULT_BATCH_SIZE = 200
 
     def perform(batch_size = DEFAULT_BATCH_SIZE)
+      return if NpqApiEndpoint.disabled?
+
       outcomes.first(batch_size).each { |outcome| SendToQualifiedTeachersApiJob.perform_later(participant_outcome_id: outcome.id) }
     end
 

--- a/app/jobs/participant_outcomes/send_to_qualified_teachers_api_job.rb
+++ b/app/jobs/participant_outcomes/send_to_qualified_teachers_api_job.rb
@@ -6,6 +6,8 @@ module ParticipantOutcomes
     retry_on TooManyRequests, attempts: 3
 
     def perform(participant_outcome_id:)
+      return if NpqApiEndpoint.disabled?
+
       QualifiedTeachersApiSender.new(participant_outcome_id:).call
     end
   end

--- a/app/jobs/participant_outcomes/stream_api_requests_to_big_query_job.rb
+++ b/app/jobs/participant_outcomes/stream_api_requests_to_big_query_job.rb
@@ -5,7 +5,7 @@ module ParticipantOutcomes
     queue_as :big_query
 
     def perform(participant_outcome_api_request_id:)
-      return if table.nil?
+      return if NpqApiEndpoint.disabled? || table.nil?
 
       api_request = ParticipantOutcomeApiRequest.find(participant_outcome_api_request_id)
 

--- a/app/jobs/participant_outcomes/stream_big_query_job.rb
+++ b/app/jobs/participant_outcomes/stream_big_query_job.rb
@@ -5,6 +5,8 @@ module ParticipantOutcomes
     queue_as :big_query
 
     def perform(participant_outcome_id:)
+      return if NpqApiEndpoint.disabled?
+
       bigquery = Google::Cloud::Bigquery.new
       dataset = bigquery.dataset "npq_participant_outcomes", skip_lookup: true
       table = dataset.table "npq_participant_outcomes_#{Rails.env.downcase}"

--- a/app/jobs/stream_big_query_participant_declarations_job.rb
+++ b/app/jobs/stream_big_query_participant_declarations_job.rb
@@ -12,7 +12,8 @@ class StreamBigQueryParticipantDeclarationsJob < ApplicationJob
 
     return if table.nil?
 
-    ParticipantDeclaration
+    scope = NpqApiEndpoint.disabled? ? ParticipantDeclaration::ECF : ParticipantDeclaration
+    scope
       .where(updated_at: 1.hour.ago.beginning_of_hour..1.hour.ago.end_of_hour)
       .find_in_batches do |declarations|
         rows = declarations.map do |participant_declaration|

--- a/app/services/statements/mark_as_paid.rb
+++ b/app/services/statements/mark_as_paid.rb
@@ -7,6 +7,8 @@ module Statements
     end
 
     def call
+      return if NpqApiEndpoint.disabled? && statement.npq?
+
       Finance::Statement.transaction do
         participant_declarations.find_each do |participant_declaration|
           declaration_mark_as_paid_service.call(participant_declaration)

--- a/app/services/statements/mark_as_payable.rb
+++ b/app/services/statements/mark_as_payable.rb
@@ -7,6 +7,8 @@ module Statements
     end
 
     def call
+      return if NpqApiEndpoint.disabled? && statement.npq?
+
       Finance::Statement.transaction do
         participant_declarations.find_each do |declaration|
           declaration_mark_as_payable_service.call(declaration)

--- a/spec/jobs/create_new_fake_sandbox_data_job_spec.rb
+++ b/spec/jobs/create_new_fake_sandbox_data_job_spec.rb
@@ -2,8 +2,10 @@
 
 require "rails_helper"
 
-RSpec.describe "CreateNewFakeSandboxDataJob" do
+RSpec.describe CreateNewFakeSandboxDataJob, type: :job do
   describe "#perform" do
+    subject { described_class.new }
+
     let!(:npq_course) { create(:npq_course, identifier: "npq-senior-leadership") }
     let!(:cpd_lead_provider) { create(:cpd_lead_provider, name: "Education Development Trust") }
     let!(:ecf_lead_provider) { create(:lead_provider, cpd_lead_provider:, name: "Education Development Trust") }
@@ -17,22 +19,38 @@ RSpec.describe "CreateNewFakeSandboxDataJob" do
     end
 
     it "should create 10 new ECTs" do
-      CreateNewFakeSandboxDataJob.new.perform
+      subject.perform
 
       expect(ecf_lead_provider.reload.ecf_participants.count).to eq(10)
     end
 
     it "should create 10 new NPQ applications" do
-      CreateNewFakeSandboxDataJob.new.perform
+      subject.perform
 
       expect(npq_lead_provider.reload.npq_applications.count).to eq(10)
       expect(npq_lead_provider.reload.npq_participants.count).to eq(0)
     end
 
     it "should associate the NPQ applications to the active registration cohort" do
-      CreateNewFakeSandboxDataJob.new.perform
+      subject.perform
 
       expect(npq_lead_provider.reload.npq_applications.last.cohort.start_year).to eq(Cohort.active_registration_cohort.start_year)
+    end
+
+    context "when `disable_npq` feature flag is active" do
+      before { FeatureFlag.activate(:disable_npq) }
+
+      it "creates new ECTs" do
+        subject.perform
+
+        expect(ecf_lead_provider.reload.ecf_participants.count).to eq(10)
+      end
+
+      it "does not create NPQ applications" do
+        subject.perform
+
+        expect(npq_lead_provider.reload.npq_applications.count).to be_zero
+      end
     end
   end
 end

--- a/spec/jobs/npq/stream_big_query_enrollment_job_spec.rb
+++ b/spec/jobs/npq/stream_big_query_enrollment_job_spec.rb
@@ -58,5 +58,19 @@ RSpec.describe NPQ::StreamBigQueryEnrollmentJob do
         expect(table).not_to have_received(:insert)
       end
     end
+
+    context "when `disable_npq` feature flag is active" do
+      before { FeatureFlag.activate(:disable_npq) }
+
+      it "returns nil" do
+        expect(described_class.perform_now(npq_application_id: npq_application.id)).to be_nil
+      end
+
+      it "doesn't attempt to stream" do
+        described_class.perform_now(npq_application_id: npq_application.id)
+
+        expect(table).not_to have_received(:insert)
+      end
+    end
   end
 end

--- a/spec/jobs/npq/stream_big_query_profile_job_spec.rb
+++ b/spec/jobs/npq/stream_big_query_profile_job_spec.rb
@@ -43,5 +43,19 @@ RSpec.describe NPQ::StreamBigQueryProfileJob do
         expect(table).not_to have_received(:insert)
       end
     end
+
+    context "when `disable_npq` feature flag is active" do
+      before { FeatureFlag.activate(:disable_npq) }
+
+      it "returns nil" do
+        expect(described_class.perform_now(profile_id: profile.id)).to be_nil
+      end
+
+      it "doesn't attempt to stream" do
+        described_class.perform_now(profile_id: profile.id)
+
+        expect(table).not_to have_received(:insert)
+      end
+    end
   end
 end

--- a/spec/jobs/participant_outcomes/batch_send_latest_outcomes_job_spec.rb
+++ b/spec/jobs/participant_outcomes/batch_send_latest_outcomes_job_spec.rb
@@ -35,6 +35,20 @@ RSpec.describe ParticipantOutcomes::BatchSendLatestOutcomesJob do
         expect(ParticipantOutcomes::SendToQualifiedTeachersApiJob).not_to have_been_enqueued.with(participant_outcome_id: 2)
       end
     end
+
+    context "when `disable_npq` feature flag is active" do
+      before { FeatureFlag.activate(:disable_npq) }
+
+      it "returns nil" do
+        expect(described_class.perform_now).to be_nil
+      end
+
+      it "does not enqueue the job" do
+        described_class.perform_now
+
+        expect(ParticipantOutcomes::SendToQualifiedTeachersApiJob).not_to have_been_enqueued
+      end
+    end
   end
 
   describe "#perform_later" do

--- a/spec/jobs/participant_outcomes/send_to_qualified_teachers_api_job_spec.rb
+++ b/spec/jobs/participant_outcomes/send_to_qualified_teachers_api_job_spec.rb
@@ -23,5 +23,19 @@ RSpec.describe ParticipantOutcomes::SendToQualifiedTeachersApiJob do
 
       job
     end
+
+    context "when `disable_npq` feature flag is active" do
+      before { FeatureFlag.activate(:disable_npq) }
+
+      it "returns nil" do
+        expect(job).to be_nil
+      end
+
+      it "does not call the service" do
+        job
+
+        expect(api_sender).not_to have_received(:call)
+      end
+    end
   end
 end

--- a/spec/jobs/participant_outcomes/stream_api_requests_to_big_query_job_spec.rb
+++ b/spec/jobs/participant_outcomes/stream_api_requests_to_big_query_job_spec.rb
@@ -3,7 +3,8 @@
 require "rails_helper"
 
 RSpec.describe ParticipantOutcomes::StreamApiRequestsToBigQueryJob do
-  let(:api_request) { create(:participant_outcome_api_request, :with_trn_success) }
+  let(:participant_outcome_api_request) { create(:participant_outcome_api_request, :with_trn_success) }
+  let(:participant_outcome_api_request_id) { participant_outcome_api_request.id }
 
   describe "#perform" do
     let(:bigquery) { double("bigquery") }
@@ -17,25 +18,25 @@ RSpec.describe ParticipantOutcomes::StreamApiRequestsToBigQueryJob do
     end
 
     it "sends correct data to BigQuery" do
-      described_class.perform_now(participant_outcome_api_request_id: api_request.id)
+      described_class.perform_now(participant_outcome_api_request_id:)
 
       expect(table).to have_received(:insert).with([{
-        participant_outcome_api_request_id: api_request.id,
-          request_path: api_request.request_path,
-          status_code: api_request.status_code,
-          request_headers: api_request.request_headers.to_json,
-          request_body: api_request.request_body.to_json,
-          response_body: api_request.response_body.to_json,
-          response_headers: api_request.response_headers.to_json,
-          participant_outcome_id: api_request.participant_outcome_id,
-          created_at: api_request.created_at,
-          updated_at: api_request.updated_at,
+        participant_outcome_api_request_id: participant_outcome_api_request.id,
+          request_path: participant_outcome_api_request.request_path,
+          status_code: participant_outcome_api_request.status_code,
+          request_headers: participant_outcome_api_request.request_headers.to_json,
+          request_body: participant_outcome_api_request.request_body.to_json,
+          response_body: participant_outcome_api_request.response_body.to_json,
+          response_headers: participant_outcome_api_request.response_headers.to_json,
+          participant_outcome_id: participant_outcome_api_request.participant_outcome_id,
+          created_at: participant_outcome_api_request.created_at,
+          updated_at: participant_outcome_api_request.updated_at,
       }.stringify_keys], ignore_unknown: true)
     end
 
-    it "queues job" do
+    it "enqueues job" do
       expect {
-        described_class.perform_now(participant_outcome_api_request_id: api_request.id)
+        described_class.perform_now(participant_outcome_api_request_id:)
       }.to have_enqueued_job(described_class).on_queue("big_query")
     end
 
@@ -45,7 +46,23 @@ RSpec.describe ParticipantOutcomes::StreamApiRequestsToBigQueryJob do
       end
 
       it "doesn't attempt to stream" do
-        described_class.perform_now(participant_outcome_api_request_id: api_request.id)
+        described_class.perform_now(participant_outcome_api_request_id:)
+        expect(table).not_to have_received(:insert)
+      end
+    end
+
+    context "when `disable_npq` feature flag is active" do
+      let(:participant_outcome_api_request_id) { SecureRandom.uuid }
+
+      before { FeatureFlag.activate(:disable_npq) }
+
+      it "returns nil" do
+        expect(described_class.perform_now(participant_outcome_api_request_id:)).to be_nil
+      end
+
+      it "doesn't attempt to stream" do
+        described_class.perform_now(participant_outcome_api_request_id:)
+
         expect(table).not_to have_received(:insert)
       end
     end

--- a/spec/jobs/participant_outcomes/stream_big_query_job_spec.rb
+++ b/spec/jobs/participant_outcomes/stream_big_query_job_spec.rb
@@ -50,5 +50,21 @@ RSpec.describe ParticipantOutcomes::StreamBigQueryJob do
         expect(table).not_to have_received(:insert)
       end
     end
+
+    context "when `disable_npq` feature flag is active" do
+      let(:participant_outcome_id) { SecureRandom.uuid }
+
+      before { FeatureFlag.activate(:disable_npq) }
+
+      it "returns nil" do
+        expect(described_class.perform_now(participant_outcome_id:)).to be_nil
+      end
+
+      it "doesn't attempt to stream" do
+        described_class.perform_now(participant_outcome_id:)
+
+        expect(table).not_to have_received(:insert)
+      end
+    end
   end
 end

--- a/spec/jobs/stream_big_query_participant_declarations_job_spec.rb
+++ b/spec/jobs/stream_big_query_participant_declarations_job_spec.rb
@@ -3,11 +3,12 @@
 require "rails_helper"
 
 RSpec.describe StreamBigQueryParticipantDeclarationsJob do
-  let!(:streamable_declaration) { travel_to(1.hour.ago) { create(:ect_participant_declaration) } }
-  let(:cpd_lead_provider)       { streamable_declaration.cpd_lead_provider }
+  let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_npq_lead_provider) }
+  let!(:streamable_declaration) { travel_to(1.hour.ago) { create(:ect_participant_declaration, cpd_lead_provider:) } }
+  let!(:streamable_npq_declaration) { travel_to(1.hour.ago) { create(:npq_participant_declaration, cpd_lead_provider:) } }
+
   before do
     travel_to(2.hours.ago) { create(:ect_participant_declaration) }
-    create(:ect_participant_declaration)
   end
 
   describe "#perform" do
@@ -24,11 +25,14 @@ RSpec.describe StreamBigQueryParticipantDeclarationsJob do
     it "sends correct data to BigQuery" do
       described_class.perform_now
 
-      expect(table).to have_received(:insert).with([
-        streamable_declaration.attributes.merge(
-          "cpd_lead_provider_name" => cpd_lead_provider.name,
-        ),
-      ], { ignore_unknown: true })
+      expect(table).to have_received(:insert).with(contain_exactly(
+                                                     streamable_declaration.attributes.merge(
+                                                       "cpd_lead_provider_name" => cpd_lead_provider.name,
+                                                     ),
+                                                     streamable_npq_declaration.attributes.merge(
+                                                       "cpd_lead_provider_name" => cpd_lead_provider.name,
+                                                     ),
+                                                   ), { ignore_unknown: true })
     end
 
     it "doesn't attempt to stream when there are no updates" do
@@ -46,6 +50,20 @@ RSpec.describe StreamBigQueryParticipantDeclarationsJob do
         ParticipantDeclaration.update_all(updated_at: 0.5.hours.ago)
         described_class.perform_now
         expect(table).not_to have_received(:insert)
+      end
+    end
+
+    context "when `disable_npq` feature flag is active" do
+      before { FeatureFlag.activate(:disable_npq) }
+
+      it "sends correct data to BigQuery" do
+        described_class.perform_now
+
+        expect(table).to have_received(:insert).with(contain_exactly(
+                                                       streamable_declaration.attributes.merge(
+                                                         "cpd_lead_provider_name" => cpd_lead_provider.name,
+                                                       ),
+                                                     ), { ignore_unknown: true })
       end
     end
   end

--- a/spec/services/statements/mark_as_paid_spec.rb
+++ b/spec/services/statements/mark_as_paid_spec.rb
@@ -68,5 +68,18 @@ RSpec.describe Statements::MarkAsPaid do
         }.to change(statement.reload.statement_line_items.clawed_back, :count).from(0).to(1)
       end
     end
+
+    context "when `disable_npq` feature flag is active" do
+      before { FeatureFlag.activate(:disable_npq) }
+
+      it "does not transition the statement, declarations and line items" do
+        expect {
+          subject.call
+          statement.reload
+        }.to not_change { statement.type }
+        .and(not_change { statement.participant_declarations.paid.count })
+        .and(not_change { statement.statement_line_items.paid.count })
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-3517](https://dfedigital.atlassian.net/browse/CPDLP-3517)

### Changes proposed in this pull request

- Add the existing turning off NPQ feature flag to the following jobs:
  - BatchSendLatestOutcomesJob
  - CreateNewFakeSandboxDataJob
  - StreamBigQueryEnrollmentJob
  - StreamBigQueryProfileJob
  - StreamApiRequestsToBigQueryJob
  - StreamBigQueryJob
- Update the following jobs to not include NPQ if the same feature flag is on:
  - StreamBigQueryParticipantDeclarationsJob
  - MarkAsPayable
  - MarkAsPaidJob

[CPDLP-3517]: https://dfedigital.atlassian.net/browse/CPDLP-3517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ