### PR TITLE
Bump snapshot storage from 32gb to 64gb

### DIFF
--- a/terraform/application/databases.tf
+++ b/terraform/application/databases.tf
@@ -82,6 +82,7 @@ module "postgres-snapshot" {
   azure_enable_high_availability = false
   azure_enable_backup_storage    = false
   azure_enable_monitoring        = false
+  azure_storage_mb               = "65536"
   azure_extensions               = ["citext", "fuzzystrmatch", "pg_stat_statements", "pgcrypto", "plpgsql", "uuid-ossp"]
   server_version                 = "14"
 }


### PR DESCRIPTION
### Context

- Ticket: n/a

We need to increase storage to match production to avoid errors on restoring

### Changes proposed in this pull request

Bump storage tier for snapshot from 32GB to 64GB

### Guidance to review
n/a
