### PR TITLE
Switch inheritance column back to `type`

### DIFF
--- a/app/models/participant_declaration/ecf.rb
+++ b/app/models/participant_declaration/ecf.rb
@@ -5,7 +5,7 @@ class ParticipantDeclaration::ECF < ParticipantDeclaration
 
   validate :validate_against_profile_type
 
-  before_save :populate_type
+  before_save :populate_temp_type
 
   def ecf?
     true
@@ -25,7 +25,7 @@ class ParticipantDeclaration::ECF < ParticipantDeclaration
     errors.add(:type, I18n.t(:declaration_type_must_match_profile_type))
   end
 
-  def populate_type
-    self.type = temp_type
+  def populate_temp_type
+    self.temp_type = type
   end
 end

--- a/app/models/participant_declaration/ecf.rb
+++ b/app/models/participant_declaration/ecf.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class ParticipantDeclaration::ECF < ParticipantDeclaration
-  self.inheritance_column = :temp_type
-
   has_many :statements, class_name: "Finance::Statement::ECF", through: :statement_line_items
 
   validate :validate_against_profile_type
@@ -22,7 +20,7 @@ class ParticipantDeclaration::ECF < ParticipantDeclaration
 
   def validate_against_profile_type
     return unless participant_profile
-    return if participant_profile.type.demodulize == temp_type.demodulize
+    return if participant_profile.type.demodulize == type.demodulize
 
     errors.add(:type, I18n.t(:declaration_type_must_match_profile_type))
   end

--- a/app/serializers/archive/participant_declaration_serializer.rb
+++ b/app/serializers/archive/participant_declaration_serializer.rb
@@ -5,7 +5,8 @@ module Archive
     include JSONAPI::Serializer
 
     set_id :id
-    attribute :type, &:temp_type
+
+    attribute :type
     attribute :participant_profile_id
     attribute :cpd_lead_provider_id
     attribute :declaration_type

--- a/app/serializers/finance/ecf/duplicate_serializer.rb
+++ b/app/serializers/finance/ecf/duplicate_serializer.rb
@@ -85,7 +85,7 @@ module Finance
             declaration_date: participant_declaration.declaration_date&.rfc3339,
             course_identifier: participant_declaration.course_identifier,
             evidence_held: participant_declaration.evidence_held,
-            type: participant_declaration.temp_type,
+            type: participant_declaration.type,
             cpd_lead_provider: participant_declaration.cpd_lead_provider&.name,
             state: participant_declaration.state,
             superseded_by_id: participant_declaration.superseded_by_id,

--- a/app/services/api/v3/participant_declarations_query.rb
+++ b/app/services/api/v3/participant_declarations_query.rb
@@ -16,7 +16,7 @@ module Api
       end
 
       def participant_declarations_for_pagination
