### PR TITLE
Upgrade GitHub actions/upload-artifact to v4

### DIFF
--- a/.github/actions/test-performance/action.yml
+++ b/.github/actions/test-performance/action.yml
@@ -123,7 +123,7 @@ runs:
         node ./performance/dfe-k6-reporter.js ./reports/${{ inputs.scenario }}-report.json ./reports/${{ inputs.scenario }}-report.html ./reports/${{ inputs.scenario }}-summary.md
 
     - name: Upload the reports
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.scenario }}-report
         path: |


### PR DESCRIPTION
v3 [is soon going away](https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/), we should be using v4. None of the breaking changes look like they'll affect us.
