### PR TITLE
[CPDLP-3958] Remove extra lead providers from seeds

### DIFF
--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -2,6 +2,16 @@
 
 # This is actually ECFLeadProvider in all but name. See https://github.com/DFE-Digital/early-careers-framework/issues/698
 class LeadProvider < ApplicationRecord
+  ALL_PROVIDERS = [
+    "Ambition Institute",
+    "Best Practice Network",
+    "Capita",
+    "Education Development Trust",
+    "National Institute of Teaching",
+    "Teach First",
+    "UCL Institute of Education",
+  ].freeze
+
   belongs_to :cpd_lead_provider, optional: true
 
   has_many :participant_declarations, through: :cpd_lead_provider, class_name: "ParticipantDeclaration::ECF"

--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -2,16 +2,6 @@
 
 # This is actually ECFLeadProvider in all but name. See https://github.com/DFE-Digital/early-careers-framework/issues/698
 class LeadProvider < ApplicationRecord
-  ALL_PROVIDERS = [
-    "Ambition Institute",
-    "Best Practice Network",
-    "Capita",
-    "Education Development Trust",
-    "National Institute of Teaching",
-    "Teach First",
-    "UCL Institute of Education",
-  ].freeze
-
   belongs_to :cpd_lead_provider, optional: true
 
   has_many :participant_declarations, through: :cpd_lead_provider, class_name: "ParticipantDeclaration::ECF"

--- a/db/new_seeds/base/add_environment_specific_data.rb
+++ b/db/new_seeds/base/add_environment_specific_data.rb
@@ -6,13 +6,10 @@ if Rails.env.in?(%w[development staging review])
   delivery_partner_credentials = {
     "Ambition Institute" => "ambition-institute-sit-%d-%d-%d@example.com",
     "Best Practice Network" => "best-practice-network-sit-%d-%d-%d@example.com",
-    "Church of England" => "church-of-england-sit-%d-%d-%d@example.com",
+    "Capita" => "capita-sit-%d-%d-%d@example.com",
     "Education Development Trust" => "education-development-trust-sit-%d-%d-%d@example.com",
-    "LLSE" => "leadership-learning-south-east-sit-%d-%d-%d@example.com",
     "National Institute of Teaching" => "niot-sit-%d-%d-%d@example.com",
-    "School-Led Network" => "school-led-network-sit-%d-%d-%d@example.com",
     "Teach First" => "teach-first-sit-%d-%d-%d@example.com",
-    "Teacher Development Trust" => "teacher-development-trust-sit-%d-%d-%d@example.com",
     "UCL Institute of Education" => "ucl-sit-%d-%d-%d@example.com",
   }
 
@@ -24,7 +21,7 @@ if Rails.env.in?(%w[development staging review])
         NewSeeds::Scenarios::Schools::School
           .new(name: "#{name} Test School #{i} #{cohort.start_year}")
           .build
-          .with_partnership_in(cohort:, delivery_partner:)
+          .with_partnership_in(cohort:, delivery_partner:, lead_provider: LeadProvider.find_by_name(name))
           .with_an_induction_tutor(full_name: "#{name} Test SIT #{i} #{cohort.start_year}", email: email % [Array.wrap(i), cohort.start_year, 0].flatten)
           .with_school_cohort_and_programme(cohort:, programme_type: :fip)
 
@@ -32,7 +29,7 @@ if Rails.env.in?(%w[development staging review])
         school = NewSeeds::Scenarios::Schools::School
           .new(name: "#{name} Test School #{i} #{cohort.start_year} independent gias type 10")
           .build
-          .with_partnership_in(cohort:, delivery_partner:)
+          .with_partnership_in(cohort:, delivery_partner:, lead_provider: LeadProvider.find_by_name(name))
           .with_an_induction_tutor(full_name: "#{name} Test SIT #{i} #{cohort.start_year} school type 10", email: email % [Array.wrap(i), cohort.start_year, 10].flatten)
           .with_school_cohort_and_programme(cohort:, programme_type: :fip)
         school.school.update!(school_type_code: 10)
