### PR TITLE
Ignore `npq_course_id` on `ParticipantProfile`

### DIFF
--- a/app/models/participant_profile.rb
+++ b/app/models/participant_profile.rb
@@ -3,7 +3,7 @@
 class ParticipantProfile < ApplicationRecord
   has_paper_trail
 
-  # self.ignored_columns = %w[user_id]
+  self.ignored_columns = %w[npq_course_id]
 
   attr_reader :participant_type
 

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -112,7 +112,6 @@
   - school_cohort_id
   - teacher_profile_id
   - schedule_id
-  - npq_course_id
   - school_urn
   - school_ukprn
   - request_for_details_sent_at


### PR DESCRIPTION
[Jira-4011](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-4011)

### Context

This is no longer used; we are ignoring it ahead of dropping the column in a follow up PR.

### Changes proposed in this pull request

- Ignore `npq_course_id` on `ParticipantProfile`
- Remove npq_course_id from dfe-analytics

### Guidance for review

Follow on PR: #5500.