### PR TITLE
Update api docs for unfunded mentors

### DIFF
--- a/docs/lib/govuk_tech_docs/open_api/templates/schema.html.erb
+++ b/docs/lib/govuk_tech_docs/open_api/templates/schema.html.erb
@@ -40,12 +40,14 @@
               <% end %>
             <% end %>
 
-            <% schema_location = nested_schema.node_context.source_location.to_s %>
-            <% # Only print a link if it's a referenced schema. %>
-            <% if !schema_location.include?('/properties/') %>
-              <%= "It conforms to #{get_schema_link(nested_schema)} schema." %>
-            <% elsif schema_location.end_with?("data") %>
-              <%= "It conforms to #{get_schema_link_data(nested_schema)} schema." %>
+            <% unless property[1].node_data["anyOf"].node.present? %>
+              <% schema_location = nested_schema.node_context.source_location.to_s %>
+              <% # Only print a link if it's a referenced schema. %>
+              <% if !schema_location.include?('/properties/') %>
+                <%= "It conforms to #{get_schema_link(nested_schema)} schema." %>
+              <% elsif schema_location.end_with?("data") %>
+                <%= "It conforms to #{get_schema_link_data(nested_schema)} schema." %>
+              <% end %>
             <% end %>
 
             <% if property[1].node_data["anyOf"].node.present? %>

--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -7,7 +7,7 @@ weight: 8
 
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
 
-## XX February 2025
+## 19 February 2025
 
 We’ve added the schedules and contract data for the 2025/26 intake of early career teachers (ECTs) and mentors to the test (sandbox) environment.
 

--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -7,6 +7,36 @@ weight: 8
 
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
 
+## XX February 2025
+
+We’ve added the schedules and contract data for the 2025/26 intake of early career teachers (ECTs) and mentors to the test (sandbox) environment.
+
+Lead providers can either add participants via the ECF interface or by using the seed data we’ve created. This will allow them to test the full end-to-end process and ensure smooth integration for any upcoming changes.
+
+When registering participants in the test environment, providers must use the following date of birth if they want the 2025/26 ECTs to appear as eligible for funding:
+
+- 25/1/1900
+
+For mentors, use the following date of birth:
+
+- 1/1/1900
+
+### Changes to mentor declarations for the 2025/6 intake 
+
+We’ve removed the following declarations from the ``POST participant-declarations`` test environment endpoint for mentors starting in 2025/26:  
+
+- ``retained-1`` 
+- ``retained-2`` 
+- ``retained-3`` 
+- ``retained-4`` 
+- ``extended-1``
+- ``extended-2``
+- ``extended-3``
+
+This is because there’ll only be 2 mentor declarations from the 2025/26 academic year onwards, ``started`` and ``completed``.  
+
+These changes align with the updated frameworks and payment guidelines shared with lead providers.
+
 ## 8 January 2025
 
 Lead providers getting participant declarations via the API endpoints will now see previous declarations attached to completed participants rather than just active participants.

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -2784,8 +2784,8 @@
           }
         }
       },
-      "ParticipantDeclarationDataRequest": {
-        "description": "A participant declaration data request",
+      "ParticipantDeclarationPost2024ECTDataRequest": {
+        "description": " A participant declaration data request for ECT participants from cohort 2025 onwards",
         "type": "object",
         "properties": {
           "type": {
@@ -2795,6 +2795,59 @@
             ]
           },
           "attributes": {
+            "type": "object",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ECFParticipantDeclarationStartedAttributesRequest"
+              },
+              {
+                "$ref": "#/components/schemas/ECFParticipantDeclarationRetainedAttributesRequest"
+              },
+              {
+                "$ref": "#/components/schemas/ECFParticipantDeclarationCompletedAttributesRequest"
+              },
+              {
+                "$ref": "#/components/schemas/ECFParticipantDeclarationExtendedAttributesRequest"
+              }
+            ]
+          }
+        }
+      },
+      "ParticipantDeclarationPost2024MentorDataRequest": {
+        "description": "A participant declaration data request for mentor participants from cohort 2025 onwards",
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "participant-declaration"
+            ]
+          },
+          "attributes": {
+            "type": "object",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ECFParticipantDeclarationStartedAttributesRequest"
+              },
+              {
+                "$ref": "#/components/schemas/ECFParticipantDeclarationCompletedAttributesRequest"
+              }
+            ]
+          }
+        }
+      },
+      "ParticipantDeclarationPre2025DataRequest": {
+        "description": "A participant declaration data request for participants in cohort 2024 and previous years",
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "participant-declaration"
+            ]
+          },
+          "attributes": {
+            "type": "object",
             "anyOf": [
               {
                 "$ref": "#/components/schemas/ECFParticipantDeclarationStartedAttributesRequest"
@@ -2820,7 +2873,18 @@
         ],
         "properties": {
           "data": {
-            "$ref": "#/components/schemas/ParticipantDeclarationDataRequest"
+            "type": "object",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ParticipantDeclarationPre2025DataRequest"
+              },
+              {
+                "$ref": "#/components/schemas/ParticipantDeclarationPost2024ECTDataRequest"
+              },
+              {
+                "$ref": "#/components/schemas/ParticipantDeclarationPost2024MentorDataRequest"
+              }
+            ]
           }
         }
       },

