### PR TITLE
Add migration to populate type from temp_type

### DIFF
--- a/app/models/participant_declaration/ecf.rb
+++ b/app/models/participant_declaration/ecf.rb
@@ -7,6 +7,8 @@ class ParticipantDeclaration::ECF < ParticipantDeclaration
 
   validate :validate_against_profile_type
 
+  before_save :populate_type
+
   def ecf?
     true
   end
@@ -25,8 +27,7 @@ class ParticipantDeclaration::ECF < ParticipantDeclaration
     errors.add(:type, I18n.t(:declaration_type_must_match_profile_type))
   end
 
-  def temp_type=(value)
-    super
-    self.type = value
+  def populate_type
+    self.type = temp_type
   end
 end

--- a/app/models/participant_declaration/ecf.rb
+++ b/app/models/participant_declaration/ecf.rb
@@ -24,4 +24,9 @@ class ParticipantDeclaration::ECF < ParticipantDeclaration
 
     errors.add(:type, I18n.t(:declaration_type_must_match_profile_type))
   end
+
+  def temp_type=(value)
+    super
+    self.type = value
+  end
 end

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -204,7 +204,8 @@ private
   end
 
   def update_declaration_types!
-    participant_declarations.update_all(temp_type: type.sub("ParticipantProfile", "ParticipantDeclaration"))
+    declaration_type = type.sub("ParticipantProfile", "ParticipantDeclaration")
+    participant_declarations.update_all(type: declaration_type, temp_type: declaration_type)
   end
 end
 

--- a/db/migrate/20250110134507_populate_type_from_temp_type_on_participant_declarations.rb
+++ b/db/migrate/20250110134507_populate_type_from_temp_type_on_participant_declarations.rb
@@ -10,6 +10,6 @@ class PopulateTypeFromTempTypeOnParticipantDeclarations < ActiveRecord::Migratio
   end
 
   def down
-    ParticipantDeclaration::ECF.in_batches(of: 1_000) { |batch| batch.update_all(temp_type: "ParticipantDeclaration::ECF") }
+    ParticipantDeclaration::ECF.in_batches(of: 1_000) { |batch| batch.update_all(type: "ParticipantDeclaration::ECF") }
   end
 end

--- a/db/migrate/20250110134507_populate_type_from_temp_type_on_participant_declarations.rb
+++ b/db/migrate/20250110134507_populate_type_from_temp_type_on_participant_declarations.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class PopulateTypeFromTempTypeOnParticipantDeclarations < ActiveRecord::Migration[7.1]
+  def up
+    raise "Migration aborted: `temp_type` contains NULL values." if ParticipantDeclaration::ECF.where(temp_type: nil).exists?
+
+    ParticipantDeclaration::ECF.find_in_batches(batch_size: 1_000) do |batch|
+      ParticipantDeclaration.where(id: batch.map(&:id)).update_all("type = temp_type")
+    end
+  end
+
+  def down
+    ParticipantDeclaration::ECF.in_batches(of: 1_000) { |batch| batch.update_all(temp_type: "ParticipantDeclaration::ECF") }
+  end
+end

--- a/spec/models/participant_declaration/ecf_spec.rb
+++ b/spec/models/participant_declaration/ecf_spec.rb
@@ -3,6 +3,13 @@
 require "rails_helper"
 
 RSpec.describe ParticipantDeclaration::ECF, mid_cohort: true do
+  it "sets the type from temp_type" do
+    declaration = build(:mentor_participant_declaration)
+    expect(declaration.type).to eq(declaration.temp_type)
+    declaration.temp_type = "ParticipantDeclaration::ECF"
+    expect(declaration.type).to eq(declaration.temp_type)
+  end
+
   describe "type validation against participant_profile" do
     it "raises an error when the declaration type is ECT and the profile type is Mentor" do
       declaration = create(:mentor_participant_declaration)

--- a/spec/models/participant_declaration/ecf_spec.rb
+++ b/spec/models/participant_declaration/ecf_spec.rb
@@ -4,9 +4,7 @@ require "rails_helper"
 
 RSpec.describe ParticipantDeclaration::ECF, mid_cohort: true do
   it "sets the type from temp_type" do
