### PR TITLE
Ensure OpenStruct is loaded outside the finance class

### DIFF
--- a/app/forms/finance/choose_payment_breakdown_form.rb
+++ b/app/forms/finance/choose_payment_breakdown_form.rb
@@ -10,10 +10,10 @@ module Finance
     validates :provider, presence: { message: I18n.t("errors.provider.blank") }, on: :choose_provider
 
     def programme_choices
-      choices = [OpenStruct.new(id: "ecf", name: "ECF payments")]
+      choices = [::OpenStruct.new(id: "ecf", name: "ECF payments")]
 
       unless FeatureFlag.active?(:disable_npq)
-        choices << OpenStruct.new(id: "npq", name: "NPQ payments")
+        choices << ::OpenStruct.new(id: "npq", name: "NPQ payments")
       end
 
       choices

--- a/spec/forms/finance/choose_payment_breakdown_form_spec.rb
+++ b/spec/forms/finance/choose_payment_breakdown_form_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe Finance::ChoosePaymentBreakdownForm, type: :model do
+  let(:form) { described_class.new({}) }
+
+  describe "programme_choices" do
+    it "returns the programme choices for NPQ and ECF" do
+      expect(form.programme_choices).to match_array([
+        OpenStruct.new(id: "ecf", name: "ECF payments"),
+        OpenStruct.new(id: "npq", name: "NPQ payments"),
+      ])
+    end
+
+    context "when disable_npq feature is on" do
+      it "returns the programme choices for ECF only" do
+        FeatureFlag.activate(:disable_npq)
+
+        expect(form.programme_choices).to match_array([
+          OpenStruct.new(id: "ecf", name: "ECF payments"),
+        ])
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

We are getting an error in production with the following: `uninitialized constant Finance::ChoosePaymentBreakdownForm::OpenStruct`

- Ticket: n/a

### Changes proposed in this pull request

Ensure that OpenStruct is not loaded under the finance class, but separately.


### Guidance to review

