### PR TITLE
Revert ParticipantProfile::NPQ to avoid session restore errors

### DIFF
--- a/app/models/participant_profile/npq.rb
+++ b/app/models/participant_profile/npq.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class ParticipantProfile::NPQ < ParticipantProfile
+end


### PR DESCRIPTION
### Context

- Session restore errors:
- https://dfe-teacher-services.sentry.io/issues/6220712622/?alert_rule_id=7310304&alert_type=issue&environment=production&notification_uuid=c37d10d9-b6f2-47cf-a1ce-9715b8b0922b&project=5748989&referrer=slack
- https://dfe-teacher-services.sentry.io/issues/6220727360/?alert_rule_id=14507789&alert_type=issue&environment=production&notification_uuid=63ac6e10-d39a-48fe-8f78-6008de1ad4b8&project=5748989&referrer=slack
### Changes proposed in this pull request

* To avoid these errors, reverting `ParticipantProfile::NPQ`

### Guidance to review

