### PR TITLE
[CPDLP-4010] Add tweaks for mentor funding creation in cohort 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ exactly what and how their test data is configured. These magic values are only 
 | 22/1/1900 | Participant matched and has a 2022 cohort induction start date |
 | 23/1/1900 | Participant matched and has a 2023 cohort induction start date |
 | 24/1/1900 | Participant matched and has a 2024 cohort induction start date |
+| 25/1/1900 | Participant matched and has a 2025 cohort induction start date |
 
 ## Deployment infrastructure
 

--- a/app/services/dqt_record_check.rb
+++ b/app/services/dqt_record_check.rb
@@ -136,6 +136,9 @@ private
 
       # all matches 24 cohort start date - use 24/1/1900
       24 => CheckResult.new(magic_dqt_record(induction_start_date: Date.new(2024, 9, 1)), true, true, true, true, 4),
+
+      # all matches 25 cohort start date - use 25/1/1900
+      25 => CheckResult.new(magic_dqt_record(induction_start_date: Date.new(2025, 9, 1)), true, true, true, true, 4),
     }
   end
 

--- a/app/services/importers/create_call_off_contract.rb
+++ b/app/services/importers/create_call_off_contract.rb
@@ -100,7 +100,12 @@ module Importers
         per_participant: band_data[:per_participant],
       }
 
-      attributes.merge!(output_payment_percentage: 100, service_fee_percentage: 0) if band_d
+      if band_d
+        return true unless band_data[:min] && band_data[:max] && band_data[:per_participant]
+
+        attributes.merge!(output_payment_percentage: 100, service_fee_percentage: 0)
+      end
+
       ParticipantBand.create!(**attributes)
     end
 

--- a/app/services/importers/create_cohort.rb
+++ b/app/services/importers/create_cohort.rb
@@ -60,7 +60,7 @@ module Importers
     end
 
     def check_headers!
-      unless %w[start-year registration-start-date academic-year-start-date automatic-assignment-period-end-date payments-frozen-at].all? { |header| rows.headers.include?(header) }
+      unless %w[start-year registration-start-date academic-year-start-date automatic-assignment-period-end-date payments-frozen-at mentor-funding].all? { |header| rows.headers.include?(header) }
         raise NameError, "Invalid headers"
       end
     end

--- a/spec/fixtures/files/importers/cohort_csv_data.csv
+++ b/spec/fixtures/files/importers/cohort_csv_data.csv
@@ -1,2 +1,2 @@
-start-year,registration-start-date,academic-year-start-date,automatic-assignment-period-end-date,payments-frozen-at
-2026,2026/05/10,2026/09/01,
+start-year,registration-start-date,academic-year-start-date,automatic-assignment-period-end-date,payments-frozen-at,mentor-funding
+2026,2026/05/10,2026/09/01,2026/03/31,,true

--- a/spec/fixtures/files/importers/contract_csv_data.csv
+++ b/spec/fixtures/files/importers/contract_csv_data.csv
@@ -1,2 +1,2 @@
 lead-provider-name,cohort-start-year,uplift-target,uplift-amount,recruitment-target,revised-target,set-up-fee,monthly-service-fee,band-a-min,band-a-max,band-a-per-participant,band-b-min,band-b-max,band-b-per-participant,band-c-min,band-c-max,band-c-per-participant,band-d-min,band-d-max,band-d-per-participant
-Ambition Institute,2026,0.44,200,4600,4790,0,0,90,895,91,199,700,200,299,600,300,400,500
+Ambition Institute,2026,0.44,200,4600,4790,0,0,90,895,91,199,700,200,299,600,300,400,500,400

--- a/spec/services/importers/create_call_off_contract_spec.rb
+++ b/spec/services/importers/create_call_off_contract_spec.rb
@@ -222,14 +222,15 @@ RSpec.describe Importers::CreateCallOffContract do
         csv.write "\n"
         csv.close
       end
+      let(:created_call_off_contract) { CallOffContract.last }
 
       it "creates 3 participant bands" do
         importer.call
 
-        expect(lead_provider.call_off_contract.band_a).to be_present
-        expect(lead_provider.call_off_contract.bands.order(max: :asc).second).to be_present
-        expect(lead_provider.call_off_contract.bands.order(max: :asc).third).to be_present
-        expect(lead_provider.call_off_contract.bands.order(max: :asc).fourth).to be_nil
+        expect(created_call_off_contract.band_a).to be_present
+        expect(created_call_off_contract.bands.order(max: :asc).second).to be_present
+        expect(created_call_off_contract.bands.order(max: :asc).third).to be_present
+        expect(created_call_off_contract.bands.order(max: :asc).fourth).to be_nil
       end
     end
   end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-4010

### Changes proposed in this pull request

- Add magic date for cohort 25;
  - So a valid participant in cohort 2025 can be created with date of birth 25/01/1900
- Include missing header to cohorts importer;
- Do not create band D when there is no band D data in call off contracts csv;

### Guidance to review

Review app
