### PR TITLE
 Bump up snapshot database to match production 

### DIFF
--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -69,7 +69,7 @@ variable "postgres_flexible_server_sku" {
 }
 
 variable "postgres_snapshot_flexible_server_sku" {
-  default = "GP_Standard_D2ds_v4"
+  default = "GP_Standard_D4ds_v4"
 }
 
 variable "postgres_enable_high_availability" {


### PR DESCRIPTION
### Context

- Ticket: n/a
The db size is 32gb, prod is 64gb. We are maxing out the storage on the snapshot and it is not completing the restore.

### Changes proposed in this pull request

Bump up the storage to match production to enable the restore to complete successfully.

### Guidance to review

