### PR TITLE
Switch API doc NPQ removal to feature flag

### DIFF
--- a/app/lib/lead_provider_api_specification/preprocessor.rb
+++ b/app/lib/lead_provider_api_specification/preprocessor.rb
@@ -49,7 +49,7 @@ class LeadProviderApiSpecification::Preprocessor
 private
 
   def remove_npq_references?
-    Rails.env.separation?
+    FeatureFlag.active?(:disable_npq)
   end
 
   def swagger_string

--- a/config/initializers/api_reference.rb
+++ b/config/initializers/api_reference.rb
@@ -1,14 +1,23 @@
 # frozen_string_literal: true
 
-return unless Rails.env.separation?
+# Only run this initializer in the context of a Rails server.
+return unless defined?(Rails::Server)
 
-api_reference_path = Rails.root.join("public/api-reference")
-api_reference_without_npq_path = Rails.root.join("public/api-reference-without-npq")
+# Ensure autoloading as finished.
+Rails.application.config.after_initialize do
+  # Wait for database connection to be established.
+  ActiveRecord::Base.connection_pool.with_connection do
+    if FeatureFlag.active?(:disable_npq)
+      api_reference_path = Rails.root.join("public/api-reference")
+      api_reference_without_npq_path = Rails.root.join("public/api-reference-without-npq")
 
-if [api_reference_path, api_reference_without_npq_path].all? { |d| Dir.exist?(d) }
-  # Remove the existing 'api-reference' directory
-  FileUtils.rm_rf(api_reference_path)
+      if [api_reference_path, api_reference_without_npq_path].all? { |d| Dir.exist?(d) }
+        # Remove the existing 'api-reference' directory
+        FileUtils.rm_rf(api_reference_path)
 
-  # Move 'api-reference-without-npq' to 'api-reference'
-  FileUtils.mv(api_reference_without_npq_path, api_reference_path) if Dir.exist?(api_reference_without_npq_path)
+        # Move 'api-reference-without-npq' to 'api-reference'
+        FileUtils.mv(api_reference_without_npq_path, api_reference_path)
+      end
+    end
+  end
 end

--- a/spec/lib/lead_provider_api_specification/preprocessor_spec.rb
+++ b/spec/lib/lead_provider_api_specification/preprocessor_spec.rb
@@ -5,9 +5,7 @@ RSpec.describe LeadProviderApiSpecification::Preprocessor do
   let(:instance) { described_class.new(swagger_path) }
 
   describe "#preprocess!" do
-    let(:environment) { "separation" }
-
-    before { allow(Rails).to receive(:env) { environment.inquiry } }
+    before { FeatureFlag.activate(:disable_npq) }
 
     context "when the swagger doc contains NPQ references" do
       it "removes the NPQ references" do
@@ -83,7 +81,7 @@ RSpec.describe LeadProviderApiSpecification::Preprocessor do
     end
 
     context "when not removing NPQ references" do
-      let(:environment) { "production" }
+      before { FeatureFlag.deactivate(:disable_npq) }
 
       it "does not read or write any files" do
         expect(File).not_to receive(:read)


### PR DESCRIPTION
[Jira-3768](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345%2Cunassigned&selectedIssue=CPDLP-3768)

### Context

Currently we remove NPQ references on the separation environment; going forward we want to remove all references when the `disable_npq` feature is enabled.

### Changes proposed in this pull request

- Switch API doc NPQ removal to feature flag

Currently we remove NPQ references on the separation environment; going forward we want to remove all references when the disable_npq feature is enabled.

We will need to reboot the app instance to get the correct API docs as we determine this in an initializer on boot.

Only run initializer when ran in the context of a `rails server` so that wedon't get database connection errors when pre-compiling assets. Move to after_initialize to ensure the autoloading has finished and FeatureFlag is defined/loaded. We also need to wait for/ensure the DB is connected so this initializer can check the feature state.

### Guidance to review

This took a bit more work than I expected; we need to ensure the autoloading has finished before we can access `FeatureFlag` and we need to wait for the database before we can check the feature flag state. We also need to ensure that it doesn't run outside the context of a `rails server`, as Rails will boot without a database for other tasks (such as asset pre-compilation).

I attempted to dynamically select the right API doc version in middleware, but I couldn't get this working reliably.

To test it out, you can hop onto the rails console for the review app, toggle the feature flag and then reboot the web instance. After it has rebooted you can do a hard-refresh and you should get the correct API docs:

```
PULL_REQUEST_NUMBER=5317 make ci review aks-console
FeatureFlag.activate(:disable_npq)
kubectl rollout restart deployment cpd-ecf-review-5317-web -n cpd-development
```