### PR TITLE
Update `ParticipantDeclarationsQuery` to include `completed` previous

### DIFF
--- a/app/services/api/participant_declarations/index.rb
+++ b/app/services/api/participant_declarations/index.rb
@@ -3,6 +3,8 @@
 module Api
   module ParticipantDeclarations
     class Index
+      RELEVANT_INDUCTION_STATUS = %w[active completed].freeze
+
       attr_reader :cpd_lead_provider, :updated_since, :participant_id
 
       def initialize(cpd_lead_provider:, updated_since: nil, participant_id: nil)
@@ -38,7 +40,7 @@ module Api
         ParticipantDeclaration::ECF
           .joins(participant_profile: { induction_records: { induction_programme: { partnership: [:lead_provider] } } })
           .where(participant_profile: { induction_records: { induction_programme: { partnerships: { lead_provider: } } } })
-          .where(participant_profile: { induction_records: { induction_status: "active" } }) # only want induction records that are the winning latest ones
+          .where(participant_profile: { induction_records: { induction_status: RELEVANT_INDUCTION_STATUS } }) # only want induction records that are the winning latest ones
           .where(state: %w[submitted eligible payable paid])
       end
     end

--- a/app/services/api/v3/participant_declarations_query.rb
+++ b/app/services/api/v3/participant_declarations_query.rb
@@ -6,7 +6,7 @@ module Api
       include Api::Concerns::FilterCohorts
       include Api::Concerns::FilterUpdatedSince
 
-      RELEVANT_INDUCTION_STATUS = %w[active completed].freeze
+      RELEVANT_INDUCTION_STATUS = Api::ParticipantDeclarations::Index::RELEVANT_INDUCTION_STATUS
 
       attr_reader :cpd_lead_provider, :params
 

--- a/app/services/api/v3/participant_declarations_query.rb
+++ b/app/services/api/v3/participant_declarations_query.rb
@@ -6,7 +6,7 @@ module Api
       include Api::Concerns::FilterCohorts
       include Api::Concerns::FilterUpdatedSince
 
-      RELEVANT_INDUCTION_STATUS = Api::ParticipantDeclarations::Index::RELEVANT_INDUCTION_STATUS
+      RELEVANT_INDUCTION_STATUS = %w[active completed].freeze
 
       attr_reader :cpd_lead_provider, :params
 

--- a/app/services/api/v3/participant_declarations_query.rb
+++ b/app/services/api/v3/participant_declarations_query.rb
@@ -6,6 +6,8 @@ module Api
       include Api::Concerns::FilterCohorts
       include Api::Concerns::FilterUpdatedSince
 
+      RELEVANT_INDUCTION_STATUS = %w[active completed].freeze
+
       attr_reader :cpd_lead_provider, :params
 
       def initialize(cpd_lead_provider:, params:)
@@ -81,7 +83,7 @@ module Api
           )
           .where.not(participant_profile: { induction_records: { induction_programmes: { partnership_id: nil } } }) # Exclude any nil partnerships (eg: cip)
           .where(participant_profile: { induction_records: { induction_programme: { partnerships: { lead_provider_id: lead_provider&.id } } } })
-          .where(participant_profile: { induction_records: { induction_status: "active" } }) # only want induction records that are the winning latest ones
+          .where(participant_profile: { induction_records: { induction_status: RELEVANT_INDUCTION_STATUS } }) # only want induction records that are the winning latest ones
           .where(state: %w[submitted eligible payable paid])
 
         scope = filter_cohorts(scope) if lead_provider.present?

--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -7,6 +7,12 @@ weight: 8
 
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
 
+## 24 December 2024
+
+Lead providers getting participant declarations via the API endpoints will now see previous declarations attached to completed participants rather than just active participants.
+
+Before this update they could only view previous declarations of participants who had an active <code>induction_status</code> and had not completed.
+
 ## 11 December 2024
 
 We’ve fixed a bug that meant providers could see declarations from participants that were not relevant to them.  They would not have been able to identify the participants with this information.

--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -7,7 +7,7 @@ weight: 8
 
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
 
-## 24 December 2024
+## 8 January 2025
 
 Lead providers getting participant declarations via the API endpoints will now see previous declarations attached to completed participants rather than just active participants.
 


### PR DESCRIPTION
[Jira-3880](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345%2Cunassigned&selectedIssue=CPDLP-3880)

### Context

Currently, the `ParticipantDeclarationsQuery` filters declarations based only on an `active` induction_status. This prevents declarations from being surfaced for participants with a `completed` induction status.

### Changes proposed in this pull request

- Update `ParticipantDeclarationsQuery` to include `completed` previous declarations

Update the `ParticipantDeclarationsQuery` to include `completed` declarations for a previous provider in addition to `active`.

### Guidance to review

TODO: testing