### PR TITLE
Add manual deployment Github workflow

### DIFF
--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -1,0 +1,64 @@
+name: "Manually deploy to an environment"
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch-name:
+        description: Set branch name
+        required: true
+        type: string
+      environment:
+        description: "Deploy environment"
+        required: true
+        default: migration
+        type: choice
+        options:
+          - staging
+          - migration
+          - sandbox
+          - production
+
+permissions:
+  id-token: write
+  pull-requests: write
+  packages: write
+  security-events: write
+
+jobs:
+  docker:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    outputs:
+      docker-image: ${{ steps.build-docker-image.outputs.image }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch-name }}
+
+      - uses: DFE-Digital/github-actions/build-docker-image@master
+        id: build-docker-image
+        with:
+          docker-repository: ghcr.io/dfe-digital/early-careers-framework
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          snyk-token: ${{ secrets.SNYK_TOKEN }}
+
+  deploy:
+    name: Deploy to environment
+    needs: [docker]
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    outputs:
+      docker-image: ${{ needs.docker.outputs.docker-image }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch-name }}
+
+      - uses: ./.github/actions/deploy-environment-to-aks
+        id: deploy
+        with:
+          environment: ${{ inputs.environment }}
+          docker-image: ${{ needs.docker.outputs.docker-image }}
+          azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
+          current-commit-sha: ${{ github.sha }}
+          statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}


### PR DESCRIPTION
### Context

- Ticket: n/a

We need allow manual deployments to envs as terraform apply in the console now requires gcloud logins as well where not all developers will have gcloud accounts or access.

### Changes proposed in this pull request

Add a new workflow where we can select an environment to deploy to, select the branch we wish to deploy and it will deploy manually using the github actions without any CI tests.

Review environment has not been included as it is not required.

### Guidance to review
This was tested on the maintenance workflow [here](https://github.com/DFE-Digital/early-careers-framework/actions/runs/13060359728/job/36441835650), where we were able to deploy successfully. This also required work on the DfE github [actions](https://github.com/DFE-Digital/github-actions/pull/114), thanks @saliceti  

