### PR TITLE
CST-2790: frozen cohort triggers must also include unfinished participants with no billable declarations

### DIFF
--- a/app/controllers/admin/participants/change_cohort_controller.rb
+++ b/app/controllers/admin/participants/change_cohort_controller.rb
@@ -20,7 +20,9 @@ module Admin::Participants
       @latest_induction_record = @participant_profile.latest_induction_record
 
       @amend_participant_cohort = Induction::AmendParticipantCohort.new(
-        { **default_amend_participant_cohort_attributes, **amend_participant_cohort_params }.symbolize_keys,
+        { **default_amend_participant_cohort_attributes,
+          **amend_participant_cohort_params,
+          force_from_frozen_cohort: true }.symbolize_keys,
       )
 
       if @amend_participant_cohort.save

--- a/app/forms/schools/add_participants/base_wizard.rb
+++ b/app/forms/schools/add_participants/base_wizard.rb
@@ -494,7 +494,7 @@ module Schools
 
       def cohort_for_transfer
         cohort = Cohort.active_registration_cohort
-        return cohort if existing_participant_profile&.eligible_to_change_cohort_and_continue_training?(cohort:)
+        return cohort if existing_participant_profile&.unfinished?(cohort:)
 
         existing_participant_cohort || existing_participant_profile&.schedule&.cohort
       end

--- a/app/models/participant_declaration.rb
+++ b/app/models/participant_declaration.rb
@@ -118,6 +118,14 @@ class ParticipantDeclaration < ApplicationRecord
     states.keys.excluding(ARCHIVABLE_STATES)
   end
 
+  def billable?
+    %w[eligible payable paid].include?(current_state)
+  end
+
+  def completed?
+    declaration_type == "completed"
+  end
+
   def voidable?
     %w[submitted eligible payable ineligible].include?(state)
   end

--- a/app/models/participant_profile/ect.rb
+++ b/app/models/participant_profile/ect.rb
@@ -59,7 +59,7 @@ class ParticipantProfile::ECT < ParticipantProfile::ECF
     "Early career teacher"
   end
 
-  def self.eligible_to_change_cohort_and_continue_training(cohort:, restrict_to_participant_ids: [])
+  def self.unfinished_with_billable_declaration(cohort:, restrict_to_participant_ids: [])
     super(cohort:, restrict_to_participant_ids:).where(induction_completion_date: nil)
   end
 end

--- a/app/models/participant_profile/mentor.rb
+++ b/app/models/participant_profile/mentor.rb
@@ -82,7 +82,7 @@ class ParticipantProfile::Mentor < ParticipantProfile::ECF
     "Mentor"
   end
 
-  def self.eligible_to_change_cohort_and_continue_training(cohort:, restrict_to_participant_ids: [])
+  def self.unfinished_with_billable_declaration(cohort:, restrict_to_participant_ids: [])
     super(cohort:, restrict_to_participant_ids:).where(mentor_completion_date: nil)
   end
 end

--- a/app/services/change_schedule.rb
+++ b/app/services/change_schedule.rb
@@ -86,7 +86,7 @@ private
   def changing_cohort_due_to_payments_frozen?
     return false unless participant_profile.ecf?
     return false unless allow_change_to_from_frozen_cohort
-    return true if participant_profile.eligible_to_change_cohort_and_continue_training?(cohort:)
+    return true if participant_profile.unfinished_with_billable_declaration?(cohort:)
 
     participant_profile.eligible_to_change_cohort_back_to_their_payments_frozen_original?(cohort:, current_cohort:)
   end

--- a/app/services/early_career_teachers/create.rb
+++ b/app/services/early_career_teachers/create.rb
@@ -56,13 +56,12 @@ module EarlyCareerTeachers
     def amend_mentor_cohort
       Induction::AmendParticipantCohort.new(participant_profile: mentor_profile,
                                             source_cohort_start_year: mentor_profile.schedule.cohort.start_year,
-                                            target_cohort_start_year: Cohort.active_registration_cohort.start_year).save
+                                            target_cohort_start_year: Cohort.active_registration_cohort.start_year,
+                                            force_from_frozen_cohort: true).save
     end
 
     def change_mentor_cohort?
-      return false if cohort.payments_frozen?
-
-      mentor_profile&.eligible_to_change_cohort_and_continue_training?(cohort: Cohort.active_registration_cohort)
+      !cohort.payments_frozen? && mentor_profile&.schedule&.cohort&.payments_frozen?
     end
 
     def ect_attributes

--- a/app/services/early_career_teachers/create.rb
+++ b/app/services/early_career_teachers/create.rb
@@ -61,7 +61,7 @@ module EarlyCareerTeachers
     end
 
     def change_mentor_cohort?
-      !cohort.payments_frozen? && mentor_profile&.schedule&.cohort&.payments_frozen?
+      !cohort.payments_frozen? && mentor_profile&.unfinished?
     end
 
     def ect_attributes

--- a/app/services/early_career_teachers/reactivate.rb
+++ b/app/services/early_career_teachers/reactivate.rb
@@ -54,7 +54,7 @@ module EarlyCareerTeachers
     end
 
     def change_mentor_cohort?
