### PR TITLE
Send correct school name in withdrawn participant email

### DIFF
--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -344,7 +344,7 @@ class SchoolMailer < ApplicationMailer
   end
 
   def fip_provider_has_withdrawn_a_participant
-    withdrawn_participant = params[:withdrawn_participant]
+    induction_record = params[:induction_record]
     induction_coordinator = params[:induction_coordinator]
     partnership = params[:partnership]
 
@@ -355,8 +355,8 @@ class SchoolMailer < ApplicationMailer
       rails_mail_template: action_name,
       personalisation: {
         name: induction_coordinator.user.full_name,
-        withdrawn_participant_name: withdrawn_participant.user.full_name,
-        school: withdrawn_participant.school.name,
+        withdrawn_participant_name: induction_record.user.full_name,
+        school: induction_record.school.name,
         delivery_partner: partnership&.delivery_partner_name || "No delivery partner",
         lead_provider: partnership&.lead_provider_name || "No lead provider",
       },
@@ -364,7 +364,8 @@ class SchoolMailer < ApplicationMailer
     email
       .tag(:sit_fip_provider_has_withdrawn_a_participant)
       .associate_with(induction_coordinator, as: :induction_coordinator)
-      .associate_with(withdrawn_participant, as: :participant_profile)
+      .associate_with(induction_record.participant_profile, as: :participant_profile)
+      .associate_with(induction_record, as: :induction_record)
   end
 
   # Pilot one-off mailers

--- a/app/services/withdraw_participant.rb
+++ b/app/services/withdraw_participant.rb
@@ -32,10 +32,10 @@ class WithdrawParticipant
       participant_profile.training_status_withdrawn!
     end
 
-    induction_coordinator = participant_profile.school.induction_coordinator_profiles.first
+    induction_coordinator = relevant_induction_record.school.induction_coordinator_profiles.first
     if induction_coordinator.present?
       SchoolMailer.with(
-        withdrawn_participant: participant_profile,
+        induction_record: relevant_induction_record,
         induction_coordinator:,
         partnership: relevant_induction_record.partnership,
       ).fip_provider_has_withdrawn_a_participant.deliver_later

--- a/spec/services/withdraw_participant_spec.rb
+++ b/spec/services/withdraw_participant_spec.rb
@@ -113,7 +113,7 @@ RSpec.shared_examples "withdrawing an ECF participant" do
     }.to have_enqueued_mail(SchoolMailer, :fip_provider_has_withdrawn_a_participant)
       .with(
         params: {
-          withdrawn_participant: participant_profile,
+          induction_record:,
           induction_coordinator:,
           partnership: induction_record.partnership,
         },


### PR DESCRIPTION
[Jira-3979](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-3979)

### Context

When we withdraw a participant we send an email with details of the school they were withdrawn from. Currently, however, we take the participant profile -> school, which is not always the school relevant to the withdraw action. We should instead be taking the school from the relevant induction record, in case the participant has transferred schools in the past.

### Changes proposed in this pull request

- Send correct school name in withdrawn participant email

Update `WithdrawParticipant` action to take the school from the `relevant_induction_record` instead of the `participant_profile`.

### Guidance to review

There is a temp commit that adds a GOV.UK notify API key for testing to the review credentials.

There are scripts attached to the ticket to setup the test scenario.