### PR TITLE
Revert "Support filtering by declaration type in migration environment"

### DIFF
--- a/app/controllers/api/v1/participant_declarations_controller.rb
+++ b/app/controllers/api/v1/participant_declarations_controller.rb
@@ -51,7 +51,6 @@ module Api
           cpd_lead_provider:,
           updated_since:,
           participant_id: participant_id_filter,
-          type: type_filter,
         ).scope
       end
 
@@ -61,10 +60,6 @@ module Api
 
       def participant_id_filter
         filter[:participant_id]
-      end
-
-      def type_filter
-        filter[:type]
       end
 
       def cpd_lead_provider

--- a/app/controllers/api/v3/participant_declarations_controller.rb
+++ b/app/controllers/api/v3/participant_declarations_controller.rb
@@ -66,7 +66,7 @@ module Api
       end
 
       def query_params
-        params.permit(:id, filter: %i[cohort participant_id updated_since delivery_partner_id type])
+        params.permit(:id, filter: %i[cohort participant_id updated_since delivery_partner_id])
       end
 
       def permitted_params

--- a/app/services/api/participant_declarations/index.rb
+++ b/app/services/api/participant_declarations/index.rb
@@ -3,13 +3,12 @@
 module Api
   module ParticipantDeclarations
     class Index
-      attr_reader :cpd_lead_provider, :updated_since, :participant_id, :type
+      attr_reader :cpd_lead_provider, :updated_since, :participant_id
 
-      def initialize(cpd_lead_provider:, updated_since: nil, participant_id: nil, type: nil)
+      def initialize(cpd_lead_provider:, updated_since: nil, participant_id: nil)
         @cpd_lead_provider = cpd_lead_provider
         @updated_since = updated_since
         @participant_id = participant_id
-        @type = format_type(type)
       end
 
       def scope
@@ -20,23 +19,11 @@ module Api
 
         scope = scope.where("user_id = ?", participant_id) if participant_id.present?
         scope = scope.where("updated_at > ?", updated_since) if updated_since.present?
-        scope = scope.where(type:) if type.present?
 
         scope.order(:created_at)
       end
 
     private
-
-      def format_type(type)
-        return nil unless Rails.env.migration?
-
-        case type&.downcase&.to_sym
-        when :npq
-          "ParticipantDeclaration::NPQ"
-        when :ecf
-          "ParticipantDeclaration::ECF"
-        end
-      end
 
       def lead_provider
         cpd_lead_provider.lead_provider

--- a/app/services/api/v3/participant_declarations_query.rb
+++ b/app/services/api/v3/participant_declarations_query.rb
@@ -113,20 +113,7 @@ module Api
         filter[:delivery_partner_id]&.split(",")
       end
 
-      def type
-        return nil unless Rails.env.migration?
-
-        case filter[:type]&.downcase&.to_sym
-        when :npq
-          ParticipantDeclaration::NPQ
-        when :ecf
-          ParticipantDeclaration::ECF
-        end
-      end
-
       def declaration_class
-        return type if type.present?
-
         if NpqApiEndpoint.disabled?
           ParticipantDeclaration::ECF
         else

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -779,33 +779,6 @@ RSpec.describe "participant-declarations endpoint spec", type: :request, mid_coh
         end
       end
 
-      context "when a type filter used" do
-        let(:environment) { "migration" }
-        before { allow(Rails).to receive(:env).and_return(environment.inquiry) }
-
-        it "returns NPQ declarations when filtering by NPQ" do
-          get "/api/v1/participant-declarations", params: { filter: { type: :npq } }
-          expect(response.status).to eq 200
-          expect(parsed_response["data"].size).to eq 0
-        end
-
-        it "returns ECF declarations when filtering by ECF" do
-          get "/api/v1/participant-declarations", params: { filter: { type: :ecf } }
-          expect(response.status).to eq 200
-          expect(parsed_response["data"].size).to eq 1
-        end
-
-        context "when the environment is not migration" do
-          let(:environment) { "production" }
-
-          it "ignores the type filter" do
-            get "/api/v1/participant-declarations", params: { filter: { type: :npq } }
-            expect(response.status).to eq 200
-            expect(parsed_response["data"].size).to eq 1
-          end
-        end
-      end
-
       context "when a participant id filter used" do
         let(:second_participant_profile) { create(:ect, school_cohort:) }
         let!(:second_participant_declaration) { create(:ect_participant_declaration, participant_profile: second_participant_profile, cpd_lead_provider:) }

--- a/spec/requests/api/v2/participant_declarations_spec.rb
+++ b/spec/requests/api/v2/participant_declarations_spec.rb
@@ -506,37 +506,6 @@ RSpec.describe "participant-declarations endpoint spec", type: :request, mid_coh
         end
       end
 
-      context "when a type filter used" do
-        let(:environment) { "migration" }
-
-        before do
-          create(:ect_participant_declaration, cpd_lead_provider:, participant_profile: ect_profile)
-          allow(Rails).to receive(:env).and_return(environment.inquiry)
-        end
-
-        it "returns NPQ declarations when filtering by NPQ" do
-          get "/api/v2/participant-declarations", params: { filter: { type: :npq } }
-          expect(response.status).to eq 200
-          expect(parsed_response["data"].size).to eq 0
-        end
-
-        it "returns ECF declarations when filtering by ECF" do
-          get "/api/v2/participant-declarations", params: { filter: { type: :ecf } }
-          expect(response.status).to eq 200
-          expect(parsed_response["data"].size).to eq 1
-        end
-
-        context "when the environment is not migration" do
-          let(:environment) { "production" }
-
-          it "ignores the type filter" do
-            get "/api/v2/participant-declarations", params: { filter: { type: :npq } }
-            expect(response.status).to eq 200
-            expect(parsed_response["data"].size).to eq 1
-          end
-        end
-      end
-
       context "when a participant id filter used" do
         let!(:second_ect_profile) { create(:ect, lead_provider: cpd_lead_provider.lead_provider) }
         let!(:second_participant_declaration) do

