### PR TITLE
[CPDLP-3913] migration to remove cohorts.npq_registration_start_date

### DIFF
--- a/db/migrate/20250127140541_remove_npq_registration_start_date_from_cohorts.rb
+++ b/db/migrate/20250127140541_remove_npq_registration_start_date_from_cohorts.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveNPQRegistrationStartDateFromCohorts < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured { remove_column :cohorts, :npq_registration_start_date, :datetime, precision: nil }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_01_24_134039) do
+ActiveRecord::Schema[7.1].define(version: 2025_01_27_140541) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -259,7 +259,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_24_134039) do
     t.integer "start_year", limit: 2, null: false
     t.datetime "registration_start_date", precision: nil
     t.datetime "academic_year_start_date", precision: nil
-    t.datetime "npq_registration_start_date", precision: nil
     t.date "automatic_assignment_period_end_date"
     t.datetime "payments_frozen_at"
     t.boolean "mentor_funding", default: false, null: false


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-3913
- Rebasing from: https://github.com/DFE-Digital/early-careers-framework/pull/5461

### Changes proposed in this pull request

* Remove column `cohorts.npq_registration_start_date`

### Guidance to review

