### PR TITLE
Add and maintain `temp_type` on `ParticipantDeclaration::ECF`

### DIFF
--- a/app/models/participant_declaration/ecf.rb
+++ b/app/models/participant_declaration/ecf.rb
@@ -3,6 +3,8 @@
 class ParticipantDeclaration::ECF < ParticipantDeclaration
   has_many :statements, class_name: "Finance::Statement::ECF", through: :statement_line_items
 
+  before_save :set_temp_type
+
   def ecf?
     true
   end
@@ -12,5 +14,12 @@ class ParticipantDeclaration::ECF < ParticipantDeclaration
       declaration_type == "started" &&
       %w[paid awaiting_clawback clawed_back].include?(state) &&
       (sparsity_uplift || pupil_premium_uplift)
+  end
+
+  def set_temp_type
+    return unless participant_profile
+    return unless temp_type.nil?
+
+    self.temp_type = participant_profile.type.sub("ParticipantProfile", "ParticipantDeclaration")
   end
 end

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -43,6 +43,7 @@ class ParticipantProfile::ECF < ParticipantProfile
   # Callbacks
   after_save :update_analytics
   after_update :sync_status_with_induction_record
+  after_update :update_declaration_temp_types!, if: :saved_change_to_type?
 
   # Class methods
   def self.ransackable_attributes(_auth_object = nil)
@@ -200,6 +201,10 @@ private
     induction_record = induction_records.latest
     induction_record&.update!(induction_status: status) if saved_change_to_status?
     induction_record&.update!(mentor_profile:) if saved_change_to_mentor_profile_id?
+  end
+
+  def update_declaration_temp_types!
+    participant_declarations.update_all(temp_type: type.sub("ParticipantProfile", "ParticipantDeclaration"))
   end
 end
 

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -223,6 +223,8 @@
   - participant_declaration_id
   - created_at
   - updated_at
+  :participant_declarations:
+  - temp_type
   :participant_bands:
   - id
   - call_off_contract_id

--- a/db/migrate/20250110125608_add_temp_type_to_participant_declarations.rb
+++ b/db/migrate/20250110125608_add_temp_type_to_participant_declarations.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class AddTempTypeToParticipantDeclarations < ActiveRecord::Migration[7.1]
+  def up
+    add_column :participant_declarations, :temp_type, :string
+
+    declarations = ParticipantDeclaration::ECF.joins(:participant_profile)
+    mentor_declarations = declarations.where(participant_profile: { type: "ParticipantProfile::Mentor"})
+    ect_declarations = declarations.where(participant_profile: { type: "ParticipantProfile::ECT"})
+
+    mentor_declarations.in_batches(of: 1_000) { |batch| batch.update_all(temp_type: "ParticipantDeclaration::Mentor") }
+    ect_declarations.in_batches(of: 1_000) { |batch| batch.update_all(temp_type: "ParticipantDeclaration::ECT") }
+  end
+
+  def down
+    remove_column :participant_declarations, :temp_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_01_06_145039) do
+ActiveRecord::Schema[7.1].define(version: 2025_01_10_125608) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -743,6 +743,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_06_145039) do
     t.uuid "delivery_partner_id"
     t.uuid "mentor_user_id"
     t.uuid "cohort_id", null: false
+    t.string "temp_type"
     t.index ["cohort_id"], name: "index_participant_declarations_on_cohort_id"
     t.index ["cpd_lead_provider_id", "participant_profile_id", "declaration_type", "course_identifier", "state"], name: "unique_declaration_index", unique: true, where: "((state)::text = ANY (ARRAY[('submitted'::character varying)::text, ('eligible'::character varying)::text, ('payable'::character varying)::text, ('paid'::character varying)::text]))"
     t.index ["cpd_lead_provider_id"], name: "index_participant_declarations_on_cpd_lead_provider_id"

--- a/spec/models/participant_declaration/ecf_spec.rb
+++ b/spec/models/participant_declaration/ecf_spec.rb
@@ -30,4 +30,20 @@ RSpec.describe ParticipantDeclaration::ECF, mid_cohort: true do
       end
     end
   end
+
+  describe "before_save set_temp_type" do
+    subject { declaration.temp_type }
+
+    context "when an ECT declaration" do
+      let(:declaration) { create(:ect_participant_declaration) }
+
+      it { is_expected.to eq("ParticipantDeclaration::ECT") }
+    end
+
+    context "when a Mentor declaration" do
+      let(:declaration) { create(:mentor_participant_declaration) }
+
+      it { is_expected.to eq("ParticipantDeclaration::Mentor") }
+    end
+  end
 end

--- a/spec/models/participant_profile/ecf_spec.rb
+++ b/spec/models/participant_profile/ecf_spec.rb
@@ -406,4 +406,28 @@ RSpec.describe ParticipantProfile::ECF, type: :model do
       expect(profile.relevant_induction_record_for(delivery_partner: another_partnership.delivery_partner)).to eq(induction_record_latest_second_delivery_partner)
     end
   end
+
+  describe "changing the profile type" do
+    it "updates the declarations to the correct temp_type when changing from ECT to mentor" do
+      declaration = travel_to(1.day.ago) { create(:ect_participant_declaration) }
+      profile = declaration.participant_profile
+
+      profile.update!(type: "ParticipantProfile::Mentor")
+
+      expect(ParticipantProfile.find(profile.id)).to be_an_instance_of(ParticipantProfile::Mentor)
+      expect(ParticipantDeclaration.find(declaration.id).temp_type).to eq("ParticipantDeclaration::Mentor")
+      expect(ParticipantDeclaration.find(declaration.id).updated_at).to be_within(1.minute).of(1.day.ago)
+    end
+
+    it "updates the declarations to the correct type when changing from mentor to ECT" do
+      declaration = travel_to(1.day.ago) { create(:mentor_participant_declaration) }
+      profile = declaration.participant_profile
+
+      profile.update!(type: "ParticipantProfile::ECT")
+
+      expect(ParticipantProfile.find(profile.id)).to be_an_instance_of(ParticipantProfile::ECT)
+      expect(ParticipantDeclaration.find(declaration.id).temp_type).to eq("ParticipantDeclaration::ECT")
+      expect(ParticipantDeclaration.find(declaration.id).updated_at).to be_within(1.minute).of(1.day.ago)
+    end
+  end
 end


### PR DESCRIPTION
[Jira-3897](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-3897)

### Context

We are splitting `ECF` declarations into `ECT` and `Mentor` declarations. As calculating the declaration type takes a few minutes, in order to do it without downtime or data errors we are going to add a `temp_type` column that we can populate and maintain ahead of the switch.

The original/complete PR is #5404.

### Changes proposed in this pull request

- Add and maintain `temp_type` on `ParticipantDeclaration::ECF`
 
Once shipped, we can then switch the data of `new_type` to `type` quickly and start referencing the new column.

### Guidance to review

These changes introduce the the `temp_type` field with correct subtype of declaration (ECT/Mentor). We backfill existing and set on new declarations. If a profile changes type we will update the declaration for consistency.

The next steps will be:

- Add ECT/Mentor models and use `temp_type` as STI column #5429
- Add migration to populate `type` from `temp_type` #5433 
- Switch STI column back to `type` and remove `temp_type` #5430