### PR TITLE
Bump IOPS of database

### DIFF
--- a/terraform/application/databases.tf
+++ b/terraform/application/databases.tf
@@ -58,6 +58,7 @@ module "postgres" {
   azure_enable_backup_storage    = var.azure_enable_backup_storage
   use_azure                      = var.deploy_azure_backing_services
   azure_enable_monitoring        = var.enable_monitoring
+  azure_storage_tier             = var.azure_storage_tier
   azure_extensions               = ["citext", "fuzzystrmatch", "pg_stat_statements", "pgcrypto", "plpgsql", "uuid-ossp"]
   azure_maintenance_window       = var.azure_maintenance_window
   server_version                 = "14"

--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -147,7 +147,7 @@ variable "azure_cpu_threshold" {
 
 variable "azure_storage_tier" {
   type    = string
-  default = "P6"
+  default = "P4"
 }
 
 variable "enable_logit" { default = false }

--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -145,6 +145,11 @@ variable "azure_cpu_threshold" {
   default = 60
 }
 
+variable "azure_storage_tier" {
+  type    = string
+  default = "P6"
+}
+
 variable "enable_logit" { default = false }
 
 variable "send_traffic_to_maintenance_page" {

--- a/terraform/application/workspace_variables/migration.tfvars.json
+++ b/terraform/application/workspace_variables/migration.tfvars.json
@@ -11,6 +11,7 @@
   "webapp_memory_max": "4Gi",
   "worker_memory_max": "2Gi",
   "azure_storage_mb": "65536",
+  "azure_storage_tier": "P30",
   "azure_cpu_threshold": 70,
   "domain": "mg.manage-training-for-early-career-teachers.education.gov.uk",
   "external_hostname": "mg.manage-training-for-early-career-teachers.education.gov.uk/",

--- a/terraform/application/workspace_variables/migration.tfvars.json
+++ b/terraform/application/workspace_variables/migration.tfvars.json
@@ -11,7 +11,7 @@
   "webapp_memory_max": "4Gi",
   "worker_memory_max": "2Gi",
   "azure_storage_mb": "65536",
-  "azure_storage_tier": "P30",
+  "azure_storage_tier": "P6",
   "azure_cpu_threshold": 70,
   "domain": "mg.manage-training-for-early-career-teachers.education.gov.uk",
   "external_hostname": "mg.manage-training-for-early-career-teachers.education.gov.uk/",

--- a/terraform/application/workspace_variables/production.tfvars.json
+++ b/terraform/application/workspace_variables/production.tfvars.json
@@ -18,6 +18,7 @@
   "webapp_memory_max": "4Gi",
   "worker_memory_max": "2Gi",
   "azure_storage_mb": "65536",
+  "azure_storage_tier": "P30",
   "azure_cpu_threshold": 70,
   "azure_maintenance_window": {
     "day_of_week": 0,


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-3984

To improve performance we'd like to bump up the IOPS on the production DB

### Changes proposed in this pull request

- Add new performance tier variable `azure_storage_tier` to postgres dbs in terraform
- Set `azure_storage_tier` in production to P30 (5000 iops) to match some spikes we've seen. We'll monitor to see if this improves things
- Set `azure_storage_tier` in migration to P6 to match it's current state
- Default to P4 as that's the value on other envs

Before merging I'll ensure that nothing changes apart from production dbs. I'll also reset migration back to P6 (I can't in the next 12 hours as I've already tested P30 on it)

### Guidance to review
I've tested this on migration, and bumped the IOPS, it took around 6 minutes to apply and there was no downtime. When applying this in production, I will do this outside hours regardless and apply manually before merging the PR
