### PR TITLE
Prevent retained declarations for mentors in funded cohorts

### DIFF
--- a/app/services/record_declaration.rb
+++ b/app/services/record_declaration.rb
@@ -30,6 +30,7 @@ class RecordDeclaration
   validate :output_fee_statement_available
   validate :validate_milestone_exists
   validate :validates_billable_slot_available
+  validate :validate_only_started_or_completed_if_mentor
   validates :course_identifier, course: true
   validates :cpd_lead_provider, induction_record: true
 
@@ -203,6 +204,14 @@ private
 
   def original_participant_declaration
     @original_participant_declaration ||= participant_declaration.duplicate_declarations.order(created_at: :asc).first
+  end
+
+  def validate_only_started_or_completed_if_mentor
+    return if declaration_type&.in?(%w[started completed])
+    return unless participant_profile && participant_profile.mentor?
+    return unless cohort && cohort.mentor_funding?
+
+    errors.add(:declaration_type, I18n.t(:retained_declaration_not_allowed_for_mentor))
   end
 
   def validates_billable_slot_available

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,6 +58,7 @@ en:
   future_date: "The '#/%{attribute}' value cannot be a future date. Check the date and try again."
   future_date_outcomes: "The attribute '#/%{attribute}' cannot contain a future date. Resubmit the outcome update with a valid date."
   mismatch_declaration_type_for_schedule: "The property '#/declaration_type' does not exist for this schedule."
+  retained_declaration_not_allowed_for_mentor: "You cannot send retained or extended declarations for participants who began their mentor training after June 2025. Resubmit this declaration with either a started or completed declaration."
   missing_declaration_type: "Enter a '#/declaration_type'."
   missing_evidence_held: "Enter a '#/evidence_held' value for this participant."
   missing_has_passed: "Enter 'true' or 'false' in the '#/has_passed' field to indicate whether this participant has passed or failed their course."

--- a/spec/services/record_declaration_spec.rb
+++ b/spec/services/record_declaration_spec.rb
@@ -331,9 +331,8 @@ RSpec.describe RecordDeclaration do
     }
   end
 
-  let(:cutoff_start_datetime) { participant_profile.schedule.milestones.find_by(declaration_type: "started").start_date.beginning_of_day }
-  let(:cutoff_end_datetime)   { participant_profile.schedule.milestones.find_by(declaration_type: "started").milestone_date.end_of_day }
-
+  let(:cutoff_start_datetime) { participant_profile.schedule.milestones.find_by(declaration_type:).start_date.beginning_of_day }
+  let(:cutoff_end_datetime)   { participant_profile.schedule.milestones.find_by(declaration_type:).milestone_date.end_of_day }
   subject(:service) do
     described_class.new(params)
   end
@@ -344,7 +343,7 @@ RSpec.describe RecordDeclaration do
 
   context "when the participant is an ECF" do
     let(:schedule)              { Finance::Schedule::ECF.find_by(schedule_identifier: "ecf-standard-september", cohort: current_cohort) }
-    let(:declaration_date)      { schedule.milestones.find_by(declaration_type: "started").start_date }
+    let(:declaration_date)      { schedule.milestones.find_by(declaration_type:).start_date }
     let(:traits)                { [] }
     let(:opts)                  { {} }
     let(:participant_profile) do
@@ -404,6 +403,23 @@ RSpec.describe RecordDeclaration do
       it_behaves_like "creates a participant declaration"
       it_behaves_like "creates participant declaration attempt"
       it_behaves_like "checks for mentor completion event"
+
+      %w[retained-1 retained-2 retained-3 retained-4 extended-1 extended-2 extended-3].each do |disallowed_for_mentor_funding_type|
+        context "when the declaration_type is #{disallowed_for_mentor_funding_type}" do
+          let(:declaration_type) { disallowed_for_mentor_funding_type }
+
+          before { create(:milestone, schedule:, declaration_type:, start_date: 1.day.ago) }
+
+          it "allows #{disallowed_for_mentor_funding_type} declarations when in a mentor_funding cohort" do
+            schedule.cohort.update!(mentor_funding: true)
+
+            expect { service.call }.to change { ParticipantDeclaration.count }.by(1)
+
+            created_declaration = ParticipantDeclaration.last
+            expect(created_declaration.declaration_type).to eq(disallowed_for_mentor_funding_type)
+          end
+        end
+      end
     end
 
     context "when the participant is a Mentor" do
@@ -418,6 +434,51 @@ RSpec.describe RecordDeclaration do
       it_behaves_like "creates a participant declaration"
       it_behaves_like "creates participant declaration attempt"
       it_behaves_like "checks for mentor completion event"
+
+      %w[started completed].each do |allowed_for_mentor_funding_type|
+        context "when the declaration_type is #{allowed_for_mentor_funding_type}" do
+          let(:declaration_type) { allowed_for_mentor_funding_type }
+
+          before { create(:milestone, schedule:, declaration_type:, start_date: 1.day.ago) }
+
+          it "allows started declarations when in a mentor_funding cohort" do
+            schedule.cohort.update!(mentor_funding: true)
+
+            travel_to(declaration_date + 1.day) do
+              expect { service.call }.to change { ParticipantDeclaration.count }.by(1)
+            end
+
+            created_declaration = ParticipantDeclaration.last
+            expect(created_declaration.declaration_type).to eq(allowed_for_mentor_funding_type)
+          end
+        end
+      end
+
+      %w[retained-1 retained-2 retained-3 retained-4 extended-1 extended-2 extended-3].each do |disallowed_for_mentor_funding_type|
+        context "when the declaration_type is #{disallowed_for_mentor_funding_type}" do
+          let(:declaration_type) { disallowed_for_mentor_funding_type }
+
+          before { create(:milestone, schedule:, declaration_type:, start_date: 1.day.ago) }
+
+          it "does not allow #{disallowed_for_mentor_funding_type} declarations when in a mentor_funding cohort" do
+            schedule.cohort.update!(mentor_funding: true)
+
+            expect(service).to be_invalid
+            expect(service.errors.messages_for(:declaration_type)).to include("You cannot send retained or extended declarations for participants who began their mentor training after June 2025. Resubmit this declaration with either a started or completed declaration.")
+          end
+
+          it "allows #{disallowed_for_mentor_funding_type} declarations when not in a mentor_funding cohort" do
+            schedule.cohort.update!(mentor_funding: false)
+
+            travel_to(declaration_date + 1.day) do
+              expect { service.call }.to change { ParticipantDeclaration.count }.by(1)
+            end
+
+            created_declaration = ParticipantDeclaration.last
+            expect(created_declaration.declaration_type).to eq(disallowed_for_mentor_funding_type)
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
[Jira-3907](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-3907)

### Context

We have a new `mentor_funding` attribute on `Cohort`. Going forward we want to prevent mentors from adding `retained-x` declarations to a `mentor_funding` cohort. We should continue to allow `retained-x` declarations for ECTs.

### Changes proposed in this pull request

- Prevent retained declarations for mentors in funded cohorts

Update `RecordDeclaration` with appropriate validation.

### Guidance to review

Error message updated to Mark's copy.