### PR TITLE
Ignore `temp_type` column

### DIFF
--- a/app/models/participant_declaration.rb
+++ b/app/models/participant_declaration.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ParticipantDeclaration < ApplicationRecord
-  self.ignored_columns = %w[statement_type statement_id voided_at]
+  self.ignored_columns = %w[statement_type statement_id voided_at temp_type]
 
   ARCHIVABLE_STATES = %w[ineligible voided submitted].freeze
 


### PR DESCRIPTION
As this is being dropped, strong migrations cancels the migration unless we ignore it.
