### PR TITLE
Fix Knapsack manifest refresh PRs

### DIFF
--- a/.github/workflows/refresh_knapsack_manifest.yml
+++ b/.github/workflows/refresh_knapsack_manifest.yml
@@ -40,9 +40,16 @@ jobs:
       - name: Run tests
         run: KNAPSACK_GENERATE_REPORT=true bundle exec rake knapsack:rspec
 
+      - uses: actions/create-github-app-token@v1
+        id: generate-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Create pull request 
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           branch: refresh-knapsack-manifest
           delete-branch: true
           add-paths: knapsack_rspec_report.json


### PR DESCRIPTION
### Context

GitHub prevents the PRs raised from a GitHub action from triggering further CI actions by default. We need to use another authentication method than the default `GITHUB_TOKEN`.

### Changes proposed in this pull request

- Fix Knapsack manifest refresh PRs

Switch to GitHub App authentication This will allow the CI checks will be ran on the PR raised by the `create-pull-request` action.

### Guidance to review

[Example PR raised by run](https://github.com/DFE-Digital/early-careers-framework/pull/5477)