### PR TITLE
[CST-2788] Add mailer to remind SITs to set up training for the current year

### DIFF
--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -28,6 +28,7 @@ class SchoolMailer < ApplicationMailer
   REMIND_SIT_THAT_AB_HAS_NOT_REGISTERED_ECT = "a9dbd93e-4358-414d-832c-b0aea585a72b"
   REMIND_SIT_TO_APPOINT_AB_FOR_UNREGISTERED_ECT = "e697e076-a0f6-4738-a421-ae507d804499"
   SIT_PRE_TERM_REMINDER_TO_REPORT_ANY_CHANGES = "59983db6-678f-4a7d-9a3b-80bed4f6ef17"
+  REMIND_SIT_TO_REPORT_SCHOOL_TRAINING_DETAILS = "38e2e143-2b11-4acf-b305-26185f28d58c"
 
   def remind_sit_that_ab_has_not_registered_ect
     school = params[:school]
@@ -568,5 +569,22 @@ class SchoolMailer < ApplicationMailer
         nomination_link: nomination_url,
       },
     ).tag(:sit_pre_term_reminder_to_report_any_changes).associate_with(induction_coordinator, as: :induction_coordinator_profile)
+  end
+
+  def remind_sit_to_report_school_training_details
+    induction_coordinator = params[:induction_coordinator]
+    sit_name = induction_coordinator.user.full_name
+    email_address = induction_coordinator.user.email
+
+    template_mail(
+      REMIND_SIT_TO_REPORT_SCHOOL_TRAINING_DETAILS,
+      to: email_address,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        name: sit_name,
+        email_address:,
+      },
+    ).tag(:remind_sit_to_report_school_training_details).associate_with(induction_coordinator, as: :induction_coordinator_profile)
   end
 end

--- a/spec/mailers/school_mailer_spec.rb
+++ b/spec/mailers/school_mailer_spec.rb
@@ -569,4 +569,28 @@ RSpec.describe SchoolMailer, type: :mailer do
       expect(SchoolMailer::SIT_PRE_TERM_REMINDER_TO_REPORT_ANY_CHANGES).to eq("59983db6-678f-4a7d-9a3b-80bed4f6ef17")
     end
   end
+
+  describe "#remind_sit_to_report_school_training_details" do
+    let(:induction_coordinator) { create(:seed_induction_coordinator_profile, :with_user) }
+    let(:email_address) { induction_coordinator.user.email }
+
+    let(:mailer) do
+      SchoolMailer.with(induction_coordinator:).remind_sit_to_report_school_training_details.deliver_now
+    end
+
+    it "renders the right headers" do
+      expect(mailer.to).to eq([email_address])
+      expect(mailer.from).to eq(["mail@example.com"])
+    end
+
+    it "calls template_mail with the correct template and placeholders" do
+      expect_any_instance_of(SchoolMailer).to receive(:template_mail).with(
+        "38e2e143-2b11-4acf-b305-26185f28d58c",
+        hash_including(to: email_address, personalisation: { name: induction_coordinator.user.full_name, email_address: }),
+      ).and_call_original
+
+      # Trigger the method
+      mailer
+    end
+  end
 end

--- a/spec/services/bulk_mailers/school_reminder_comms_spec.rb
+++ b/spec/services/bulk_mailers/school_reminder_comms_spec.rb
@@ -409,4 +409,43 @@ RSpec.describe BulkMailers::SchoolReminderComms, type: :mailer do
       end
     end
   end
+
+  describe "#remind_sits_to_report_school_training_details" do
+    context "when the school has not made a programme choice" do
+      context "and ran FIP last year" do
+        let!(:query_cohort) { create(:seed_cohort, start_year: cohort.start_year + 1) }
+
+        it "mails the induction coordinator" do
+          expect {
+            service.remind_sits_to_report_school_training_details
+          }.to have_enqueued_mail(SchoolMailer, :remind_sit_to_report_school_training_details)
+            .with(params: { induction_coordinator: sit_profile }, args: [])
+        end
+
+        context "when the dry_run flag is set" do
+          let(:dry_run) { true }
+
+          it "does not mail the induction coordinator" do
+            expect {
+              service.remind_sits_to_report_school_training_details
+            }.not_to have_enqueued_mail
+          end
+
+          it "returns the count of emails that would be sent" do
+            expect(service.remind_sits_to_report_school_training_details).to eq 1
+          end
+        end
+      end
+
+      context "and did not run FIP last year" do
+        let!(:school) { create(:seed_school, :valid) }
+
+        it "does not mail the induction coordinator" do
+          expect {
+            service.remind_sits_to_report_school_training_details
+          }.not_to have_enqueued_mail
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

- Ticket: CST-2788 

We need to send reminders to SITs from schools that ran FIP programs in 23/24 but haven’t yet engaged this year to set up their training.

Should exclude:
- CIP and DIY schools 
- independent or independent special schools (even if in receipt of Section-41 funding)
- children's centres
- British Schools Overseas
- Welsh schools

### Changes proposed in this pull request
- Add the mailer for the Notify template
- Add the bulk mailer to trigger the emails

### Guidance to review

