### PR TITLE
Auto-generate swagger documentation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,10 @@ jobs:
     name: Lint
     uses: ./.github/workflows/lint.yml
 
+  openapi:
+    name: Lead Provider OpenAPI Check
+    uses: ./.github/workflows/lead_provider_openapi_check.yml
+
   rspec:
     name: Run the RSpec tests
     uses: ./.github/workflows/rspec.yml

--- a/.github/workflows/lead_provider_openapi_check.yml
+++ b/.github/workflows/lead_provider_openapi_check.yml
@@ -1,0 +1,65 @@
+name: "Lead Provider OpenAPI Check"
+
+on:
+  workflow_call:
+
+jobs:
+  api_schema_check:
+    name: Check OpenAPI schema
+
+    runs-on: ubuntu-latest
+
+    env:
+      RAILS_ENV: test
+      DB_USERNAME: postgres
+      DB_PASSWORD: ""
+      DB_HOSTNAME: 127.0.0.1
+      DB_PORT: 5432
+      ANALYTICS_DB_USERNAME: postgres
+      ANALYTICS_DB_PASSWORD: ""
+      ANALYTICS_DB_HOSTNAME: 127.0.0.1
+      ANALYTICS_DB_PORT: 5432
+
+    services:
+      postgres:
+        image: postgres:11.6-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: ""
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - uses: ./.github/actions/prepare-app-env
+        id: test
+        with:
+          prepare-test-database: "true"
+          prepare-assets: "true"
+
+      - name: Generate API doc checksums (original)
+        run: |
+          find swagger/**/api_spec.json -type f -exec sed -i 's/[[:space:]]\+$//' {} \;
+          find swagger/**/api_spec.json -type f | sort | xargs shasum -a 256 > api-doc-checksums-original.txt
+          cat api-doc-checksums-original.txt
+
+      - name: Run swaggerize
+        run: bundle exec rake rswag:specs:swaggerize
+
+      - name: Generate API doc checksums (after swaggerize)
+        run: |
+          find swagger/**/api_spec.json -type f -exec sed -i 's/[[:space:]]\+$//' {} \;
+          find swagger/**/api_spec.json -type f | sort | xargs shasum -a 256 > api-doc-checksums-after-swaggerize.txt
+          cat api-doc-checksums-after-swaggerize.txt
+
+      - name: Compare Checksums
+        run: |
+          if ! diff -q api-doc-checksums-original.txt api-doc-checksums-after-swaggerize.txt; then
+            echo "OpenAPI schema has changed! run rake rswag:specs:swaggerize"
+            exit 1
+          else
+            echo "OpenAPI schema has not changed"
+          fi

--- a/docs/lib/govuk_tech_docs/open_api/renderer.rb
+++ b/docs/lib/govuk_tech_docs/open_api/renderer.rb
@@ -177,9 +177,29 @@ module GovukTechDocs
     private
 
       def document_paths
-        @document.paths.to_h.reject do |path, _|
+        sorted_paths(@document.paths.to_h).reject do |path, _|
           remove_npq_references? && path.downcase.include?("npq")
         end
+      end
+
+      def sorted_paths(paths)
+        sort_order = %w[
+          delivery-partners
+          partnerships
+          schools
+          participant-declarations
+          participants
+          unfunded-mentors
+          statements
+        ].freeze
+
+        paths.sort_by { |path, _|
+          path_group = path.split("/")[3]&.chomp(".csv")
+
+          raise "Unknown path group: #{path_group}" unless path_group.in?(sort_order)
+
+          [sort_order.index(path_group), path.length]
+        }.to_h
       end
 
       def remove_npq_references?

--- a/docs/spec/govuk_tech_docs/open_api/renderer_spec.rb
+++ b/docs/spec/govuk_tech_docs/open_api/renderer_spec.rb
@@ -240,5 +240,71 @@ RSpec.describe GovukTechDocs::OpenApi::Renderer do
         end
       end
     end
