### PR TITLE
Revert to using the induction->start_date field

### DIFF
--- a/app/presenters/dqt_record_presenter.rb
+++ b/app/presenters/dqt_record_presenter.rb
@@ -31,19 +31,11 @@ class DQTRecordPresenter < SimpleDelegator
     dqt_record.dig("qualified_teacher_status", "qts_date")
   end
 
-  # This is a patch until we migrate this presenter from DQT::V1 to DQT::V3
-  # The "induction", "start_date" coming in DQT::V1 is not the more accurate one so,
-  # either we get it from the "induction" "periods" coming V1 or V3
+  # The issues with the induction start date accuracy have been fixed in the API
+  # and in addition the induction period data is being removed so we revert to 
+  # the original start_date
   def induction_start_date
-    return @induction_start_date if instance_variable_defined?(:@induction_start_date)
-
-    @induction_start_date = (
-      dqt_record.dig("induction", "periods") ||
-        DQT::V3::Client.new.get_record(trn:)&.dig("induction", "periods")
-    ).to_a
-     .map { |period| period["startDate"] }
-     .compact
-     .min
+    @induction_start_date ||= dqt_record.dig("induction", "start_date")
   end
 
   def induction_completion_date


### PR DESCRIPTION
### Context

- Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-2839)

With the induction data moving to the AB portal replacement, the TRS/DQT API will no longer support having induction period data.  We changed to checking induction period data for the start date because there were issues in the API where changes to the period dates were not reflected at the top level `start_date`.  These issues have been fixed so we can revert to using the single `start_date` field in the `induction` rather than checking the `periods` data for the earliest starting date.

### Changes proposed in this pull request

Update the presenter to use the `induction -> start_date` field instead of querying the V3 API for the induction periods and evaluating them.

### Guidance to review

