### PR TITLE
Update codeql action to v3 as v2 has been deprecated

### DIFF
--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -37,6 +37,6 @@ jobs:
           brakeman -f sarif -o output.sarif.json .
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: output.sarif.json


### PR DESCRIPTION
### Context

- Ticket: n/a

Brakeman is failing due to deprecated github action

### Changes proposed in this pull request

Update `github/codeql-action/upload-sarif@v3` to v3 to avoid failures

### Guidance to review