-      !cohort.payments_frozen? && mentor_profile&.schedule&.cohort&.payments_frozen?
+      !cohort.payments_frozen? && mentor_profile&.unfinished?
     end
 
     def mentor_profile

--- a/app/services/early_career_teachers/reactivate.rb
+++ b/app/services/early_career_teachers/reactivate.rb
@@ -49,13 +49,12 @@ module EarlyCareerTeachers
     def amend_mentor_cohort
       Induction::AmendParticipantCohort.new(participant_profile: mentor_profile,
                                             source_cohort_start_year: mentor_profile.schedule.cohort.start_year,
-                                            target_cohort_start_year: Cohort.active_registration_cohort.start_year).save
+                                            target_cohort_start_year: Cohort.active_registration_cohort.start_year,
+                                            force_from_frozen_cohort: true).save
     end
 
     def change_mentor_cohort?
-      return false if cohort.payments_frozen?
-
-      mentor_profile&.eligible_to_change_cohort_and_continue_training?(cohort: Cohort.active_registration_cohort)
+      !cohort.payments_frozen? && mentor_profile&.schedule&.cohort&.payments_frozen?
     end
 
     def mentor_profile

--- a/app/services/induction/amend_cohort_after_eligibility_checks.rb
+++ b/app/services/induction/amend_cohort_after_eligibility_checks.rb
@@ -10,7 +10,7 @@ module Induction
     attr_accessor :participant_profile
 
     def call
-      amend_participant_cohort if eligible_participant_in_frozen_cohort?
+      amend_participant_cohort if unfinished_eligible_participant?
     end
 
   private
@@ -18,15 +18,16 @@ module Induction
     def amend_participant_cohort
       Induction::AmendParticipantCohort.new(participant_profile:,
                                             source_cohort_start_year: participant_profile.schedule&.cohort&.start_year,
-                                            target_cohort_start_year: Cohort.active_registration_cohort.start_year)
+                                            target_cohort_start_year: Cohort.active_registration_cohort.start_year,
+                                            force_from_frozen_cohort: true)
                                        .save
     end
 
-    def eligible_participant_in_frozen_cohort?
+    def unfinished_eligible_participant?
       return false unless participant_profile.eligible?
       return false if participant_profile.ecf_participant_eligibility&.reason != "none"
 
-      participant_profile.schedule&.cohort&.payments_frozen?
+      participant_profile.unfinished?
     end
   end
 end

--- a/app/services/induction/change_mentor.rb
+++ b/app/services/induction/change_mentor.rb
@@ -27,7 +27,12 @@ private
   def amend_mentor_cohort
     Induction::AmendParticipantCohort.new(participant_profile: mentor_profile,
                                           source_cohort_start_year: mentor_profile.schedule.cohort.start_year,
-                                          target_cohort_start_year: Cohort.active_registration_cohort.start_year).save
+                                          target_cohort_start_year: Cohort.active_registration_cohort.start_year,
+                                          force_from_frozen_cohort: true).save
+  end
+
+  def change_mentor_cohort?
+    !ect_in_payments_frozen_cohort? && mentor_profile&.schedule&.cohort&.payments_frozen?
   end
 
   def cip_materials
@@ -54,12 +59,6 @@ private
       sit_name:,
     ).training_materials
                 .deliver_later
-  end
-
-  def change_mentor_cohort?
-    return false if ect_in_payments_frozen_cohort?
-
-    mentor_profile&.eligible_to_change_cohort_and_continue_training?(cohort: Cohort.active_registration_cohort)
   end
 
   def sit_name

--- a/app/services/induction/change_mentor.rb
+++ b/app/services/induction/change_mentor.rb
@@ -32,7 +32,7 @@ private
   end
 
   def change_mentor_cohort?
-    !ect_in_payments_frozen_cohort? && mentor_profile&.schedule&.cohort&.payments_frozen?
+    !ect_in_payments_frozen_cohort? && mentor_profile&.unfinished?
   end
 
   def cip_materials

--- a/app/services/induction/schedule_for_new_cohort.rb
+++ b/app/services/induction/schedule_for_new_cohort.rb
@@ -12,15 +12,15 @@ class Induction::ScheduleForNewCohort < BaseService
 
 private
 
-  attr_reader :cohort, :induction_record, :cohort_changed_after_payments_frozen
+  attr_reader :cohort, :induction_record, :extended_schedule
 
-  def initialize(cohort:, induction_record:, cohort_changed_after_payments_frozen: false)
+  def initialize(cohort:, induction_record:, extended_schedule: false)
     @cohort = cohort
     @induction_record = induction_record
-    @cohort_changed_after_payments_frozen = cohort_changed_after_payments_frozen
+    @extended_schedule = extended_schedule
   end
 
   def schedule_identifier
-    cohort_changed_after_payments_frozen ? EXTENDED_SCHEDULE_IDENTIFIER : induction_record&.schedule_identifier
+    extended_schedule ? EXTENDED_SCHEDULE_IDENTIFIER : induction_record&.schedule_identifier
   end
 end

