### PR TITLE
Remove unused cookie session store from `production.rb`

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,7 +40,6 @@ Rails.application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
-  config.session_store :cookie_store, key: "_early_career_framework_session", secure: true, expire_after: 2.weeks
 
   config.cache_store = :redis_cache_store,
                        {


### PR DESCRIPTION
### Context

We have two `session_store` configurations in the app; one in `production.rb` and one in `initializers/session_store.rb`. As there can be only one we need to determine which is in use and remove the unused/overridden reference.

### Changes proposed in this pull request

- Remove unused cookie session store from `production.rb`

We define a `cookie_store` in `production.rb`, however this is later overridden by the `session_store.rb` initializer, which specifies an `active_record_store`.

### Guidance to review

It has been confirmed on the production rails console that the active record store is in use:

```
irb(main):001> Rails.application.config.session_store
=> ActionDispatch::Session::ActiveRecordStore
```

The cookies have also been checked in production to ensure the `_early_career_framework_session` cookie key is not present (only the `_ecf_session` which relates to the `active_record_store`).

<img width="637" alt="Screenshot 2025-02-13 at 11 41 28" src="https://github.com/user-attachments/assets/33e2d8d7-fad4-489c-90df-0c13d6353d4e" />

