### PR TITLE
Switch to Mentor and ECT types for ParticipantDeclaration 

### DIFF
--- a/app/models/participant_declaration/ecf.rb
+++ b/app/models/participant_declaration/ecf.rb
@@ -3,7 +3,7 @@
 class ParticipantDeclaration::ECF < ParticipantDeclaration
   has_many :statements, class_name: "Finance::Statement::ECF", through: :statement_line_items
 
-  before_save :set_temp_type
+  validate :validate_against_profile_type
 
   def ecf?
     true
@@ -16,10 +16,10 @@ class ParticipantDeclaration::ECF < ParticipantDeclaration
       (sparsity_uplift || pupil_premium_uplift)
   end
 
-  def set_temp_type
+  def validate_against_profile_type
     return unless participant_profile
-    return unless temp_type.nil?
+    return if participant_profile.type.demodulize == type.demodulize
 
-    self.temp_type = participant_profile.type.sub("ParticipantProfile", "ParticipantDeclaration")
+    errors.add(:type, I18n.t(:declaration_type_must_match_profile_type))
   end
 end

--- a/app/models/participant_declaration/ecf.rb
+++ b/app/models/participant_declaration/ecf.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ParticipantDeclaration::ECF < ParticipantDeclaration
+  self.inheritance_column = :temp_type
+
   has_many :statements, class_name: "Finance::Statement::ECF", through: :statement_line_items
 
   validate :validate_against_profile_type
@@ -18,7 +20,7 @@ class ParticipantDeclaration::ECF < ParticipantDeclaration
 
   def validate_against_profile_type
     return unless participant_profile
-    return if participant_profile.type.demodulize == type.demodulize
+    return if participant_profile.type.demodulize == temp_type.demodulize
 
     errors.add(:type, I18n.t(:declaration_type_must_match_profile_type))
   end

--- a/app/models/participant_declaration/ect.rb
+++ b/app/models/participant_declaration/ect.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class ParticipantDeclaration::ECT < ParticipantDeclaration::ECF
+end

--- a/app/models/participant_declaration/mentor.rb
+++ b/app/models/participant_declaration/mentor.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class ParticipantDeclaration::Mentor < ParticipantDeclaration::ECF
+end

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -43,7 +43,7 @@ class ParticipantProfile::ECF < ParticipantProfile
   # Callbacks
   after_save :update_analytics
   after_update :sync_status_with_induction_record
-  after_update :update_declaration_temp_types!, if: :saved_change_to_type?
+  after_update :update_declaration_types!, if: :saved_change_to_type?
 
   # Class methods
   def self.ransackable_attributes(_auth_object = nil)
@@ -203,7 +203,7 @@ private
     induction_record&.update!(mentor_profile:) if saved_change_to_mentor_profile_id?
   end
 
-  def update_declaration_temp_types!
+  def update_declaration_types!
     participant_declarations.update_all(temp_type: type.sub("ParticipantProfile", "ParticipantDeclaration"))
   end
 end

--- a/app/models/participant_profile/ect.rb
+++ b/app/models/participant_profile/ect.rb
@@ -5,6 +5,7 @@ class ParticipantProfile::ECT < ParticipantProfile::ECF
 
   belongs_to :mentor_profile, class_name: "Mentor", optional: true
   has_one :mentor, through: :mentor_profile, source: :user
