### PR TITLE
[CST-2775] Revisit misleading content in the add participant journey

### DIFF
--- a/app/views/schools/add_participants/cannot_find_their_details.html.erb
+++ b/app/views/schools/add_participants/cannot_find_their_details.html.erb
@@ -8,19 +8,40 @@
   <div class="govuk-grid-column-two-thirds">
 
     <span class="govuk-caption-l"><%= @school.name %></span>
-    <h1 class="govuk-heading-l">We cannot find <%= @wizard.possessive_name %> record</h1>
+    <h1 class="govuk-heading-l">No results found for <%= @wizard.full_name %></h1>
 
-    <p class="govuk-body">Check the information you entered is correct.</p>
+    <p class="govuk-body">Check that you have:</p>
     <p class="govuk-body">
-      We need to find <%= @wizard.full_name %> in the Teaching Regulation Agency records to make sure
-      they’re eligible for this funded programme.
-      When participants move school, we need to find their record so it can be transferred to your school.
+      <ul class="govuk-list govuk-list--bullet">
+        <li>entered their details correctly</li>
+        <li>not included a title, like Mr, Mrs or Dr</li>
+        <li>used their full name as it appears in their teaching record (shortened names might not match)</li>
+      </ul>
     </p>
+
+    <p class="govuk-body">
+      You could ask <%= @wizard.full_name %> to
+          <%= govuk_link_to "check their teaching record (opens in new tab)",
+                            "https://find-a-lost-trn.education.gov.uk/start",
+                            target: :_blank,
+                            no_visited_state: true %>
+        to make sure their details match.
+    </p>
+
 
     <%= govuk_summary_list do |summary_list| %>
       <% summary_list.with_row do |row| %>
+        <% row.with_key { "Name" } %>
+        <% row.with_value { @wizard.full_name } %>
+        <% row.with_action(text: "Change",
+                      visually_hidden_text: "name",
+                      href: @wizard.change_path_for(step: :name)) %>
+      <% end %>
+
+      <% summary_list.with_row do |row| %>
         <% row.with_key { "TRN" } %>
         <% row.with_value { @wizard.trn } %>
+
         <% row.with_action(text: "Change",
                       visually_hidden_text: "TRN",
                       href: @wizard.change_path_for(step: :trn)) %>
@@ -36,7 +57,10 @@
     <% end %>
 
     <h3 class="govuk-heading-m">If this information is correct</h3>
-    <p class="govuk-body">We may be able to find their record using their National Insurance number.</p>
-    <%= govuk_button_link_to "Continue", url_for(step: :nino) %>
+    <p class="govuk-body">We may be able to
+      <%= govuk_link_to "find their record using their National Insurance number",
+                        url_for(step: :nino),
+                        no_visited_state: true %>.
+    </p>
   </div>
 </div>

--- a/spec/features/schools/participants/add_participants/unhappy_path_can_validate_with_nino_spec.rb
+++ b/spec/features/schools/participants/add_participants/unhappy_path_can_validate_with_nino_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Add participants", js: true, early_in_cohort: true do
       when_i_add_full_name_to_the_school_add_participant_wizard @participant_data[:full_name]
       and_i_add_teacher_reference_number_to_the_school_add_participant_wizard @participant_data[:full_name], @participant_data[:trn]
       and_i_add_date_of_birth_to_the_school_add_participant_wizard @participant_data[:date_of_birth]
-      and_i_confirm_details_and_continue_on_the_school_add_participant_wizard
+      and_i_click_the_link_to_lookup_the_record_with_nino_on_the_school_add_participant_wizard
       and_i_add_nino_to_the_school_add_participant_wizard @participant_data[:full_name], @participant_data[:nino]
       and_i_add_email_address_to_the_school_add_participant_wizard "Sally Teacher", @participant_data[:email]
       and_i_choose_a_mentor_on_the_school_add_participant_wizard @participant_profile_mentor.full_name
@@ -46,7 +46,7 @@ RSpec.describe "Add participants", js: true, early_in_cohort: true do
       when_i_add_mentor_full_name_to_the_school_add_participant_wizard @participant_data[:full_name]
       and_i_add_teacher_reference_number_to_the_school_add_participant_wizard @participant_data[:full_name], @participant_data[:trn]
       and_i_add_date_of_birth_to_the_school_add_participant_wizard @participant_data[:date_of_birth]
-      and_i_confirm_details_and_continue_on_the_school_add_participant_wizard
+      and_i_click_the_link_to_lookup_the_record_with_nino_on_the_school_add_participant_wizard
       and_i_add_nino_to_the_school_add_participant_wizard @participant_data[:full_name], @participant_data[:nino]
       and_i_add_email_address_to_the_school_add_participant_wizard "Sally Teacher", @participant_data[:email]
       and_i_choose_current_providers_on_the_school_add_participant_wizard
@@ -67,7 +67,7 @@ RSpec.describe "Add participants", js: true, early_in_cohort: true do
       when_i_add_mentor_full_name_to_the_school_add_participant_wizard @participant_data[:full_name]
       and_i_add_teacher_reference_number_to_the_school_add_participant_wizard @participant_data[:full_name], @participant_data[:trn]
       and_i_add_date_of_birth_to_the_school_add_participant_wizard @participant_data[:date_of_birth]
