### PR TITLE
[CST-2805] Display correct completion date on Admin participant details page

### DIFF
--- a/app/presenters/admin/participant_presenter.rb
+++ b/app/presenters/admin/participant_presenter.rb
@@ -65,6 +65,12 @@ class Admin::ParticipantPresenter
 
   delegate :id, to: :participant_profile
 
+  def mentor_completion_date
+    return "Not yet recorded" unless participant_profile.mentor_completion_date
+
+    participant_profile.mentor_completion_date.to_formatted_s(:govuk)
+  end
+
   def induction_completion_date
     if participant_profile.induction_completion_date
       participant_profile.induction_completion_date.to_formatted_s(:govuk)

--- a/app/views/admin/participants/details/_show_ecf.html.erb
+++ b/app/views/admin/participants/details/_show_ecf.html.erb
@@ -73,14 +73,20 @@
     end
   end
 
-  sl.with_row do |row|
-    row.with_key(text: "Induction start date")
-    row.with_value(text: @participant_presenter.induction_start_date)
-  end
-
-  sl.with_row do |row|
-    row.with_key(text: "Induction completion date")
-    row.with_value(text: @participant_presenter.induction_completion_date)
+  if @participant_profile.mentor?
+    sl.with_row do |row|
+      row.with_key(text: "Mentor completion date")
+      row.with_value(text: @participant_presenter.mentor_completion_date)
+    end
+  else
+    sl.with_row do |row|
+      row.with_key(text: "Induction start date")
+      row.with_value(text: @participant_presenter.induction_start_date)
+    end
+    sl.with_row do |row|
+      row.with_key(text: "Induction completion date")
+      row.with_value(text: @participant_presenter.induction_completion_date)
+    end
   end
 
   sl.with_row do |row|


### PR DESCRIPTION
### Context

- Ticket: CST-2805

Currently, the Admin page displays the induction completion date for both ECT and Mentor profiles. However, the induction completion date is specific to ECTs, while mentors have a separate mentor completion date. This PR addresses that inconsistency by ensuring the appropriate completion date is shown for each profile type.

### Changes proposed in this pull request
- Update the participant details view page to display the appropriate completion date based on the profile type

### Guidance to review
| Before | After |
|--------|--------|
|<img width="1117" alt="Screenshot 2024-11-19 at 13 42 06" src="https://github.com/user-attachments/assets/5d877922-2874-427a-abe2-340ed880e524">|<img width="1112" alt="Screenshot 2024-11-19 at 13 39 35" src="https://github.com/user-attachments/assets/517e3c58-7b4b-412d-92f1-caa5e9841578">|