### PR TITLE
Fix Email scheduler on the admin section.

### DIFF
--- a/app/queries/schools/that_have_not_added_participants_query.rb
+++ b/app/queries/schools/that_have_not_added_participants_query.rb
@@ -29,7 +29,11 @@ module Schools
       SchoolCohort
         .where(cohort:)
         .where(induction_programme_choice: %w[full_induction_programme core_induction_programme])
-        .where.not(id: InductionProgramme.joins(:induction_records, :school_cohort).where(school_cohort: { cohort: }).select(:school_cohort_id))
+        .where.not(id: InductionProgramme
+                         .joins(:induction_records, :school_cohort)
+                         .where(school_cohort: { cohort: })
+                         .select(:school_cohort_id)
+                         .distinct)
     end
   end
 end


### PR DESCRIPTION


### Context

The Email scheduler tool was raising on the `Register ECTs and mentors` entry after a few seconds waiting for a response. 

- [Ticket](https://dfedigital.atlassian.net/browse/CST-2841): 

### Changes proposed in this pull request
 Optimise a query that was trying to retrieve too many records and eventually cancelled by PostgreSQL

### Guidance to review