-      and_i_confirm_details_and_continue_on_the_school_add_participant_wizard
+      and_i_click_the_link_to_lookup_the_record_with_nino_on_the_school_add_participant_wizard
       and_i_add_nino_to_the_school_add_participant_wizard @participant_data[:full_name], @participant_data[:nino]
       and_i_add_email_address_to_the_school_add_participant_wizard "Sally Teacher", @participant_data[:email]
       and_i_choose_summer_term_on_the_school_add_participant_wizard

--- a/spec/features/schools/participants/add_participants/unhappy_path_cannot_validate_with_nino_spec.rb
+++ b/spec/features/schools/participants/add_participants/unhappy_path_cannot_validate_with_nino_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Add participants", js: true, early_in_cohort: true do
     and_i_add_full_name_to_the_school_add_participant_wizard @participant_data[:full_name]
     and_i_add_teacher_reference_number_to_the_school_add_participant_wizard @participant_data[:full_name], @participant_data[:trn]
     and_i_add_date_of_birth_to_the_school_add_participant_wizard @participant_data[:date_of_birth]
-    and_i_confirm_details_and_continue_on_the_school_add_participant_wizard
+    and_i_click_the_link_to_lookup_the_record_with_nino_on_the_school_add_participant_wizard
     and_i_add_nino_to_the_school_add_participant_wizard @participant_data[:full_name], @participant_data[:nino]
     then_i_am_on_the_school_add_participant_still_cannot_find_their_details_page
     then_the_page_should_be_accessible
@@ -38,7 +38,7 @@ RSpec.describe "Add participants", js: true, early_in_cohort: true do
     and_i_add_mentor_full_name_to_the_school_add_participant_wizard @participant_data[:full_name]
     and_i_add_teacher_reference_number_to_the_school_add_participant_wizard @participant_data[:full_name], @participant_data[:trn]
     and_i_add_date_of_birth_to_the_school_add_participant_wizard @participant_data[:date_of_birth]
-    and_i_confirm_details_and_continue_on_the_school_add_participant_wizard
+    and_i_click_the_link_to_lookup_the_record_with_nino_on_the_school_add_participant_wizard
     and_i_add_nino_to_the_school_add_participant_wizard @participant_data[:full_name], @participant_data[:nino]
     then_i_am_on_the_school_add_participant_still_cannot_find_their_details_page
     then_the_page_should_be_accessible

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/unhappy_path_cannot_validate_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/unhappy_path_cannot_validate_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "transferring participants", type: :feature, js: true, early_in_c
 
         then_i_should_be_taken_to_the_cannot_find_their_details
         then_the_page_should_be_accessible
-        click_on "Continue"
+        click_on "find their record using their National Insurance number"
 
         then_i_should_be_on_the_nino_page
         then_the_page_should_be_accessible
@@ -155,8 +155,8 @@ RSpec.describe "transferring participants", type: :feature, js: true, early_in_c
       end
 
       def then_i_should_be_taken_to_the_cannot_find_their_details
-        expect(page).to have_selector("h1", text: "We cannot find #{@participant_data[:full_name]}’s record")
-        expect(page).to have_text("Check the information you entered is correct.")
+        expect(page).to have_selector("h1", text: "No results found for #{@participant_data[:full_name]}")
+        expect(page).to have_text("Check that you have")
       end
 
       def then_i_should_be_on_the_nino_page

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -1294,8 +1294,8 @@ module ManageTrainingSteps
   end
 
   def then_i_am_taken_to_the_cannot_find_their_details
-    expect(page).to have_selector("h1", text: "We cannot find #{@participant_data[:full_name]}’s record")
-    expect(page).to have_text("Check the information you entered is correct.")
+    expect(page).to have_selector("h1", text: "No results found for #{@participant_data[:full_name]}")
+    expect(page).to have_text("Check that you have")
   end
 
   def then_i_can_view_the_design_our_own_induction_dashboard

--- a/spec/support/features/pages/schools/school_add_participant_wizard.rb
+++ b/spec/support/features/pages/schools/school_add_participant_wizard.rb
@@ -263,8 +263,8 @@ module Pages
       Pages::SchoolTransferParticipantCompletedPage.loaded
     end
 
-    def confirm_details_and_continue
-      click_on "Continue"
+    def click_the_link_to_lookup_the_record_with_nino
+      click_on "find their record using their National Insurance number"
 
       self
     end


### PR DESCRIPTION
### Context

- Ticket: CST-2775

The content displayed in the Add ECT and Mentor journeys when a record can’t be found was misleading. It has now been revised for clarity.

### Changes proposed in this pull request
- Updated the view page with the new content

### Guidance to review

| Before | After |
|--------|--------|
|<img width="591" alt="Screenshot 2024-12-13 at 16 13 22" src="https://github.com/user-attachments/assets/7b89a05f-ab00-45ab-9d4d-7e539ef03928" />|<img width="587" alt="Screenshot 2024-12-13 at 16 13 07" src="https://github.com/user-attachments/assets/02566c52-2a5a-4d26-8162-573e869cfa07" />|