--- a/app/services/induction/transfer_and_continue_existing_fip.rb
+++ b/app/services/induction/transfer_and_continue_existing_fip.rb
@@ -39,7 +39,7 @@ private
   end
 
   def change_mentor_cohort?
-    !cohort.payments_frozen? && mentor_profile&.schedule&.cohort&.payments_frozen?
+    !cohort.payments_frozen? && mentor_profile&.unfinished?
   end
 
   def enrol_participant_at_new_programme
@@ -71,7 +71,7 @@ private
   end
 
   def cohort_changed_after_payments_frozen
-    participant_profile.eligible_to_change_cohort_and_continue_training?(cohort:)
+    participant_profile.unfinished_with_billable_declaration?(cohort:)
   end
 
   def create_induction_programme

--- a/app/services/induction/transfer_and_continue_existing_fip.rb
+++ b/app/services/induction/transfer_and_continue_existing_fip.rb
@@ -34,13 +34,12 @@ private
   def amend_mentor_cohort
     Induction::AmendParticipantCohort.new(participant_profile: mentor_profile,
                                           source_cohort_start_year: mentor_profile.schedule.cohort.start_year,
-                                          target_cohort_start_year: Cohort.active_registration_cohort.start_year).save
+                                          target_cohort_start_year: Cohort.active_registration_cohort.start_year,
+                                          force_from_frozen_cohort: true).save
   end
 
   def change_mentor_cohort?
-    return false if cohort.payments_frozen?
-
-    mentor_profile&.eligible_to_change_cohort_and_continue_training?(cohort: Cohort.active_registration_cohort)
+    !cohort.payments_frozen? && mentor_profile&.schedule&.cohort&.payments_frozen?
   end
 
   def enrol_participant_at_new_programme
@@ -118,6 +117,6 @@ private
   def schedule
     @schedule ||= Induction::ScheduleForNewCohort.call(cohort:,
                                                        induction_record: latest_induction_record,
-                                                       cohort_changed_after_payments_frozen:)
+                                                       extended_schedule: cohort_changed_after_payments_frozen)
   end
 end

--- a/app/services/induction/transfer_to_schools_programme.rb
+++ b/app/services/induction/transfer_to_schools_programme.rb
@@ -55,13 +55,12 @@ private
   def amend_mentor_cohort
     Induction::AmendParticipantCohort.new(participant_profile: mentor_profile,
                                           source_cohort_start_year: mentor_profile.schedule.cohort.start_year,
-                                          target_cohort_start_year: Cohort.active_registration_cohort.start_year).save
+                                          target_cohort_start_year: Cohort.active_registration_cohort.start_year,
+                                          force_from_frozen_cohort: true).save
   end
 
   def change_mentor_cohort?
-    return false if cohort.payments_frozen?
-
-    mentor_profile&.eligible_to_change_cohort_and_continue_training?(cohort: Cohort.active_registration_cohort)
+    !cohort.payments_frozen? && mentor_profile&.schedule&.cohort&.payments_frozen?
   end
 
   def check_different_school!
@@ -79,6 +78,6 @@ private
   def schedule
     @schedule ||= Induction::ScheduleForNewCohort.call(cohort:,
                                                        induction_record: latest_induction_record,
-                                                       cohort_changed_after_payments_frozen:)
+                                                       extended_schedule: cohort_changed_after_payments_frozen)
   end
 end

--- a/app/services/induction/transfer_to_schools_programme.rb
+++ b/app/services/induction/transfer_to_schools_programme.rb
@@ -60,7 +60,7 @@ private
   end
 
   def change_mentor_cohort?
-    !cohort.payments_frozen? && mentor_profile&.schedule&.cohort&.payments_frozen?
+    !cohort.payments_frozen? && mentor_profile&.unfinished?
   end
 
   def check_different_school!
@@ -68,7 +68,7 @@ private
   end
 
   def cohort_changed_after_payments_frozen
-    participant_profile.eligible_to_change_cohort_and_continue_training?(cohort:)
+    participant_profile.unfinished_with_billable_declaration?(cohort:)
   end
 
   def latest_induction_record

--- a/app/services/participants/check_and_set_completion_date.rb
+++ b/app/services/participants/check_and_set_completion_date.rb
@@ -56,7 +56,7 @@ module Participants
     end
 
     def continue_training?
-      in_progress_induction_status? && participant_cohort&.payments_frozen?
+      in_progress_induction_status? && participant_profile.unfinished?
     end
 
     def induction

--- a/app/services/participants/check_and_set_completion_date.rb
+++ b/app/services/participants/check_and_set_completion_date.rb
@@ -8,7 +8,7 @@ module Participants
       return unless participant_profile.ect?
 
       complete_induction if complete_induction?
-      continue_training if sync_with_dqt && unfinished_participant_continue_training?
+      continue_training if sync_with_dqt && continue_training?
       record_completion_date_mismatch if completion_date_mismatch?
     end
 
