### PR TITLE
Show completed ECTs in list of school participants in admin UI

### DIFF
--- a/app/controllers/admin/schools/participants_controller.rb
+++ b/app/controllers/admin/schools/participants_controller.rb
@@ -8,7 +8,7 @@ module Admin
     def index
       @participant_profiles = policy_scope(ParticipantProfile, policy_scope_class: ParticipantProfilePolicy::Scope)
         .ecf
-        .where(id: InductionRecord.for_school(school).current_or_transferring_in.select(:participant_profile_id))
+        .where(id: InductionRecord.for_school(school).current_completed_or_transferring_in.select(:participant_profile_id))
         .includes(participant_identity: :user)
         .order("users.full_name")
     end

--- a/app/models/induction_record.rb
+++ b/app/models/induction_record.rb
@@ -65,6 +65,7 @@ class InductionRecord < ApplicationRecord
   scope :transferred, -> { leaving_induction_status.merge(end_date_in_past) }
 
   scope :current_or_transferring_in, -> { current.or(transferring_in) }
+  scope :current_completed_or_transferring_in, -> { current_or_transferring_in.or(completed_induction_status) }
   scope :school_dashboard_relevant, -> { completed_induction_status.or(current).or(transferring_in).or(transferred).or(training_status_withdrawn).or(training_status_deferred) }
 
   scope :ects, -> { joins(:participant_profile).merge(ParticipantProfile.ects) }

--- a/spec/models/induction_record_spec.rb
+++ b/spec/models/induction_record_spec.rb
@@ -234,6 +234,12 @@ RSpec.describe InductionRecord, type: :model do
       let(:tina_transferred_ir) { Induction::Enrol.call(participant_profile: create(:ect_participant_profile), induction_programme:, start_date: 2.months.ago) }
       let(:wendy_withdrawn_ir) { Induction::Enrol.call(participant_profile: create(:ect_participant_profile), induction_programme:, start_date: 2.months.ago) }
       let(:terry_transferring_out_ir) { Induction::Enrol.call(participant_profile: create(:ect_participant_profile), induction_programme:, start_date: 2.months.ago) }
+      let(:carol_active_ir) { Induction::Enrol.call(participant_profile: create(:ect_participant_profile), induction_programme:, start_date: 2.months.ago) }
+      let!(:carol_completed_ir) do
+        carol_profile = carol_active_ir.participant_profile
+        Induction::Complete.call(participant_profile: carol_profile, completion_date: 1.day.ago)
+        carol_profile.induction_records.latest
+      end
 
       before do
         linda_leaving_ir.leaving!(1.month.from_now)
@@ -244,27 +250,31 @@ RSpec.describe InductionRecord, type: :model do
 
       context "when .current" do
         it "includes current users" do
-          expect(induction_programme.induction_records.current_or_transferring_in).to include charlie_current_ir
+          expect(induction_programme.induction_records.current).to include charlie_current_ir
         end
 
         it "includes transferring out users" do
-          expect(induction_programme.induction_records.current_or_transferring_in).to include terry_transferring_out_ir
+          expect(induction_programme.induction_records.current).to include terry_transferring_out_ir
         end
 
         it "includes users leaving for another school" do
-          expect(induction_programme.induction_records.current_or_transferring_in).to include linda_leaving_ir
+          expect(induction_programme.induction_records.current).to include linda_leaving_ir
         end
 
         it "does not include transferring in users" do
-          expect(induction_programme.induction_records.current_or_transferring_in).to include theresa_transfer_in_ir
+          expect(induction_programme.induction_records.current).not_to include theresa_transfer_in_ir
         end
 
         it "does not include transferred users" do
-          expect(induction_programme.induction_records.current_or_transferring_in).not_to include tina_transferred_ir
+          expect(induction_programme.induction_records.current).not_to include tina_transferred_ir
         end
 
         it "does not include withdrawn users" do
-          expect(induction_programme.induction_records.current_or_transferring_in).not_to include wendy_withdrawn_ir
+          expect(induction_programme.induction_records.current).not_to include wendy_withdrawn_ir
+        end
+
+        it "does not include completed users" do
+          expect(induction_programme.induction_records.current).not_to include carol_completed_ir
         end
       end
 
@@ -291,6 +301,40 @@ RSpec.describe InductionRecord, type: :model do
 
         it "does not include withdrawn users" do
           expect(induction_programme.induction_records.current_or_transferring_in).not_to include wendy_withdrawn_ir
+        end
+
+        it "does not include completed users" do
+          expect(induction_programme.induction_records.current_or_transferring_in).not_to include carol_completed_ir
+        end
+      end
+
+      context "when .current_completed_or_transferring_in" do
+        it "includes current users" do
+          expect(induction_programme.induction_records.current_completed_or_transferring_in).to include charlie_current_ir
+        end
+
+        it "includes transferring in users" do
+          expect(induction_programme.induction_records.current_completed_or_transferring_in).to include theresa_transfer_in_ir
+        end
+
+        it "includes transferring out users" do
+          expect(induction_programme.induction_records.current_completed_or_transferring_in).to include terry_transferring_out_ir
+        end
+
+        it "includes users leaving for another school" do
+          expect(induction_programme.induction_records.current_completed_or_transferring_in).to include linda_leaving_ir
+        end
+
+        it "does not include transferred users" do
+          expect(induction_programme.induction_records.current_completed_or_transferring_in).not_to include tina_transferred_ir
+        end
+
+        it "does not include withdrawn users" do
+          expect(induction_programme.induction_records.current_completed_or_transferring_in).not_to include wendy_withdrawn_ir
+        end
+
+        it "includes completed users" do
+          expect(induction_programme.induction_records.current_completed_or_transferring_in).to include carol_completed_ir
         end
       end
     end


### PR DESCRIPTION
### Context

When an ECT has a `completed` induction status they disappear from the list of participants in a school for an admin in the admin UI.

### Changes proposed in this pull request

Create a new scope to include `completed` induction status and use this for the admin school participants view.

### Guidance to review

I've set 1 participant as completed, sign in to the review app as admin and the completed participant can be seen in the list [school participants](https://cpd-ecf-review-5498-web.test.teacherservices.cloud/admin/schools/077443-samirastad-high-school/participants)