@@ -41,7 +38,7 @@ if Rails.env.in?(%w[development staging review])
         school = NewSeeds::Scenarios::Schools::School
                    .new(name: "#{name} Test School #{i} #{cohort.start_year} independent gias type 11")
                    .build
-                   .with_partnership_in(cohort:, delivery_partner:)
+                   .with_partnership_in(cohort:, delivery_partner:, lead_provider: LeadProvider.find_by_name(name))
                    .with_an_induction_tutor(full_name: "#{name} Test SIT #{i} #{cohort.start_year} 11", email: email % [Array.wrap(i), cohort.start_year, 11].flatten)
                    .with_school_cohort_and_programme(cohort:, programme_type: :fip)
         school.school.update!(school_type_code: 11)
@@ -50,7 +47,7 @@ if Rails.env.in?(%w[development staging review])
         school = NewSeeds::Scenarios::Schools::School
                    .new(name: "#{name} Test School #{i} #{cohort.start_year} independent gias type 37")
                    .build
-                   .with_partnership_in(cohort:, delivery_partner:)
+                   .with_partnership_in(cohort:, delivery_partner:, lead_provider: LeadProvider.find_by_name(name))
                    .with_an_induction_tutor(full_name: "#{name} Test SIT #{i} #{cohort.start_year} 37", email: email % [Array.wrap(i), cohort.start_year, 37].flatten)
                    .with_school_cohort_and_programme(cohort:, programme_type: :fip)
         school.school.update!(school_type_code: 37)