@@ -23,7 +23,8 @@ module Participants
     def amend_cohort_to_continue_training
       @amend_cohort_to_continue_training ||= Induction::AmendParticipantCohort.new(participant_profile:,
                                                                                    source_cohort_start_year:,
-                                                                                   target_cohort_start_year:)
+                                                                                   target_cohort_start_year:,
+                                                                                   force_from_frozen_cohort: true)
     end
 
     def clear_participant_continue_training_errors
@@ -52,6 +53,10 @@ module Participants
     def continue_training
       clear_participant_continue_training_errors
       amend_cohort_to_continue_training.save || save_error(amend_cohort_to_continue_training.errors.full_messages.first)
+    end
+
+    def continue_training?
+      in_progress_induction_status? && participant_cohort&.payments_frozen?
     end
 
     def induction
@@ -108,14 +113,7 @@ module Participants
       Cohort.active_registration_cohort
     end
 
-    def target_cohort_start_year
-      target_cohort.start_year
-    end
-
-    def unfinished_participant_continue_training?
-      in_progress_induction_status? &&
-        participant_cohort&.payments_frozen? &&
-        participant_profile.eligible_to_change_cohort_and_continue_training?(cohort: target_cohort)
-    end
+    # target_cohort_start_year
+    delegate :start_year, to: :target_cohort, prefix: true
   end
 end

--- a/documentation/handling_participants_moving_from_a_frozen_cohort.md
+++ b/documentation/handling_participants_moving_from_a_frozen_cohort.md
@@ -13,7 +13,7 @@ These will happen automatically for school transfers, mentor assignments, re-val
 In addition to seeing that they are continuing with training, we need to check the participant's induction status and declarations to determine whether they are eligible to move from 2021 to 2024:
 
 ```ruby
-participant_profile.eligible_to_change_cohort_and_continue_training?(cohort:)
+participant_profile.unfinished_with_billable_declaration?(cohort:)
 ```
 
 Where `cohort` is `Cohort.active_registration_cohort`

--- a/spec/features/schools/participants/add_participants/payments_frozen/assign_ect_to_mentor_spec.rb
+++ b/spec/features/schools/participants/add_participants/payments_frozen/assign_ect_to_mentor_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "SIT assigns a mentor to an ECT", js: true, early_in_cohort: true
     # FIXME: This factory fails validation on participant_id, despite this being present on participant identity.
     # Stubbing the eligibility check to return the participant_profile for now.
     # create(:ect_participant_declaration, participant_profile:, declaration_type: "completed")
-    allow(ParticipantProfile::ECT).to receive(:eligible_to_change_cohort_and_continue_training)
+    allow(ParticipantProfile::ECT).to receive(:unfinished_with_billable_declaration)
                                         .and_return(ParticipantProfile::ECT.where(id: participant_profile.id))
 
     induction_programme = InductionProgramme.find_by(school_cohort: active_registration_school_cohort)
@@ -73,7 +73,7 @@ RSpec.describe "SIT assigns a mentor to an ECT", js: true, early_in_cohort: true
     # FIXME: This factory fails validation on participant_id, despite this being present on participant identity.
     # Stubbing the eligibility check to return the participant_profile for now.
     # create(:ect_participant_declaration, participant_profile:, declaration_type: "completed")
-    allow(ParticipantProfile::Mentor).to receive(:eligible_to_change_cohort_and_continue_training)
+    allow(ParticipantProfile::Mentor).to receive(:unfinished_with_billable_declaration)
                                            .and_return(ParticipantProfile::Mentor.where(id: participant_profile.id))
 
     induction_programme = InductionProgramme.find_by(school_cohort: @school_cohort)

--- a/spec/requests/admin/participants/change_cohort_spec.rb
+++ b/spec/requests/admin/participants/change_cohort_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe "Admin::Participants", type: :request do
           source_cohort_start_year: Cohort.current.start_year,
           target_cohort_start_year: next_cohort.display_name, # string because this one is passed in from the form
           participant_profile: mentor_profile,
+          force_from_frozen_cohort: true,
         )
 
         expect(response).to redirect_to(admin_participant_path(mentor_profile))

--- a/spec/services/induction/amend_cohort_after_eligibility_checks_spec.rb
+++ b/spec/services/induction/amend_cohort_after_eligibility_checks_spec.rb
@@ -55,7 +55,8 @@ RSpec.describe Induction::AmendCohortAfterEligibilityChecks do
       it "try and place them in the currently active registration cohort" do
         expect(Induction::AmendParticipantCohort).to have_received(:new).with(participant_profile:,
                                                                               source_cohort_start_year:,
-                                                                              target_cohort_start_year:)
+                                                                              target_cohort_start_year:,
+                                                                              force_from_frozen_cohort: true)
       end
     end
   end

--- a/spec/services/induction/amend_participant_cohort_spec.rb
+++ b/spec/services/induction/amend_participant_cohort_spec.rb
@@ -134,11 +134,11 @@ RSpec.describe Induction::AmendParticipantCohort do
           source_cohort.update!(payments_frozen_at: Time.current)
         end
 
-        context "when the participant is eligible to be transferred" do
+        context "when the participant is unfinished with billable declarations" do
           before do
             Induction::Enrol.call(participant_profile:,
                                   induction_programme: source_school_cohort.default_induction_programme)
