### PR TITLE
Attempt to fix/mitigate flakey Capybara feature specs

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -7,16 +7,16 @@ on:
         type: boolean
         required: false
         default: true
-
+        
 jobs:
-  backend-tests:
+  tests:
     name: Run rspec
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
-        ci_node_total: [8]
-        ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7]
+        ci_node_total: [6]
+        ci_node_index: [0, 1, 2, 3, 4, 5]
 
     env:
       RAILS_ENV: test
@@ -28,9 +28,9 @@ jobs:
       ANALYTICS_DB_PASSWORD: ""
       ANALYTICS_DB_HOSTNAME: 127.0.0.1
       ANALYTICS_DB_PORT: 5432
+      CI: true
       CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
       CI_NODE_INDEX: ${{ matrix.ci_node_index }}
-      CI: true
 
     services:
       postgres:
@@ -57,7 +57,57 @@ jobs:
           CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
           CI_NODE_INDEX: ${{ matrix.ci_node_index }}
         run: |-
-          bundle exec rake knapsack:rspec
+          bundle exec rake "knapsack:rspec[--tag ~type:feature]"
+
+  feature-tests:
+    name: Run rspec (features)
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        ci_node_total: [4]
+        ci_node_index: [0, 1, 2, 3]
+
+    env:
+      RAILS_ENV: test
+      DB_USERNAME: postgres
+      DB_PASSWORD: ""
+      DB_HOSTNAME: 127.0.0.1
+      DB_PORT: 5432
+      ANALYTICS_DB_USERNAME: postgres
+      ANALYTICS_DB_PASSWORD: ""
+      ANALYTICS_DB_HOSTNAME: 127.0.0.1
+      ANALYTICS_DB_PORT: 5432
+      CI: true
+      CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
+      CI_NODE_INDEX: ${{ matrix.ci_node_index }}
+
+    services:
+      postgres:
+        image: postgres:11.6-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: ""
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - uses: ./.github/actions/prepare-app-env
+        id: test
+        with:
+          prepare-test-database: "true"
+          prepare-assets: "true"
+
+      - name: Run tests
+        env:
+          CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
+          CI_NODE_INDEX: ${{ matrix.ci_node_index }}
+        run: |-
+          bundle exec rake "knapsack:rspec[--tag type:feature --fail-fast]"
 
   e2e-scenarios:
     if: ${{ inputs.run-end-to-end-tests }}
@@ -79,9 +129,9 @@ jobs:
       ANALYTICS_DB_PASSWORD: ""
       ANALYTICS_DB_HOSTNAME: 127.0.0.1
       ANALYTICS_DB_PORT: 5432
+      CI: true
       CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
       CI_NODE_INDEX: ${{ matrix.ci_node_index }}
-      CI: true
 
     services:
       postgres:


### PR DESCRIPTION
### Context

We are finding that our tests hang in CI randomly on a consistent error:

```
Net::ReadTimeout:
       Net::ReadTimeout with #<TCPSocket:(closed)>
```

We want to investigate why this happens and see if we can fix it to make our CI more reliable.

### Changes proposed in this pull request

- Minor tweaks to Capybara/chrome settings

In an attempt to fix/reduce the impact of feature spec failures where we get a `Net:HTTP` timeout error on multiple tests, resulting in a long time until the suite fails this commit will:

```
- Add additional args to reduce flakiness (based on various GitHub issues around similar problems)
- Increase the client open/read timeout
- Remove the allowed external domain (in case its rate limiting us/causing the timeouts)
- Increase the default Capybara wait time
```

- Split feature specs in CI and fail fast

So that we aren't waiting a long time to see a failure when we get a random Net:HTTP timeout issue, we can split the feature specs and pass `--fail-fast` so that the job will fail on the first feature spec that fails. Otherwise we can end up waiting a long time for each test to fail and as a result the workflow won't fail for over an hour.

### Guidance to review

This is a bit of a 'throw various fixes at it and see what sticks' approach, as its not easy to replicate or debug.

I've re-ran the rspec tests 3 times without failure.

If we find its still flakey after this, it might be worth using a gem like `rspec-retry` to retry the javascript feature specs (this could be a sticking plaster fix, but given we're decommissioning ECF shortly it could be a quick win to keep us going/reduce the impact of the issue).