### PR TITLE
Address brakeman warnings

### DIFF
--- a/app/controllers/appropriate_bodies/participants_controller.rb
+++ b/app/controllers/appropriate_bodies/participants_controller.rb
@@ -45,7 +45,7 @@ module AppropriateBodies
     end
 
     def filter_params
-      params.permit(:query, :role, :academic_year, :status)
+      params.permit(:query, :status)
     end
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,10 +2,29 @@
 
 class PagesController < ApplicationController
   def show
-    render template: "pages/#{params[:page].tr('-', '_')}"
+    template = template_resolver.resolve(params[:page])
+
+    raise_not_found! unless template
+
+    render template:
   end
 
   def induction_tutor_materials
-    render template: "pages/induction_tutor_materials/#{params[:provider].tr('-', '_')}/#{params[:year].tr('-', '_')}"
+    page = "induction_tutor_materials/#{params[:provider]}/#{params[:year]}"
+    template = template_resolver.resolve(page)
+
+    raise_not_found! unless template
+
+    render template:
+  end
+
+private
+
+  def raise_not_found!
+    raise ActionController::RoutingError, "Not Found"
+  end
+
+  def template_resolver
+    @template_resolver ||= Pages::TemplateResolver.new(lookup_context)
   end
 end

--- a/app/controllers/schools/cohorts/appropriate_body_controller.rb
+++ b/app/controllers/schools/cohorts/appropriate_body_controller.rb
@@ -23,10 +23,19 @@ module Schools
       end
 
       def confirm
-        @confirmation_type = params[:confirmation_type]
+        @confirmation_type = sanitized_confirmation_type
       end
 
     private
+
+      def sanitized_confirmation_type
+        allowed_confirmation_types = %w[add change].freeze
+        confirmation_type = params[:confirmation_type]
+
+        raise ActionController::RoutingError, "Invalid confirmation type" unless confirmation_type.in?(allowed_confirmation_types)
+
+        confirmation_type
+      end
 
       def start_appropriate_body_selection(preconfirmation: false)
         super action_name:,

--- a/app/services/pages/template_resolver.rb
+++ b/app/services/pages/template_resolver.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Pages
+  class TemplateResolver
+    attr_reader :lookup_context
+
+    def initialize(lookup_context)
+      @lookup_context = lookup_context
+    end
+
+    def resolve(page)
+      return nil unless template_exists?(page)
+
+      template(page)
+    end
+
+  private
+
+    def template(page)
+      "pages/#{page.tr('-', '_')}"
+    end
+
+    def template_exists?(page)
+      lookup_context.template_exists?(template(page), [], false)
+    end
+  end
+end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,74 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Mass Assignment",
+      "warning_code": 105,
+      "fingerprint": "2b4fc2a19a28821de681909146012851307438aea2bff28161386e34663bc220",
+      "check_name": "PermitAttributes",
+      "message": "Potentially dangerous key allowed for mass assignment",
+      "file": "app/controllers/choose_roles_controller.rb",
+      "line": 34,
+      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
+      "code": "params.fetch(:choose_role_form, {}).permit(:role)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ChooseRolesController",
+        "method": "choose_role_form_params"
+      },
+      "user_input": ":role",
+      "confidence": "Medium",
+      "cwe_id": [
+        915
+      ],
+      "note": "We sanitize the role parameter against known/allowed roles in ChooseRoleForm."
+    },
+    {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
+      "fingerprint": "7147eb4bea81677312e9eeaca2b62a4b937e07bc2458fa7f5e55aed1c673dbb9",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "app/controllers/schools/participants_controller.rb",
+      "line": 32,
+      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(action => helpers.edit_name_template(params[:reason].to_sym), {})",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Schools::ParticipantsController",
+        "method": "edit_name"
+      },
+      "user_input": "params[:reason].to_sym",
+      "confidence": "Weak",
+      "cwe_id": [
+        22
+      ],
+      "note": "The render path is constrained by the EDIT_NAME_TEMPLATE_BY_REASON hash."
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "d8f26910bc7b0d4aa383c8e9694992eaf2553e8989af31433a0032403ef65655",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/services/api/v3/ecf/unfunded_mentors_query.rb",
+      "line": 49,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "Arel.sql(\"ROW_NUMBER() OVER (#{latest_induction_record_order}) AS row_number, induction_records.participant_profile_id, induction_records.preferred_identity_id\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Api::V3::ECF::UnfundedMentorsQuery",
+        "method": "latest_induction_records_for_mentor_join"
+      },
+      "user_input": "latest_induction_record_order",
+      "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
+      "note": "TPO"
+    }
+  ],
+  "brakeman_version": "7.0.0"
+}

--- a/spec/features/schools/add_appropriate_body_spec.rb
+++ b/spec/features/schools/add_appropriate_body_spec.rb
@@ -136,6 +136,21 @@ RSpec.describe "Add a school cohort appropriate body", type: :feature, js: true,
     end
   end
 
