### PR TITLE
Run CI on all pull requests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,8 +18,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
   merge_group:
 
 jobs:


### PR DESCRIPTION
We want to run CI on all pull requests, not just those than branch off main. This is going to be useful during the NPQ removal tasks as we're often branching off other branches.

