### PR TITLE
Remove declaration states from analytics as no longer required

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -263,13 +263,6 @@
   - created_at
   - updated_at
   - delivery_partner_to_be_confirmed
-  :declaration_states:
-  - id
-  - participant_declaration_id
-  - state
-  - created_at
-  - updated_at
-  - state_reason
   :cohorts:
   - id
   - created_at

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -548,3 +548,10 @@
   - user_description
   - created_at
   - updated_at
+  :declaration_states:
+  - id
+  - participant_declaration_id
+  - state
+  - created_at
+  - updated_at
+  - state_reason


### PR DESCRIPTION
### Context

Declaration states no longer required for analytics

- Ticket: n/a

### Changes proposed in this pull request
remove from required file and move to blocked analytics list

### Guidance to review
-
