### PR TITLE
[CPDLP-3830] Spike: Investigate how we can stop providers declaring retained types for mentors in 2025 or mentors

### DIFF
--- a/app/services/record_declaration.rb
+++ b/app/services/record_declaration.rb
@@ -34,6 +34,7 @@ class RecordDeclaration
   validates :course_identifier, course: true
   validates :cpd_lead_provider, induction_record: true
   validates :cohort, npq_contract_for_cohort_and_course: { message: I18n.t(:missing_npq_contract_for_cohort_and_course_new_declaration) }
+  validate :validate_mentor_funding
 
   attr_reader :raw_declaration_date
 
@@ -285,6 +286,16 @@ private
 
   def check_mentor_completion
     ParticipantDeclarations::HandleMentorCompletion.call(participant_declaration:)
+  end
+
+  def validate_mentor_funding
+    return if errors.any?
+    return unless cohort.mentor_funding
+    return unless participant_declaration.participant_profile.mentor?
+
+    unless %w[started completed].include?(declaration_type)
+      errors.add(:declaration_type, "Can only declare 'started' and 'completed' for mentors")
+    end
   end
 
   def validate_if_npq_course_supported

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -273,6 +273,7 @@
   - npq_registration_start_date
   - automatic_assignment_period_end_date
   - payments_frozen_at
+  - mentor_funding
   :provider_relationships:
   - id
   - lead_provider_id

--- a/db/migrate/20241219154331_add_mentor_funding_to_cohorts.rb
+++ b/db/migrate/20241219154331_add_mentor_funding_to_cohorts.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMentorFundingToCohorts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :cohorts, :mentor_funding, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_11_01_133851) do
+ActiveRecord::Schema[7.1].define(version: 2024_12_19_154331) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -262,6 +262,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_01_133851) do
     t.datetime "npq_registration_start_date", precision: nil
     t.date "automatic_assignment_period_end_date"
     t.datetime "payments_frozen_at"
+    t.boolean "mentor_funding", default: false, null: false
     t.index ["start_year"], name: "index_cohorts_on_start_year", unique: true
   end
 

--- a/spec/services/record_declaration_spec.rb
+++ b/spec/services/record_declaration_spec.rb
@@ -415,6 +415,29 @@ RSpec.describe RecordDeclaration do
       it_behaves_like "creates a participant declaration"
       it_behaves_like "creates participant declaration attempt"
       it_behaves_like "checks for mentor completion event"
+
+      context "when cohort has mentor_funding enabled" do
+        let(:participant_type) { :mentor }
+        let(:course_identifier) { "ecf-mentor" }
+        let(:declaration_date) { schedule.milestones.find_by(declaration_type:).start_date }
+
+        before { current_cohort.update!(mentor_funding: true) }
+
+        context "when declaration_type is started" do
+          let(:declaration_type) { "started" }
+
+          it_behaves_like "creates a participant declaration"
+        end
+
+        context "when declaration_type is retained-1" do
+          let(:declaration_type) { "retained-1" }
+
+          it "returns validation error", :aggregate_failures do
+            expect(service).to be_invalid
+            expect(service.errors.messages_for(:declaration_type)).to eql(["Can only declare 'started' and 'completed' for mentors"])
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-3830

### Changes proposed in this pull request

* New `mentor_funding` column on `Cohort`, boolean default false.
* Validation to `RecordDeclaration` prevents declaration types other than started/completed for mentor.

### Guidance to review

