### PR TITLE
Switch to `pagy_countless` for API pagination

### DIFF
--- a/app/controllers/concerns/api_pagination.rb
+++ b/app/controllers/concerns/api_pagination.rb
@@ -7,7 +7,7 @@ module ApiPagination
 private
 
   def paginate(scope)
-    _pagy, paginated_records = pagy(scope, limit: per_page, page:)
+    _pagy, paginated_records = pagy_countless(scope, limit: per_page, page:)
 
     paginated_records
   end

--- a/app/services/api/v3/ecf/participants_query.rb
+++ b/app/services/api/v3/ecf/participants_query.rb
@@ -38,7 +38,7 @@ module Api
                   .joins(left_outer_join_participant_profiles)
                   .joins(left_outer_join_induction_records)
                   .joins("JOIN (#{latest_induction_records_join.to_sql}) AS latest_induction_records ON latest_induction_records.latest_id = induction_records.id")
-                  .joins("INNER JOIN (#{paginated_join.to_sql}) as tmp on tmp.id = users.id")
+                  .where(users: { id: paginated_join.map(&:id) })
                   .group("users.id")
                   .distinct
 

--- a/app/services/api/v3/participant_declarations_query.rb
+++ b/app/services/api/v3/participant_declarations_query.rb
@@ -47,7 +47,7 @@ module Api
             :participant_profile,
             :cpd_lead_provider,
           )
-          .joins("INNER JOIN (#{paginated_join.to_sql}) as tmp on tmp.id = participant_declarations.id")
+          .where(participant_declarations: { id: paginated_join.map(&:id) })
           .order(:created_at)
           .distinct
       end

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "pagy/extras/countless"
 require "pagy/extras/overflow"
 require "pagy/extras/array"
 


### PR DESCRIPTION
[Jira-3985](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-3985)

### Context

As we don't expose the total count we can switch from `pagy` to `pagy_countless`, which should be more efficient at paginating large data sets. 

### Changes proposed in this pull request

- Switch to `pagy_countless` for API pagination

### Guidance to review

Test scripts used to verify participant/declarations queries which were the two that had to change for this update:

