### PR TITLE
Fix flakey spec `spec/presenters/admin/participant_presenter_spec.rb:314`

### DIFF
--- a/spec/presenters/admin/participant_presenter_spec.rb
+++ b/spec/presenters/admin/participant_presenter_spec.rb
@@ -312,7 +312,9 @@ RSpec.describe(Admin::ParticipantPresenter) do
     end
 
     describe "#declarations" do
-      let!(:declarations) { FactoryBot.create_list(:seed_ect_participant_declaration, 2, :valid, participant_profile:) }
+      let(:declaration1) { FactoryBot.create(:seed_ect_participant_declaration, :valid, :started, participant_profile:) }
+      let(:declaration2) { FactoryBot.create(:seed_ect_participant_declaration, :valid, :retained_1, participant_profile:) }
+      let!(:declarations) { [declaration1, declaration2] }
 
       it "returns the declarations belonging to the participant" do
         expect(subject.declarations).to match_array(declarations)


### PR DESCRIPTION

### Context

- Ticket: N/A

Spec `spec/presenters/admin/participant_presenter_spec.rb:314` is flakey.

### Changes proposed in this pull request

Fix flakey spec above.

### Guidance to review

