### PR TITLE
[CST-2788] Update placeholders for the remind_sit_to_report_school_training_details school mailer

### DIFF
--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -575,6 +575,7 @@ class SchoolMailer < ApplicationMailer
     induction_coordinator = params[:induction_coordinator]
     sit_name = induction_coordinator.user.full_name
     email_address = induction_coordinator.user.email
+    school_name = induction_coordinator.user.school.name
 
     template_mail(
       REMIND_SIT_TO_REPORT_SCHOOL_TRAINING_DETAILS,
@@ -582,8 +583,9 @@ class SchoolMailer < ApplicationMailer
       rails_mailer: mailer_name,
       rails_mail_template: action_name,
       personalisation: {
-        name: sit_name,
+        sit_name:,
         email_address:,
+        school_name:,
       },
     ).tag(:remind_sit_to_report_school_training_details).associate_with(induction_coordinator, as: :induction_coordinator_profile)
   end

--- a/spec/mailers/school_mailer_spec.rb
+++ b/spec/mailers/school_mailer_spec.rb
@@ -571,8 +571,11 @@ RSpec.describe SchoolMailer, type: :mailer do
   end
 
   describe "#remind_sit_to_report_school_training_details" do
-    let(:induction_coordinator) { create(:seed_induction_coordinator_profile, :with_user) }
+    let(:school) { create(:seed_school, :valid) }
+    let(:induction_coordinator) { create(:seed_induction_coordinator_profiles_school, :valid, school:).induction_coordinator_profile }
     let(:email_address) { induction_coordinator.user.email }
+    let(:school_name) { induction_coordinator.user.school.name }
+    let(:sit_name) { induction_coordinator.user.full_name }
 
     let(:mailer) do
       SchoolMailer.with(induction_coordinator:).remind_sit_to_report_school_training_details.deliver_now
@@ -586,10 +589,9 @@ RSpec.describe SchoolMailer, type: :mailer do
     it "calls template_mail with the correct template and placeholders" do
       expect_any_instance_of(SchoolMailer).to receive(:template_mail).with(
         "38e2e143-2b11-4acf-b305-26185f28d58c",
-        hash_including(to: email_address, personalisation: { name: induction_coordinator.user.full_name, email_address: }),
+        hash_including(to: email_address, personalisation: { sit_name:, email_address:, school_name: }),
       ).and_call_original
 
-      # Trigger the method
       mailer
     end
   end


### PR DESCRIPTION
### Context

- Ticket: CST-2788

### Changes proposed in this pull request
- Pass the school_name to the notify template
- Change the `name` to `sit_name` placeholder to match the template

### Guidance to review

