### PR TITLE
Clean up maintenance banner

### DIFF
--- a/app/components/banners/maintenance_component.html.erb
+++ b/app/components/banners/maintenance_component.html.erb
@@ -1,21 +1,3 @@
-<%= tag.div(class: class_names("govuk-width-container", "govuk-width-container__wide" => wide_container_view)) do %>
-  <div class="govuk-notification-banner"
-       role="region"
-       aria-labelledby="govuk-notification-banner-title"
-       data-module="govuk-notification-banner">
-    <div class="govuk-notification-banner__header">
-      <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-        Important
-      </h2>
-    </div>
-    <div class="govuk-notification-banner__content govuk-notification-banner__content--full-width">
-      <p class="govuk-notification-banner__heading">
-        This service will be unavailable <%= unavailable_timeframe_string %>.
-      </p>
-
-      <%= form_with url: maintenance_banner_dismissal_path, method: :patch do |f| %>
-        <%= f.govuk_submit("Dismiss", secondary: true, class: "govuk-!-margin-0") %>
-      <% end %>
-    </div>
-  </div>
-<% end %>
+<div class="govuk-width-container govuk-!-margin-top-4">
+  <%= govuk_notification_banner(title_text:) { |banner| banner.with_heading(text:, link_text:, link_href:) } %>
+</div>

--- a/app/controllers/maintenance_banners_controller.rb
+++ b/app/controllers/maintenance_banners_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-class MaintenanceBannerDismissalsController < ApplicationController
-  def update
+class MaintenanceBannersController < ApplicationController
+  def dismiss
     cookies[:dismiss_maintenance_banner_until] = 1.week.from_now
 
     redirect_back(fallback_location: root_path)

--- a/app/helpers/phase_banner_helper.rb
+++ b/app/helpers/phase_banner_helper.rb
@@ -17,13 +17,12 @@ module PhaseBannerHelper
   end
 
   def maintenance_banner_dismissed?
-    dismissed_until = cookies[:dismiss_maintenance_banner_until]
-    return if dismissed_until.blank?
+    cookie_value = cookies[:dismiss_maintenance_banner_until]
+    return unless cookie_value
 
-    Time.zone.parse(dismissed_until) <= 1.week.from_now
-  rescue StandardError => e
-    Rails.logger.error "Error parsing maintenance banner dismissal cookie: #{e.message}"
-    Sentry.capture_exception(e)
-    false
+    dismissed_until = Time.zone.parse(cookie_value)
+    return unless dismissed_until
+
+    dismissed_until > Time.zone.now
   end
 end

--- a/app/views/layouts/_maintenance_notification_banner.erb
+++ b/app/views/layouts/_maintenance_notification_banner.erb
@@ -1,1 +1,1 @@
-<%= render Banners::MaintenanceComponent.new(wide_container_view: wide_container_view?) unless maintenance_banner_dismissed? %>
+<%= render Banners::MaintenanceComponent.new unless maintenance_banner_dismissed? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,7 +78,8 @@ Rails.application.routes.draw do
       get "success", action: :success
     end
   end
-  resource :maintenance_banner_dismissal, only: :update
+
+  get "maintenance_banners/dismiss", to: "maintenance_banners#dismiss", as: :maintenance_banner_dismiss
 
   namespace :api, defaults: { format: "json" } do
     resource :notify_callback, only: :create, path: "notify-callback"

--- a/spec/components/banners/maintenance_component_spec.rb
+++ b/spec/components/banners/maintenance_component_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Banners::MaintenanceComponent, type: :component do
+  let(:maintenance_window) { Time.zone.local(2050, 11, 27, 19)..Time.zone.local(2050, 11, 27, 21) }
+  let(:component) { described_class.new }
+
+  before do
+    FeatureFlag.activate(:maintenance_banner)
+    stub_const("Banners::MaintenanceComponent::MAINTENANCE_WINDOW", maintenance_window)
+  end
+
+  subject do
+    render_inline(component)
+    page
+  end
+
+  it { is_expected.to have_css(".govuk-width-container") }
+  it { is_expected.to have_css("h2", text: "Important") }
+  it { is_expected.to have_css(".govuk-notification-banner__heading", text: "This service will be unavailable from 7pm to 9pm on 27 November.") }
+  it { is_expected.to have_link("Dismiss", href: maintenance_banner_dismiss_path) }
+
+  context "when the maintenance window spans multiple days" do
+    let(:maintenance_window) { Time.zone.local(2050, 11, 27, 19)..Time.zone.local(2050, 11, 28, 21) }
+
+    it { is_expected.to have_css(".govuk-notification-banner__heading", text: "This service will be unavailable from 7pm on 27 November to 9pm on 28 November.") }
+  end
+
+  describe "#render?" do
+    subject { component }
+
+    it { is_expected.to render }
+
+    context "when the maintenance window has ended" do
+      let(:maintenance_window) { 2.days.ago..1.minute.ago }
+
+      it { is_expected.not_to render }
+    end
+
+    context "when the maintenance banner feature flag is not active" do
+      before { FeatureFlag.deactivate(:maintenance_banner) }
+
+      it { is_expected.not_to render }
+    end
+  end
+end