--- a/db/new_seeds/base/add_lead_providers_and_cips.rb
+++ b/db/new_seeds/base/add_lead_providers_and_cips.rb
@@ -39,7 +39,7 @@ ambition                       = FactoryBot.create(:seed_cpd_lead_provider, name
 best_practice_network          = FactoryBot.create(:seed_cpd_lead_provider, name: "Best Practice Network")
 capita                         = FactoryBot.create(:seed_cpd_lead_provider, name: "Capita")
 education_development_trust    = FactoryBot.create(:seed_cpd_lead_provider, name: "Education Development Trust")
-FactoryBot.create(:seed_cpd_lead_provider, name: "National Institute of Teaching")
+niot                           = FactoryBot.create(:seed_cpd_lead_provider, name: "National Institute of Teaching")
 teach_first                    = FactoryBot.create(:seed_cpd_lead_provider, name: "Teach First")
 ucl_institute_of_education     = FactoryBot.create(:seed_cpd_lead_provider, name: "UCL Institute of Education")
 
@@ -49,12 +49,14 @@ ambition_cip = FactoryBot.create(:seed_core_induction_programme, name: ambition.
 edt_cip = FactoryBot.create(:seed_core_induction_programme, name: education_development_trust.name)
 teach_first_cip = FactoryBot.create(:seed_core_induction_programme, name: teach_first.name)
 ucl_cip = FactoryBot.create(:seed_core_induction_programme, name: ucl_institute_of_education.name)
+niot_cip = FactoryBot.create(:seed_core_induction_programme, name: niot.name)
 
 {
   ambition_cip    => [ambition, capita],
   ucl_cip         => [ucl_institute_of_education, best_practice_network],
   edt_cip         => [education_development_trust],
   teach_first_cip => [teach_first],
+  niot_cip        => [niot],
 }.each do |cip, cpd_lead_providers|
   cpd_lead_providers.each do |cpd_lead_provider|
     FactoryBot.create(:seed_lead_provider, cpd_lead_provider:, name: cpd_lead_provider.name).tap do |lead_provider|

--- a/db/new_seeds/scenarios/lead_providers/lead_provider.rb
+++ b/db/new_seeds/scenarios/lead_providers/lead_provider.rb
@@ -4,6 +4,16 @@ module NewSeeds
   module Scenarios
     module LeadProviders
       class LeadProvider
+        ALL_PROVIDERS = [
+          "Ambition Institute",
+          "Best Practice Network",
+          "Capita",
+          "Education Development Trust",
+          "National Institute of Teaching",
+          "Teach First",
+          "UCL Institute of Education",
+        ].freeze
+
         attr_reader :name, :lead_provider, :delivery_partners, :user, :cohorts
 
         delegate :cpd_lead_provider, to: :lead_provider

--- a/db/new_seeds/scenarios/participants/transfers/fip_to_fip.rb
+++ b/db/new_seeds/scenarios/participants/transfers/fip_to_fip.rb
@@ -84,7 +84,7 @@ module NewSeeds
           end
 
           def lead_provider_to
-            @lead_provider_to ||= @supplied_lead_provider_to || FactoryBot.create(:seed_lead_provider)
+            @lead_provider_to ||= @supplied_lead_provider_to || LeadProvider.excluding(lead_provider_from).sample || FactoryBot.create(:seed_lead_provider)
           end
 
           def setup

--- a/db/new_seeds/scenarios/users/lead_provider_user.rb
+++ b/db/new_seeds/scenarios/users/lead_provider_user.rb
@@ -9,7 +9,7 @@ module NewSeeds
         def initialize(user: nil, lead_provider: nil, full_name: nil, email: nil)
           @user = user
           @new_user_attributes = { full_name:, email: }.compact
-          @lead_provider = lead_provider || LeadProvider.all.sample
+          @lead_provider = lead_provider || FactoryBot.create(:seed_lead_provider)
         end
 
         def build

--- a/spec/factories/seeds/cpd_lead_provider_factory.rb
+++ b/spec/factories/seeds/cpd_lead_provider_factory.rb
@@ -2,7 +2,11 @@
 
 FactoryBot.define do
   factory(:seed_cpd_lead_provider, class: "CpdLeadProvider") do
-    name { Faker::Company.name }
+    name { LeadProvider::ALL_PROVIDERS.sample }
+
+    initialize_with do
+      CpdLeadProvider.find_or_create_by(name:)
+    end
 
     trait(:valid) {}
 

--- a/spec/factories/seeds/cpd_lead_provider_factory.rb
+++ b/spec/factories/seeds/cpd_lead_provider_factory.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory(:seed_cpd_lead_provider, class: "CpdLeadProvider") do
-    name { LeadProvider::ALL_PROVIDERS.sample }
+    name { NewSeeds::Scenarios::LeadProviders::LeadProvider::ALL_PROVIDERS.sample }
 
     initialize_with do
       CpdLeadProvider.find_or_create_by(name:)

--- a/spec/factories/seeds/lead_provider_factory.rb
+++ b/spec/factories/seeds/lead_provider_factory.rb
@@ -2,7 +2,11 @@
 
 FactoryBot.define do
   factory(:seed_lead_provider, class: "LeadProvider") do
-    name { Faker::Company.name }
+    name { LeadProvider::ALL_PROVIDERS.sample }
+
+    initialize_with do
+      LeadProvider.find_or_create_by(name:)
+    end
 
     trait(:with_cpd_lead_provider) { association(:cpd_lead_provider, factory: :seed_cpd_lead_provider, name: :name) }
 

--- a/spec/factories/seeds/lead_provider_factory.rb
+++ b/spec/factories/seeds/lead_provider_factory.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory(:seed_lead_provider, class: "LeadProvider") do
-    name { LeadProvider::ALL_PROVIDERS.sample }
+    name { NewSeeds::Scenarios::LeadProviders::LeadProvider::ALL_PROVIDERS.sample }
 
     initialize_with do
       LeadProvider.find_or_create_by(name:)

--- a/spec/services/induction/find_by_spec.rb
+++ b/spec/services/induction/find_by_spec.rb
@@ -9,9 +9,12 @@ RSpec.describe Induction::FindBy do
   # after the start_date but before the end_date of induction_4
   let!(:an_earlier_point_in_time) { Date.new(current_year, 12, 25) }
 
-  let(:school_1) { NewSeeds::Scenarios::Schools::School.new.build.chosen_fip_and_partnered_in(cohort:) }
-  let(:school_2) { NewSeeds::Scenarios::Schools::School.new.build.chosen_fip_and_partnered_in(cohort:) }
-  let(:school_3) { NewSeeds::Scenarios::Schools::School.new.build.chosen_fip_and_partnered_in(cohort:) }
+  let(:lead_provider_1) { create(:lead_provider, name: "Ambition Institute") }
+  let(:school_1) { NewSeeds::Scenarios::Schools::School.new.build.with_partnership_in(cohort:, lead_provider: lead_provider_1).chosen_fip_and_partnered_in(cohort:) }
+  let(:lead_provider_2) { create(:lead_provider, name: "Capita") }
+  let(:school_2) { NewSeeds::Scenarios::Schools::School.new.build.with_partnership_in(cohort:, lead_provider: lead_provider_2).chosen_fip_and_partnered_in(cohort:) }
+  let(:lead_provider_3) { create(:lead_provider, name: "Teach First") }
+  let(:school_3) { NewSeeds::Scenarios::Schools::School.new.build.with_partnership_in(cohort:, lead_provider: lead_provider_3).chosen_fip_and_partnered_in(cohort:) }
   let(:ect) { NewSeeds::Scenarios::Participants::Ects::Ect.new(school_cohort: school_1.school_cohort).build }
 
   let(:appropriate_body_1) { create(:appropriate_body_local_authority) }

--- a/spec/services/participants/check_and_set_completion_date_spec.rb
+++ b/spec/services/participants/check_and_set_completion_date_spec.rb
@@ -13,8 +13,6 @@ RSpec.describe Participants::CheckAndSetCompletionDate do
       .chosen_fip_and_partnered_in(cohort:)
       .school
   end
-  let(:lead_provider_1) { create(:lead_provider, name: "Capita") }
-  let(:school_1) { NewSeeds::Scenarios::Schools::School.new.build.with_partnership_in(cohort:, lead_provider: lead_provider_1).chosen_fip_and_partnered_in(cohort:) }
   let(:school_cohort) { school.school_cohorts.first }
   let(:induction_programme) { school_cohort.default_induction_programme }
   let(:participant_profile) do

--- a/spec/services/participants/check_and_set_completion_date_spec.rb
+++ b/spec/services/participants/check_and_set_completion_date_spec.rb
@@ -4,13 +4,17 @@ require "rails_helper"
 
 RSpec.describe Participants::CheckAndSetCompletionDate do
   let(:cohort) { Cohort.previous || create(:cohort, :previous) }
+  let(:lead_provider) { create(:lead_provider, name: "Ambition Institute") }
   let(:school) do
     NewSeeds::Scenarios::Schools::School
       .new
       .build
+      .with_partnership_in(cohort:, lead_provider:)
       .chosen_fip_and_partnered_in(cohort:)
       .school
   end
+  let(:lead_provider_1) { create(:lead_provider, name: "Capita") }
+  let(:school_1) { NewSeeds::Scenarios::Schools::School.new.build.with_partnership_in(cohort:, lead_provider: lead_provider_1).chosen_fip_and_partnered_in(cohort:) }
   let(:school_cohort) { school.school_cohorts.first }
   let(:induction_programme) { school_cohort.default_induction_programme }
   let(:participant_profile) do


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-3958](https://dfedigital.atlassian.net/browse/CPDLP-3958)

We currently have a set of known providers in production, however in seeds we create many other providers unnecessarily and the data for contracts and statements is not set up properly.

### Changes proposed in this pull request

Ensure all seed data and participants for both ECTs/Mentors is attached to only the known lead providers.

[CPDLP-3958]: https://dfedigital.atlassian.net/browse/CPDLP-3958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