### PR TITLE
Allow brakeman contents permission to upload file to github

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,7 @@ permissions:
   id-token: write
   pull-requests: write
   packages: write
+  security-events: write
 
 jobs:
   lint:


### PR DESCRIPTION
### Context

- Ticket: n/a

On merging to main brakeman fails due to permissions being added. We need to define a specific permission for it to run on staging

### Changes proposed in this pull request

Add `  security-events: write` permission to allow breakman to run on staging

### Guidance to review
I ran this manually this will pass on staging [here](https://github.com/DFE-Digital/early-careers-framework/actions/runs/12688019924) as it passes on review