+  context "When attempting an unsupported confirmation type on an appropriate body", exceptions_app: true do
+    let!(:appropriate_body) { create(:appropriate_body_teaching_school_hub) }
+
+    scenario "It raises an error" do
+      given_there_is_a_school_and_an_induction_coordinator
+      and_i_have_added_an_ect
+      and_i_am_signed_in_as_an_induction_coordinator
+      then_i_am_on_the_manage_your_training_page
+
+      visit confirm_schools_cohort_path(school_id: @school.slug, cohort_id: @cohort.start_year, confirmation_type: "unsupported_confirmation_type")
+
+      expect(page).to have_content("Page not found")
+    end
+  end
+
 private
 
   def given_there_is_a_school_and_an_induction_coordinator

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -126,7 +126,7 @@ RSpec.configure do |config|
     # Make the app behave how it does in non dev/test environments and use the
     # ErrorsController via config.exceptions_app = routes in config/application.rb
     method = Rails.application.method(:env_config)
-    expect(Rails.application).to receive(:env_config).with(no_args) do
+    allow(Rails.application).to receive(:env_config).with(no_args) do
       method.call.merge(
         "action_dispatch.show_exceptions" => :all,
         "action_dispatch.show_detailed_exceptions" => false,

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -24,4 +24,12 @@ RSpec.describe "Static pages", type: :request do
       expect(response).to render_template("shared/_roles")
     end
   end
+
+  describe "GET /pages/not-found", exceptions_app: true do
+    it "returns 404 not found" do
+      get "/pages/not-found"
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
 end

--- a/spec/requests/schools/core_programme/induction_tutor_materials_spec.rb
+++ b/spec/requests/schools/core_programme/induction_tutor_materials_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Pages for induction tutor materials for existing CIPs", type: :r
     end
 
     it "fails to renders the year one materials template for anything else" do
-      expect { get induction_tutor_materials_path(provider: "harvard-institute", year:) }.to raise_error ActionView::MissingTemplate
+      expect { get induction_tutor_materials_path(provider: "harvard-institute", year:) }.to raise_error ActionController::RoutingError
     end
   end
 
@@ -43,7 +43,7 @@ RSpec.describe "Pages for induction tutor materials for existing CIPs", type: :r
     end
 
     it "fails to renders the year one materials template for anything else" do
-      expect { get induction_tutor_materials_path(provider: "harvard-institute", year:) }.to raise_error ActionView::MissingTemplate
+      expect { get induction_tutor_materials_path(provider: "harvard-institute", year:) }.to raise_error ActionController::RoutingError
     end
   end
 end

--- a/spec/services/pages/template_resolver_spec.rb
+++ b/spec/services/pages/template_resolver_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Pages::TemplateResolver do
+  let(:page) { "a/nested-page" }
+  let(:page_template) { "pages/a/nested_page" }
+  let(:lookup_context) { instance_double(ActionView::LookupContext) }
+  let(:instance) { described_class.new(lookup_context) }
+
+  before { allow(lookup_context).to receive(:template_exists?).with(page_template, [], false).and_return(template_exists) }
+
+  describe "#resolve" do
+    subject { instance.resolve(page) }
+
+    context "when the template exists" do
+      let(:template_exists) { true }
+
+      it { is_expected.to eq(page_template) }
+    end
+
+    context "when the template does not exist" do
+      let(:template_exists) { false }
+
+      it { is_expected.to be_nil }
+    end
+  end
+end


### PR DESCRIPTION
[Jira-3987](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-3987)

### Context

We have a number of `brakeman` security warnings in the app that we want to review and address where appropriate.

### Changes proposed in this pull request

- Fix dynamic render path brakeman warning

We have a warning due to dynamically rendering an unsanitised page parameter.

Extract template resolving to `TemplateResolver` service and only allow rendering of valid templates in the `app/views/page` directory.

- Remove unused permitted filter attributes

We only appear to filter on `query` and `status` in the `AppropriateBodies::ParticipantsFilter` service.

The `role` attribute is flagged by Brakeman (albeit as a false positive), but as its not used we can just remove it to silence the warning.

- Sanitize confirmation page rendering

We only want to allow rendering certain partials to avoid dynamic render paths.

Switch `expect` to `allow` for `exceptions_app` helper so that we can use it in feature specs (the method is called multiple times in the feature specs).

- Add brakeman.ignore file

A few of the `brakeman` warnings are false positives that we can ignore.

Add `config/brakeman.ignore` file to allow ignoring warnings. We're using the default file path here for the ignore file so we shouldn't need to update any of the commands that run `brakeman`.

### Guidance to review

I started this as a spike/investigation, but figured it wasn't going to be much more work to just address them with solutions and we can then use this PR for discussion.