### PR TITLE
[CST-2765] Update the participant AB name crosscheck

### DIFF
--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -532,5 +532,6 @@
   - participant_profile_id
   - appropriate_body_name
   - dqt_appropriate_body_name
+  - dqt_induction_status
   - created_at
   - updated_at

--- a/db/migrate/20241101133851_add_dqt_induction_status_to_participant_appropriate_body_dqt_checks.rb
+++ b/db/migrate/20241101133851_add_dqt_induction_status_to_participant_appropriate_body_dqt_checks.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDQTInductionStatusToParticipantAppropriateBodyDQTChecks < ActiveRecord::Migration[7.1]
+  def change
+    add_column :participant_appropriate_body_dqt_checks, :dqt_induction_status, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_21_071942) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_01_133851) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -792,6 +792,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_21_071942) do
     t.string "dqt_appropriate_body_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "dqt_induction_status"
   end
 
   create_table "participant_bands", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/lib/tasks/participant_appropriate_body_dqt_checks.rake
+++ b/lib/tasks/participant_appropriate_body_dqt_checks.rake
@@ -36,20 +36,56 @@ namespace :participant_appropriate_body_dqt_checks do
     end
   end
 
-  desc "Generate a CSV with the Participant's and DQT's appropriate body missmatches"
-  task export_mismatches: :environment do
-    csv_file_path = Rails.root.join("tmp/mismatched_records.csv")
+  # DQT records provide the AB names in a different format than what is stored in ECF.
+  # To enable accurate comparison, a CSV file is required that maps all DQT AB names
+  # to their corresponding ECF AB records.
+  desc "Generate a CSV with the Participant's and DQT's appropriate body mismatches"
+  task :export_mismatches, [:path_to_mappings_csv] => :environment do |_task, args|
+    raise ArgumentError, "Please provide the path to the mappings CSV" unless args.path_to_mappings_csv
 
-    CSV.open(csv_file_path, "w", headers: true) do |csv|
-      csv << ["TRN", "Appropriate Body Name", "DQT Appropriate Body Name"]
+    ab_mappings = load_ab_mappings(args.path_to_mappings_csv)
+    results_csv_file_path = "tmp/mismatched_records.csv"
 
-      ParticipantAppropriateBodyDQTCheck.includes(:participant_profile).find_each do |record|
-        if record.normalised_appropriate_body_name != record.dqt_appropriate_body_name
-          csv << [record.participant_profile.trn, record.normalised_appropriate_body_name, record.dqt_appropriate_body_name]
-        end
-      end
+    generate_mismatches_csv(results_csv_file_path, ab_mappings)
+  end
+end
+
+# Helper method to load appropriate body mappings from the CSV
+def load_ab_mappings(path_to_csv)
+  ab_mappings = {}
+  CSV.foreach(path_to_csv, headers: true) do |row|
+    unless row.headers.include?("DQT AB name") && row.headers.include?("CPD ID")
+      raise "CSV is missing required headers: 'DQT AB name' and 'CPD ID'"
     end
 
-    puts "CSV file with mismatched records generated at #{csv_file_path}"
+    ab_mappings[row["DQT AB name"]] = row["CPD ID"]
+  end
+  ab_mappings
+end
+
+# Helper method to generate the mismatches CSV
+def generate_mismatches_csv(file_path, ab_mappings)
+  CSV.open(file_path, "w", headers: true) do |csv|
+    csv << ["Participant Profile ID", "Participant TRN", "ECF AB ID", "ECF AB Name", "CPD ID (from mappings CSV)", "DQT AB Name"]
+
+    ParticipantAppropriateBodyDQTCheck.includes(:participant_profile).find_each do |record|
+      ecf_ab = AppropriateBody.find_by(name: record.appropriate_body_name)
+      csv_mapped_id = ab_mappings[record.dqt_appropriate_body_name] || "not found in the mappings CSV"
+
+      # Exclude records whose DQT Induction Status is not InProgress.
+      next if record.dqt_induction_status != "InProgress"
+
+      # Add record to CSV if there is a mismatch
+      if csv_mapped_id != ecf_ab&.id
+        csv << [
+          record.participant_profile_id,
+          record.participant_profile&.trn,
+          ecf_ab&.id,
+          ecf_ab&.name,
+          csv_mapped_id,
+          record.dqt_appropriate_body_name,
+        ]
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

- Ticket: CST-2765



The crosscheck needs to be updated to: 
1. Skip any mismatches that don't have `InProgress` dqt induction status
2. Compare the ids of the Appropriate Bodies, instead of their names. Since the DQT responses includes only AB names, a csv is provided to us that maps them to their corresponding records in ECF Manage service.

### Changes proposed in this pull request
- Store the dqt induction status in the check records
- Update the extract to skip mismatches that don't have `InProgress` dqt induction status

### Guidance to review