--- a/swagger/v1/component_schemas/ParticipantDeclarationPost2024ECTDataRequest.yml
+++ b/swagger/v1/component_schemas/ParticipantDeclarationPost2024ECTDataRequest.yml
@@ -1,0 +1,14 @@
+description: " A participant declaration data request for ECT participants from cohort 2025 onwards"
+type: object
+properties:
+  type:
+    type: string
+    enum:
+      - participant-declaration
+  attributes:
+    type: object
+    anyOf:
+      - $ref: "#/components/schemas/ECFParticipantDeclarationStartedAttributesRequest"
+      - $ref: "#/components/schemas/ECFParticipantDeclarationRetainedAttributesRequest"
+      - $ref: "#/components/schemas/ECFParticipantDeclarationCompletedAttributesRequest"
+      - $ref: "#/components/schemas/ECFParticipantDeclarationExtendedAttributesRequest"

--- a/swagger/v1/component_schemas/ParticipantDeclarationPost2024MentorDataRequest.yml
+++ b/swagger/v1/component_schemas/ParticipantDeclarationPost2024MentorDataRequest.yml
@@ -1,4 +1,4 @@
-description: "A participant declaration data request"
+description: "A participant declaration data request for mentor participants from cohort 2025 onwards"
 type: object
 properties:
   type:
@@ -6,8 +6,7 @@ properties:
     enum:
       - participant-declaration
   attributes:
+    type: object
     anyOf:
       - $ref: "#/components/schemas/ECFParticipantDeclarationStartedAttributesRequest"
-      - $ref: "#/components/schemas/ECFParticipantDeclarationRetainedAttributesRequest"
       - $ref: "#/components/schemas/ECFParticipantDeclarationCompletedAttributesRequest"
-      - $ref: "#/components/schemas/ECFParticipantDeclarationExtendedAttributesRequest"

--- a/swagger/v1/component_schemas/ParticipantDeclarationPre2025DataRequest.yml
+++ b/swagger/v1/component_schemas/ParticipantDeclarationPre2025DataRequest.yml
@@ -1,0 +1,14 @@
+description: "A participant declaration data request for participants in cohort 2024 and previous years"
+type: object
+properties:
+  type:
+    type: string
+    enum:
+      - participant-declaration
+  attributes:
+    type: object
+    anyOf:
+      - $ref: "#/components/schemas/ECFParticipantDeclarationStartedAttributesRequest"
+      - $ref: "#/components/schemas/ECFParticipantDeclarationRetainedAttributesRequest"
+      - $ref: "#/components/schemas/ECFParticipantDeclarationCompletedAttributesRequest"
+      - $ref: "#/components/schemas/ECFParticipantDeclarationExtendedAttributesRequest"

--- a/swagger/v1/component_schemas/ParticipantDeclarationRequest.yml
+++ b/swagger/v1/component_schemas/ParticipantDeclarationRequest.yml
@@ -4,4 +4,8 @@ required:
   - data
 properties:
   data:
-    $ref: "#/components/schemas/ParticipantDeclarationDataRequest"
+    type: object
+    anyOf:
+      - $ref: "#/components/schemas/ParticipantDeclarationPre2025DataRequest"
+      - $ref: "#/components/schemas/ParticipantDeclarationPost2024ECTDataRequest"
+      - $ref: "#/components/schemas/ParticipantDeclarationPost2024MentorDataRequest"

--- a/swagger/v2/api_spec.json
+++ b/swagger/v2/api_spec.json
@@ -2519,8 +2519,8 @@
           }
         }
       },
