### PR TITLE
[CPDLP-3931] Add new field to cohort to drive the new evidence types logic

### DIFF
--- a/app/services/importers/create_cohort.rb
+++ b/app/services/importers/create_cohort.rb
@@ -41,6 +41,7 @@ module Importers
           automatic_assignment_period_end_date: safe_parse(row["automatic-assignment-period-end-date"]) || default_automatic_assignment_period_end_date,
           payments_frozen_at: safe_parse(row["payments-frozen-at"]).presence,
           mentor_funding: (row["mentor-funding"] == "true"),
+          detailed_evidence_types: (row["detailed-evidence-types"] == "true"),
           created_at: Time.zone.now,
           updated_at: Time.zone.now,
         },
@@ -60,7 +61,7 @@ module Importers
     end
 
     def check_headers!
-      unless %w[start-year registration-start-date academic-year-start-date automatic-assignment-period-end-date payments-frozen-at mentor-funding].all? { |header| rows.headers.include?(header) }
+      unless %w[start-year registration-start-date academic-year-start-date automatic-assignment-period-end-date payments-frozen-at mentor-funding detailed-evidence-types].all? { |header| rows.headers.include?(header) }
         raise NameError, "Invalid headers"
       end
     end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -197,6 +197,7 @@
   - automatic_assignment_period_end_date
   - payments_frozen_at
   - mentor_funding
+  - detailed_evidence_types
   :provider_relationships:
   - id
   - lead_provider_id

--- a/db/data/cohorts/cohorts.csv
+++ b/db/data/cohorts/cohorts.csv
@@ -1,7 +1,7 @@
-start-year,registration-start-date,academic-year-start-date,automatic-assignment-period-end-date,payments-frozen-at,mentor-funding
-2020,2020/05/10,2020/09/01,2021/03/31,,false
-2021,2021/05/10,2021/09/01,2022/03/31,2024/04/03,false
-2022,2022/05/10,2022/09/01,2023/03/31,,false
-2023,2023/06/05,2023/09/01,2024/03/31,,false
-2024,2024/04/03,2024/09/01,2025/03/31,,false
-2025,2024/12/31,2025/09/01,2026/03/31,,true
+start-year,registration-start-date,academic-year-start-date,automatic-assignment-period-end-date,payments-frozen-at,mentor-funding,detailed-evidence-types
+2020,2020/05/10,2020/09/01,2021/03/31,,false,false
+2021,2021/05/10,2021/09/01,2022/03/31,2024/04/03,false,false
+2022,2022/05/10,2022/09/01,2023/03/31,,false,false
+2023,2023/06/05,2023/09/01,2024/03/31,,false,false
+2024,2024/04/03,2024/09/01,2025/03/31,,false,false
+2025,2024/12/31,2025/09/01,2026/03/31,,true,true

--- a/db/migrate/20250211191336_add_detailed_evidence_types_to_cohort.rb
+++ b/db/migrate/20250211191336_add_detailed_evidence_types_to_cohort.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDetailedEvidenceTypesToCohort < ActiveRecord::Migration[7.1]
+  def change
+    add_column :cohorts, :detailed_evidence_types, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_01_30_101804) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_11_191336) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -262,6 +262,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_30_101804) do
     t.date "automatic_assignment_period_end_date"
     t.datetime "payments_frozen_at"
     t.boolean "mentor_funding", default: false, null: false
+    t.boolean "detailed_evidence_types", default: false, null: false
     t.index ["start_year"], name: "index_cohorts_on_start_year", unique: true
   end
 

--- a/spec/factories/cohorts.rb
+++ b/spec/factories/cohorts.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
     academic_year_start_date { Date.new(start_year.to_i, 9, 1) }
     automatic_assignment_period_end_date { Date.new(start_year.to_i + 1, 3, 31) }
     mentor_funding { false }
+    detailed_evidence_types { false }
 
     initialize_with do
       Cohort.find_by(start_year:) || new(**attributes)