--- a/spec/requests/api/v3/participant_declarations_spec.rb
+++ b/spec/requests/api/v3/participant_declarations_spec.rb
@@ -220,33 +220,6 @@ RSpec.describe "API Participant Declarations", type: :request, mid_cohort: true 
         end
       end
 
-      context "when a type filter used" do
-        let(:environment) { "migration" }
-        before { allow(Rails).to receive(:env).and_return(environment.inquiry) }
-
-        it "returns NPQ declarations when filtering by NPQ" do
-          get "/api/v3/participant-declarations", params: { filter: { type: :npq } }
-          expect(response.status).to eq 200
-          expect(parsed_response["data"].size).to eq 0
-        end
-
-        it "returns ECF declarations when filtering by ECF" do
-          get "/api/v3/participant-declarations", params: { filter: { type: :ecf } }
-          expect(response.status).to eq 200
-          expect(parsed_response["data"].size).to eq 3
-        end
-
-        context "when the environment is not migration" do
-          let(:environment) { "production" }
-
-          it "ignores the type filter" do
-            get "/api/v3/participant-declarations", params: { filter: { type: :npq } }
-            expect(response.status).to eq 200
-            expect(parsed_response["data"].size).to eq 3
-          end
-        end
-      end
-
       context "when filtering by updated_since" do
         before do
           participant_declaration1.update!(updated_at: 3.days.ago)

--- a/spec/services/api/participant_declarations/index_spec.rb
+++ b/spec/services/api/participant_declarations/index_spec.rb
@@ -97,51 +97,6 @@ RSpec.describe Api::ParticipantDeclarations::Index do
       end
     end
 
-    context "when filtering by type" do
-      let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider, :with_npq_lead_provider) }
-      let!(:npq_declaration) do
-        create(
-          :npq_participant_declaration,
-          declaration_type: "started",
-          cpd_lead_provider:,
-        )
-      end
-      let!(:ecf_declaration) do
-        create(
-          :ect_participant_declaration,
-          declaration_type: "started",
-          cpd_lead_provider:,
-        )
-      end
-      let(:environment) { "migration" }
-
-      before { allow(Rails).to receive(:env) { environment.inquiry } }
-
-      subject { described_class.new(cpd_lead_provider:, type:) }
-
-      context "when filtering by NPQ declarations" do
-        let(:type) { "npq" }
-
-        it { expect(subject.scope.to_a).to contain_exactly(npq_declaration) }
-      end
-
-      context "when filtering by ECF declarations" do
-        let(:type) { "ECF" }
-
-        it { expect(subject.scope.to_a).to contain_exactly(ecf_declaration) }
-      end
-
-      context "when environment is not migration" do
-        let(:environment) { "production" }
-
-        context "when filtering by type" do
-          let(:type) { "npq" }
-
-          it { expect(subject.scope.to_a).to contain_exactly(ecf_declaration, npq_declaration) }
-        end
-      end
-    end
-
     context "when using 'disable_npq' feature" do
       let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider, :with_npq_lead_provider) }
       let!(:npq_declaration) do

--- a/spec/services/api/v3/participant_declarations_query_spec.rb
+++ b/spec/services/api/v3/participant_declarations_query_spec.rb
@@ -127,40 +127,6 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery do
       end
     end
 
-    context "with type filter" do
-      let(:environment) { "migration" }
-      let(:params) { { filter: { type: } } }
-      let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider, :with_npq_lead_provider) }
-      let!(:npq_participant_declaration_id) { create(:npq_participant_declaration, cpd_lead_provider:).id }
-      let!(:ecf_participant_declaration_id) { create(:ect_participant_declaration, cpd_lead_provider:).id }
-
-      before { allow(Rails).to receive(:env) { environment.inquiry } }
-
-      subject { described_class.new(cpd_lead_provider:, params:) }
-
-      context "when filtering by NPQ declarations" do
-        let(:type) { "npq" }
-
-        it { expect(subject.participant_declarations_for_pagination.pluck(:id)).to contain_exactly(npq_participant_declaration_id) }
-      end
-
-      context "when filtering by ECF declarations" do
-        let(:type) { "ECF" }
-
-        it { expect(subject.participant_declarations_for_pagination.pluck(:id)).to contain_exactly(ecf_participant_declaration_id) }
-      end
-
-      context "when not in migration environment" do
-        let(:environment) { "production" }
-
-        context "when filtering by type" do
-          let(:type) { "npq" }
-
-          it { expect(subject.participant_declarations_for_pagination.pluck(:id)).to contain_exactly(ecf_participant_declaration_id, npq_participant_declaration_id) }
-        end
-      end
-    end
-
     context "with cohort filter" do
       let(:params) { { filter: { cohort: cohort2.start_year.to_s } } }
 


### PR DESCRIPTION
[Jira-3791](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345%2Cunassigned&selectedIssue=CPDLP-3791)

Reverts DFE-Digital/early-careers-framework#5261 - we no longer need this as the parity checking has finished.