+
+    describe "ordering sidebar links" do
+      let(:spec) do
+        {
+          openapi: "3.0.0",
+          info: {
+            title: "title",
+            version: "0.0.1",
+          },
+          paths: {
+            "/api/v3/schools": { get: { responses: {} } },
+            "/api/v3/partnerships": { get: { responses: {} } },
+            "/api/v3/participants": { get: { responses: {} } },
+            "/api/v3/statements": { get: { responses: {} } },
+            "/api/v3/unfunded-mentors": { get: { responses: {} } },
+            "/api/v3/delivery-partners": { get: { responses: {} } },
+            "/api/v3/participant-declarations/{id}": { get: { responses: {} } },
+            "/api/v3/participant-declarations": { get: { responses: {} } },
+          },
+        }
+      end
+
+      subject(:rendered) do
+        spec["servers"] = [
+          { url: "https://example.com" },
+        ]
+        document = Openapi3Parser.load(spec)
+
+        render = described_class.new(nil, document)
+        Capybara::Node::Simple.new(render.api_full)
+      end
+
+      it "renders a sorted list of paths, by group and then length" do
+        expected_order = [
+          "/api/v3/delivery-partners",
+          "/api/v3/partnerships",
+          "/api/v3/schools",
+          "/api/v3/participant-declarations",
+          "/api/v3/participant-declarations/{id}",
+          "/api/v3/participants",
+          "/api/v3/unfunded-mentors",
+          "/api/v3/statements",
+        ]
+
+        rendered_paths = rendered.all(".govuk-heading-l").map(&:text).map(&:strip)
+
+        expect(rendered_paths).to eq(expected_order)
+      end
+
+      context "when the sort order is not known for a path" do
+        let(:spec) do
+          {
+            openapi: "3.0.0",
+            info: {
+              title: "title",
+              version: "0.0.1",
+            },
+            paths: {
+              "/api/v1/unknown": { get: { responses: {} } },
+            },
+          }
+        end
+
+        it { expect { rendered }.to raise_error("Unknown path group: unknown") }
+      end
+    end
   end
 end

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -33,14 +33,10 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
-        "parameters": [
-
-        ],
+        "parameters": [],
         "responses": {
           "200": {
             "description": "Successful",
@@ -101,9 +97,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "parameters": [
@@ -165,9 +159,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "responses": {
@@ -203,9 +195,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "parameters": [
@@ -263,9 +253,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "parameters": [
@@ -303,9 +291,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "parameters": [
@@ -367,9 +353,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "parameters": [
@@ -419,9 +403,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "parameters": [
@@ -469,9 +451,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "parameters": [
@@ -519,9 +499,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "parameters": [
@@ -569,9 +547,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "parameters": [
@@ -619,9 +595,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "parameters": [
@@ -669,9 +643,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "parameters": [
@@ -719,9 +691,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "parameters": [
@@ -769,9 +739,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "parameters": [
@@ -819,9 +787,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "parameters": [
@@ -2925,9 +2891,7 @@
   },
   "security": [
     {
-      "bearerAuth": [
-
-      ]
+      "bearerAuth": []
     }
   ]
 }

--- a/swagger/v2/api_spec.json
+++ b/swagger/v2/api_spec.json
@@ -33,14 +33,10 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
-        "parameters": [
-
-        ],
+        "parameters": [],
         "responses": {
           "200": {
             "description": "Successful",
@@ -101,9 +97,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "parameters": [
@@ -165,9 +159,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "responses": {
@@ -203,9 +195,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "parameters": [
@@ -263,9 +253,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "parameters": [
@@ -303,9 +291,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "parameters": [
@@ -367,9 +353,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "parameters": [
@@ -419,9 +403,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "parameters": [
@@ -469,9 +451,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "parameters": [
@@ -519,9 +499,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "parameters": [
@@ -569,9 +547,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "parameters": [
@@ -619,9 +595,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "parameters": [
@@ -2652,9 +2626,7 @@
   },
   "security": [
     {
-      "bearerAuth": [
-
-      ]
+      "bearerAuth": []
     }
   ]
 }

--- a/swagger/v3/api_spec.json
+++ b/swagger/v3/api_spec.json
@@ -33,9 +33,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "parameters": [
@@ -109,9 +107,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "parameters": [
@@ -161,6 +157,587 @@
         }
       }
     },
+    "/api/v3/participants/ecf/transfers": {
+      "get": {
+        "summary": "<b>Note, this endpoint is new.</b><br/>Retrieve multiple ECF participant transfers",
+        "operationId": "participants",
+        "tags": [
+          "participant transfers"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "filter",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/ListFilter"
+            },
+            "style": "deepObject",
+            "explode": true,
+            "required": false,
+            "description": "Refine participant transfers to return.",
+            "example": "filter[updated_since]=2020-11-13T11:21:55Z"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/Pagination"
+            },
+            "style": "deepObject",
+            "explode": true,
+            "required": false,
+            "example": "page[page]=1&page[per_page]=5",
+            "description": "Pagination options to navigate through the list of participant transfers."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of ECF participant transfers",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "success": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+                          "type": "participant-transfer",
+                          "attributes": {
+                            "updated_at": "2021-05-31T02:22:32.000Z",
+                            "transfers": {
+                              "training_record_id": "000a97ff-d2a9-4779-a397-9bfd9063072e",
+                              "transfer_type": "new_provider",
+                              "status": "complete",
+                              "leaving": {
+                                "school_urn": "123456",
+                                "provider": "Old Institute",
+                                "date": "2021-05-31"
+                              },
+                              "joining": {
+                                "school_urn": "654321",
+                                "provider": "New Institute",
+                                "date": "2021-06-01"
+                              },
+                              "created_at": "2021-05-31T02:22:32.000Z"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/MultipleECFParticipantTransferResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorisedResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/participants/ecf/{id}/transfers": {
+      "get": {
+        "summary": "<b>Note, this endpoint is new.</b><br/>Get a single participant's transfers",
+        "operationId": "participant_transfers",
+        "tags": [
+          "participant transfers"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "example": "28c461ee-ffc0-4e56-96bd-788579a0ed75",
+            "description": "The ID of the ECF participant.",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A single participant's transfers",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ECFParticipantTransferResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorisedResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/participants/ecf": {
+      "get": {
+        "summary": "<b>Note, this endpoint includes updated specifications.</b><br/>Retrieve multiple participants, replaces <code>/api/v3/participants</code>",
+        "operationId": "participants",
+        "tags": [
+          "ECF participants"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "filter",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/ECFParticipantFilter"
+            },
+            "style": "deepObject",
+            "explode": true,
+            "required": false,
+            "description": "Refine ECF participants to return.",
+            "example": "filter[cohort]=2022&filter[from_participant_id]=439ac4fe-a003-417f-9694-07c45b3482f8&filter[training_status]=active&filter[updated_since]=2020-11-13T11:21:55Z"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/Pagination"
+            },
+            "style": "deepObject",
+            "explode": true,
+            "required": false,
+            "example": "page[page]=1&page[per_page]=5",
+            "description": "Pagination options to navigate through the list of ECF participants."
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/ECFParticipantsSort"
+            },
+            "style": "form",
+            "explode": false,
+            "required": false,
+            "description": "Sort ECF participants being returned.",
+            "example": "sort=-updated_at"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of ECF participants",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MultipleECFParticipantsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorisedResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/participants/ecf/{id}": {
+      "get": {
+        "summary": "<b>Note, this endpoint includes updated specifications.</b><br/>Get a single ECF participant",
+        "operationId": "ecf_participant",
+        "tags": [
+          "ECF participants"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "example": "28c461ee-ffc0-4e56-96bd-788579a0ed75",
+            "description": "The ID of the ECF participant.",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A single ECF participant",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ECFParticipantResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorisedResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/participants/ecf/{id}/defer": {
+      "put": {
+        "summary": "<b>Note, this endpoint includes updated specifications.</b><br/>Notify that an ECF participant is taking a break from their course",
+        "operationId": "ecf_participant_defer",
+        "tags": [
+          "ECF Participant"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "example": "28c461ee-ffc0-4e56-96bd-788579a0ed75",
+            "description": "The ID of the participant to defer",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The ECF participant being deferred",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "success": {
+                    "value": {
+                      "data": {
+                        "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+                        "type": "participant",
+                        "attributes": {
+                          "full_name": "Jane Smith",
+                          "teacher_reference_number": "1234567",
+                          "updated_at": "2021-05-31T02:22:32.000Z",
+                          "ecf_enrolments": [
+                            {
+                              "training_record_id": "000a97ff-d2a9-4779-a397-9bfd9063072e",
+                              "email": "jane.smith@some-school.example.com",
+                              "mentor_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+                              "school_urn": "106286",
+                              "participant_type": "ect",
+                              "cohort": "2021",
+                              "training_status": "withdrawn",
+                              "participant_status": "withdrawn",
+                              "teacher_reference_number_validated": true,
+                              "eligible_for_funding": true,
+                              "pupil_premium_uplift": true,
+                              "sparsity_uplift": true,
+                              "schedule_identifier": "ecf-standard-january",
+                              "delivery_partner_id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+                              "withdrawal": null,
+                              "deferral": {
+                                "reason": "other",
+                                "date": "2021-06-31T02:22:32.000Z"
+                              },
+                              "created_at": "2022-11-09T16:07:38Z",
+                              "induction_end_date": "2022-01-12",
+                              "mentor_funding_end_date": "2021-04-19",
+                              "cohort_changed_after_payments_frozen": true,
+                              "mentor_ineligible_for_funding_reason": null
+                            }
+                          ],
+                          "participant_id_changes": [
+                            {
+                              "from_participant_id": "23dd8d66-e11f-4139-9001-86b4f9abcb02",
+                              "to_participant_id": "db3a7848-7308-4879-942a-c4a70ced400a",
+                              "changed_at": "2023-09-23T02:22:32.000Z"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ECFParticipantResponse"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ECFParticipantDeferRequest"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/api/v3/participants/ecf/{id}/resume": {
+      "put": {
+        "summary": "<b>Note, this endpoint includes updated specifications.</b><br/>Notify that an ECF participant is resuming their course",
+        "operationId": "ecf_participant_resume",
+        "tags": [
+          "ECF Participant"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "example": "28c461ee-ffc0-4e56-96bd-788579a0ed75",
+            "description": "The ID of the participant to resume",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The ECF participant being resumed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ECFParticipantResponse"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ECFParticipantResumeRequest"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/api/v3/participants/ecf/{id}/withdraw": {
+      "put": {
+        "summary": "<b>Note, this endpoint includes updated specifications.</b><br/>Notify that an ECF participant has withdrawn from their course",
+        "operationId": "participant",
+        "tags": [
+          "ECF Participant"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "example": "28c461ee-ffc0-4e56-96bd-788579a0ed75",
+            "description": "The ID of the participant to withdraw",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The ECF participant being withdrawn",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "success": {
+                    "value": {
+                      "data": {
+                        "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+                        "type": "participant",
+                        "attributes": {
+                          "full_name": "Jane Smith",
+                          "teacher_reference_number": "1234567",
+                          "updated_at": "2021-05-31T02:22:32.000Z",
+                          "ecf_enrolments": [
+                            {
+                              "training_record_id": "000a97ff-d2a9-4779-a397-9bfd9063072e",
+                              "email": "jane.smith@some-school.example.com",
+                              "mentor_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+                              "school_urn": "106286",
+                              "participant_type": "ect",
+                              "cohort": "2021",
+                              "training_status": "withdrawn",
+                              "participant_status": "withdrawn",
+                              "teacher_reference_number_validated": true,
+                              "eligible_for_funding": true,
+                              "pupil_premium_uplift": true,
+                              "sparsity_uplift": true,
+                              "schedule_identifier": "ecf-standard-january",
+                              "delivery_partner_id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+                              "withdrawal": {
+                                "reason": "other",
+                                "date": "2021-06-31T02:22:32.000Z"
+                              },
+                              "deferral": null,
+                              "created_at": "2022-11-09T16:07:38Z",
+                              "induction_end_date": "2022-01-12",
+                              "mentor_funding_end_date": "2021-04-19",
+                              "cohort_changed_after_payments_frozen": false,
+                              "mentor_ineligible_for_funding_reason": null
+                            }
+                          ],
+                          "participant_id_changes": [
+                            {
+                              "from_participant_id": "23dd8d66-e11f-4139-9001-86b4f9abcb02",
+                              "to_participant_id": "db3a7848-7308-4879-942a-c4a70ced400a",
+                              "changed_at": "2023-09-23T02:22:32.000Z"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ECFParticipantResponse"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ECFParticipantWithdrawRequest"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/api/v3/participants/ecf/{id}/change-schedule": {
+      "put": {
+        "summary": "<b>Note, this endpoint includes updated specifications.</b><br/>Notify that an ECF Participant is changing training schedule",
+        "operationId": "ecf_participant_change_schedule",
+        "tags": [
+          "ECF Participant"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "example": "28c461ee-ffc0-4e56-96bd-788579a0ed75",
+            "description": "The ID of the participant",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The ECF Participant changing schedule",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ECFParticipantResponse"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ECFParticipantChangeScheduleRequest"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
     "/api/v3/partnerships/ecf": {
       "get": {
         "summary": "<b>Note, this endpoint is new.</b><br/>Retrieve multiple ECF partnerships",
@@ -170,9 +747,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "parameters": [
@@ -244,14 +819,10 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
-        "parameters": [
-
-        ],
+        "parameters": [],
         "responses": {
           "200": {
             "description": "Create an ECF partnership",
@@ -329,9 +900,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "parameters": [
@@ -388,9 +957,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "parameters": [
@@ -493,9 +1060,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "parameters": [
@@ -593,9 +1158,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "parameters": [
@@ -657,6 +1220,139 @@
         }
       }
     },
+    "/api/v3/unfunded-mentors/ecf": {
+      "get": {
+        "summary": "<b>Note, this endpoint is new.</b><br/>Retrieve multiple unfunded mentors",
+        "operationId": "participants",
+        "tags": [
+          "unfunded mentors"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "filter",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/ListFilter"
+            },
+            "style": "deepObject",
+            "explode": true,
+            "required": false,
+            "description": "Refine unfunded mentors to return.",
+            "example": "filter[updated_since]=2020-11-13T11:21:55Z"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/Pagination"
+            },
+            "style": "deepObject",
+            "explode": true,
+            "required": false,
+            "example": "page[page]=1&page[per_page]=5",
+            "description": "Pagination options to navigate through the list of unfunded mentors."
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/ECFUnfundedMentorsSort"
+            },
+            "style": "form",
+            "explode": false,
+            "required": false,
+            "description": "Sort unfunded mentors being returned.",
+            "example": "sort=-updated_at"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of unfunded mentors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MultipleUnfundedMentorsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorisedResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/unfunded-mentors/ecf/{id}": {
+      "get": {
+        "summary": "<b>Note, this endpoint is new.</b><br/>Get a single unfunded mentor",
+        "operationId": "unfunded_mentors",
+        "tags": [
+          "unfunded mentors"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "example": "28c461ee-ffc0-4e56-96bd-788579a0ed75",
+            "description": "The ID of the unfunded mentor.",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A single unfunded mentor",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnfundedMentorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorisedResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v3/participant-declarations": {
       "get": {
         "summary": "<b>Note, this endpoint includes updated specifications.</b><br/>List all participant declarations",
@@ -666,9 +1362,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "parameters": [
@@ -758,14 +1452,10 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
-        "parameters": [
-
-        ],
+        "parameters": [],
         "responses": {
           "200": {
             "description": "Successful",
@@ -857,9 +1547,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "parameters": [
@@ -946,9 +1634,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "parameters": [
@@ -1006,740 +1692,6 @@
         }
       }
     },
-    "/api/v3/participants/ecf": {
-      "get": {
-        "summary": "<b>Note, this endpoint includes updated specifications.</b><br/>Retrieve multiple participants, replaces <code>/api/v3/participants</code>",
-        "operationId": "participants",
-        "tags": [
-          "ECF participants"
-        ],
-        "security": [
-          {
-            "bearerAuth": [
-
-            ]
-          }
-        ],
-        "parameters": [
-          {
-            "name": "filter",
-            "in": "query",
-            "schema": {
-              "$ref": "#/components/schemas/ECFParticipantFilter"
-            },
-            "style": "deepObject",
-            "explode": true,
-            "required": false,
-            "description": "Refine ECF participants to return.",
-            "example": "filter[cohort]=2022&filter[from_participant_id]=439ac4fe-a003-417f-9694-07c45b3482f8&filter[training_status]=active&filter[updated_since]=2020-11-13T11:21:55Z"
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "schema": {
-              "$ref": "#/components/schemas/Pagination"
-            },
-            "style": "deepObject",
-            "explode": true,
-            "required": false,
-            "example": "page[page]=1&page[per_page]=5",
-            "description": "Pagination options to navigate through the list of ECF participants."
-          },
-          {
-            "name": "sort",
-            "in": "query",
-            "schema": {
-              "$ref": "#/components/schemas/ECFParticipantsSort"
-            },
-            "style": "form",
-            "explode": false,
-            "required": false,
-            "description": "Sort ECF participants being returned.",
-            "example": "sort=-updated_at"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "A list of ECF participants",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MultipleECFParticipantsResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UnauthorisedResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v3/participants/ecf/{id}": {
-      "get": {
-        "summary": "<b>Note, this endpoint includes updated specifications.</b><br/>Get a single ECF participant",
-        "operationId": "ecf_participant",
-        "tags": [
-          "ECF participants"
-        ],
-        "security": [
-          {
-            "bearerAuth": [
-
-            ]
-          }
-        ],
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "example": "28c461ee-ffc0-4e56-96bd-788579a0ed75",
-            "description": "The ID of the ECF participant.",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "A single ECF participant",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ECFParticipantResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UnauthorisedResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFoundResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v3/participants/ecf/transfers": {
-      "get": {
-        "summary": "<b>Note, this endpoint is new.</b><br/>Retrieve multiple ECF participant transfers",
-        "operationId": "participants",
-        "tags": [
-          "participant transfers"
-        ],
-        "security": [
-          {
-            "bearerAuth": [
-
-            ]
-          }
-        ],
-        "parameters": [
-          {
-            "name": "filter",
-            "in": "query",
-            "schema": {
-              "$ref": "#/components/schemas/ListFilter"
-            },
-            "style": "deepObject",
-            "explode": true,
-            "required": false,
-            "description": "Refine participant transfers to return.",
-            "example": "filter[updated_since]=2020-11-13T11:21:55Z"
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "schema": {
-              "$ref": "#/components/schemas/Pagination"
-            },
-            "style": "deepObject",
-            "explode": true,
-            "required": false,
-            "example": "page[page]=1&page[per_page]=5",
-            "description": "Pagination options to navigate through the list of participant transfers."
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "A list of ECF participant transfers",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {
-                      "data": [
-                        {
-                          "id": "db3a7848-7308-4879-942a-c4a70ced400a",
-                          "type": "participant-transfer",
-                          "attributes": {
-                            "updated_at": "2021-05-31T02:22:32.000Z",
-                            "transfers": {
-                              "training_record_id": "000a97ff-d2a9-4779-a397-9bfd9063072e",
-                              "transfer_type": "new_provider",
-                              "status": "complete",
-                              "leaving": {
-                                "school_urn": "123456",
-                                "provider": "Old Institute",
-                                "date": "2021-05-31"
-                              },
-                              "joining": {
-                                "school_urn": "654321",
-                                "provider": "New Institute",
-                                "date": "2021-06-01"
-                              },
-                              "created_at": "2021-05-31T02:22:32.000Z"
-                            }
-                          }
-                        }
-                      ]
-                    }
-                  }
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/MultipleECFParticipantTransferResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UnauthorisedResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v3/participants/ecf/{id}/transfers": {
-      "get": {
-        "summary": "<b>Note, this endpoint is new.</b><br/>Get a single participant's transfers",
-        "operationId": "participant_transfers",
-        "tags": [
-          "participant transfers"
-        ],
-        "security": [
-          {
-            "bearerAuth": [
-
-            ]
-          }
-        ],
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "example": "28c461ee-ffc0-4e56-96bd-788579a0ed75",
-            "description": "The ID of the ECF participant.",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "A single participant's transfers",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ECFParticipantTransferResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UnauthorisedResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFoundResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v3/participants/ecf/{id}/defer": {
-      "put": {
-        "summary": "<b>Note, this endpoint includes updated specifications.</b><br/>Notify that an ECF participant is taking a break from their course",
-        "operationId": "ecf_participant_defer",
-        "tags": [
-          "ECF Participant"
-        ],
-        "security": [
-          {
-            "bearerAuth": [
-
-            ]
-          }
-        ],
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "example": "28c461ee-ffc0-4e56-96bd-788579a0ed75",
-            "description": "The ID of the participant to defer",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "The ECF participant being deferred",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {
-                      "data": {
-                        "id": "db3a7848-7308-4879-942a-c4a70ced400a",
-                        "type": "participant",
-                        "attributes": {
-                          "full_name": "Jane Smith",
-                          "teacher_reference_number": "1234567",
-                          "updated_at": "2021-05-31T02:22:32.000Z",
-                          "ecf_enrolments": [
-                            {
-                              "training_record_id": "000a97ff-d2a9-4779-a397-9bfd9063072e",
-                              "email": "jane.smith@some-school.example.com",
-                              "mentor_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
-                              "school_urn": "106286",
-                              "participant_type": "ect",
-                              "cohort": "2021",
-                              "training_status": "withdrawn",
-                              "participant_status": "withdrawn",
-                              "teacher_reference_number_validated": true,
-                              "eligible_for_funding": true,
-                              "pupil_premium_uplift": true,
-                              "sparsity_uplift": true,
-                              "schedule_identifier": "ecf-standard-january",
-                              "delivery_partner_id": "cd3a12347-7308-4879-942a-c4a70ced400a",
-                              "withdrawal": null,
-                              "deferral": {
-                                "reason": "other",
-                                "date": "2021-06-31T02:22:32.000Z"
-                              },
-                              "created_at": "2022-11-09T16:07:38Z",
-                              "induction_end_date": "2022-01-12",
-                              "mentor_funding_end_date": "2021-04-19",
-                              "cohort_changed_after_payments_frozen": true,
-                              "mentor_ineligible_for_funding_reason": null
-                            }
-                          ],
-                          "participant_id_changes": [
-                            {
-                              "from_participant_id": "23dd8d66-e11f-4139-9001-86b4f9abcb02",
-                              "to_participant_id": "db3a7848-7308-4879-942a-c4a70ced400a",
-                              "changed_at": "2023-09-23T02:22:32.000Z"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ECFParticipantResponse"
-                }
-              }
-            }
-          }
-        },
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ECFParticipantDeferRequest"
-              }
-            }
-          },
-          "required": true
-        }
-      }
-    },
-    "/api/v3/participants/ecf/{id}/resume": {
-      "put": {
-        "summary": "<b>Note, this endpoint includes updated specifications.</b><br/>Notify that an ECF participant is resuming their course",
-        "operationId": "ecf_participant_resume",
-        "tags": [
-          "ECF Participant"
-        ],
-        "security": [
-          {
-            "bearerAuth": [
-
-            ]
-          }
-        ],
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "example": "28c461ee-ffc0-4e56-96bd-788579a0ed75",
-            "description": "The ID of the participant to resume",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "The ECF participant being resumed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ECFParticipantResponse"
-                }
-              }
-            }
-          }
-        },
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ECFParticipantResumeRequest"
-              }
-            }
-          },
-          "required": true
-        }
-      }
-    },
-    "/api/v3/participants/ecf/{id}/withdraw": {
-      "put": {
-        "summary": "<b>Note, this endpoint includes updated specifications.</b><br/>Notify that an ECF participant has withdrawn from their course",
-        "operationId": "participant",
-        "tags": [
-          "ECF Participant"
-        ],
-        "security": [
-          {
-            "bearerAuth": [
-
-            ]
-          }
-        ],
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "example": "28c461ee-ffc0-4e56-96bd-788579a0ed75",
-            "description": "The ID of the participant to withdraw",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "The ECF participant being withdrawn",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "success": {
-                    "value": {
-                      "data": {
-                        "id": "db3a7848-7308-4879-942a-c4a70ced400a",
-                        "type": "participant",
-                        "attributes": {
-                          "full_name": "Jane Smith",
-                          "teacher_reference_number": "1234567",
-                          "updated_at": "2021-05-31T02:22:32.000Z",
-                          "ecf_enrolments": [
-                            {
-                              "training_record_id": "000a97ff-d2a9-4779-a397-9bfd9063072e",
-                              "email": "jane.smith@some-school.example.com",
-                              "mentor_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
-                              "school_urn": "106286",
-                              "participant_type": "ect",
-                              "cohort": "2021",
-                              "training_status": "withdrawn",
-                              "participant_status": "withdrawn",
-                              "teacher_reference_number_validated": true,
-                              "eligible_for_funding": true,
-                              "pupil_premium_uplift": true,
-                              "sparsity_uplift": true,
-                              "schedule_identifier": "ecf-standard-january",
-                              "delivery_partner_id": "cd3a12347-7308-4879-942a-c4a70ced400a",
-                              "withdrawal": {
-                                "reason": "other",
-                                "date": "2021-06-31T02:22:32.000Z"
-                              },
-                              "deferral": null,
-                              "created_at": "2022-11-09T16:07:38Z",
-                              "induction_end_date": "2022-01-12",
-                              "mentor_funding_end_date": "2021-04-19",
-                              "cohort_changed_after_payments_frozen": false,
-                              "mentor_ineligible_for_funding_reason": null
-                            }
-                          ],
-                          "participant_id_changes": [
-                            {
-                              "from_participant_id": "23dd8d66-e11f-4139-9001-86b4f9abcb02",
-                              "to_participant_id": "db3a7848-7308-4879-942a-c4a70ced400a",
-                              "changed_at": "2023-09-23T02:22:32.000Z"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ECFParticipantResponse"
-                }
-              }
-            }
-          }
-        },
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ECFParticipantWithdrawRequest"
-              }
-            }
-          },
-          "required": true
-        }
-      }
-    },
-    "/api/v3/participants/ecf/{id}/change-schedule": {
-      "put": {
-        "summary": "<b>Note, this endpoint includes updated specifications.</b><br/>Notify that an ECF Participant is changing training schedule",
-        "operationId": "ecf_participant_change_schedule",
-        "tags": [
-          "ECF Participant"
-        ],
-        "security": [
-          {
-            "bearerAuth": [
-
-            ]
-          }
-        ],
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "example": "28c461ee-ffc0-4e56-96bd-788579a0ed75",
-            "description": "The ID of the participant",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "The ECF Participant changing schedule",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ECFParticipantResponse"
-                }
-              }
-            }
-          }
-        },
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ECFParticipantChangeScheduleRequest"
-              }
-            }
-          },
-          "required": true
-        }
-      }
-    },
-    "/api/v3/unfunded-mentors/ecf": {
-      "get": {
-        "summary": "<b>Note, this endpoint is new.</b><br/>Retrieve multiple unfunded mentors",
-        "operationId": "participants",
-        "tags": [
-          "unfunded mentors"
-        ],
-        "security": [
-          {
-            "bearerAuth": [
-
-            ]
-          }
-        ],
-        "parameters": [
-          {
-            "name": "filter",
-            "in": "query",
-            "schema": {
-              "$ref": "#/components/schemas/ListFilter"
-            },
-            "style": "deepObject",
-            "explode": true,
-            "required": false,
-            "description": "Refine unfunded mentors to return.",
-            "example": "filter[updated_since]=2020-11-13T11:21:55Z"
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "schema": {
-              "$ref": "#/components/schemas/Pagination"
-            },
-            "style": "deepObject",
-            "explode": true,
-            "required": false,
-            "example": "page[page]=1&page[per_page]=5",
-            "description": "Pagination options to navigate through the list of unfunded mentors."
-          },
-          {
-            "name": "sort",
-            "in": "query",
-            "schema": {
-              "$ref": "#/components/schemas/ECFUnfundedMentorsSort"
-            },
-            "style": "form",
-            "explode": false,
-            "required": false,
-            "description": "Sort unfunded mentors being returned.",
-            "example": "sort=-updated_at"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "A list of unfunded mentors",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MultipleUnfundedMentorsResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UnauthorisedResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v3/unfunded-mentors/ecf/{id}": {
-      "get": {
-        "summary": "<b>Note, this endpoint is new.</b><br/>Get a single unfunded mentor",
-        "operationId": "unfunded_mentors",
-        "tags": [
-          "unfunded mentors"
-        ],
-        "security": [
-          {
-            "bearerAuth": [
-
-            ]
-          }
-        ],
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "example": "28c461ee-ffc0-4e56-96bd-788579a0ed75",
-            "description": "The ID of the unfunded mentor.",
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "A single unfunded mentor",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UnfundedMentorResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UnauthorisedResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFoundResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/v3/statements": {
       "get": {
         "summary": "<b>Note, this endpoint is new.</b><br/>Retrieve financial statements",
@@ -1749,9 +1701,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "parameters": [
@@ -1813,9 +1763,7 @@
         ],
         "security": [
           {
-            "bearerAuth": [
-
-            ]
+            "bearerAuth": []
           }
         ],
         "parameters": [
@@ -4389,9 +4337,7 @@
   },
   "security": [
     {
-      "bearerAuth": [
-
-      ]
+      "bearerAuth": []
     }
   ]
 }


### PR DESCRIPTION
[Jira-3960](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-3960)

### Context

Historically we haven't been able to auto-generate the v3 API documentation as it results in the links in the api-reference page becoming out of order.

We want to be able to auto-generate all the API documentation going forward so that we don't have to maintain it manually.

### Changes proposed in this pull request

- Sort the links in the api-reference sidebar

Sort the links by a predefined order for each category of endpoints. There are minor differences with the ordering within the groups when compared to production. I opted for ordering by group and then by the length of the path, but maybe alphabetical would make more sense?

- Auto-generate swagger documentation

Now that the order of the sidebar links is fixed, we can auto-generate the API documentation. It was verified in #5439 that only the ordering changes when you generate the swagger docs.

- Check Swagger docs on build

We can generate the swagger docs in CI and comapre them to the version committed to the codebase to ensure there are no differences.

### Guidance to review

[Example run to test failure](https://github.com/DFE-Digital/early-careers-framework/actions/runs/12930719032/job/36062902122?pr=5470)

I've ordered by group to match prod and then by path length. In prod I think we're ordered by group and then how recently the endpoint was added (latest at the bottom). We could also try grouped then alphabetical if that would make more sense 🤔 

| Current | This Branch | 
| -- | -- | 
| ![prod](https://github.com/user-attachments/assets/c96548af-e2e5-4ad2-90bf-ffb95f508e3b) | ![branch](https://github.com/user-attachments/assets/ef9acdfa-c980-4a99-b433-16a9665b63da) |
