### PR TITLE
Revert "Bump nokogiri from 1.17.2 to 1.18.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -366,11 +366,11 @@ GEM
       net-protocol
     nio4r (2.7.3)
     nkf (0.2.0)
-    nokogiri (1.18.0-arm64-darwin)
+    nokogiri (1.17.2-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.0-x86_64-darwin)
+    nokogiri (1.17.2-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.0-x86_64-linux-gnu)
+    nokogiri (1.17.2-x86_64-linux)
       racc (~> 1.4)
     nori (2.7.0)
       bigdecimal


### PR DESCRIPTION
Reverts DFE-Digital/early-careers-framework#5391