### PR TITLE
Fix 500 error on change schedule endpoint

### DIFF
--- a/app/services/change_schedule.rb
+++ b/app/services/change_schedule.rb
@@ -127,7 +127,7 @@ private
   end
 
   def current_cohort
-    relevant_induction_record.schedule.cohort
+    relevant_induction_record&.schedule&.cohort
   end
 
   def update_induction_records!


### PR DESCRIPTION
[Jira-3953](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3953)

### Context

We have noticed lead providers getting a 500 error on the `change-schedule` endpoint when they attempt to change the schedule of a participant not associated with them via their induction records (so `relevant_induction_record` is `nil`).

We want to capture this exception and raise a helpful error message instead.

### Changes proposed in this pull request

- Fix 500 error on change schedule endpoint

On a normal change schedule operation one or more validators will catch this and return an error to the lead provider. If they are changing schedule due to payments being frozen, however, and the participant has no billable declarations, then the error occurs when the code attemps to determine the `current_cohort` of the participant (as it does this via `relevant_induction_record`).

To bring the behaviour for changing cohort due to payments frozen inline with the normal change schedule operation we can instead fail silently on `current_cohort`, returning `nil` if there is no `relevant_induction_record` and thereby let one of the follow up validations catch and raise a bad request error.

Add test case to cover this scenario explicitly.

### Guidance to review

The ticket suggests raising this as a 404, however on investigating further we already handle this with a validation error for non-payments frozen cohort changes. I opted to keep it consistent, but open to discuss the approach.

I also looked into adding a validation rule to catch this use case more specifically, but that has knock-on effects and would supercede some existing errors we return, so I chose to try and keep it consistent instead and only handle the particular use case that returns a 500.