### PR TITLE
Add workflow for refreshing the Knapsack manifest

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+knapsack_rspec_report.json @DFE-Digital/lead-provider-cpd

--- a/.github/workflows/refresh_knapsack_manifest.yml
+++ b/.github/workflows/refresh_knapsack_manifest.yml
@@ -1,0 +1,57 @@
+name: "Refresh Knapsack manifest"
+
+on:
+  schedule:
+    - cron: '0 8 * * 1' # Monday at 8am
+  workflow_dispatch: 
+
+jobs:
+  refresh_manifest:
+    name: Refresh Knapsack manifest
+    runs-on: ubuntu-20.04
+
+    env:
+      RAILS_ENV: test
+      DB_USERNAME: postgres
+      DB_PASSWORD: ""
+      DB_HOSTNAME: 127.0.0.1
+      DB_PORT: 5432
+
+    services:
+      postgres:
+        image: postgres:11.6-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: ""
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - uses: ./.github/actions/prepare-app-env
+        id: test
+        with:
+          prepare-test-database: "true"
+          prepare-assets: "true"
+
+      - name: Run tests
+        run: KNAPSACK_GENERATE_REPORT=true bundle exec rake knapsack:rspec
+
+      - name: Create pull request 
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: refresh-knapsack-manifest
+          delete-branch: true
+          add-paths: knapsack_rspec_report.json
+          base: main
+          commit-message: |
+            Refresh Knapsack manifest
+
+            We run the Knapsack manifest generation in CI on a schedule; once complete
+            it raises this commit in a PR so that we can keep our test suite optimal.
+          title: Refresh Knapsack manifest
+          body: |
+            We run the Knapsack manifest generation in CI on a schedule; once complete it raises this commit in a PR so that we can keep our test suite optimal.


### PR DESCRIPTION
[Jira-3946](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-3946)

### Context

As we add/remove tests the manifest becomes gradually outdated and as a result Knapsack can't distribute the test suite across workers as efficiently.

We want to add a workflow to recompute the Knapsack manifest and raise a pull request with the changes. This can be triggered manually and will also run on a weekly schedule.

### Changes proposed in this pull request

- Add workflow for refreshing the Knapsack manifest

The action to create a pull request also supports assigning a team, but in order to do this you need to generate a personal access token. To avoid coupling the action to a user account I haven't done this, but if we have access to a generic 'dfe user' we could do this in the future.

### Guidance to review

Example pull request: https://github.com/DFE-Digital/early-careers-framework/pull/5444

If an existing PR is already open from the previous week it will update it rather than creating another PR.

Action details for raising a PR: https://github.com/marketplace/actions/create-pull-request

Example CI run: https://github.com/DFE-Digital/early-careers-framework/actions/runs/12792397881/job/35662752136