-      "ParticipantDeclarationDataRequest": {
-        "description": "A participant declaration data request",
+      "ParticipantDeclarationPost2024ECTDataRequest": {
+        "description": " A participant declaration data request for ECT participants from cohort 2025 onwards",
         "type": "object",
         "properties": {
           "type": {
@@ -2530,6 +2530,59 @@
             ]
           },
           "attributes": {
+            "type": "object",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ECFParticipantDeclarationStartedAttributesRequest"
+              },
+              {
+                "$ref": "#/components/schemas/ECFParticipantDeclarationRetainedAttributesRequest"
+              },
+              {
+                "$ref": "#/components/schemas/ECFParticipantDeclarationCompletedAttributesRequest"
+              },
+              {
+                "$ref": "#/components/schemas/ECFParticipantDeclarationExtendedAttributesRequest"
+              }
+            ]
+          }
+        }
+      },
+      "ParticipantDeclarationPost2024MentorDataRequest": {
+        "description": "A participant declaration data request for mentor participants from cohort 2025 onwards",
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "participant-declaration"
+            ]
+          },
+          "attributes": {
+            "type": "object",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ECFParticipantDeclarationStartedAttributesRequest"
+              },
+              {
+                "$ref": "#/components/schemas/ECFParticipantDeclarationCompletedAttributesRequest"
+              }
+            ]
+          }
+        }
+      },
+      "ParticipantDeclarationPre2025DataRequest": {
+        "description": "A participant declaration data request for participants in cohort 2024 and previous years",
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "participant-declaration"
+            ]
+          },
+          "attributes": {
+            "type": "object",
             "anyOf": [
               {
                 "$ref": "#/components/schemas/ECFParticipantDeclarationStartedAttributesRequest"
@@ -2555,7 +2608,18 @@
         ],
         "properties": {
           "data": {
-            "$ref": "#/components/schemas/ParticipantDeclarationDataRequest"
+            "type": "object",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ParticipantDeclarationPre2025DataRequest"
+              },
+              {
+                "$ref": "#/components/schemas/ParticipantDeclarationPost2024ECTDataRequest"
+              },
+              {
+                "$ref": "#/components/schemas/ParticipantDeclarationPost2024MentorDataRequest"
+              }
+            ]
           }
         }
       },

--- a/swagger/v2/component_schemas/ParticipantDeclarationPost2024ECTDataRequest.yml
+++ b/swagger/v2/component_schemas/ParticipantDeclarationPost2024ECTDataRequest.yml
@@ -1,0 +1,14 @@
+description: " A participant declaration data request for ECT participants from cohort 2025 onwards"
+type: object
+properties:
+  type:
+    type: string
+    enum:
+      - participant-declaration
+  attributes:
+    type: object
+    anyOf:
+      - $ref: "#/components/schemas/ECFParticipantDeclarationStartedAttributesRequest"
+      - $ref: "#/components/schemas/ECFParticipantDeclarationRetainedAttributesRequest"
+      - $ref: "#/components/schemas/ECFParticipantDeclarationCompletedAttributesRequest"
+      - $ref: "#/components/schemas/ECFParticipantDeclarationExtendedAttributesRequest"

--- a/swagger/v2/component_schemas/ParticipantDeclarationPost2024MentorDataRequest.yml
+++ b/swagger/v2/component_schemas/ParticipantDeclarationPost2024MentorDataRequest.yml
@@ -1,4 +1,4 @@
-description: "A participant declaration data request"
+description: "A participant declaration data request for mentor participants from cohort 2025 onwards"
 type: object
 properties:
   type:
@@ -6,8 +6,7 @@ properties:
     enum:
       - participant-declaration
   attributes:
+    type: object
     anyOf:
       - $ref: "#/components/schemas/ECFParticipantDeclarationStartedAttributesRequest"
-      - $ref: "#/components/schemas/ECFParticipantDeclarationRetainedAttributesRequest"
       - $ref: "#/components/schemas/ECFParticipantDeclarationCompletedAttributesRequest"
-      - $ref: "#/components/schemas/ECFParticipantDeclarationExtendedAttributesRequest"

--- a/swagger/v2/component_schemas/ParticipantDeclarationPre2025DataRequest.yml
+++ b/swagger/v2/component_schemas/ParticipantDeclarationPre2025DataRequest.yml
@@ -1,0 +1,14 @@
+description: "A participant declaration data request for participants in cohort 2024 and previous years"
+type: object
+properties:
+  type:
+    type: string
+    enum:
+      - participant-declaration
+  attributes:
+    type: object
+    anyOf:
+      - $ref: "#/components/schemas/ECFParticipantDeclarationStartedAttributesRequest"
+      - $ref: "#/components/schemas/ECFParticipantDeclarationRetainedAttributesRequest"
+      - $ref: "#/components/schemas/ECFParticipantDeclarationCompletedAttributesRequest"
+      - $ref: "#/components/schemas/ECFParticipantDeclarationExtendedAttributesRequest"

