### PR TITLE
Ensure CI workflow fails when psql restore encounters an error

### DIFF
--- a/.github/actions/backup-and-restore-snapshot-database/action.yml
+++ b/.github/actions/backup-and-restore-snapshot-database/action.yml
@@ -62,4 +62,4 @@ runs:
 
     - name: Restore snapshot database
       shell: bash
-      run: bin/konduit.sh -d s189p01-cpdecf-pd-pg-snapshot -k s189p01-cpdecf-pd-app-kv -i backup-${{ inputs.environment }}.sql.gz -c -t 7200 cpd-ecf-${{ inputs.environment }}-web -- psql
+      run: bin/konduit.sh -d s189p01-cpdecf-pd-pg-snapshot -k s189p01-cpdecf-pd-app-kv -i backup-${{ inputs.environment }}.sql.gz -c -t 7200 cpd-ecf-${{ inputs.environment }}-web -- psql -v ON_ERROR_STOP=1


### PR DESCRIPTION
[Jira-3954](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-3954)

### Context

We have an issue with our snapsort restore workflow whereby if the psql operation errors it will continue and the workflow will succeed, even though it was not successful.

We want to fail the workflow if the restore has errors.
 
### Changes proposed in this pull request

- Ensure CI workflow fails when psql restore encounters an error

We can do this by passing the `ON_ERROR_STOP` flag.

### Guidance to review

I ran the restore a couple of times off this branch and it was successful, I haven't been able to trigger an error - its something I think we'll just need to keep an eye out for after its merged to ensure its behaving as expected.