-            allow(participant_profile).to receive(:eligible_to_change_cohort_and_continue_training?).and_return(true)
+            allow(participant_profile).to receive(:unfinished_with_billable_declaration?).and_return(true)
           end
 
           context "when the target_school_cohort has not been set yet" do
@@ -182,11 +182,11 @@ RSpec.describe Induction::AmendParticipantCohort do
           end
         end
 
-        context "when the participant is not eligible to be transferred" do
+        context "when the participant is not unfinished with billable declarations" do
           before do
             Induction::Enrol.call(participant_profile:,
                                   induction_programme: source_school_cohort.default_induction_programme)
-            allow(participant_profile).to receive(:eligible_to_change_cohort_and_continue_training?).and_return(false)
+            allow(participant_profile).to receive(:unfinished_with_billable_declaration?).and_return(false)
           end
 
           context "when the force flag is not true" do
@@ -198,7 +198,20 @@ RSpec.describe Induction::AmendParticipantCohort do
             end
           end
 
-          context "when the force flag is true" do
+          context "when the force flag is true but the participant is not unfinished with no billable declarations" do
+            let(:force_from_frozen_cohort) { true }
+
+            before do
+              participant_profile.update!(induction_completion_date: Date.yesterday)
+            end
+
+            it "set errors on participant profile" do
+              expect(form.save).to be_falsey
+              expect(form.errors[:participant_profile]).to include("Participant not eligible to be transferred from their current cohort")
+            end
+          end
+
+          context "when the force flag is true and the participant is unfinished with no billable declarations" do
             let(:force_from_frozen_cohort) { true }
 
             it "set no errors on participant profile" do
@@ -469,25 +482,39 @@ RSpec.describe Induction::AmendParticipantCohort do
               context "when the transfer is due to payments frozen in the cohort of the participant" do
                 before do
                   source_cohort.update!(payments_frozen_at: Time.current)
-                  allow(participant_profile).to receive(:eligible_to_change_cohort_and_continue_training?).and_return(true)
+                  allow(participant_profile).to receive(:unfinished_with_billable_declaration?).and_return(true)
                   create(:ecf_extended_schedule, cohort: target_cohort)
                 end
 
-                context "when the participant is unfinished" do
+                context "when the participant is unfinished with billable declaration" do
                   it "mark the participant as transferred for that reason" do
                     expect(form.save).to be_truthy
                     expect(participant_profile).to be_cohort_changed_after_payments_frozen
                   end
                 end
 
-                context "when the participant is not unfinished but the force flag is set" do
+                context "when the participant is complete, unfinished and the force flag is set" do
                   let(:force_from_frozen_cohort) { true }
 
                   before do
-                    allow(participant_profile).to receive(:eligible_to_change_cohort_and_continue_training?).and_return(false)
+                    participant_profile.update!(induction_completion_date: Date.yesterday)
+                    allow(participant_profile).to receive(:unfinished_with_billable_declaration?).and_return(false)
                   end
 
-                  it "don't mark the participant as transferred for that reason" do
+                  it "don't execute the transfer" do
+                    expect(form.save).to be_falsey
+                  end
+                end
+
+                context "when the participant is unfinished with no billable declaration and the force flag is set" do
+                  let(:force_from_frozen_cohort) { true }
+
+                  before do
+                    allow(participant_profile).to receive(:unfinished_with_billable_declaration?).and_return(false)
+                    allow(participant_profile).to receive(:unfinished_with_no_billable_declaration?).and_return(true)
+                  end
+
+                  it "don't mark the participant as transferred from the original cohort" do
                     expect(form.save).to be_truthy
                     expect(participant_profile).not_to be_cohort_changed_after_payments_frozen
                   end

--- a/spec/services/induction/amend_participant_cohort_spec.rb
+++ b/spec/services/induction/amend_participant_cohort_spec.rb
@@ -5,11 +5,13 @@ RSpec.describe Induction::AmendParticipantCohort do
     let(:participant_profile) {}
     let(:source_cohort_start_year) { Cohort.previous.start_year }
     let(:target_cohort_start_year) { Cohort.current.start_year }
+    let(:force_from_frozen_cohort) { false }
 
     subject(:form) do
       described_class.new(participant_profile:,
                           source_cohort_start_year:,
-                          target_cohort_start_year:)
+                          target_cohort_start_year:,
+                          force_from_frozen_cohort:)
     end
 
     context "when the source_cohort_start_year is not an integer" do
@@ -187,9 +189,22 @@ RSpec.describe Induction::AmendParticipantCohort do
             allow(participant_profile).to receive(:eligible_to_change_cohort_and_continue_training?).and_return(false)
           end
 
-          it "set errors on participant profile" do
-            expect(form.save).to be_falsey
-            expect(form.errors[:participant_profile]).to include("Participant not eligible to be transferred from their current cohort")
+          context "when the force flag is not true" do
+            let(:force_from_frozen_cohort) { false }
+
+            it "set errors on participant profile" do
+              expect(form.save).to be_falsey
+              expect(form.errors[:participant_profile]).to include("Participant not eligible to be transferred from their current cohort")
+            end
+          end
+
+          context "when the force flag is true" do
+            let(:force_from_frozen_cohort) { true }
+
+            it "set no errors on participant profile" do
+              expect(form.save).to be_truthy
+              expect(form.errors[:participant_profile]).to be_blank
+            end
           end
         end
       end
