### PR TITLE
[CST-2732] Add bulk mailer to chase unengaged schools

### DIFF
--- a/app/queries/schools/that_have_not_engaged_query.rb
+++ b/app/queries/schools/that_have_not_engaged_query.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Schools
+  class ThatHaveNotEngagedQuery < BaseService
+    def call
+      schools_to_include.merge(schools_that_have_not_engaged)
+    end
+
+    attr_reader :cohort, :school_type_codes
+
+    def initialize(cohort:, school_type_codes: [])
+      @cohort = cohort
+      @school_type_codes = school_type_codes
+    end
+
+    def schools_to_include
+      scope = School.currently_open.in_england
+      return scope if school_type_codes.blank?
+
+      scope.where(school_type_code: school_type_codes)
+    end
+
+    def schools_that_have_not_engaged
+      School.where.not(id: SchoolCohort.where(cohort:).select(:school_id))
+    end
+  end
+end

--- a/spec/queries/schools/that_have_not_engaged_query_spec.rb
+++ b/spec/queries/schools/that_have_not_engaged_query_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Schools::ThatHaveNotEngagedQuery do
+  describe "#call" do
+    let(:cohort) { create(:seed_cohort) }
+    let(:query_cohort) { cohort.next || create(:seed_cohort, start_year: cohort.start_year + 1) }
+    let(:school_type_codes) { [] }
+
+    let(:school_cohort) { create(:seed_school_cohort, :with_school, cohort:) }
+    let!(:school) { school_cohort.school }
+
+    subject(:query_result) { described_class.call(cohort: query_cohort, school_type_codes:) }
+
+    context "when the school has not engaged" do
+      it "includes the school" do
+        expect(query_result).to include(school)
+      end
+    end
+
+    context "when the school has engaged" do
+      let!(:query_school_cohort) { create(:seed_school_cohort, :fip, school:, cohort: query_cohort) }
+
+      it "does not include the school" do
+        expect(query_result).not_to include(school)
+      end
+    end
+
+    context "when school type codes are supplied" do
+      let(:school_type_codes) { [1, 2, 3] }
+
+      context "and the school matches one of the school types" do
+        before do
+          school.update!(school_type_code: 2)
+        end
+
+        context "when the school has not engaged" do
+          it "includes the school" do
+            expect(query_result).to include(school)
+          end
+        end
+
+        context "when the school has engaged" do
+          let!(:query_school_cohort) { create(:seed_school_cohort, school:, cohort: query_cohort) }
+
+          it "does not include the school" do
+            expect(query_result).not_to include(school)
+          end
+        end
+      end
+
+      context "and the school does not match one of the school types" do
+        before do
+          school.update!(school_type_code: 5)
+        end
+
+        context "when the school has not engaged" do
+          it "does not include the school" do
+            expect(query_result).not_to include(school)
+          end
+        end
+
+        context "when the school has engaged" do
+          let!(:query_school_cohort) { create(:seed_school_cohort, school:, cohort: query_cohort) }
+
+          it "does not include the school" do
+            expect(query_result).not_to include(school)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: CST-2732

We emailed SITs to report their school training information for the current year, but many still haven't responded. We'd like to send a follow-up email to the schools' GIAS contacts, asking them to review their SIT information and required actions.

### Changes proposed in this pull request
- Add query to pull all the unengaged schools
- Add bulk school mailer to trigger the emails

### Guidance to review
- Please check the Notify template to confirm that all required placeholders are included