### PR TITLE
[CPDLP-3899] Ensure Void/Show declarations are scoped to ECF declarations

### DIFF
--- a/app/controllers/api/v1/participant_declarations_controller.rb
+++ b/app/controllers/api/v1/participant_declarations_controller.rb
@@ -71,7 +71,7 @@ module Api
       end
 
       def participant_declaration_for_lead_provider
-        @participant_declaration_for_lead_provider ||= ParticipantDeclaration.for_lead_provider(cpd_lead_provider).find(params[:id])
+        @participant_declaration_for_lead_provider ||= ParticipantDeclaration::ECF.for_lead_provider(cpd_lead_provider).find(params[:id])
       end
 
       def permitted_params

--- a/app/controllers/api/v3/participant_declarations_controller.rb
+++ b/app/controllers/api/v3/participant_declarations_controller.rb
@@ -99,7 +99,7 @@ module Api
       end
 
       def participant_declaration_for_lead_provider
-        @participant_declaration_for_lead_provider ||= ParticipantDeclaration.for_lead_provider(cpd_lead_provider).find(params[:id])
+        @participant_declaration_for_lead_provider ||= ParticipantDeclaration::ECF.for_lead_provider(cpd_lead_provider).find(params[:id])
       end
 
       def serializer_class


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-3899

As part of our clean up of NPQ in ECF, we are scoping all endpoints and queries to ECF only. We need to also scope void/show declaration to ECF as well.

### Changes proposed in this pull request

- For voiding declarations in v1/v2/v3 scope the queries to only allow voiding ECF declarations only and not NPQ;
- Tried to replace `participant_declaration_for_lead_provider` by `participant_declaration_query_scope` but the queries of the second are slightly different taking in consideration `induction records` & `partnerships` as well. That would allow past lead providers to void declarations currently with other lead providers;
- Single declaration endpoints are already scoped by ECF;