### PR TITLE
Disable deployment to separation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -166,25 +166,6 @@ jobs:
   #         current-commit-sha: ${{ github.sha }}
   #         statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}
 
-  deploy_separation:
-    name: Deploy separation
-    needs: [deploy_staging]
-    runs-on: ubuntu-latest
-    environment:
-      name: separation
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: ./.github/actions/deploy-environment-to-aks
-        id: deploy
-        with:
-          environment: separation
-          docker-image: ${{ needs.deploy_staging.outputs.docker-image }}
-          azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
-          current-commit-sha: ${{ github.sha }}
-          statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}
-
   deploy_production:
     name: Deploy production
     needs: [deploy_staging]


### PR DESCRIPTION
Ahead of removing the environment to prevent other deploys causing issues while we tear down the environment.