@@ -458,9 +473,24 @@ RSpec.describe Induction::AmendParticipantCohort do
                   create(:ecf_extended_schedule, cohort: target_cohort)
                 end
 
-                it "mark the participant as transferred for that reason" do
-                  expect(form.save).to be_truthy
-                  expect(participant_profile).to be_cohort_changed_after_payments_frozen
+                context "when the participant is unfinished" do
+                  it "mark the participant as transferred for that reason" do
+                    expect(form.save).to be_truthy
+                    expect(participant_profile).to be_cohort_changed_after_payments_frozen
+                  end
+                end
+
+                context "when the participant is not unfinished but the force flag is set" do
+                  let(:force_from_frozen_cohort) { true }
+
+                  before do
+                    allow(participant_profile).to receive(:eligible_to_change_cohort_and_continue_training?).and_return(false)
+                  end
+
+                  it "don't mark the participant as transferred for that reason" do
+                    expect(form.save).to be_truthy
+                    expect(participant_profile).not_to be_cohort_changed_after_payments_frozen
+                  end
                 end
 
                 it "sets the schedule to ecf-extended-september" do

--- a/spec/services/induction/schedule_for_new_cohort_spec.rb
+++ b/spec/services/induction/schedule_for_new_cohort_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Induction::ScheduleForNewCohort do
     let(:cohort) { Cohort.current }
     let(:schedule_identifier) { "ecf-standard-september" }
     let(:schedule) { double(Finance::Schedule::ECF, schedule_identifier:) }
-    let(:cohort_changed_after_payments_frozen) { false }
-    let(:service) { described_class.call(cohort:, induction_record:, cohort_changed_after_payments_frozen:) }
+    let(:extended_schedule) { false }
+    let(:service) { described_class.call(cohort:, induction_record:, extended_schedule:) }
 
     context "when induction record is nil" do
       let(:default_schedule) { double(Finance::Schedule::ECF) }
@@ -34,8 +34,8 @@ RSpec.describe Induction::ScheduleForNewCohort do
       let(:induction_record) { double(InductionRecord, cohort: Cohort.previous, schedule_identifier:) }
       let(:new_schedule) { double(Finance::Schedule::ECF, schedule_identifier:, cohort:) }
 
-      context "when cohort_changed_after_payments_frozen is true" do
-        let(:cohort_changed_after_payments_frozen) { true }
+      context "when extended_schedule is true" do
+        let(:extended_schedule) { true }
 
         context "when the ecf-extended-september schedule in the cohort exists" do
           let(:default_schedule) { double(Finance::Schedule::ECF, cohort:, schedule_identifier: "ecf-extended-september") }
@@ -68,8 +68,8 @@ RSpec.describe Induction::ScheduleForNewCohort do
         end
       end
 
-      context "when cohort_changed_after_payments_frozen is false" do
-        let(:cohort_changed_after_payments_frozen) { false }
+      context "when extended_schedule is false" do
+        let(:extended_schedule) { false }
 
         context "when a schedule in the cohort exists with the same schedule-identifier as the induction record's schedule" do
           let(:default_schedule) { double(Finance::Schedule::ECF, cohort:, schedule_identifier:) }

--- a/spec/services/induction/transfer_and_continue_existing_fip_spec.rb
+++ b/spec/services/induction/transfer_and_continue_existing_fip_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Induction::TransferAndContinueExistingFip do
       end
 
       before do
-        allow(participant_profile).to receive(:eligible_to_change_cohort_and_continue_training?)
+        allow(participant_profile).to receive(:unfinished_with_billable_declaration?)
                                         .with(cohort: Cohort.next)
                                         .and_return(true)
         create(:ecf_extended_schedule, cohort: Cohort.next)
@@ -83,7 +83,7 @@ RSpec.describe Induction::TransferAndContinueExistingFip do
 
     context "when the participant is not eligible to be moved from a frozen cohort to the target one" do
       before do
-        allow(participant_profile).to receive(:eligible_to_change_cohort_and_continue_training?)
+        allow(participant_profile).to receive(:unfinished_with_billable_declaration?)
                                         .with(cohort: school_cohort_2.cohort)
                                         .and_return(false)
         service_call

--- a/spec/services/induction/transfer_and_continue_existing_fip_spec.rb
+++ b/spec/services/induction/transfer_and_continue_existing_fip_spec.rb
@@ -122,6 +122,32 @@ RSpec.describe Induction::TransferAndContinueExistingFip do
       end
     end
 
