### PR TITLE
[CPDLP-3952] Add index to participant declaration type field

### DIFF
--- a/db/migrate/20250124134039_add_type_index_to_participant_declarations.rb
+++ b/db/migrate/20250124134039_add_type_index_to_participant_declarations.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddTypeIndexToParticipantDeclarations < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :participant_declarations, :type, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_01_15_143446) do
+ActiveRecord::Schema[7.1].define(version: 2025_01_24_134039) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -763,6 +763,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_15_143446) do
     t.index ["mentor_user_id"], name: "index_participant_declarations_on_mentor_user_id"
     t.index ["participant_profile_id"], name: "index_participant_declarations_on_participant_profile_id"
     t.index ["superseded_by_id"], name: "superseded_by_index"
+    t.index ["type"], name: "index_participant_declarations_on_type"
     t.index ["user_id"], name: "index_participant_declarations_on_user_id"
   end
 


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-3952](https://dfedigital.atlassian.net/browse/CPDLP-3952)

We don’t have an index on the type on participant declarations.

### Changes proposed in this pull request

- Add an index to the participant declaration field type

Snapshot db:
```
== 20250124134039 AddTypeIndexToParticipantDeclarations: migrating ============
-- add_index(:participant_declarations, :type, {:algorithm=>:concurrently})
   -> 0.7996s
== 20250124134039 AddTypeIndexToParticipantDeclarations: migrated (1.2468s) ===
```

[CPDLP-3952]: https://dfedigital.atlassian.net/browse/CPDLP-3952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