### PR TITLE
[CPDLP-3968] Amend void declarations service to include ineligible statement line items

### DIFF
--- a/app/services/void_participant_declaration.rb
+++ b/app/services/void_participant_declaration.rb
@@ -42,6 +42,6 @@ private
   attr_accessor :participant_declaration
 
   def line_item
-    participant_declaration.statement_line_items.find_by(state: %w[eligible payable submitted])
+    participant_declaration.statement_line_items.find_by(state: %w[eligible payable ineligible])
   end
 end

--- a/spec/services/void_participant_declaration_spec.rb
+++ b/spec/services/void_participant_declaration_spec.rb
@@ -52,22 +52,6 @@ RSpec.describe VoidParticipantDeclaration do
       end
     end
 
-    context "when declaration is payable" do
-      let(:participant_declaration) do
-        create(
-          :ect_participant_declaration,
-          :payable,
-          cpd_lead_provider:,
-          participant_profile:,
-        )
-      end
-
-      it "can be voided" do
-        subject.call
-        expect(participant_declaration.reload).to be_voided
-      end
-    end
-
     context "when declaration is paid" do
       let(:participant_declaration) do
         create(
@@ -107,21 +91,59 @@ RSpec.describe VoidParticipantDeclaration do
     end
 
     context "when declaration is attached to a statement" do
-      let(:participant_declaration) do
-        create(
-          :ect_participant_declaration,
-          :payable,
-          cpd_lead_provider:,
-          participant_profile:,
-        )
-      end
-
       let(:line_item) { participant_declaration.statement_line_items.first }
 
-      it "updates declaration and line item state to voided" do
-        subject.call
-        expect(participant_declaration.reload).to be_voided
-        expect(line_item.reload).to be_voided
+      context "when declaration is eligible" do
+        let(:participant_declaration) do
+          create(
+            :ect_participant_declaration,
+            :eligible,
+            cpd_lead_provider:,
+            participant_profile:,
+          )
+        end
+
+        it "updates declaration and line item state to voided" do
+          subject.call
+          expect(participant_declaration.reload).to be_voided
+          expect(line_item.reload).to be_voided
+        end
+      end
+
+      context "when declaration is payable" do
+        let(:participant_declaration) do
+          create(
+            :ect_participant_declaration,
+            :payable,
+            cpd_lead_provider:,
+            participant_profile:,
+          )
+        end
+
+        it "updates declaration and line item state to voided" do
+          subject.call
+          expect(participant_declaration.reload).to be_voided
+          expect(line_item.reload).to be_voided
+        end
+      end
+
+      context "when declaration is ineligible" do
+        let(:participant_declaration) do
+          create(
+            :ect_participant_declaration,
+            :ineligible,
+            cpd_lead_provider:,
+            participant_profile:,
+          )
+        end
+
+        before { line_item.ineligible! }
+
+        it "updates declaration and line item state to voided" do
+          subject.call
+          expect(participant_declaration.reload).to be_voided
+          expect(line_item.reload).to be_voided
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-3968](https://dfedigital.atlassian.net/browse/CPDLP-3968)

Contract managers are not able to see voids for ineligible declarations in the CSV extracts.

### Changes proposed in this pull request

- Amend void declarations service to include `ineligible` statement line items, so the record state is updated to `voided`;
- Removed `submitted` line items from the logic as it's not a valid state for `StatementLineItem`. Checked prod and there's no `submitted` line itens currently in the db;
- Improved tests coverage to cover all 3 states in the logic;

[CPDLP-3968]: https://dfedigital.atlassian.net/browse/CPDLP-3968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