+  has_many :participant_declarations, class_name: "ParticipantDeclaration::ECT", foreign_key: :participant_profile_id
 
   scope :awaiting_induction_registration, lambda {
     where(induction_start_date: nil).joins(:ecf_participant_eligibility).merge(ECFParticipantEligibility.waiting_for_induction)

--- a/app/models/participant_profile/mentor.rb
+++ b/app/models/participant_profile/mentor.rb
@@ -13,6 +13,7 @@ class ParticipantProfile::Mentor < ParticipantProfile::ECF
 
   has_many :school_mentors, dependent: :destroy, foreign_key: :participant_profile_id
   has_many :schools, through: :school_mentors
+  has_many :participant_declarations, class_name: "ParticipantDeclaration::Mentor", foreign_key: :participant_profile_id
 
   attribute :mentor_completion_reason, :string
   enum mentor_completion_reason: {

--- a/app/serializers/archive/participant_declaration_serializer.rb
+++ b/app/serializers/archive/participant_declaration_serializer.rb
@@ -5,8 +5,7 @@ module Archive
     include JSONAPI::Serializer
 
     set_id :id
-
-    attribute :type
+    attribute :type, &:temp_type
     attribute :participant_profile_id
     attribute :cpd_lead_provider_id
     attribute :declaration_type

--- a/app/serializers/finance/ecf/duplicate_serializer.rb
+++ b/app/serializers/finance/ecf/duplicate_serializer.rb
@@ -85,7 +85,7 @@ module Finance
             declaration_date: participant_declaration.declaration_date&.rfc3339,
             course_identifier: participant_declaration.course_identifier,
             evidence_held: participant_declaration.evidence_held,
-            type: participant_declaration.type,
+            type: participant_declaration.temp_type,
             cpd_lead_provider: participant_declaration.cpd_lead_provider&.name,
             state: participant_declaration.state,
             superseded_by_id: participant_declaration.superseded_by_id,

--- a/app/services/api/v3/participant_declarations_query.rb
+++ b/app/services/api/v3/participant_declarations_query.rb
@@ -16,7 +16,7 @@ module Api
       end
 
       def participant_declarations_for_pagination
-        filterable_attributes = %i[id created_at user_id updated_at delivery_partner_id type]
+        filterable_attributes = %i[id created_at user_id updated_at delivery_partner_id temp_type]
         scope = ParticipantDeclaration::ECF.union(
           declarations_scope.select(*filterable_attributes),
           ecf_previous_declarations_scope.select(*filterable_attributes),

--- a/app/services/finance/ecf/assurance_report/query.rb
+++ b/app/services/finance/ecf/assurance_report/query.rb
@@ -47,7 +47,8 @@ module Finance
               pd.declaration_date                                              AS declaration_date,
               pd.created_at                                                    AS declaration_created_at,
               s.name                                                           AS statement_name,
-              s.id                                                             AS statement_id
+              s.id                                                             AS statement_id,
+              pd.type                                                          AS type
             FROM participant_declarations pd
             JOIN statement_line_items sli  ON sli.participant_declaration_id = pd.id
             JOIN statements s              ON s.id = sli.statement_id
@@ -80,7 +81,7 @@ module Finance
             JOIN schools sc ON sc.id = latest_induction_record.school_id
             LEFT OUTER JOIN ecf_participant_eligibilities epe ON epe.participant_profile_id = pp.id
             JOIN delivery_partners dp ON dp.id = COALESCE(pd.delivery_partner_id, latest_induction_record.delivery_partner_id)
-            WHERE pd.type = 'ParticipantDeclaration::ECF' AND #{where_values}
+            WHERE pd.type IN ('ParticipantDeclaration::ECT', 'ParticipantDeclaration::Mentor') AND #{where_values}
             ORDER BY u.full_name ASC
           EOSQL
         end

--- a/app/services/finance/ecf/assurance_report/query.rb
+++ b/app/services/finance/ecf/assurance_report/query.rb
@@ -48,7 +48,7 @@ module Finance
               pd.created_at                                                    AS declaration_created_at,
               s.name                                                           AS statement_name,
               s.id                                                             AS statement_id,
-              pd.type                                                          AS type
+              pd.temp_type                                                     AS temp_type
             FROM participant_declarations pd
             JOIN statement_line_items sli  ON sli.participant_declaration_id = pd.id
             JOIN statements s              ON s.id = sli.statement_id
@@ -81,7 +81,7 @@ module Finance
             JOIN schools sc ON sc.id = latest_induction_record.school_id
             LEFT OUTER JOIN ecf_participant_eligibilities epe ON epe.participant_profile_id = pp.id
             JOIN delivery_partners dp ON dp.id = COALESCE(pd.delivery_partner_id, latest_induction_record.delivery_partner_id)
-            WHERE pd.type IN ('ParticipantDeclaration::ECT', 'ParticipantDeclaration::Mentor') AND #{where_values}
+            WHERE pd.temp_type IN ('ParticipantDeclaration::ECT', 'ParticipantDeclaration::Mentor') AND #{where_values}
             ORDER BY u.full_name ASC
           EOSQL
         end

--- a/app/services/record_declaration.rb
+++ b/app/services/record_declaration.rb
@@ -208,7 +208,7 @@ private
   def validates_billable_slot_available
     return unless participant_profile
 
-    return unless ParticipantDeclaration::ECF
+    return unless participant_declaration_class
                     .where(state: %w[submitted eligible payable paid])
                     .where(
                       user: participant_identity.user,
@@ -217,6 +217,14 @@ private
                     ).exists?
 
     errors.add(:base, I18n.t(:declaration_already_exists))
+  end
+
+  def participant_declaration_class
+    if participant_profile.mentor?
+      ParticipantDeclaration::Mentor
+    else
+      ParticipantDeclaration::ECT
+    end
   end
 
   def check_mentor_completion

--- a/app/views/admin/participants/_declarations_history.erb
+++ b/app/views/admin/participants/_declarations_history.erb
@@ -27,7 +27,7 @@
 
       sl.with_row do |row|
         row.with_key(text: "Type")
-        row.with_value(text: participant_declaration.type)
+        row.with_value(text: participant_declaration.temp_type)
       end
 
       sl.with_row do |row|

--- a/app/views/admin/participants/declaration_history/show.html.erb
+++ b/app/views/admin/participants/declaration_history/show.html.erb
@@ -41,7 +41,7 @@
 
         sl.with_row do |row|
           row.with_key(text: "Type")
-          row.with_value(text: participant_declaration.type)
+          row.with_value(text: participant_declaration.temp_type)
         end
 
         sl.with_row do |row|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,6 +45,7 @@ en:
   missing_npq_contract_or_statement: "There’s an issue with your contract data. Contact us so we can rectify this for you"
   no_output_fee_statements_for_cohort: "You cannot submit or void declarations for the %{cohort} cohort. The funding contract for this cohort has ended. Get in touch if you need to discuss this with us"
   invalid_page_parameters: "The '#/page[page]' and '#/page[per_page]' parameter values must be a valid number (equal and more than 1)"
+  declaration_type_must_match_profile_type: "The declaration type must match the participant profile type."
   cannot_change_cohort: "You cannot change the '#/cohort' field"
   cannot_create_completed_declaration: "Could not create completed declaration. Contact the DfE for support."
   invalid_participant: "Your update cannot be made as the '#/participant_id' is not recognised. Check participant details and try again."

--- a/db/new_seeds/base/add_testing_scenarios_for_closing_2021.rb
+++ b/db/new_seeds/base/add_testing_scenarios_for_closing_2021.rb
@@ -24,12 +24,14 @@ ActiveRecord::Base.transaction do
       { "Mentor" => NewSeeds::Scenarios::Participants::Mentors::MentorWithNoEcts,
         "Ect" => NewSeeds::Scenarios::Participants::Ects::Ect }.each do |participant_type, scenario_klass|
         # #{participant_type} with only completed billable declaration
+        declaration_factory_type = participant_type == "Mentor" ? :seed_mentor_participant_declaration : :seed_ect_participant_declaration
+
         scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with completed billable declaration")
         .build
         .with_induction_record(induction_programme: school_cohort.default_induction_programme)
         .with_validation_data
         .with_eligibility.tap do |scenario|
-          FactoryBot.create(:seed_ecf_participant_declaration,
+          FactoryBot.create(declaration_factory_type,
                             participant_profile: scenario.participant_profile,
                             cohort: school_cohort.cohort,
                             user: scenario.user,
@@ -44,7 +46,7 @@ ActiveRecord::Base.transaction do
         .with_induction_record(induction_programme: school_cohort.default_induction_programme)
         .with_validation_data
         .with_eligibility.tap do |scenario|
-          FactoryBot.create(:seed_ecf_participant_declaration,
+          FactoryBot.create(declaration_factory_type,
                             participant_profile: scenario.participant_profile,
                             cohort: school_cohort.cohort,
                             user: scenario.user,
@@ -59,7 +61,7 @@ ActiveRecord::Base.transaction do
         .with_induction_record(induction_programme: school_cohort.default_induction_programme)
         .with_validation_data
         .with_eligibility.tap do |scenario|
-          FactoryBot.create(:seed_ecf_participant_declaration,
+          FactoryBot.create(declaration_factory_type,
                             participant_profile: scenario.participant_profile,
                             cohort: school_cohort.cohort,
                             user: scenario.user,
@@ -81,7 +83,7 @@ ActiveRecord::Base.transaction do
         .with_induction_record(induction_programme: school_cohort.default_induction_programme)
         .with_validation_data
         .with_eligibility.tap do |scenario|
-          FactoryBot.create(:seed_ecf_participant_declaration,
+          FactoryBot.create(declaration_factory_type,
                             participant_profile: scenario.participant_profile,
                             cohort: school_cohort.cohort,
                             user: scenario.user,
@@ -96,7 +98,7 @@ ActiveRecord::Base.transaction do
         .with_induction_record(induction_programme: school_cohort.default_induction_programme)
         .with_validation_data
         .with_eligibility.tap do |scenario|
-          FactoryBot.create(:seed_ecf_participant_declaration,
+          FactoryBot.create(declaration_factory_type,
                             participant_profile: scenario.participant_profile,
                             cohort: school_cohort.cohort,
                             user: scenario.user,
@@ -111,7 +113,7 @@ ActiveRecord::Base.transaction do
         .with_induction_record(induction_programme: school_cohort.default_induction_programme)
         .with_validation_data
         .with_eligibility.tap do |scenario|
-          FactoryBot.create(:seed_ecf_participant_declaration,
+          FactoryBot.create(declaration_factory_type,
                             participant_profile: scenario.participant_profile,
                             cohort: school_cohort.cohort,
                             user: scenario.user,
@@ -159,7 +161,7 @@ ActiveRecord::Base.transaction do
         .with_induction_record(induction_programme: school_cohort.default_induction_programme)
         .with_validation_data
         .with_eligibility(status: "ineligible", reason: "no_induction").tap do |scenario|
-          FactoryBot.create(:seed_ecf_participant_declaration,
+          FactoryBot.create(declaration_factory_type,
                             participant_profile: scenario.participant_profile,
                             cohort: school_cohort.cohort,
                             user: scenario.user,
@@ -174,7 +176,7 @@ ActiveRecord::Base.transaction do
         .with_induction_record(induction_programme: school_cohort.default_induction_programme)
         .with_validation_data
         .with_eligibility(status: "ineligible", reason: "no_induction").tap do |scenario|
-          FactoryBot.create(:seed_ecf_participant_declaration,
+          FactoryBot.create(declaration_factory_type,
                             participant_profile: scenario.participant_profile,
                             cohort: school_cohort.cohort,
                             user: scenario.user,
@@ -189,7 +191,7 @@ ActiveRecord::Base.transaction do
         .with_induction_record(induction_programme: school_cohort.default_induction_programme)
         .with_validation_data
         .with_eligibility(status: "ineligible", reason: "no_induction").tap do |scenario|
-          FactoryBot.create(:seed_ecf_participant_declaration,
+          FactoryBot.create(declaration_factory_type,
                             participant_profile: scenario.participant_profile,
                             cohort: school_cohort.cohort,
                             user: scenario.user,
@@ -204,7 +206,7 @@ ActiveRecord::Base.transaction do
         .with_induction_record(induction_programme: school_cohort.default_induction_programme)
         .with_validation_data
         .with_eligibility(status: "ineligible", reason: "no_induction").tap do |scenario|
-          FactoryBot.create(:seed_ecf_participant_declaration,
+          FactoryBot.create(declaration_factory_type,
                             participant_profile: scenario.participant_profile,
                             cohort: school_cohort.cohort,
                             user: scenario.user,
@@ -219,7 +221,7 @@ ActiveRecord::Base.transaction do
         .with_induction_record(induction_programme: school_cohort.default_induction_programme)
         .with_validation_data
         .with_eligibility(status: "ineligible", reason: "no_induction").tap do |scenario|
-          FactoryBot.create(:seed_ecf_participant_declaration,
+          FactoryBot.create(declaration_factory_type,
                             participant_profile: scenario.participant_profile,
                             cohort: school_cohort.cohort,
                             user: scenario.user,
@@ -234,7 +236,7 @@ ActiveRecord::Base.transaction do
         .with_induction_record(induction_programme: school_cohort.default_induction_programme)
         .with_validation_data
         .with_eligibility(status: "ineligible", reason: "no_induction").tap do |scenario|
-          FactoryBot.create(:seed_ecf_participant_declaration,
+          FactoryBot.create(declaration_factory_type,
                             participant_profile: scenario.participant_profile,
                             cohort: school_cohort.cohort,
                             user: scenario.user,
@@ -249,7 +251,7 @@ ActiveRecord::Base.transaction do
         .with_induction_record(induction_programme: school_cohort.default_induction_programme)
         .with_validation_data
         .with_eligibility(status: "ineligible", reason: "no_induction").tap do |scenario|
-          FactoryBot.create(:seed_ecf_participant_declaration,
+          FactoryBot.create(declaration_factory_type,
                             participant_profile: scenario.participant_profile,
                             cohort: school_cohort.cohort,
                             user: scenario.user,
@@ -264,7 +266,7 @@ ActiveRecord::Base.transaction do
         .with_induction_record(induction_programme: school_cohort.default_induction_programme)
         .with_validation_data
         .with_eligibility(status: "ineligible", reason: "no_induction").tap do |scenario|
-          FactoryBot.create(:seed_ecf_participant_declaration,
+          FactoryBot.create(declaration_factory_type,
                             participant_profile: scenario.participant_profile,
                             cohort: school_cohort.cohort,
                             user: scenario.user,
@@ -279,7 +281,7 @@ ActiveRecord::Base.transaction do
         .with_induction_record(induction_programme: school_cohort.default_induction_programme)
         .with_validation_data
         .with_eligibility(status: "ineligible", reason: "no_induction").tap do |scenario|
-          FactoryBot.create(:seed_ecf_participant_declaration,
+          FactoryBot.create(declaration_factory_type,
                             participant_profile: scenario.participant_profile,
                             cohort: school_cohort.cohort,
                             user: scenario.user,
@@ -294,7 +296,7 @@ ActiveRecord::Base.transaction do
         .with_induction_record(induction_programme: school_cohort.default_induction_programme)
         .with_validation_data
         .with_eligibility(status: "ineligible", reason: "no_induction").tap do |scenario|
-          FactoryBot.create(:seed_ecf_participant_declaration,
+          FactoryBot.create(declaration_factory_type,
                             participant_profile: scenario.participant_profile,
                             cohort: school_cohort.cohort,
                             user: scenario.user,
@@ -309,7 +311,7 @@ ActiveRecord::Base.transaction do
         .with_induction_record(induction_programme: school_cohort.default_induction_programme)
         .with_validation_data
         .with_eligibility(status: "ineligible", reason: "no_induction").tap do |scenario|
-          FactoryBot.create(:seed_ecf_participant_declaration,
+          FactoryBot.create(declaration_factory_type,
                             participant_profile: scenario.participant_profile,
                             cohort: school_cohort.cohort,
                             user: scenario.user,
@@ -324,7 +326,7 @@ ActiveRecord::Base.transaction do
         .with_induction_record(induction_programme: school_cohort.default_induction_programme)
         .with_validation_data
         .with_eligibility(status: "ineligible", reason: "no_induction").tap do |scenario|
-          FactoryBot.create(:seed_ecf_participant_declaration,
+          FactoryBot.create(declaration_factory_type,
                             participant_profile: scenario.participant_profile,
                             cohort: school_cohort.cohort,
                             user: scenario.user,

--- a/spec/factories/participant_declaration.rb
+++ b/spec/factories/participant_declaration.rb
@@ -15,18 +15,18 @@ FactoryBot.define do
       has_passed     { false }
     end
 
-    factory :ecf_participant_declaration, class: "ParticipantDeclaration::ECF" do
+    factory :ect_participant_declaration, class: ParticipantDeclaration::ECT do
+      type { "ParticipantDeclaration::ECT" }
       cpd_lead_provider { create(:cpd_lead_provider, :with_lead_provider) }
+      course_identifier { "ecf-induction" }
+      participant_profile { create(:ect, *uplifts, *profile_traits, lead_provider: cpd_lead_provider.lead_provider, cohort:) }
+    end
 
-      factory :ect_participant_declaration, class: "ParticipantDeclaration::ECF" do
-        course_identifier { "ecf-induction" }
-        participant_profile { create(:ect, *uplifts, *profile_traits, lead_provider: cpd_lead_provider.lead_provider, cohort:) }
-      end
-
-      factory :mentor_participant_declaration, class: "ParticipantDeclaration::ECF" do
-        course_identifier { "ecf-mentor" }
-        participant_profile { create(:mentor, *uplifts, *profile_traits, lead_provider: cpd_lead_provider.lead_provider, cohort:) }
-      end
+    factory :mentor_participant_declaration, class: ParticipantDeclaration::Mentor do
+      type { "ParticipantDeclaration::Mentor" }
+      cpd_lead_provider { create(:cpd_lead_provider, :with_lead_provider) }
+      course_identifier { "ecf-mentor" }
+      participant_profile { create(:mentor, *uplifts, *profile_traits, lead_provider: cpd_lead_provider.lead_provider, cohort:) }
     end
 
     initialize_with do

--- a/spec/factories/seeds/participant_declaration_factory.rb
+++ b/spec/factories/seeds/participant_declaration_factory.rb
@@ -6,9 +6,21 @@ FactoryBot.define do
   # being able to infer a user via the participant profile. If possible hard
   # code these values when calling this factory
   factory(:seed_abstract_participant_declaration, class: "ParticipantDeclaration") do
-    factory(:seed_ecf_participant_declaration, class: "ParticipantDeclaration::ECF") do
+    factory(:seed_ect_participant_declaration, class: "ParticipantDeclaration::ECT") do
       trait(:with_ecf_participant_profile) do
         association(:participant_profile, factory: %i[seed_ect_participant_profile valid])
+      end
+
+      trait(:valid) do
+        with_user
+        with_cpd_lead_provider
+        with_ecf_participant_profile
+      end
+    end
+
+    factory(:seed_mentor_participant_declaration, class: "ParticipantDeclaration::Mentor") do
+      trait(:with_ecf_participant_profile) do
+        association(:participant_profile, factory: %i[seed_mentor_participant_profile valid])
       end
 
       trait(:valid) do

--- a/spec/features/schools/participants/add_participants/payments_frozen/transfer_mentor_to_another_school_spec.rb
+++ b/spec/features/schools/participants/add_participants/payments_frozen/transfer_mentor_to_another_school_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "SIT transfers mentor to another school", js: true, early_in_coho
            full_name: "Sally Teacher", trn: @participant_data[:trn], date_of_birth: Date.new(1990, 10, 24))
     Induction::Enrol.call(participant_profile:, induction_programme:)
 
-    create(:ect_participant_declaration, participant_profile:, cpd_lead_provider:, state: :eligible, course_identifier: "ecf-mentor")
+    create(:mentor_participant_declaration, participant_profile:, cpd_lead_provider:, state: :eligible, course_identifier: "ecf-mentor")
     set_dqt_validation_result
   end
 

--- a/spec/models/participant_declaration/ecf_spec.rb
+++ b/spec/models/participant_declaration/ecf_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ParticipantDeclaration::ECF, mid_cohort: true do
     it "raises an error when the declaration type is ECT and the profile type is Mentor" do
       declaration = create(:mentor_participant_declaration)
 
-      declaration.type = "ParticipantDeclaration::ECT"
+      declaration.temp_type = "ParticipantDeclaration::ECT"
 
       expect(declaration).to be_invalid
       expect(declaration.errors[:type]).to include(I18n.t(:declaration_type_must_match_profile_type))
@@ -16,7 +16,7 @@ RSpec.describe ParticipantDeclaration::ECF, mid_cohort: true do
     it "raises an error when the declaration type is Mentor and the profile type is ECT" do
       declaration = create(:ect_participant_declaration)
 
-      declaration.type = "ParticipantDeclaration::Mentor"
+      declaration.temp_type = "ParticipantDeclaration::Mentor"
 
       expect(declaration).to be_invalid
       expect(declaration.errors[:type]).to include(I18n.t(:declaration_type_must_match_profile_type))

--- a/spec/models/participant_declaration/ecf_spec.rb
+++ b/spec/models/participant_declaration/ecf_spec.rb
@@ -3,6 +3,26 @@
 require "rails_helper"
 
 RSpec.describe ParticipantDeclaration::ECF, mid_cohort: true do
+  describe "type validation against participant_profile" do
+    it "raises an error when the declaration type is ECT and the profile type is Mentor" do
+      declaration = create(:mentor_participant_declaration)
+
+      declaration.type = "ParticipantDeclaration::ECT"
+
+      expect(declaration).to be_invalid
+      expect(declaration.errors[:type]).to include(I18n.t(:declaration_type_must_match_profile_type))
+    end
+
+    it "raises an error when the declaration type is Mentor and the profile type is ECT" do
+      declaration = create(:ect_participant_declaration)
+
+      declaration.type = "ParticipantDeclaration::Mentor"
+
+      expect(declaration).to be_invalid
+      expect(declaration.errors[:type]).to include(I18n.t(:declaration_type_must_match_profile_type))
+    end
+  end
+
   describe "#uplift_paid?" do
     %i[paid awaiting_clawback clawed_back].each do |declaration_state|
       context "started - ecf-induction - #{declaration_state} - sparsity_uplift" do
@@ -28,22 +48,6 @@ RSpec.describe ParticipantDeclaration::ECF, mid_cohort: true do
       it "should return false" do
         expect(subject.uplift_paid?).to eql(false)
       end
-    end
-  end
-
-  describe "before_save set_temp_type" do
-    subject { declaration.temp_type }
-
-    context "when an ECT declaration" do
-      let(:declaration) { create(:ect_participant_declaration) }
-
-      it { is_expected.to eq("ParticipantDeclaration::ECT") }
-    end
-
-    context "when a Mentor declaration" do
-      let(:declaration) { create(:mentor_participant_declaration) }
-
-      it { is_expected.to eq("ParticipantDeclaration::Mentor") }
     end
   end
 end

--- a/spec/models/participant_declaration/ect_spec.rb
+++ b/spec/models/participant_declaration/ect_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ParticipantDeclaration::ECT do
+  it { is_expected.to be_a(ParticipantDeclaration::ECF) }
+end

--- a/spec/models/participant_declaration/mentor_spec.rb
+++ b/spec/models/participant_declaration/mentor_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ParticipantDeclaration::Mentor do
+  it { is_expected.to be_a(ParticipantDeclaration::ECF) }
+end

--- a/spec/models/participant_declaration_spec.rb
+++ b/spec/models/participant_declaration_spec.rb
@@ -4,7 +4,8 @@ require "rails_helper"
 
 RSpec.describe ParticipantDeclaration, type: :model do
   let(:user) { create(:user) }
-  subject { described_class.new(user:) }
+  let(:declaration_class) { ParticipantDeclaration::ECT }
+  subject { declaration_class.new(user:) }
 
   describe "associations" do
     it { is_expected.to belong_to(:cpd_lead_provider) }
@@ -303,7 +304,7 @@ RSpec.describe ParticipantDeclaration, type: :model do
       { state: "clawed_back", voidable: false },
     ].each do |hash|
       context "when declaration is #{hash[:state]}" do
-        subject { described_class.new(state: hash[:state]) }
+        subject { declaration_class.new(state: hash[:state]) }
 
         it "#{hash[:voidable] ? 'can' : 'cannot'} be voided" do
           expect(subject.voidable?).to eql(hash[:voidable])
@@ -331,17 +332,17 @@ RSpec.describe ParticipantDeclaration, type: :model do
       }
     end
 
-    before { described_class.create!(attributes) }
+    before { declaration_class.create!(attributes) }
 
     it "raises an not unique error" do
-      expect { described_class.create!(attributes) }.to raise_error ActiveRecord::RecordNotUnique
+      expect { declaration_class.create!(attributes) }.to raise_error ActiveRecord::RecordNotUnique
     end
 
     context "when the declaration state id voided" do
       let(:state) { :voided }
 
       it "raises an not unique error" do
-        expect { described_class.create!(attributes) }.not_to raise_error
+        expect { declaration_class.create!(attributes) }.not_to raise_error
       end
     end
 
@@ -349,7 +350,7 @@ RSpec.describe ParticipantDeclaration, type: :model do
       let(:state) { :ineligible }
 
       it "raises an not unique error" do
-        expect { described_class.create!(attributes) }.not_to raise_error
+        expect { declaration_class.create!(attributes) }.not_to raise_error
       end
     end
 
@@ -357,7 +358,7 @@ RSpec.describe ParticipantDeclaration, type: :model do
       let(:state) { :awaiting_clawback }
 
       it "raises an not unique error" do
-        expect { described_class.create!(attributes) }.not_to raise_error
+        expect { declaration_class.create!(attributes) }.not_to raise_error
       end
     end
   end

--- a/spec/models/participant_profile/ecf_spec.rb
+++ b/spec/models/participant_profile/ecf_spec.rb
@@ -415,19 +415,21 @@ RSpec.describe ParticipantProfile::ECF, type: :model do
       profile.update!(type: "ParticipantProfile::Mentor")
 
       expect(ParticipantProfile.find(profile.id)).to be_an_instance_of(ParticipantProfile::Mentor)
-      expect(ParticipantDeclaration.find(declaration.id).temp_type).to eq("ParticipantDeclaration::Mentor")
+      expect(ParticipantDeclaration::ECF.find(declaration.id).temp_type).to eq("ParticipantDeclaration::Mentor")
+      expect(ParticipantDeclaration::ECF.find(declaration.id)).to be_an_instance_of(ParticipantDeclaration::Mentor)
       expect(ParticipantDeclaration.find(declaration.id).updated_at).to be_within(1.minute).of(1.day.ago)
     end
 
-    it "updates the declarations to the correct type when changing from mentor to ECT" do
+    it "updates the declarations to the correct temp_type when changing from mentor to ECT" do
       declaration = travel_to(1.day.ago) { create(:mentor_participant_declaration) }
       profile = declaration.participant_profile
 
       profile.update!(type: "ParticipantProfile::ECT")
 
       expect(ParticipantProfile.find(profile.id)).to be_an_instance_of(ParticipantProfile::ECT)
-      expect(ParticipantDeclaration.find(declaration.id).temp_type).to eq("ParticipantDeclaration::ECT")
-      expect(ParticipantDeclaration.find(declaration.id).updated_at).to be_within(1.minute).of(1.day.ago)
+      expect(ParticipantDeclaration::ECF.find(declaration.id).temp_type).to eq("ParticipantDeclaration::ECT")
+      expect(ParticipantDeclaration::ECF.find(declaration.id)).to be_an_instance_of(ParticipantDeclaration::ECT)
+      expect(ParticipantDeclaration::ECF.find(declaration.id).updated_at).to be_within(1.minute).of(1.day.ago)
     end
   end
 end

--- a/spec/models/participant_profile/ect_spec.rb
+++ b/spec/models/participant_profile/ect_spec.rb
@@ -8,6 +8,7 @@ describe ParticipantProfile::ECT, type: :model do
   describe "associations" do
     it { is_expected.to belong_to(:mentor_profile).class_name("ParticipantProfile::Mentor").optional }
     it { is_expected.to have_one(:mentor).through(:mentor_profile).source(:user) }
+    it { is_expected.to have_many(:participant_declarations).class_name("ParticipantDeclaration::ECT").with_foreign_key(:participant_profile_id) }
   end
 
   describe "callbacks" do

--- a/spec/models/participant_profile/mentor_spec.rb
+++ b/spec/models/participant_profile/mentor_spec.rb
@@ -10,6 +10,7 @@ describe ParticipantProfile::Mentor, type: :model do
     it { is_expected.to have_many(:mentees).through(:mentee_profiles).source(:user) }
     it { is_expected.to have_many(:school_mentors).dependent(:destroy).with_foreign_key(:participant_profile_id) }
     it { is_expected.to have_many(:schools).through(:school_mentors) }
+    it { is_expected.to have_many(:participant_declarations).class_name("ParticipantDeclaration::Mentor").with_foreign_key(:participant_profile_id) }
   end
 
   describe "#mentor" do

--- a/spec/presenters/admin/participant_presenter_spec.rb
+++ b/spec/presenters/admin/participant_presenter_spec.rb
@@ -312,7 +312,7 @@ RSpec.describe(Admin::ParticipantPresenter) do
     end
 
     describe "#declarations" do
-      let!(:declarations) { FactoryBot.create_list(:seed_ecf_participant_declaration, 2, :valid, participant_profile:) }
+      let!(:declarations) { FactoryBot.create_list(:seed_ect_participant_declaration, 2, :valid, participant_profile:) }
 
       it "returns the declarations belonging to the participant" do
         expect(subject.declarations).to match_array(declarations)

--- a/spec/seeds/seed_factories/participant_declaration_factory_spec.rb
+++ b/spec/seeds/seed_factories/participant_declaration_factory_spec.rb
@@ -2,9 +2,14 @@
 
 require_relative "./shared_factory_examples"
 
-RSpec.describe("seed_ecf_participant_declaration") do
+RSpec.describe("seed_ect_participant_declaration", "seed_mentor_participant_declaration") do
   it_behaves_like("a seed factory") do
-    let(:factory_name) { :seed_ecf_participant_declaration }
-    let(:factory_class) { ParticipantDeclaration::ECF }
+    let(:factory_name) { :seed_ect_participant_declaration }
+    let(:factory_class) { ParticipantDeclaration::ECT }
+  end
+
+  it_behaves_like("a seed factory") do
+    let(:factory_name) { :seed_mentor_participant_declaration }
+    let(:factory_class) { ParticipantDeclaration::Mentor }
   end
 end

--- a/spec/serializers/archive/participant_declaration_serializer_spec.rb
+++ b/spec/serializers/archive/participant_declaration_serializer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Archive::ParticipantDeclarationSerializer do
       expect(data[:type]).to eq :participant_declaration
 
       attrs = data[:attributes]
-      expect(attrs[:type]).to eq declaration.type
+      expect(attrs[:type]).to eq declaration.temp_type
       expect(attrs[:participant_profile_id]).to eq declaration.participant_profile_id
       expect(attrs[:cpd_lead_provider_id]).to eq declaration.cpd_lead_provider_id
       expect(attrs[:declaration_type]).to eq declaration.declaration_type

--- a/spec/serializers/archive/participant_declaration_serializer_spec.rb
+++ b/spec/serializers/archive/participant_declaration_serializer_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Archive::ParticipantDeclarationSerializer do
-  let(:declaration) { create(:seed_ecf_participant_declaration, :valid) }
+  let(:declaration) { create(:seed_ect_participant_declaration, :valid) }
 
   subject { described_class.new(declaration) }
 

--- a/spec/services/archive/destroy_ecf_profile_data_spec.rb
+++ b/spec/services/archive/destroy_ecf_profile_data_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Archive::DestroyECFProfileData do
 
   context "when the profile has a declaration" do
     let(:state) { "submitted" }
-    let!(:declaration) { create(:seed_ecf_participant_declaration, :with_cpd_lead_provider, state:, user:, participant_profile:) }
+    let!(:declaration) { create(:seed_ect_participant_declaration, :with_cpd_lead_provider, state:, user:, participant_profile:) }
 
     it "destroys the declarations" do
       expect { service_call }.to change { ParticipantDeclaration.count }.by(-1)

--- a/spec/services/archive/frozen_cohort_profile_spec.rb
+++ b/spec/services/archive/frozen_cohort_profile_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Archive::FrozenCohortProfile do
 
   context "when the profile has a declaration" do
     let(:state) { "payable" }
-    let!(:declaration) { create(:seed_ecf_participant_declaration, :with_cpd_lead_provider, state:, user:, participant_profile:) }
+    let!(:declaration) { create(:seed_ect_participant_declaration, :with_cpd_lead_provider, state:, user:, participant_profile:) }
 
     it "raises an ArchiveError" do
       expect {

--- a/spec/services/archive/frozen_cohort_user_spec.rb
+++ b/spec/services/archive/frozen_cohort_user_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Archive::FrozenCohortUser do
 
   context "when the user has a declaration" do
     let(:state) { "payable" }
-    let!(:declaration) { create(:seed_ecf_participant_declaration, :with_cpd_lead_provider, state:, user:, participant_profile:) }
+    let!(:declaration) { create(:seed_ect_participant_declaration, :with_cpd_lead_provider, state:, user:, participant_profile:) }
 
     it "raises an ArchiveError" do
       expect {
@@ -82,7 +82,7 @@ RSpec.describe Archive::FrozenCohortUser do
 
     context "when the declaration has a different profile but same user (bad data)" do
       let(:profile2) { create(:ect_participant_profile) }
-      let!(:declaration) { create(:seed_ecf_participant_declaration, :with_cpd_lead_provider, participant_profile: profile2, state:, user:) }
+      let!(:declaration) { create(:seed_ect_participant_declaration, :with_cpd_lead_provider, participant_profile: profile2, state:, user:) }
 
       it "raises an ArchiveError" do
         expect {
@@ -236,7 +236,7 @@ RSpec.describe Archive::FrozenCohortUser do
 
   context "when the user is a mentor user on a participants declaration" do
     let(:participant_profile) { create(:mentor_participant_profile) }
-    let!(:declaration) { create(:seed_ecf_participant_declaration, :valid, mentor_user_id: user.id) }
+    let!(:declaration) { create(:seed_mentor_participant_declaration, :valid, mentor_user_id: user.id) }
 
     it "raises an ArchiveError" do
       expect {

--- a/spec/services/archive/unvalidated_profile_spec.rb
+++ b/spec/services/archive/unvalidated_profile_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Archive::UnvalidatedProfile do
 
   context "when the profile has a declaration" do
     let(:state) { "submitted" }
-    let!(:declaration) { create(:seed_ecf_participant_declaration, :with_cpd_lead_provider, state:, user:, participant_profile:) }
+    let!(:declaration) { create(:seed_ect_participant_declaration, :with_cpd_lead_provider, state:, user:, participant_profile:) }
 
     it "raises an ArchiveError" do
       expect {

--- a/spec/services/archive/unvalidated_user_spec.rb
+++ b/spec/services/archive/unvalidated_user_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Archive::UnvalidatedUser do
 
   context "when the user has a declaration" do
     let(:state) { "submitted" }
-    let!(:declaration) { create(:seed_ecf_participant_declaration, :with_cpd_lead_provider, state:, user:, participant_profile:) }
+    let!(:declaration) { create(:seed_ect_participant_declaration, :with_cpd_lead_provider, state:, user:, participant_profile:) }
 
     it "raises an ArchiveError" do
       expect {
@@ -75,7 +75,7 @@ RSpec.describe Archive::UnvalidatedUser do
 
     context "when the declaration has a different profile but same user (bad data)" do
       let(:profile2) { create(:ect_participant_profile) }
-      let!(:declaration) { create(:seed_ecf_participant_declaration, :with_cpd_lead_provider, participant_profile: profile2, state:, user:) }
+      let!(:declaration) { create(:seed_ect_participant_declaration, :with_cpd_lead_provider, participant_profile: profile2, state:, user:) }
 
       it "raises an ArchiveError" do
         expect {
@@ -219,7 +219,7 @@ RSpec.describe Archive::UnvalidatedUser do
 
   context "when the user is a mentor user on a participants declaration" do
     let(:participant_profile) { create(:mentor_participant_profile) }
-    let!(:declaration) { create(:seed_ecf_participant_declaration, :valid, mentor_user_id: user.id) }
+    let!(:declaration) { create(:seed_mentor_participant_declaration, :valid, mentor_user_id: user.id) }
 
     it "raises an ArchiveError" do
       expect {

--- a/spec/services/finance/ecf/assurance_report/query_spec.rb
+++ b/spec/services/finance/ecf/assurance_report/query_spec.rb
@@ -41,6 +41,14 @@ RSpec.describe Finance::ECF::AssuranceReport::Query, mid_cohort: true do
       it { is_expected.to contain_exactly(participant_declaration) }
       it { expect(assurance_report.participant_id).to eq(participant_identity.user_id) }
     end
+
+    context "when there are ECT and Mentor declarations in the results" do
+      let(:mentor_participant_profile) { create(:mentor, :eligible_for_funding, uplifts:, lead_provider: cpd_lead_provider.lead_provider) }
+      let!(:mentor_declaration) { travel_to(statement.deadline_date) { create(:mentor_participant_declaration, participant_profile: mentor_participant_profile, cpd_lead_provider:, delivery_partner:) } }
+
+      it { is_expected.to contain_exactly(participant_declaration, mentor_declaration) }
+      it { expect(subject.map(&:type)).to contain_exactly(/ECT/, /Mentor/) }
+    end
   end
 
   describe "#delivery_partner_name" do

--- a/spec/services/finance/ecf/assurance_report/query_spec.rb
+++ b/spec/services/finance/ecf/assurance_report/query_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Finance::ECF::AssuranceReport::Query, mid_cohort: true do
       let!(:mentor_declaration) { travel_to(statement.deadline_date) { create(:mentor_participant_declaration, participant_profile: mentor_participant_profile, cpd_lead_provider:, delivery_partner:) } }
 
       it { is_expected.to contain_exactly(participant_declaration, mentor_declaration) }
-      it { expect(subject.map(&:type)).to contain_exactly(/ECT/, /Mentor/) }
+      it { expect(subject.map(&:temp_type)).to contain_exactly(/ECT/, /Mentor/) }
     end
   end
 

--- a/spec/services/mentors/check_training_completion_spec.rb
+++ b/spec/services/mentors/check_training_completion_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Mentors::CheckTrainingCompletion do
   end
 
   context "when the mentor has a completed declaration" do
-    let!(:declaration) { create(:seed_ecf_participant_declaration, :with_cpd_lead_provider, :completed, user: mentor_profile.user, participant_profile: mentor_profile) }
+    let!(:declaration) { create(:seed_mentor_participant_declaration, :with_cpd_lead_provider, :completed, user: mentor_profile.user, participant_profile: mentor_profile) }
 
     it "sets the mentor_completion_date to the declaration date" do
       service_call

--- a/spec/services/participant_declarations/handle_mentor_completion_spec.rb
+++ b/spec/services/participant_declarations/handle_mentor_completion_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ParticipantDeclarations::HandleMentorCompletion do
   let(:participant_profile) { create(:seed_mentor_participant_profile, :valid) }
 
   let(:participant_declaration) do
-    create(:seed_ecf_participant_declaration, user: participant_profile.user, participant_profile:, cpd_lead_provider:, course_identifier:, declaration_type:)
+    create(:seed_mentor_participant_declaration, user: participant_profile.user, participant_profile:, cpd_lead_provider:, course_identifier:, declaration_type:)
   end
 
   subject(:service) { described_class.new(participant_declaration:) }
@@ -27,6 +27,9 @@ RSpec.describe ParticipantDeclarations::HandleMentorCompletion do
       context "when the participant profile is not a mentor" do
         let(:course_identifier) { "ecf-induction" }
         let(:participant_profile) { create(:seed_ect_participant_profile, :valid) }
+        let(:participant_declaration) do
+          create(:seed_ect_participant_declaration, user: participant_profile.user, participant_profile:, cpd_lead_provider:, course_identifier:, declaration_type:)
+        end
 
         it "does not call the Mentors::CheckTrainingCompletion service" do
           expect_any_instance_of(Mentors::CheckTrainingCompletion).not_to receive(:call)
@@ -48,6 +51,9 @@ RSpec.describe ParticipantDeclarations::HandleMentorCompletion do
       context "when the participant profile is not a mentor" do
         let(:course_identifier) { "ecf-induction" }
         let(:participant_profile) { create(:seed_ect_participant_profile, :valid) }
+        let(:participant_declaration) do
+          create(:seed_ect_participant_declaration, user: participant_profile.user, participant_profile:, cpd_lead_provider:, course_identifier:, declaration_type:)
+        end
 
         it "does not call the Mentors::CheckTrainingCompletion service" do
           expect_any_instance_of(Mentors::CheckTrainingCompletion).not_to receive(:call)

--- a/spec/services/participants/change_relationship_spec.rb
+++ b/spec/services/participants/change_relationship_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Participants::ChangeRelationship do
       context "when the participant has declarations from the current provider" do
         let(:user) { participant_profile.user }
         let(:cpd_lead_provider) { current_induction_record.lead_provider.cpd_lead_provider }
-        let!(:declaration) { create(:seed_ecf_participant_declaration, participant_profile:, user:, cpd_lead_provider:) }
+        let!(:declaration) { create(:seed_ect_participant_declaration, participant_profile:, user:, cpd_lead_provider:) }
 
         it "raises an error" do
           expect {

--- a/spec/services/record_declaration_spec.rb
+++ b/spec/services/record_declaration_spec.rb
@@ -269,7 +269,7 @@ RSpec.shared_examples "creates a participant declaration" do
     expected_type = participant_profile.mentor? ? "ParticipantDeclaration::Mentor" : "ParticipantDeclaration::ECT"
 
     declaration = ParticipantDeclaration.last
-    expect(declaration.type).to eq(expected_type)
+    expect(declaration.temp_type).to eq(expected_type)
   end
 
   it "stores the correct data" do

--- a/spec/services/record_declaration_spec.rb
+++ b/spec/services/record_declaration_spec.rb
@@ -263,6 +263,15 @@ RSpec.shared_examples "creates a participant declaration" do
     expect { service.call }.to change { ParticipantDeclaration.count }.by(1)
   end
 
+  it "creates the correct type of declaration" do
+    service.call
+
+    expected_type = participant_profile.mentor? ? "ParticipantDeclaration::Mentor" : "ParticipantDeclaration::ECT"
+
+    declaration = ParticipantDeclaration.last
+    expect(declaration.type).to eq(expected_type)
+  end
+
   it "stores the correct data" do
     subject.call
 


### PR DESCRIPTION
[Jira-3897](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-3897)

### Context

The original/complete PR is #5404.
Depends on #5428.

Now that we have `temp_type` populating and backfilled, we can switch to use `Mentor` and `ECT` declaration sub-types, backfilling the `type` field quickly from the `temp_type` field to avoid downtime/data inconsistencies.

### Changes proposed in this pull request

- Add Mentor and ECT types for ParticipantDeclaration

Going forward we need to differentiate between Mentor and ECT declarations. In order to do this we are leveraging the existing STI setup and adding two new classes that inherit from the `ParticipantDeclaration::ECF` class.

- Update specs and factories for new declaration types

Update specs and factories to use the new declaration types so that they are correctly referenced through the new relationship types.

- Fix assurance report to return ECT and Mentor

Previously this was scoped to just ECF declarations; we now need to scope it to include both ECT and Mentor declarations and include the `type` so that Rails correctly type-casts them in the results.

- Update RecordDeclaration to use correct declaration type

When creating a declaration we go through the relationship so it will by typed correctly as a by-product. The only place we need to specify the declaration type explicitly is when validating that there is a billable slot available.

- Add migration to populate type from temp_type

Add a migration to populate the `type` field from the backfilled/populated `temp_type`, which will contain the `ECT` or `Mentor` declaration type.

- Add callbacks and validation to ensure profile/declaration type consistency

Add a callback to `ParticipantProfile::ECF` to ensure if the type is changed then the declarations also reflect the correct type.

Add validation to `ParticipantDeclaration::ECF` to ensure that their type cannot be changed, resulting in a mismatch with the `ParticipantProfile`.

- Switch inheritance column to temp_type for ECF declarations

Until we can safely backfill the `type` column, we are using `temp_type`, which has already been backfilled and is kept up to date.

### Guidance to review

Once this has shipped we can remove the `temp_type` field. #5433
