### PR TITLE
[CST-2748] Focus on the cookie banner before the skip to main content

### DIFF
--- a/app/views/layouts/_application.html.erb
+++ b/app/views/layouts/_application.html.erb
@@ -61,11 +61,11 @@
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
 
-    <a href="#main-content" class="govuk-skip-link" tabindex="0">Skip to main content</a>
-
     <% unless cookies[:cookie_consent_1] || current_page?(cookies_path) %>
       <%= render "cookies/banner" %>
     <% end %>
+
+    <a href="#main-content" class="govuk-skip-link" tabindex="0">Skip to main content</a>
 
     <%= govuk_header(service_name:, container_classes: ("govuk-width-container__wide" if wide_container_view?)) do |header|
       if user_signed_in?


### PR DESCRIPTION
### Context

- Ticket: CST-2748

This follows a11y best practices to ensure users will interact with the cookie before navigating the rest of the page.

### Changes proposed in this pull request
- Move the "Skip to main content" link after the cookie banner is rendered

### Guidance to review

