### PR TITLE
[CPDLP-3956] Middleware to catch SessionRestoreError and clear the session

### DIFF
--- a/app/middlewares/session_restore_error_rescue_middleware.rb
+++ b/app/middlewares/session_restore_error_rescue_middleware.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class SessionRestoreErrorRescueMiddleware
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    @app.call(env)
+  rescue ActionDispatch::Session::SessionRestoreError
+    req = ActionDispatch::Request.new(env)
+    req.cookies.delete(session_key)
+    req.env.delete("rack.session")
+    req.env.delete("rack.session.options")
+
+    @app.call(req.env)
+  end
+
+  def session_key
+    Rails.application.config.session_options[:key]
+  end
+end

--- a/app/middlewares/session_restore_error_rescue_middleware.rb
+++ b/app/middlewares/session_restore_error_rescue_middleware.rb
@@ -9,9 +9,9 @@ class SessionRestoreErrorRescueMiddleware
     @app.call(env)
   rescue ActionDispatch::Session::SessionRestoreError
     req = ActionDispatch::Request.new(env)
-    req.cookies.delete(session_key)
-    req.env.delete("rack.session")
-    req.env.delete("rack.session.options")
+    session_id = req.cookies[session_key]
+    private_id = Rack::Session::SessionId.new(session_id).private_id
+    ActiveRecord::SessionStore::Session.where(session_id: private_id).delete_all
 
     @app.call(req.env)
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -58,6 +58,6 @@ module EarlyCareerFramework
       require file
     end
 
-    config.middleware.insert_after ActionDispatch::Cookies, SessionRestoreErrorRescueMiddleware
+    config.middleware.use SessionRestoreErrorRescueMiddleware
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -57,5 +57,7 @@ module EarlyCareerFramework
     Dir.glob(Rails.root.join("app/middlewares/*.rb")).sort.each do |file|
       require file
     end
+
+    config.middleware.insert_after ActionDispatch::Cookies, SessionRestoreErrorRescueMiddleware
   end
 end

--- a/spec/middlewares/session_restore_error_rescue_middleware_spec.rb
+++ b/spec/middlewares/session_restore_error_rescue_middleware_spec.rb
@@ -4,59 +4,93 @@ require "rails_helper"
 
 RSpec.describe SessionRestoreErrorRescueMiddleware do
   let(:session_key) { Rails.application.config.session_options[:key] }
+  let(:session_id) { "f2cea1a7bd96a923a778d474cca911e8" }
+  let(:session_private_id) { Rack::Session::SessionId.new(session_id).private_id }
+  let(:session_data) { { user_id: 42 } }
+  let(:session) { ActiveRecord::SessionStore::Session.create!(session_id: session_private_id, data: session_data) }
 
   let(:env) do
     {
-      "HTTP_COOKIE" => "#{session_key}=session_data; other_cookie=bar",
-      "rack.session" => { user_id: 42 },
+      "HTTP_COOKIE" => "#{session_key}=#{session_id}; other_cookie=bar",
+      "rack.session" => session_data,
       "rack.session.options" => { expire_after: 3600 },
     }
   end
 
-  let(:good_app) { ->(env) { [200, env, %w[OK]] } }
-
-  let(:bad_app) do
+  let(:app) do
     lambda do |env|
-      if env["rack.session"].present?
-        begin
-          raise "Test error"
-        rescue StandardError
-          raise ActionDispatch::Session::SessionRestoreError
-        end
-      else
-        [200, env, %w[OK]]
+      req = ActionDispatch::Request.new(env)
+
+      # Try loading current session
+      begin
+        session_id = req.cookies[session_key]
+        private_id = Rack::Session::SessionId.new(session_id).private_id
+        ActiveRecord::SessionStore::Session.find_by(session_id: private_id)&.data
+      rescue ArgumentError
+        raise ActionDispatch::Session::SessionRestoreError
       end
+
+      [200, env, %w[OK]]
     end
   end
 
+  before do
+    # Create random sessions
+    3.times do
+      ActiveRecord::SessionStore::Session.create!(
+        session_id: Rack::Session::SessionId.new(SecureRandom.uuid).private_id,
+        data: { test: 123 },
+      )
+    end
+
+    # Create this session
+    session
+  end
+
   context "when no session restore error is raised" do
-    it "calls the downstream app and returns its response" do
-      middleware = described_class.new(good_app)
+    it "calls the downstream app and returns its response unchanged" do
+      expect(ActiveRecord::SessionStore::Session.count).to eq(4)
+
+      middleware = described_class.new(app)
       status, headers, body = middleware.call(env)
       expect(status).to eq(200)
       expect(body).to eq(%w[OK])
-      # expect(headers).to eq(env)
 
       req = ActionDispatch::Request.new(headers)
       expect(req.env["rack.session"]).to eq({ user_id: 42 })
       expect(req.env["rack.session.options"]).to eq({ expire_after: 3600 })
       expect(req.cookies["other_cookie"]).to eq("bar")