--- a/swagger/v2/component_schemas/ParticipantDeclarationRequest.yml
+++ b/swagger/v2/component_schemas/ParticipantDeclarationRequest.yml
@@ -4,4 +4,8 @@ required:
   - data
 properties:
   data:
-    $ref: "#/components/schemas/ParticipantDeclarationDataRequest"
+    type: object
+    anyOf:
+      - $ref: "#/components/schemas/ParticipantDeclarationPre2025DataRequest"
+      - $ref: "#/components/schemas/ParticipantDeclarationPost2024ECTDataRequest"
+      - $ref: "#/components/schemas/ParticipantDeclarationPost2024MentorDataRequest"

--- a/swagger/v3/api_spec.json
+++ b/swagger/v3/api_spec.json
@@ -3877,8 +3877,8 @@
           }
         }
       },
-      "ParticipantDeclarationDataRequest": {
-        "description": "A participant declaration data request",
+      "ParticipantDeclarationPost2024ECTDataRequest": {
+        "description": " A participant declaration data request for ECT participants from cohort 2025 onwards",
         "type": "object",
         "properties": {
           "type": {
@@ -3888,6 +3888,59 @@
             ]
           },
           "attributes": {
+            "type": "object",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ECFParticipantDeclarationStartedAttributesRequest"
+              },
+              {
+                "$ref": "#/components/schemas/ECFParticipantDeclarationRetainedAttributesRequest"
+              },
+              {
+                "$ref": "#/components/schemas/ECFParticipantDeclarationCompletedAttributesRequest"
+              },
+              {
+                "$ref": "#/components/schemas/ECFParticipantDeclarationExtendedAttributesRequest"
+              }
+            ]
+          }
+        }
+      },
+      "ParticipantDeclarationPost2024MentorDataRequest": {
+        "description": "A participant declaration data request for mentor participants from cohort 2025 onwards",
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "participant-declaration"
+            ]
+          },
+          "attributes": {
+            "type": "object",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ECFParticipantDeclarationStartedAttributesRequest"
+              },
+              {
+                "$ref": "#/components/schemas/ECFParticipantDeclarationCompletedAttributesRequest"
+              }
+            ]
+          }
+        }
+      },
+      "ParticipantDeclarationPre2025DataRequest": {
+        "description": "A participant declaration data request for participants in cohort 2024 and previous years",
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "participant-declaration"
+            ]
+          },
+          "attributes": {
+            "type": "object",
             "anyOf": [
               {
                 "$ref": "#/components/schemas/ECFParticipantDeclarationStartedAttributesRequest"
@@ -3913,7 +3966,18 @@
         ],
         "properties": {
           "data": {
-            "$ref": "#/components/schemas/ParticipantDeclarationDataRequest"
+            "type": "object",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ParticipantDeclarationPre2025DataRequest"
+              },
+              {
+                "$ref": "#/components/schemas/ParticipantDeclarationPost2024ECTDataRequest"
+              },
+              {
+                "$ref": "#/components/schemas/ParticipantDeclarationPost2024MentorDataRequest"
+              }
+            ]
           }
         }
       },

--- a/swagger/v3/component_schemas/ParticipantDeclarationPost2024ECTDataRequest.yml
+++ b/swagger/v3/component_schemas/ParticipantDeclarationPost2024ECTDataRequest.yml
@@ -1,0 +1,14 @@
+description: " A participant declaration data request for ECT participants from cohort 2025 onwards"
+type: object
+properties:
+  type:
+    type: string
+    enum:
+      - participant-declaration
+  attributes:
+    type: object
+    anyOf:
+      - $ref: "#/components/schemas/ECFParticipantDeclarationStartedAttributesRequest"
+      - $ref: "#/components/schemas/ECFParticipantDeclarationRetainedAttributesRequest"
+      - $ref: "#/components/schemas/ECFParticipantDeclarationCompletedAttributesRequest"
+      - $ref: "#/components/schemas/ECFParticipantDeclarationExtendedAttributesRequest"

