### PR TITLE
Fix failing spec on completion date match checking

### DIFF
--- a/spec/services/participants/check_and_set_completion_date_spec.rb
+++ b/spec/services/participants/check_and_set_completion_date_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe Participants::CheckAndSetCompletionDate do
     end
 
     context "when completion dates are not matching" do
-      let(:induction_completion_date) { 2.months.ago.to_date }
+      let(:induction_completion_date) { 2.months.from_now.to_date }
 
       before do
         participant_profile.update!(induction_completion_date:)


### PR DESCRIPTION
It looks like this spec has started failing today as the `induction_completion_date` happens to align with the DQT induction record:

```
(byebug) dqt_induction_record
{"endDate"=>Sun, 12 May 2024, "periods"=>[{"startDate"=>Thu, 01 Sep 2022, "endDate"=>Sat, 01 Jun 2024}, {"startDate"=>Sat, 01 Jun 2024, "endDate"=>Sat, 31 Aug 2024}], "status"=>"active"}
(byebug) induction_completion_date
Sat, 31 Aug 2024
```

By using a future date it should ensure its always different to the IR.
