### PR TITLE
Drop `temp_type` field from `ParticipantDeclaration`

### DIFF
--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -223,8 +223,6 @@
   - participant_declaration_id
   - created_at
   - updated_at
-  :participant_declarations:
-  - temp_type
   :participant_bands:
   - id
   - call_off_contract_id

--- a/db/migrate/20250110135952_drop_temp_type_from_participant_declarations.rb
+++ b/db/migrate/20250110135952_drop_temp_type_from_participant_declarations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class DropTempTypeFromParticipantDeclarations < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :participant_declarations, :temp_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -755,7 +755,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_15_143446) do
     t.uuid "delivery_partner_id"
     t.uuid "mentor_user_id"
     t.uuid "cohort_id", null: false
-    t.string "temp_type"
     t.index ["cohort_id"], name: "index_participant_declarations_on_cohort_id"
     t.index ["cpd_lead_provider_id", "participant_profile_id", "declaration_type", "course_identifier", "state"], name: "unique_declaration_index", unique: true, where: "((state)::text = ANY (ARRAY[('submitted'::character varying)::text, ('eligible'::character varying)::text, ('payable'::character varying)::text, ('paid'::character varying)::text]))"
     t.index ["cpd_lead_provider_id"], name: "index_participant_declarations_on_cpd_lead_provider_id"


### PR DESCRIPTION
[Jira-3897](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-3897)

### Context

This field was used to store the `type` of declarations temporarily as we migrated from `ParticipantDeclaration::ECF` to `ECT` and `Mentor` subtypes. It is no longer needed.

### Changes proposed in this pull request

- Drop `temp_type` field from `ParticipantDeclaration`

### Guidance to review

This is the last step in the work to migrate to declaration subtypes.