-    declaration = build(:mentor_participant_declaration)
-    expect(declaration.type).to eq(declaration.temp_type)
-    declaration.temp_type = "ParticipantDeclaration::ECF"
+    declaration = create(:mentor_participant_declaration)
     expect(declaration.type).to eq(declaration.temp_type)
   end
 

--- a/spec/models/participant_profile/ecf_spec.rb
+++ b/spec/models/participant_profile/ecf_spec.rb
@@ -408,28 +408,34 @@ RSpec.describe ParticipantProfile::ECF, type: :model do
   end
 
   describe "changing the profile type" do
-    it "updates the declarations to the correct temp_type when changing from ECT to mentor" do
+    it "updates the declarations to the correct type/temp_type when changing from ECT to mentor" do
       declaration = travel_to(1.day.ago) { create(:ect_participant_declaration) }
       profile = declaration.participant_profile
 
       profile.update!(type: "ParticipantProfile::Mentor")
 
       expect(ParticipantProfile.find(profile.id)).to be_an_instance_of(ParticipantProfile::Mentor)
-      expect(ParticipantDeclaration::ECF.find(declaration.id).temp_type).to eq("ParticipantDeclaration::Mentor")
-      expect(ParticipantDeclaration::ECF.find(declaration.id)).to be_an_instance_of(ParticipantDeclaration::Mentor)
-      expect(ParticipantDeclaration.find(declaration.id).updated_at).to be_within(1.minute).of(1.day.ago)
+
+      updated_declaration = ParticipantDeclaration::ECF.find(declaration.id)
+      expect(updated_declaration.temp_type).to eq("ParticipantDeclaration::Mentor")
+      expect(updated_declaration.type).to eq("ParticipantDeclaration::Mentor")
+      expect(updated_declaration).to be_an_instance_of(ParticipantDeclaration::Mentor)
+      expect(updated_declaration.updated_at).to be_within(1.minute).of(1.day.ago)
     end
 
-    it "updates the declarations to the correct temp_type when changing from mentor to ECT" do
+    it "updates the declarations to the correct type/temp_type when changing from mentor to ECT" do
       declaration = travel_to(1.day.ago) { create(:mentor_participant_declaration) }
       profile = declaration.participant_profile
 
       profile.update!(type: "ParticipantProfile::ECT")
 
       expect(ParticipantProfile.find(profile.id)).to be_an_instance_of(ParticipantProfile::ECT)
-      expect(ParticipantDeclaration::ECF.find(declaration.id).temp_type).to eq("ParticipantDeclaration::ECT")
-      expect(ParticipantDeclaration::ECF.find(declaration.id)).to be_an_instance_of(ParticipantDeclaration::ECT)
-      expect(ParticipantDeclaration::ECF.find(declaration.id).updated_at).to be_within(1.minute).of(1.day.ago)
+
+      updated_declaration = ParticipantDeclaration::ECF.find(declaration.id)
+      expect(updated_declaration.temp_type).to eq("ParticipantDeclaration::ECT")
+      expect(updated_declaration.type).to eq("ParticipantDeclaration::ECT")
+      expect(updated_declaration).to be_an_instance_of(ParticipantDeclaration::ECT)
+      expect(updated_declaration.updated_at).to be_within(1.minute).of(1.day.ago)
     end
   end
 end

--- a/spec/services/record_declaration_spec.rb
+++ b/spec/services/record_declaration_spec.rb
@@ -270,6 +270,7 @@ RSpec.shared_examples "creates a participant declaration" do
 
     declaration = ParticipantDeclaration.last
     expect(declaration.temp_type).to eq(expected_type)
+    expect(declaration.type).to eq(expected_type)
   end
 
   it "stores the correct data" do


### PR DESCRIPTION
[Jira-3897](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-3897)

### Context

The original/complete PR is #5404.
Depends on #5429.

Now that we are using the `temp_type` field, we can backfill the `type` field and maintain it ahead of finally switching over.

### Changes proposed in this pull request

- Add migration to populate type from temp_type

Add a migration to populate the `type` field from the backfilled/populated `temp_type`, which will contain the `ECT` or `Mentor` declaration type.

- Populate type when declaration changes

To ensure `type` remains up to date while we are still referencing `temp_type` we need to update it `after_commit`.

### Guidance to review

Once this has shipped we can switch back to the `type` field and remove the `temp_type` field. #5430
