### PR TITLE
[CST-2798] Remove Capita from the change lead provider support form

### DIFF
--- a/app/wizards/schools/change_request_support_query/base_wizard.rb
+++ b/app/wizards/schools/change_request_support_query/base_wizard.rb
@@ -3,6 +3,8 @@
 module Schools
   module ChangeRequestSupportQuery
     class BaseWizard < DfE::Wizard::Base
+      EXCLUDED_LEAD_PROVIDERS = ["Capita"].freeze
+
       attr_accessor :change_request_type, :current_user, :school_id, :start_year, :participant_id, :store
 
       steps do
@@ -62,7 +64,7 @@ module Schools
         if relation_klass == DeliveryPartner
           school.lead_provider(start_year).delivery_partners.order(:name)
         else
-          LeadProvider.all.order(:name)
+          LeadProvider.where.not(name: EXCLUDED_LEAD_PROVIDERS).order(:name)
         end
       end
 


### PR DESCRIPTION
### Context

- Ticket: CST-2798

Capita exited the market and are no longer providing ECF training and we just need to remove the Capita choice to reduce back and forth between support desk and SITs.

### Changes proposed in this pull request
- Add a constant in support query base class to exclude LPs we no longer want to display in the form

### Guidance to review