--- a/swagger/v3/component_schemas/ParticipantDeclarationPost2024MentorDataRequest.yml
+++ b/swagger/v3/component_schemas/ParticipantDeclarationPost2024MentorDataRequest.yml
@@ -1,4 +1,4 @@
-description: "A participant declaration data request"
+description: "A participant declaration data request for mentor participants from cohort 2025 onwards"
 type: object
 properties:
   type:
@@ -6,8 +6,7 @@ properties:
     enum:
       - participant-declaration
   attributes:
+    type: object
     anyOf:
       - $ref: "#/components/schemas/ECFParticipantDeclarationStartedAttributesRequest"
-      - $ref: "#/components/schemas/ECFParticipantDeclarationRetainedAttributesRequest"
       - $ref: "#/components/schemas/ECFParticipantDeclarationCompletedAttributesRequest"
-      - $ref: "#/components/schemas/ECFParticipantDeclarationExtendedAttributesRequest"

--- a/swagger/v3/component_schemas/ParticipantDeclarationPre2025DataRequest.yml
+++ b/swagger/v3/component_schemas/ParticipantDeclarationPre2025DataRequest.yml
@@ -1,0 +1,14 @@
+description: "A participant declaration data request for participants in cohort 2024 and previous years"
+type: object
+properties:
+  type:
+    type: string
+    enum:
+      - participant-declaration
+  attributes:
+    type: object
+    anyOf:
+      - $ref: "#/components/schemas/ECFParticipantDeclarationStartedAttributesRequest"
+      - $ref: "#/components/schemas/ECFParticipantDeclarationRetainedAttributesRequest"
+      - $ref: "#/components/schemas/ECFParticipantDeclarationCompletedAttributesRequest"
+      - $ref: "#/components/schemas/ECFParticipantDeclarationExtendedAttributesRequest"

--- a/swagger/v3/component_schemas/ParticipantDeclarationRequest.yml
+++ b/swagger/v3/component_schemas/ParticipantDeclarationRequest.yml
@@ -4,4 +4,8 @@ required:
   - data
 properties:
   data:
-    $ref: "#/components/schemas/ParticipantDeclarationDataRequest"
+    type: object  
+    anyOf:
+      - $ref: "#/components/schemas/ParticipantDeclarationPre2025DataRequest"
+      - $ref: "#/components/schemas/ParticipantDeclarationPost2024ECTDataRequest"
+      - $ref: "#/components/schemas/ParticipantDeclarationPost2024MentorDataRequest"


### PR DESCRIPTION
[Jira-4013](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-4013)

### Context

The new ECF framework requires providers to only submit started and completed declarations for mentors and started, retained and completed for ECT’s. This is different to how our current spec presents information. We’ll need our spec to dual run business logic from pre-2025 and 2025 onwards.

### Changes proposed in this pull request

- Add release note for unfunded mentors

Add a release note to details the changes for recording declarations against unfunded mentors.

- Allow anyOf on data attributes in API docs

Currently, if you set a `data` attribute up with an `anyOf` value set it will output the "It conforms to" text as well as the "This conforms to" text. This is due to `data` being a special attribute whereby we usually link to another, single schema.

To get around this and allow `anyOf` for `data` attributes we only want to output the "It conforms to" links if there is _not_ an `anyOf` value set present.

- Update POST /api/participant-declarations API docs for mentor funding

The API docs for creating a declaration need to change to inform lead providers that they will only be able to use certain payloads depending on the cohort that is being referenced and the type of participant in question.

For pre-2025 cohorts the request schemas remain the same (started, retained, extended and completed). For 2025 and later when a declaration is being made for a mentor we will only accept started and completed.

### Guidance to review

This ticket changed a bit on picking it up; adding the copy from the ticket to the API docs directly isn't how swagger wants to work, so instead we need to abstract each scenario in its own schema.

[Link to reworked ParticipantDeclarationRequest schema](https://cpd-ecf-review-5535-web.test.teacherservices.cloud/api-reference/reference-v3.html#schema-participantdeclarationrequest)
[Pre-2025 schema](https://cpd-ecf-review-5535-web.test.teacherservices.cloud/api-reference/reference-v3.html#schema-participantdeclarationpre2025datarequest)
[Post-2024 ECT schema](https://cpd-ecf-review-5535-web.test.teacherservices.cloud/api-reference/reference-v3.html#schema-participantdeclarationpost2024ectdatarequest)
[Post 2024 mentor schema](https://cpd-ecf-review-5535-web.test.teacherservices.cloud/api-reference/reference-v3.html#schema-participantdeclarationpost2024mentordatarequest)