--- a/spec/fixtures/files/importers/cohort_csv_data.csv
+++ b/spec/fixtures/files/importers/cohort_csv_data.csv
@@ -1,2 +1,2 @@
-start-year,registration-start-date,academic-year-start-date,automatic-assignment-period-end-date,payments-frozen-at,mentor-funding
-2026,2026/05/10,2026/09/01,2026/03/31,,true
+start-year,registration-start-date,academic-year-start-date,automatic-assignment-period-end-date,payments-frozen-at,mentor-funding,detailed-evidence-types
+2026,2026/05/10,2026/09/01,2026/03/31,,true,true

--- a/spec/services/importers/create_cohort_spec.rb
+++ b/spec/services/importers/create_cohort_spec.rb
@@ -11,15 +11,15 @@ RSpec.describe Importers::CreateCohort do
   describe "#call" do
     context "with new cohorts" do
       before do
-        csv.write "start-year,registration-start-date,academic-year-start-date,automatic-assignment-period-end-date,payments-frozen-at,mentor-funding"
+        csv.write "start-year,registration-start-date,academic-year-start-date,automatic-assignment-period-end-date,payments-frozen-at,mentor-funding,detailed-evidence-types"
         csv.write "\n"
-        csv.write "3030,3030/05/10,3030/09/01,,,true"
+        csv.write "3030,3030/05/10,3030/09/01,,,true,false"
         csv.write "\n"
-        csv.write "3031,3031/05/10,3031/09/01,,,false"
+        csv.write "3031,3031/05/10,3031/09/01,,,false,true"
         csv.write "\n"
-        csv.write "3032,3032/05/10,3032/09/01,,,true"
+        csv.write "3032,3032/05/10,3032/09/01,,,true,false"
         csv.write "\n"
-        csv.write "3033,3033/05/10,3033/09/01,,,false"
+        csv.write "3033,3033/05/10,3033/09/01,,,false,true"
         csv.write "\n"
         csv.close
       end
@@ -73,6 +73,18 @@ RSpec.describe Importers::CreateCohort do
           expect(cohort.mentor_funding).to be(false)
         end
       end
+
+      it "sets correctly detailed_evidence_types field" do
+        importer.call
+
+        Cohort.where(start_year: [3030, 3032]).find_each do |cohort|
+          expect(cohort.detailed_evidence_types).to be(false)
+        end
+
+        Cohort.where(start_year: [3031, 3033]).find_each do |cohort|
+          expect(cohort.detailed_evidence_types).to be(true)
+        end
+      end
     end
 
     context "with existing cohorts" do
@@ -81,13 +93,14 @@ RSpec.describe Importers::CreateCohort do
                           start_year: 4041,
                           registration_start_date: Date.new(4041, 5, 1),
                           academic_year_start_date: Date.new(4041, 8, 31),
-                          mentor_funding: true
+                          mentor_funding: true,
+                          detailed_evidence_types: false
       end
 
       before do
-        csv.write "start-year,registration-start-date,academic-year-start-date,automatic-assignment-period-end-date,payments-frozen-at,mentor-funding"
+        csv.write "start-year,registration-start-date,academic-year-start-date,automatic-assignment-period-end-date,payments-frozen-at,mentor-funding,detailed-evidence-types"
         csv.write "\n"
-        csv.write "4041,4041/05/10,4041/09/01,4042/03/31,,false"
+        csv.write "4041,4041/05/10,4041/09/01,4042/03/31,,false,true"
         csv.write "\n"
         csv.close
       end
@@ -101,6 +114,7 @@ RSpec.describe Importers::CreateCohort do
           registration_start_date: Date.new(4041, 5, 10),
           academic_year_start_date: Date.new(4041, 9, 1),
           mentor_funding: false,
+          detailed_evidence_types: true,
         )
       end
     end


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-3931](https://dfedigital.atlassian.net/browse/CPDLP-3931)

### Changes proposed in this pull request

- Add a new boolean field to cohort which defaults to false, which can be set to true on 2025 for evidence types
- Add this field to dfe analytics
- Add this field to the factories/seed data
- Add this field to creating a cohort logic and csv
- Add this field to the confluence new cohort [documentation](https://dfedigital.atlassian.net.mcas.ms/wiki/spaces/CPD/pages/3883663396/Create+new+ECF+cohort)

[CPDLP-3931]: https://dfedigital.atlassian.net/browse/CPDLP-3931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