### PR TITLE
[CPDLP-4023] Pin version of chrome to 127 in order to try and fix `Net::ReadTimeout` in specs in CI

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout Code
 
       - name: Set up Ruby
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout Code
 
       - name: Set up Node
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout Code
 
       - name: Set up Ruby
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout Code
 
       - name: Set up Ruby
@@ -146,7 +146,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: ./.github/actions/prepare-app-env
         id: test
@@ -199,6 +199,8 @@ jobs:
       CI: true
       CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
       CI_NODE_INDEX: ${{ matrix.ci_node_index }}
+      DISPLAY: "=:99"
+      CHROME_VERSION: "127.0.6533.119"
 
     services:
       postgres:
@@ -211,8 +213,25 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
+      - name: Install Chrome
+        run: |
+          # Download specific Chrome version
+          # due a possible race condition between newer versions of chromedriver and selenium
+          # causing some specs to fail intermittently on CI with the failure Net::ReadTimeout
+          # See https://github.com/teamcapybara/capybara/issues/2770
+          wget https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}-1_amd64.deb
+          # Install Chrome
+          sudo apt-get install -y --allow-downgrades ./google-chrome-stable_${CHROME_VERSION}-1_amd64.deb
+
+      - uses: nanasess/setup-chromedriver@v2
+      - name: Start chromedriver
+        run: |
+          set -x
+          chromedriver --url-base=/wd/hub &
+          sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
+
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: ./.github/actions/prepare-app-env
         id: test
@@ -279,7 +298,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: ./.github/actions/prepare-app-env
         id: test


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-4023](https://dfedigital.atlassian.net/browse/CPDLP-4023)

Currently feature specs fail intermittently on CI with the failure `Net::ReadTimeout`. This is a very common error and can be seen consistently on the workflows. 

### Changes proposed in this pull request

As suggested on https://github.com/teamcapybara/capybara/issues/2770, we'll pin the version of chrome to 127 in order to try and fix `Net::ReadTimeout` in specs in CI.

[CPDLP-4023]: https://dfedigital.atlassian.net/browse/CPDLP-4023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