### PR TITLE
Added 2024 cohort dates API guidance

### DIFF
--- a/docs/source/ecf/schedules-and-milestone-dates.html.md
+++ b/docs/source/ecf/schedules-and-milestone-dates.html.md
@@ -43,6 +43,24 @@ Providers must [notify DfE if the participant is following any other standard or
 
 ### Dates for standard schedule starting in September
 
+#### 2024 cohort
+
+Participants starting their ECF-based training on or before 31 December 2024, and who are expected to complete their training over 2 academic years, should remain on the default schedule:
+
+```
+ "schedule_identifier": "ecf-standard-september"
+```
+
+| Milestone      | Start date     | Milestone date      | Declaration type    | Payment date      | 
+| -------- | --------  | -------- | --------  | -------- | 
+| Participant Start      | 1 Jun 2024     | 31 Dec 2024     | `started`    | 30 Nov 2024      | 
+| Retention Point 1      | 1 Jan 2025     | 31 Mar 2025      | `retained-1`    | 30 Apr 2025     | 
+| Retention Point 2      | 1 Apr 2025     | 31 Jul 2025      | `retained-2`    | 31 Aug 2025     | 
+| Retention Point 3      | 1 Aug 2025     | 31 Dec 2025      | `retained-3`    | 31 Jan 2026      | 
+| Retention Point 4      | 1 Jan 2026     | 31 Mar 2026      | `retained-4`    | 30 Apr 2026     | 
+| Participant Completion      | 1 Apr 2026     | 31 Jul 2026      | `completed`    | 31 Aug 2026      | 
+
+
 #### 2023 cohort
 
 Participants starting their ECF-based training on or before 31 December 2023, and who are expected to complete their training over 2 academic years, should remain on the default schedule:
@@ -98,6 +116,25 @@ Participants starting their ECF-based training on or before 30 November 2021, an
 
 ### Dates for standard schedule starting in January
 
+#### 2024 cohort
+
+Participants starting their ECF-based training between 1 January and 31 March 2025, and who are expected to complete their training over 2 academic years, [should have their schedule updated](/api-reference/ecf/guidance.html#notify-dfe-of-a-participant-39-s-training-schedule) by providers to: 
+
+```
+ "schedule_identifier": "ecf-standard-january"
+```
+
+| Milestone      | Start date     | Milestone date      | Declaration type    | Payment date      | 
+| -------- | --------  | -------- | --------  | -------- | 
+| Participant Start      | 1 Jan 2025     | 31 Mar 2025      | `started`    | 30 Apr 2025      | 
+| Retention Point 1      | 1 Apr 2025    | 31 Jul 2025      | `retained-1`    | 31 Aug 2025      | 
+| Retention Point 2      | 1 Aug 2025     | 31 Dec 2025      | `retained-2`    | 31 Jan 2026      | 
+| Retention Point 3      | 1 Jan 2026     | 31 Mar 2026      | `retained-3`    | 30 Apr 2026      | 
+| Retention Point 4      | 1 Apr 2026     | 31 Jul 2026      | `retained-4`    | 31 Aug 2026      | 
+| Participant Completion      | 1 Aug 2026     | 31 Dec 2026      | `completed`    | 31 Jan 2027      | 
+
+#### 2023 cohort
+
 Participants starting their ECF-based training between 1 January and 31 March 2024, and who are expected to complete their training over 2 academic years, [should have their schedule updated](/api-reference/ecf/guidance.html#notify-dfe-of-a-participant-39-s-training-schedule) by providers to: 
 
 ```
@@ -149,6 +186,24 @@ For participants starting their course on or before 1 December 2021, and who are
 
 
 ### Dates for standard schedule starting in April
+
+#### 2024 cohort
+
+Participants starting their ECF-based training between 1 April and 31 July 2025, and who are expected to complete their training over 2 academic years, [should have their schedule updated](/api-reference/ecf/guidance.html#notify-dfe-of-a-participant-39-s-training-schedule) by providers to: 
+
+```
+ "schedule_identifier": "ecf-standard-april"
+```
+
+| Milestone      | Start date     | Milestone date      | Declaration type    | Payment date      | 
+| -------- | --------  | -------- | --------  | -------- | 
+| Participant Start      | 1 Apr 2025     | 31 Jul 2025      | `started`    | 31 Aug 2025      | 
+| Retention Point 1      | 1 Aug 2025     | 31 Dec 2025     | `retained-1`    | 31 Jan 2026      | 
+| Retention Point 2      | 1 Jan 2026     | 31 Mar 2026      | `retained-2`    | 30 Apr 2026     | 
+| Retention Point 3      | 1 Apr 2026    | 31 Jul 2026      | `retained-3`    | 31 Aug 2026      | 
+| Retention Point 4      | 1 Aug 2026     | 31 Dec 2026      | `retained-4`    | 31 Jan 2027      | 
+| Participant Completion      | 1 Jan 2027     | 31 Mar 2027      | `completed`    | 30 Apr 2027      | 
+
 
 #### 2023 cohort
 


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-3720

### Changes proposed in this pull request

Added the 2024/25 academic year standard schedules dates for September, January and April starts.

### Guidance to review

From the following pr: https://github.com/DFE-Digital/early-careers-framework/pull/5312