### PR TITLE
Add ECT/mentor records to sandbox for testing

### DIFF
--- a/app/services/valid_test_data_generators/mentor_ect_generator.rb
+++ b/app/services/valid_test_data_generators/mentor_ect_generator.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "active_support/testing/time_helpers"
+
+module ValidTestDataGenerators
+  class MentorECTGenerator
+    class << self
+      def call(name:, cohort: Cohort.current, number: 20)
+        new(name:, cohort:).call(number:)
+      end
+    end
+
+    def call(number:)
+      return unless partnership
+
+      number.times do
+        create_participant(klass: ParticipantProfile::ECT)
+        create_participant(klass: ParticipantProfile::Mentor)
+      end
+    end
+
+  private
+
+    attr_reader :lead_provider, :cohort
+
+    def initialize(name:, cohort:)
+      @lead_provider = ::LeadProvider.find_by!(name:)
+      @cohort = cohort
+    end
+
+    def create_random_participant_identity
+      name = Faker::Name.name
+      user = User.create!(full_name: name, email: Faker::Internet.email(name:))
+      TeacherProfile.create!(user:, trn: Helpers::TrnGenerator.next)
+      Identity::Create.call(user:, origin: :ecf)
+    end
+
+    def create_participant(klass:)
+      school_cohort = find_or_create_school_cohort
+      participant_identity = create_random_participant_identity
+      teacher_profile = participant_identity.user.teacher_profile
+      participant_profile = klass.create!(teacher_profile:, school_cohort:, status: :active, schedule:, participant_identity:)
+      ParticipantProfileState.create!(participant_profile:)
+      ECFParticipantEligibility.create!(participant_profile:).eligible_status!
+      Induction::Enrol.call(participant_profile:, induction_programme: school_cohort.induction_programmes.first)
+    end
+
+    def schedule
+      @schedule ||= Finance::Schedule::ECF.find_by!(cohort:, schedule_identifier: "ecf-standard-september")
+    end
+
+    def find_or_create_school_cohort
+      school = partnership.school
+      school_cohort = SchoolCohort.find_or_create_by!(school:, cohort:, induction_programme_choice: "full_induction_programme")
+      InductionProgramme.find_or_create_by!(school_cohort:, partnership:, training_programme: "full_induction_programme")
+      school_cohort
+    end
+
+    def partnership
+      lead_provider.partnerships.find_by(cohort:)
+    end
+  end
+end

--- a/lib/tasks/sandbox_data.rake
+++ b/lib/tasks/sandbox_data.rake
@@ -30,6 +30,7 @@ namespace :lead_providers do
         ValidTestDataGenerators::ECFLeadProviderPopulater.call(name: lp.name, cohort: c, total_schools: args[:total_schools]&.to_i || 5, participants_per_school: 50)
         ValidTestDataGenerators::CompletedMentorGenerator.call(name: lp.name, cohort: c, total_completed_mentors: args[:total_completed_mentors]&.to_i || 30)
         ValidTestDataGenerators::SandboxSharedData.new(name: lp.name, cohort: c).call
+        ValidTestDataGenerators::MentorECTGenerator.call(name: lp.name, cohort: c, number: 20)
       end
     end
   end

--- a/spec/services/valid_test_data_generators/mentor_ect_generator_spec.rb
+++ b/spec/services/valid_test_data_generators/mentor_ect_generator_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ValidTestDataGenerators::MentorECTGenerator do
+  let(:shared_users_data) { YAML.load_file(Rails.root.join("db/data/sandbox_shared_data.yml")) }
+  let(:cohort) { create(:cohort, :current) }
+  let(:lead_provider) { create(:lead_provider, name: shared_users_data.keys.sample) }
+
+  let(:instance) { described_class.new(name: lead_provider.name, cohort:) }
+
+  describe "#call" do
+    let(:number) { 1 }
+    subject(:generate) { instance.call(number:) }
+
+    context "when the lead provider does not have a partnership for the cohort" do
+      it { expect { generate }.not_to change(ParticipantProfile, :count) }
+    end
+
+    context "when the cohort has a default schedule and the lead provider has a school" do
+      before { create(:partnership, cohort:, lead_provider:) }
+
+      it { expect { generate }.to change(ParticipantProfile::ECT, :count).by(number) }
+      it { expect { generate }.to change(ParticipantProfile::Mentor, :count).by(number) }
+
+      it "creates participants that can be declared against" do
+        created_ect = ParticipantProfile::ECT.last
+
+        ParticipantProfile.find_each do |created_participant|
+          schedule_start_date = created_ect.schedule.milestones.first.start_date
+          travel_to(schedule_start_date) do
+            service = RecordDeclaration.new(
+              participant_id: created_ect.user_id,
+              course_identifier: created_participant.ect? ? "ecf-induction" : "ecf-mentor",
+              declaration_date: schedule_start_date.rfc3339,
+              cpd_lead_provider: lead_provider.cpd_lead_provider,
+              declaration_type: :started,
+            )
+
+            expect(service).to be_valid
+          end
+        end
+      end
+
+      context "when creating multiple participants" do
+        let(:number) { 5 }
+
+        it { expect { generate }.to change(ParticipantProfile::ECT, :count).by(number) }
+        it { expect { generate }.to change(ParticipantProfile::Mentor, :count).by(number) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Jira-3972](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3972)

### Context

In order to test the mentor funding feature in sandbox we will need ECT and mentor records to be created that are eligible for funding.

### Changes proposed in this pull request

- Add ECT/mentor records to sandbox for testing

### Guidance to review

This seed is a paired down version of the `ECFLeadProviderPopulator` that aims to only create ECTs/mentors without adding additional school/partnership records.