+    context "when an ECT in a non-frozen cohort is transferred and mentor is in a frozen one" do
+      let(:frozen_cohort) { Cohort.find_by_start_year(2021) || create(:cohort, start_year: 2021) }
+      let(:mentor_school_cohort) do
+        NewSeeds::Scenarios::SchoolCohorts::Fip.new(cohort: frozen_cohort).build.with_programme.school_cohort
+      end
+
+      let!(:mentor_profile_2) do
+        NewSeeds::Scenarios::Participants::Mentors::MentorWithNoEcts
+          .new(school_cohort: mentor_school_cohort)
+          .build
+          .with_induction_record(induction_programme: mentor_school_cohort.default_induction_programme)
+          .participant_profile
+      end
+
+      before do
+        frozen_cohort.update!(payments_frozen_at: 1.month.ago)
+      end
+
+      it "moves the mentor to the currently active registration cohort" do
+        expect { service_call }
+          .to change { mentor_profile_2.reload.schedule.cohort.start_year }
+                .from(2021)
+                .to(Cohort.active_registration_cohort.start_year)
+      end
+    end
+
     context "without optional params" do
       let(:service_call) { service.call(school_cohort: school_cohort_2, participant_profile:) }
 

--- a/spec/services/induction/transfer_to_schools_programme_spec.rb
+++ b/spec/services/induction/transfer_to_schools_programme_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Induction::TransferToSchoolsProgramme do
       end
 
       before do
-        allow(participant_profile).to receive(:eligible_to_change_cohort_and_continue_training?)
+        allow(participant_profile).to receive(:unfinished_with_billable_declaration?)
                                         .with(cohort: Cohort.next)
                                         .and_return(true)
         create(:ecf_extended_schedule, cohort: Cohort.next)
@@ -72,7 +72,7 @@ RSpec.describe Induction::TransferToSchoolsProgramme do
 
     context "when the participant is not eligible to be moved from a frozen cohort to the target one" do
       before do
-        allow(participant_profile).to receive(:eligible_to_change_cohort_and_continue_training?)
+        allow(participant_profile).to receive(:unfinished_with_billable_declaration?)
                                         .with(cohort: school_cohort_2.cohort)
                                         .and_return(false)
         service_call

--- a/spec/services/induction/transfer_to_schools_programme_spec.rb
+++ b/spec/services/induction/transfer_to_schools_programme_spec.rb
@@ -109,6 +109,32 @@ RSpec.describe Induction::TransferToSchoolsProgramme do
       end
     end
 
+    context "when an ECT in a non-frozen cohort is transferred and mentor is in a frozen one" do
+      let(:frozen_cohort) { Cohort.find_by_start_year(2021) || create(:cohort, start_year: 2021) }
+      let(:mentor_school_cohort) do
+        NewSeeds::Scenarios::SchoolCohorts::Fip.new(cohort: frozen_cohort).build.with_programme.school_cohort
+      end
+
+      let!(:mentor_profile_2) do
+        NewSeeds::Scenarios::Participants::Mentors::MentorWithNoEcts
+          .new(school_cohort: mentor_school_cohort)
+          .build
+          .with_induction_record(induction_programme: mentor_school_cohort.default_induction_programme)
+          .participant_profile
+      end
+
+      before do
+        frozen_cohort.update!(payments_frozen_at: 1.month.ago)
+      end
+
+      it "moves the mentor to the currently active registration cohort" do
+        expect { service_call }
+          .to change { mentor_profile_2.reload.schedule.cohort.start_year }
+                .from(2021)
+                .to(Cohort.active_registration_cohort.start_year)
+      end
+    end
+
     context "without optional params" do
       let(:new_induction_record) { participant_profile.current_induction_record }
       before do

--- a/spec/services/participants/check_and_set_completion_date_spec.rb
+++ b/spec/services/participants/check_and_set_completion_date_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Participants::CheckAndSetCompletionDate do
     end
 
     context "when DQT does not provide a completion date" do
-      let(:completion_date) { nil }
+      let(:completion_date) {}
 
       it "does not set a completion date" do
         service_call
@@ -101,7 +101,7 @@ RSpec.describe Participants::CheckAndSetCompletionDate do
 
         context "when the ect induction is not in progress" do
           before do
-            allow(participant_profile).to receive(:eligible_to_change_cohort_and_continue_training?).and_return(true)
+            allow(participant_profile).to receive(:unfinished_with_billable_declaration?).and_return(true)
           end
 
           it "leave the participant in the synced cohort" do
@@ -111,6 +111,7 @@ RSpec.describe Participants::CheckAndSetCompletionDate do
 
         context "when the ect induction is in progress" do
           let(:induction_status) { "InProgress" }
+          let(:completion_date) {}
 
           it "sit the participant in the active registration cohort" do
             expect { service_call }.to change { participant_profile.schedule.cohort }

--- a/spec/services/participants/check_and_set_completion_date_spec.rb
+++ b/spec/services/participants/check_and_set_completion_date_spec.rb
@@ -99,14 +99,6 @@ RSpec.describe Participants::CheckAndSetCompletionDate do
             .with_programme
         end
 
-        context "when the ect is not eligible to continue training" do
-          let(:induction_status) { "InProgress" }
-
-          it "leave the participant in the synced cohort" do
-            expect { service_call }.not_to change { participant_profile.schedule.cohort }
-          end
-        end
-
         context "when the ect induction is not in progress" do
           before do
             allow(participant_profile).to receive(:eligible_to_change_cohort_and_continue_training?).and_return(true)
