### PR TITLE
Fix `UnfundedMentorsQuery` to surface correct email

### DIFF
--- a/app/services/api/v3/ecf/unfunded_mentors_query.rb
+++ b/app/services/api/v3/ecf/unfunded_mentors_query.rb
@@ -14,16 +14,20 @@ module Api
         end
 
         def unfunded_mentors
+          ActiveRecord::Base.connection.execute("set statement_timeout to 0")
+
           scope = InductionRecord.distinct
                    .select(*necessary_fields)
                    .joins("JOIN participant_profiles ON participant_profiles.id = induction_records.mentor_profile_id")
                    .joins("JOIN (#{latest_induction_records_join.to_sql}) AS latest_induction_records ON latest_induction_records.latest_id = induction_records.id")
+                   .joins("JOIN (#{latest_induction_records_for_mentor_join.to_sql}) AS latest_mentor_induction_records ON latest_mentor_induction_records.participant_profile_id = participant_profiles.id AND row_number = 1")
                    .joins("JOIN induction_programmes on induction_programmes.id = induction_records.induction_programme_id")
                    .joins("JOIN partnerships on partnerships.id = induction_programmes.partnership_id")
-                   .joins("JOIN participant_identities ON participant_identities.id = participant_profiles.participant_identity_id")
+                   .joins("JOIN participant_identities ON participant_identities.id = latest_mentor_induction_records.preferred_identity_id")
                    .joins("JOIN users on users.id = participant_identities.user_id")
                    .joins("JOIN teacher_profiles ON teacher_profiles.user_id = users.id")
                    .joins("LEFT OUTER JOIN ecf_participant_validation_data on ecf_participant_validation_data.participant_profile_id = induction_records.mentor_profile_id")
+                   .where(participant_profiles: { type: "ParticipantProfile::Mentor" })
                    .where("induction_records.mentor_profile_id not in (select distinct participant_profile_id from (#{latest_induction_records_join.to_sql}) AS latest_induction_records)")
                    .order(sort_order(default: "users.created_at ASC", model: User))
 
@@ -33,8 +37,7 @@ module Api
 
         def unfunded_mentor
           scope = unfunded_mentors
-            .where(participant_profile: { participant_identities: { user_id: params[:id] } })
-          scope = scope.where(participant_profile: { type: "ParticipantProfile::Mentor" }) if scope.size > 1
+            .where(participant_identities: { user_id: params[:id] })
 
           scope.first.presence || raise(ActiveRecord::RecordNotFound)
         end
@@ -42,6 +45,21 @@ module Api
       private
 
         attr_accessor :lead_provider, :params
+
+        def latest_induction_records_for_mentor_join
+          InductionRecord
+          .select(Arel.sql("ROW_NUMBER() OVER (#{latest_induction_record_order}) AS row_number, induction_records.participant_profile_id, induction_records.preferred_identity_id"))
+          .joins(:participant_profile, { induction_programme: :partnership })
+          .where.not(induction_programme: { partnerships: { lead_provider: nil } })
+          .where(
+            induction_programme: {
+              partnerships: {
+                challenged_at: nil,
+                challenge_reason: nil,
+              },
+            },
+          )
+        end
 
         def latest_induction_records_join
           super

--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -7,6 +7,12 @@ weight: 8
 
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
 
+## 4 December 2024
+
+We’ve fixed a bug that caused the GET unfunded-mentors endpoint query to return incorrect or no longer valid email addresses in a small number of cases.
+
+The fix we’ve made ensures the endpoint is now surfacing the most up-to-date email in the GET request’s response.
+
 ## 27 November 2024
 
 We've launched a separate API for NPQs following a 3-month test phase. All NPQ data has been successfully migrated to the new environment, which means providers can no longer make NPQ-related calls from this API.

--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -7,7 +7,7 @@ weight: 8
 
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
 
-## 4 December 2024
+## 11 December 2024
 
 We’ve fixed a bug that caused the GET unfunded-mentors endpoint query to return incorrect or no longer valid email addresses in a small number of cases.
 

--- a/spec/services/api/v3/ecf/unfunded_mentors_query_spec.rb
+++ b/spec/services/api/v3/ecf/unfunded_mentors_query_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Api::V3::ECF::UnfundedMentorsQuery do
       let!(:latest_induction_record) { create(:induction_record, :future_start_date, induction_programme: other_induction_programme, participant_profile: unfunded_mentor_participant_profile, preferred_identity: latest_preferred_identity) }
 
       it "returns the preferred email from the latest induction record" do
-        expect(unfunded_mentor_participant_profile.induction_records.pluck(&:participant_email).uniq.count).to be > 1
+        expect(unfunded_mentor_participant_profile.induction_records.pluck(&:participant_email).uniq.count).to eq(2)
         expect(subject.unfunded_mentors.first.preferred_identity_email).to eq(latest_preferred_identity.email)
       end
     end