--- a/spec/features/maintenance_banner_spec.rb
+++ b/spec/features/maintenance_banner_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Maintenance banner" do
+  before do
+    FeatureFlag.activate(:maintenance_banner)
+    stub_const("Banners::MaintenanceComponent::MAINTENANCE_WINDOW", 1.day.ago..1.day.from_now)
+  end
+
+  scenario "viewing the root path" do
+    visit root_path
+    expect(page).to have_text(/This service will be unavailable from/)
+  end
+
+  context "when disabled" do
+    before { FeatureFlag.deactivate(:maintenance_banner) }
+
+    scenario "viewing the root path" do
+      visit root_path
+      expect(page).not_to have_text(/This service will be unavailable from/)
+    end
+  end
+end

--- a/spec/helpers/phase_banner_helper_spec.rb
+++ b/spec/helpers/phase_banner_helper_spec.rb
@@ -44,4 +44,30 @@ RSpec.describe PhaseBannerHelper, type: :helper do
       end
     end
   end
+
+  describe "#maintenance_banner_dismissed?" do
+    subject { helper }
+
+    context "when the dismissed_until cookie is not set" do
+      it { is_expected.not_to be_maintenance_banner_dismissed }
+    end
+
+    context "when the dismissed_until cookie is set to a future value" do
+      before { helper.request.cookies[:dismiss_maintenance_banner_until] = 1.day.from_now.to_s }
+
+      it { is_expected.to be_maintenance_banner_dismissed }
+    end
+
+    context "when the dismissed_until cookie is set to a past value" do
+      before { helper.request.cookies[:dismiss_maintenance_banner_until] = 1.day.ago.to_s }
+
+      it { is_expected.not_to be_maintenance_banner_dismissed }
+    end
+
+    context "when the dismissed_until cookie does not contain a valid time" do
+      before { helper.request.cookies[:dismiss_maintenance_banner_until] = "1 week from now" }
+
+      it { is_expected.not_to be_maintenance_banner_dismissed }
+    end
+  end
 end

--- a/spec/requests/maintenance_banner_spec.rb
+++ b/spec/requests/maintenance_banner_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Maintenance banner", type: :request do
+  describe "GET /maintenance_banners/dismiss" do
+    it "sets a cookie to dismiss the maintenance banner" do
+      get maintenance_banner_dismiss_path
+
+      cookie_value = response.cookies["dismiss_maintenance_banner_until"]
+      expect(cookie_value).to be_present
+      expect(Time.zone.parse(cookie_value)).to be_within(1.second).of(1.week.from_now)
+    end
+
+    it "redirects back to the root path if no referer is present" do
+      get maintenance_banner_dismiss_path
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "redirects back to the referer" do
+      get maintenance_banner_dismiss_path, params: {}, headers: { "HTTP_REFERER" => "/previous/page" }
+
+      expect(response).to redirect_to("/previous/page")
+    end
+  end
+end


### PR DESCRIPTION
[Jira-3531](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345%2Cunassigned&selectedIssue=CPDLP-3531)

### Context

We want to fix and clean up the maintenance banner in ECF so that we can use it for the upcoming downtime when we transition the lead provider APIs to NPQ reg.

### Changes proposed in this pull request

- Clean up maintenance banner

Clean up the maintenance banner to match the latest design.

Fix broken `Dismiss` button; swap to a link to be consistent with the GOV.UK banner component usage.

Change route to GET so we can use it from a regular link in the GOV.UK components helpers (not ideal but allows us to use the component to render the banner).

Add missing test coverage.

### Guidance to review

<img width="1231" alt="Screenshot 2024-10-29 at 14 33 52" src="https://github.com/user-attachments/assets/a91912d4-03ef-4992-ac11-44ea50aff334">