-      expect(req.cookies[session_key]).to eq("session_data")
+      expect(req.cookies[session_key]).to eq(session_id)
+
+      expect(ActiveRecord::SessionStore::Session.count).to eq(4)
+      session.reload
+      expect(session.data[:user_id]).to eq(42)
     end
   end
 
   context "when a SessionRestoreError is raised" do
-    it "rescues the error, clears session and cookie data, and retries the call" do
-      middleware = described_class.new(bad_app)
+    # A marshalled object "MadeUp", this class does not exist
+    let(:bad_data) { "BAh7CUkiDnJldHVybl90bwY6BkVGSSI3aHR0cDovL2xvY2FsaG9zdDozMDAw\nL2ZpbmFuY2UvbWFuYWdlLWNwZC1jb250cmFjdHMGOwBUSSIQX2NzcmZfdG9r\nZW4GOwBGSSIwU2ZFdHZ6c096RmUwMmk5RTFsd1ZkdG5PejVTb3VzdHhoRDZX\nakZwcmxNbwY7AEZJIhl3YXJkZW4udXNlci51c2VyLmtleQY7AFRbB1sGSSIp\nZWEzODM0NTItYzNiMC00ZGMyLWIwMzMtOTUwNzhhYjYwYmE2BjsAVDBJIgl0\nZXN0BjsARm86K0ZpbmFuY2U6OkxhbmRpbmdQYWdlQ29udHJvbGxlcjo6TWFk\nZVVwAA==\n" }
+
+    it "rescues the error, deletes bad session" do
+      expect(ActiveRecord::SessionStore::Session.count).to eq(4)
+
+      # Inject bad data into session store
+      ActiveRecord::SessionStore::Session.where(id: session.id).update_all(data: bad_data)
+
+      middleware = described_class.new(app)
       status, headers, body = middleware.call(env)
       expect(status).to eq(200)
       expect(body).to eq(%w[OK])
 
       req = ActionDispatch::Request.new(headers)
-      expect(req.env["rack.session"]).to be_nil
-      expect(req.env["rack.session.options"]).to be_nil
+      expect(req.env["rack.session"]).to eq({ user_id: 42 })
+      expect(req.env["rack.session.options"]).to eq({ expire_after: 3600 })
       expect(req.cookies["other_cookie"]).to eq("bar")
-      expect(req.cookies[session_key]).to eq(nil)
+      expect(req.cookies[session_key]).to eq(session_id)
+
+      expect(ActiveRecord::SessionStore::Session.count).to eq(3)
+      expect(ActiveRecord::SessionStore::Session.find_by(id: session.id)).to be_nil
     end
   end
 end

--- a/spec/middlewares/session_restore_error_rescue_middleware_spec.rb
+++ b/spec/middlewares/session_restore_error_rescue_middleware_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SessionRestoreErrorRescueMiddleware do
+  let(:session_key) { Rails.application.config.session_options[:key] }
+
+  let(:env) do
+    {
+      "HTTP_COOKIE" => "#{session_key}=session_data; other_cookie=bar",
+      "rack.session" => { user_id: 42 },
+      "rack.session.options" => { expire_after: 3600 },
+    }
+  end
+
+  let(:good_app) { ->(env) { [200, env, %w[OK]] } }
+
+  let(:bad_app) do
+    lambda do |env|
+      if env["rack.session"].present?
+        begin
+          raise "Test error"
+        rescue StandardError
+          raise ActionDispatch::Session::SessionRestoreError
+        end
+      else
+        [200, env, %w[OK]]
+      end
+    end
+  end
+
+  context "when no session restore error is raised" do
+    it "calls the downstream app and returns its response" do
+      middleware = described_class.new(good_app)
+      status, headers, body = middleware.call(env)
+      expect(status).to eq(200)
+      expect(body).to eq(%w[OK])
+      # expect(headers).to eq(env)
+
+      req = ActionDispatch::Request.new(headers)
+      expect(req.env["rack.session"]).to eq({ user_id: 42 })
+      expect(req.env["rack.session.options"]).to eq({ expire_after: 3600 })
+      expect(req.cookies["other_cookie"]).to eq("bar")
+      expect(req.cookies[session_key]).to eq("session_data")
+    end
+  end
+
+  context "when a SessionRestoreError is raised" do
+    it "rescues the error, clears session and cookie data, and retries the call" do
+      middleware = described_class.new(bad_app)
+      status, headers, body = middleware.call(env)
+      expect(status).to eq(200)
+      expect(body).to eq(%w[OK])
+
+      req = ActionDispatch::Request.new(headers)
+      expect(req.env["rack.session"]).to be_nil
+      expect(req.env["rack.session.options"]).to be_nil
+      expect(req.cookies["other_cookie"]).to eq("bar")
+      expect(req.cookies[session_key]).to eq(nil)
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-3956

### Changes proposed in this pull request

* New middleware `SessionRestoreErrorRescueMiddleware`
* Added to `applications.rb`
* Rescue from `ActionDispatch::Session::SessionRestoreError` error, delete session cookie and reset

### Guidance to review