-        filterable_attributes = %i[id created_at user_id updated_at delivery_partner_id temp_type]
+        filterable_attributes = %i[id created_at user_id updated_at delivery_partner_id type]
         scope = ParticipantDeclaration::ECF.union(
           declarations_scope.select(*filterable_attributes),
           ecf_previous_declarations_scope.select(*filterable_attributes),

--- a/app/services/finance/ecf/assurance_report/query.rb
+++ b/app/services/finance/ecf/assurance_report/query.rb
@@ -48,7 +48,7 @@ module Finance
               pd.created_at                                                    AS declaration_created_at,
               s.name                                                           AS statement_name,
               s.id                                                             AS statement_id,
-              pd.temp_type                                                     AS temp_type
+              pd.type                                                          AS type
             FROM participant_declarations pd
             JOIN statement_line_items sli  ON sli.participant_declaration_id = pd.id
             JOIN statements s              ON s.id = sli.statement_id
@@ -81,7 +81,7 @@ module Finance
             JOIN schools sc ON sc.id = latest_induction_record.school_id
             LEFT OUTER JOIN ecf_participant_eligibilities epe ON epe.participant_profile_id = pp.id
             JOIN delivery_partners dp ON dp.id = COALESCE(pd.delivery_partner_id, latest_induction_record.delivery_partner_id)
-            WHERE pd.temp_type IN ('ParticipantDeclaration::ECT', 'ParticipantDeclaration::Mentor') AND #{where_values}
+            WHERE pd.type IN ('ParticipantDeclaration::ECT', 'ParticipantDeclaration::Mentor') AND #{where_values}
             ORDER BY u.full_name ASC
           EOSQL
         end

--- a/app/views/admin/participants/_declarations_history.erb
+++ b/app/views/admin/participants/_declarations_history.erb
@@ -27,7 +27,7 @@
 
       sl.with_row do |row|
         row.with_key(text: "Type")
-        row.with_value(text: participant_declaration.temp_type)
+        row.with_value(text: participant_declaration.type)
       end
 
       sl.with_row do |row|

--- a/app/views/admin/participants/declaration_history/show.html.erb
+++ b/app/views/admin/participants/declaration_history/show.html.erb
@@ -41,7 +41,7 @@
 
         sl.with_row do |row|
           row.with_key(text: "Type")
-          row.with_value(text: participant_declaration.temp_type)
+          row.with_value(text: participant_declaration.type)
         end
 
         sl.with_row do |row|

--- a/spec/models/participant_declaration/ecf_spec.rb
+++ b/spec/models/participant_declaration/ecf_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ParticipantDeclaration::ECF, mid_cohort: true do
     it "raises an error when the declaration type is ECT and the profile type is Mentor" do
       declaration = create(:mentor_participant_declaration)
 
-      declaration.temp_type = "ParticipantDeclaration::ECT"
+      declaration.type = "ParticipantDeclaration::ECT"
 
       expect(declaration).to be_invalid
       expect(declaration.errors[:type]).to include(I18n.t(:declaration_type_must_match_profile_type))
@@ -21,7 +21,7 @@ RSpec.describe ParticipantDeclaration::ECF, mid_cohort: true do
     it "raises an error when the declaration type is Mentor and the profile type is ECT" do
       declaration = create(:ect_participant_declaration)
 
-      declaration.temp_type = "ParticipantDeclaration::Mentor"
+      declaration.type = "ParticipantDeclaration::Mentor"
 
       expect(declaration).to be_invalid
       expect(declaration.errors[:type]).to include(I18n.t(:declaration_type_must_match_profile_type))

--- a/spec/models/participant_declaration/ecf_spec.rb
+++ b/spec/models/participant_declaration/ecf_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe ParticipantDeclaration::ECF, mid_cohort: true do
-  it "sets the type from temp_type" do
+  it "sets the temp_type from type" do
     declaration = create(:mentor_participant_declaration)
-    expect(declaration.type).to eq(declaration.temp_type)
+    expect(declaration.temp_type).to eq(declaration.type)
   end
 
   describe "type validation against participant_profile" do

--- a/spec/serializers/archive/participant_declaration_serializer_spec.rb
+++ b/spec/serializers/archive/participant_declaration_serializer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Archive::ParticipantDeclarationSerializer do
       expect(data[:type]).to eq :participant_declaration
 
       attrs = data[:attributes]
-      expect(attrs[:type]).to eq declaration.temp_type
+      expect(attrs[:type]).to eq declaration.type
       expect(attrs[:participant_profile_id]).to eq declaration.participant_profile_id
       expect(attrs[:cpd_lead_provider_id]).to eq declaration.cpd_lead_provider_id
       expect(attrs[:declaration_type]).to eq declaration.declaration_type

--- a/spec/services/finance/ecf/assurance_report/query_spec.rb
+++ b/spec/services/finance/ecf/assurance_report/query_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Finance::ECF::AssuranceReport::Query, mid_cohort: true do
       let!(:mentor_declaration) { travel_to(statement.deadline_date) { create(:mentor_participant_declaration, participant_profile: mentor_participant_profile, cpd_lead_provider:, delivery_partner:) } }
 
       it { is_expected.to contain_exactly(participant_declaration, mentor_declaration) }
-      it { expect(subject.map(&:temp_type)).to contain_exactly(/ECT/, /Mentor/) }
+      it { expect(subject.map(&:type)).to contain_exactly(/ECT/, /Mentor/) }
     end
   end
 

--- a/spec/services/record_declaration_spec.rb
+++ b/spec/services/record_declaration_spec.rb
@@ -269,7 +269,6 @@ RSpec.shared_examples "creates a participant declaration" do
     expected_type = participant_profile.mentor? ? "ParticipantDeclaration::Mentor" : "ParticipantDeclaration::ECT"
 
     declaration = ParticipantDeclaration.last
-    expect(declaration.temp_type).to eq(expected_type)
     expect(declaration.type).to eq(expected_type)
   end
 


### PR DESCRIPTION
[Jira-3897](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-3897)

### Context

Now that the `type` field is backfilled and up to date, we can switch back to it and away from `temp_type`, which will be removed in a follow up PR.

### Changes proposed in this pull request

- Revert "Switch inheritance column to temp_type for ECF declarations"

This reverts commit https://github.com/DFE-Digital/early-careers-framework/commit/3aa79f25f00998710b22b767165ac53d3f7c3ecb.

- Populate temp_type from type

In case we need to revert, we can keep `temp_type` up to date in the same way we kept `type` up to date.