--- a/spec/services/api/v3/ecf/unfunded_mentors_query_spec.rb
+++ b/spec/services/api/v3/ecf/unfunded_mentors_query_spec.rb
@@ -24,16 +24,16 @@ RSpec.describe Api::V3::ECF::UnfundedMentorsQuery do
       expect(subject.unfunded_mentors.first.user_id).to eq(unfunded_mentor_participant_profile.user_id)
     end
 
-    context "with preferred identity" do
-      let(:preferred_email) { Faker::Internet.email }
-      let!(:preferred_identity) { create(:participant_identity, :secondary, user: unfunded_mentor_participant_profile.user, email: preferred_email) }
+    context "when the mentor has multiple induction records with different preferred_identity associations" do
+      let(:latest_preferred_identity) { create(:participant_identity, :secondary, user: unfunded_mentor_participant_profile.user) }
+      let(:other_induction_programme) { create(:induction_programme, :fip, partnership: other_partnership) }
+      let(:other_partnership) { create(:partnership, lead_provider: other_lead_provider, cohort:) }
+      let(:other_lead_provider) { create(:lead_provider) }
+      let!(:latest_induction_record) { create(:induction_record, :future_start_date, induction_programme: other_induction_programme, participant_profile: unfunded_mentor_participant_profile, preferred_identity: latest_preferred_identity) }
 
-      it "returns the user id of the participant identity" do
-        expect(subject.unfunded_mentors.first.user_id).to eq(unfunded_mentor_profile_user_id)
-      end
-
-      it "returns the preferred email" do
-        expect(subject.unfunded_mentors.first.preferred_identity_email).to eq(unfunded_mentor_participant_profile.participant_identity.email)
+      it "returns the preferred email from the latest induction record" do
+        expect(unfunded_mentor_participant_profile.induction_records.pluck(&:participant_email).uniq.count).to be > 1
+        expect(subject.unfunded_mentors.first.preferred_identity_email).to eq(latest_preferred_identity.email)
       end
     end
 


### PR DESCRIPTION
[Jira-3788](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345%2Cunassigned&selectedIssue=CPDLP-3788)

### Context

Ambition flagged 3 separate cases of the unfunded mentors query returning incorrect/old emails, instead of the lates ones from the induction record. We want to update the query to use the induction records so that we surface the correct email.

### Changes proposed in this pull request

- Fix UnfundedMentorsQuery email

We are currently surfacing the email from the `ParticipantProfile`, however we instead should be looking it up from the `InductionRecord`.

Update query to join `ParticipantIdentity` on `InductionRecord` and surface `email` from there. Note we need to join on the mentor's latest induction records (the base induction records are relative to the mentee).

- Add release note for UnfundedMentorsQuery email update

Add release note to explain the bug fix for the unfunded-mentors endpoint returning the email from the profile rather than the induction records.

- Relax UnfundedMentorsQuery

To be consistent with the current query and return the same users we need to include `InductionRecord` instances for the mentor where they have a challenged partnership or no lead provider. We also need to `LEFT OUTER JOIN` on the
`participant_identities` as some users do not have a `preferred_identity` on the `InductionRecord` that still exists.

There are also some profiles that don't have any `induction_records` so we need to `LEFT OUTER JOIN` on those as well.

### Guidance for review

The extra join makes this query quite a bit slower.

Tested against the participant `2c6fe2c6-46d9-4b32-9ee8-0ab719b4368a` in the ticket, which now returns with the correct email address from their latest induction record.

Other testing:

```
83 records that are no longer returned in the response
76 records where the email changes (I've eyeballed a lot of these and the changes look sensible)
0 records that are in the new response but not in the old response
```
Of the 83 records that are no longer returned, 82 of them are being excluded because we join the mentor profile induction records and exclude those without a partnership/lead provider or if they have a challenged partnership:

```
ids = [the 83 no longer returned]
User.where(id: ids).map { |u| u.mentor_profile.latest_induction_record.induction_programme.partnership }.compact.reject { |p| p.challenged_at || p.challenge_reason }.count

=> 1
```

The single outlier is `940ed235-1609-4c5d-ae2d-e2d3ac2ca916` and they appear to be omitted as their `latest_induction_record` does not have a `preferred_identity`. Oddly it has a `preferred_identity_id` but it no longer exists:

```
User.find("940ed235-1609-4c5d-ae2d-e2d3ac2ca916").mentor_profile.latest_induction_record.preferred_identity_id
"5352ea4d-0031-45ee-a53b-90151b77ae03"
User.find("940ed235-1609-4c5d-ae2d-e2d3ac2ca916").mentor_profile.latest_induction_record.preferred_identity
nil
```