### PR TITLE
Add external domain to migration env

### DIFF
--- a/terraform/application/workspace_variables/migration.tfvars.json
+++ b/terraform/application/workspace_variables/migration.tfvars.json
@@ -8,7 +8,7 @@
   "webapp_memory_max": "2Gi",
   "azure_storage_mb": "65536",
   "azure_cpu_threshold": 70,
-  "domain": "cpd-ecf-migration-web.teacherservices.cloud",
-  "external_hostname": "cpd-ecf-migration-web.teacherservices.cloud",
+  "domain": "mg.manage-training-for-early-career-teachers.education.gov.uk",
+  "external_hostname": "mg.manage-training-for-early-career-teachers.education.gov.uk/",
   "enable_logit": true
 }

--- a/terraform/custom_domains/environment_domains/workspace_variables/cpd_ecf_migration.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/cpd_ecf_migration.tfvars.json
@@ -1,0 +1,13 @@
+{
+    "hosted_zone": {
+      "manage-training-for-early-career-teachers.education.gov.uk": {
+        "front_door_name": "s189p01-cpdecf-edu-domains-fd",
+        "resource_group_name": "s189p01-cpdecfdomains-rg",
+        "domains": [
+          "mg"
+        ],
+        "environment_short": "mg",
+        "origin_hostname": "cpd-ecf-migration-web.teacherservices.cloud"
+      }
+    }
+  }

--- a/terraform/custom_domains/environment_domains/workspace_variables/cpd_ecf_migration_backend.tfvars
+++ b/terraform/custom_domains/environment_domains/workspace_variables/cpd_ecf_migration_backend.tfvars
@@ -1,0 +1,4 @@
+resource_group_name  = "s189p01-cpdecfdomains-rg"
+storage_account_name = "s189p01cpdecfdomainstf"
+container_name       = "cpdecfdomains-tf"
+key                  = "cpdecfdomains_mig.tfstate"


### PR DESCRIPTION
### Context

To add the maintenance page templates we need to ensure migration has an internal and external domain

- Ticket: n/a

### Changes proposed in this pull request

Setup environment domain for migration environment for an external domain

### Guidance to review
We trust in @saliceti 