### PR TITLE
Remove npq_course_id as ignored column from ParticipantProfile

### DIFF
--- a/app/models/participant_profile.rb
+++ b/app/models/participant_profile.rb
@@ -3,8 +3,6 @@
 class ParticipantProfile < ApplicationRecord
   has_paper_trail
 
-  self.ignored_columns = %w[npq_course_id]
-
   attr_reader :participant_type
 
   class_attribute :validation_steps


### PR DESCRIPTION
### Context

Now that we have dropped this column we can stop ignoring it.

### Changes proposed in this pull request

- Remove npq_course_id as ignored column from ParticipantProfile

### Guidance to review

Depends on #5500.