```
ActiveRecord::Base.connection.execute("SET statement_timeout to 0")

require "pagy"
require "pagy/extras/countless"
require "pagy/extras/overflow"
require "pagy/extras/array"
include Pagy::Backend

cpd_lead_provider = CpdLeadProvider.find_by(name: "Ambition Institute")
lead_provider = cpd_lead_provider.lead_provider

paginate_countless = ->(scope, page:) do
  _pagy, paginated_records = pagy_countless(scope, limit: 3_000, page:)
  paginated_records
end

paginate = ->(scope, page:) do
  _pagy, paginated_records = pagy_countless(scope, limit: 3_000, page:)
  paginated_records
end

# Participants

participants_benchmark_results = { paginate_countless: [], paginate: [] }
test_params = [{}, { filter: { training_status: :deferred } }]

test_params.each do |params|
  participants_query = Api::V3::ECF::ParticipantsQuery.new(lead_provider:, params:)

  (1..).each do |page|
    participants_countless = nil
    participants = nil
    paginated_countless_results = nil
    paginated_results = nil

    pagy_time = Benchmark.realtime do
      paginated_results = paginate.call(participants_query.participants_for_pagination, page:)
      participants = participants_query.participants_from(paginated_results)
    end
    participants_benchmark_results[:paginate] << pagy_time

    countless_time = Benchmark.realtime do
      paginated_countless_results = paginate_countless.call(participants_query.participants_for_pagination, page:)
      participants_countless = participants_query.participants_from(paginated_countless_results)
    end
    participants_benchmark_results[:paginate_countless] << countless_time

    raise "Page #{page} is not equal!" unless participants_countless.to_a.map(&:id) == participants.to_a.map(&:id)

    break if paginated_countless_results.empty? && paginated_results.empty?
  end

  puts "All pages equal!"
end

puts "Average participants execution time:"
puts "paginate_countless: #{participants_benchmark_results[:paginate_countless].sum / participants_benchmark_results[:paginate_countless].size} seconds"
puts "paginate: #{participants_benchmark_results[:paginate].sum / participants_benchmark_results[:paginate].size} seconds"

# Participant declarations

declarations_benchmark_results = { paginate_countless: [], paginate: [] }
test_params = [{}, { filter: { cohort: 2023 } }]

test_params.each do |params|
  declarations_query = Api::V3::ParticipantDeclarationsQuery.new(cpd_lead_provider:, params:)

  (1..).each do |page|
    declarations_countless = nil
    declarations = nil
    paginated_countless_results = nil
    paginated_results = nil

    pagy_time = Benchmark.realtime do
      paginated_results = paginate.call(declarations_query.participant_declarations_for_pagination, page:)
      declarations = declarations_query.participant_declarations_from(paginated_results)
    end
    declarations_benchmark_results[:paginate] << pagy_time

    countless_time = Benchmark.realtime do
      paginated_countless_results = paginate_countless.call(declarations_query.participant_declarations_for_pagination, page:)
      declarations_countless = declarations_query.participant_declarations_from(paginated_countless_results)
    end
    declarations_benchmark_results[:paginate_countless] << countless_time

    raise "Page #{page} is not equal!" unless declarations_countless.to_a.map(&:id) == declarations.to_a.map(&:id)

    break if paginated_countless_results.empty? && paginated_results.empty?
  end

  puts "All pages equal!"
end

puts "Average declarations execution time:"
puts "paginate_countless: #{declarations_benchmark_results[:paginate_countless].sum / declarations_benchmark_results[:paginate_countless].size} seconds"
puts "paginate: #{declarations_benchmark_results[:paginate].sum / declarations_benchmark_results[:paginate].size} seconds"

# Statements

statements_benchmark_results = { paginate_countless: [], paginate: [] }
test_params = [{}, { filter: { updated_since: "2023-11-13T11:21:55Z" } }]

test_params.each do |params|
  statements_query = Api::V3::Finance::StatementsQuery.new(cpd_lead_provider:, params:)

  (1..).each do |page|
    paginated_countless_results = nil
    paginated_results = nil

    pagy_time = Benchmark.realtime do
      paginated_results = paginate.call(statements_query.statements, page:)
    end
    statements_benchmark_results[:paginate] << pagy_time

    countless_time = Benchmark.realtime do
      paginated_countless_results = paginate_countless.call(statements_query.statements, page:)
    end
    statements_benchmark_results[:paginate_countless] << countless_time

    raise "Page #{page} is not equal!" unless paginated_countless_results.to_a.map(&:id) == paginated_results.to_a.map(&:id)

    break if paginated_countless_results.empty? && paginated_results.empty?
  end

  puts "All pages equal!"
end

puts "Average statements execution time:"
puts "paginate_countless: #{statements_benchmark_results[:paginate_countless].sum / statements_benchmark_results[:paginate_countless].size} seconds"
puts "paginate: #{statements_benchmark_results[:paginate].sum / statements_benchmark_results[:paginate].size} seconds"

# Unfunded mentors

unfunded_mentors_benchmark_results = { paginate_countless: [], paginate: [] }
test_params = [{}, { filter: { updated_since: "2023-11-13T11:21:55Z" } }]

test_params.each do |params|
  unfunded_mentors_query = Api::V3::ECF::UnfundedMentorsQuery.new(lead_provider:, params:)

  (1..).each do |page|
    paginated_countless_results = nil
    paginated_results = nil

    pagy_time = Benchmark.realtime do
      paginated_results = paginate.call(unfunded_mentors_query.unfunded_mentors, page:)
    end
    unfunded_mentors_benchmark_results[:paginate] << pagy_time

    countless_time = Benchmark.realtime do
      paginated_countless_results = paginate_countless.call(unfunded_mentors_query.unfunded_mentors, page:)
    end
    unfunded_mentors_benchmark_results[:paginate_countless] << countless_time

    raise "Page #{page} is not equal!" unless paginated_countless_results.to_a.map(&:id) == paginated_results.to_a.map(&:id)

    break if paginated_countless_results.empty? && paginated_results.empty?
  end

  puts "All pages equal!"
end

puts "Average unfunded mentors execution time:"
puts "paginate_countless: #{unfunded_mentors_benchmark_results[:paginate_countless].sum / unfunded_mentors_benchmark_results[:paginate_countless].size} seconds"
puts "paginate: #{unfunded_mentors_benchmark_results[:paginate].sum / unfunded_mentors_benchmark_results[:paginate].size} seconds"
```