### PR TITLE
[CPDLP-3738] Make declarations back to eligible when moving to an eligible statement

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -705,6 +705,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-22
   x86_64-darwin-23
   x86_64-linux

--- a/app/services/oneoffs/npq/migrate_declarations_between_statements.rb
+++ b/app/services/oneoffs/npq/migrate_declarations_between_statements.rb
@@ -122,7 +122,7 @@ module Oneoffs::NPQ
       record_info("Marking #{payable_declarations.size} payable declarations back as eligible for #{to_statement.name} statement")
 
       payable_declarations.each { |declaration| DeclarationState.eligible!(declaration) }
-      statement_line_items.map(&:eligible!)
+      statement_line_items.select(&:payable?).map(&:eligible!)
     end
 
     def filter_statement_line_items(statement_line_items)

--- a/spec/services/oneoffs/npq/migrate_declarations_between_statements_spec.rb
+++ b/spec/services/oneoffs/npq/migrate_declarations_between_statements_spec.rb
@@ -290,6 +290,7 @@ describe Oneoffs::NPQ::MigrateDeclarationsBetweenStatements, mid_cohort: true do
 
         expect(declaration.statement_line_items.map(&:statement)).to all(eq(to_statement))
         expect(declaration).to be_eligible
+        expect(to_statement.statement_line_items.map(&:state)).to eq(%w[eligible])
       end
 
       it "records information" do


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-3738](https://dfedigital.atlassian.net/browse/CPDLP-3738)

Some payable declarations might be moved to an eligible statement (not payable nor paid) via the `MigrateDeclarationsBetweenStatements` service.
### Changes proposed in this pull request

To accommodate this scenario, we're making payable `declarations` and linked `statement_line_items` back to eligible state when moving to an eligible statement when using `MigrateDeclarationsBetweenStatements` service.

[CPDLP-3738]: https://dfedigital.atlassian.net/browse/CPDLP-3738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