@@ -117,12 +109,8 @@ RSpec.describe Participants::CheckAndSetCompletionDate do
           end
         end
 
-        context "when the ect is eligible to continue training" do
+        context "when the ect induction is in progress" do
           let(:induction_status) { "InProgress" }
-
-          before do
-            allow(participant_profile).to receive(:eligible_to_change_cohort_and_continue_training?).and_return(true)
-          end
 
           it "sit the participant in the active registration cohort" do
             expect { service_call }.to change { participant_profile.schedule.cohort }

--- a/spec/support/shared_examples/change_cohort_and_continue_training_support.rb
+++ b/spec/support/shared_examples/change_cohort_and_continue_training_support.rb
@@ -3,7 +3,7 @@
 RSpec.shared_examples "can change cohort and continue training" do |participant_type, other_participant_type, completed_training_at_attribute|
   let(:declaration_type) { "#{participant_type}_participant_declaration" }
 
-  describe ".eligible_to_change_cohort_and_continue_training" do
+  describe ".unfinished_with_billable_declaration" do
     let(:current_cohort) { eligible_participant.schedule.cohort }
     let(:restrict_to_participant_ids) { [] }
     let(:cpd_lead_provider) { eligible_participant.lead_provider.cpd_lead_provider }
@@ -33,7 +33,7 @@ RSpec.shared_examples "can change cohort and continue training" do |participant_
       end
     end
 
-    subject { described_class.eligible_to_change_cohort_and_continue_training(cohort:, restrict_to_participant_ids:) }
+    subject { described_class.unfinished_with_billable_declaration(cohort:, restrict_to_participant_ids:) }
 
     it { expect(current_cohort).not_to eq(cohort) }
     it { is_expected.to contain_exactly(*eligible_participants) }
@@ -45,7 +45,7 @@ RSpec.shared_examples "can change cohort and continue training" do |participant_
     end
   end
 
-  describe "#eligible_to_change_cohort_and_continue_training?" do
+  describe "#unfinished_with_billable_declaration?" do
     let(:declaration) { create(declaration_type, :paid, declaration_type: :started, cohort: Cohort.previous) }
     let(:participant_profile) { declaration.participant_profile }
     let(:current_cohort) { participant_profile.schedule.cohort }
@@ -56,18 +56,18 @@ RSpec.shared_examples "can change cohort and continue training" do |participant_
     subject { participant_profile }
 
     it { expect(current_cohort).not_to eq(cohort) }
-    it { is_expected.to be_eligible_to_change_cohort_and_continue_training(cohort:) }
+    it { is_expected.to be_unfinished_with_billable_declaration(cohort:) }
 
     context "when the participant is not in a payments frozen cohort" do
       before { current_cohort.update!(payments_frozen_at: nil) }
 
-      it { is_expected.not_to be_eligible_to_change_cohort_and_continue_training(cohort:) }
+      it { is_expected.not_to be_unfinished_with_billable_declaration(cohort:) }
     end
 
     context "when the cohort they intend to continue training in is not the active registration cohort" do
       let(:cohort) { Cohort.active_registration_cohort.previous }
 
-      it { is_expected.not_to be_eligible_to_change_cohort_and_continue_training(cohort:) }
+      it { is_expected.not_to be_unfinished_with_billable_declaration(cohort:) }
     end
 
     %i[paid payable eligible].each do |billable_declaration_type|
@@ -84,20 +84,20 @@ RSpec.shared_examples "can change cohort and continue training" do |participant_
                  cpd_lead_provider: participant_profile.lead_provider.cpd_lead_provider)
         end
 
-        it { is_expected.not_to be_eligible_to_change_cohort_and_continue_training(cohort:) }
+        it { is_expected.not_to be_unfinished_with_billable_declaration(cohort:) }
       end
     end
 
     context "when the participant does not have billable, not completed declarations" do
       before { declaration.destroy }
 
-      it { is_expected.not_to be_eligible_to_change_cohort_and_continue_training(cohort:) }
+      it { is_expected.not_to be_unfinished_with_billable_declaration(cohort:) }
     end
 
     context "when the participant has a #{completed_training_at_attribute}" do
       before { participant_profile.update!("#{completed_training_at_attribute}": 1.month.ago) }
 
-      it { is_expected.not_to be_eligible_to_change_cohort_and_continue_training(cohort:) }
+      it { is_expected.not_to be_unfinished_with_billable_declaration(cohort:) }
     end
   end
 


### PR DESCRIPTION
### Context

We have 3 triggers to automatically move participants in 2021 to 2024 due to 2021 cohort being frozen and no more lead provider declarations/payments can be accepted.

Until now only those participants complying with some requirements (unfinished participants) were picked and moved by the triggers implemented in June.

This PR extends those triggers to include any remaining participant in 2021 (not completed induction). 

The treatment will be similar to those unfinished participants but the flag that mark them to the LP won’t be setup for this new group.

- [Ticket: ](https://dfedigital.atlassian.net/browse/CST-2790)

### Changes proposed in this pull request

### Guidance to review

