### PR TITLE
Add clawed back count to finance statements

### DIFF
--- a/app/components/finance/statements/payment_breakdown/ecf.html.erb
+++ b/app/components/finance/statements/payment_breakdown/ecf.html.erb
@@ -72,14 +72,19 @@
         </div>
       </div>
 
-      <% if calculator.extended_count.positive? %>
-        <div>
-          <strong class="govuk-body-s govuk-!-margin-bottom-0">Total extended</strong>
-          <div class="govuk-heading-m govuk-!-padding-top-0">
-            <%= calculator.extended_count %>
-          </div>
+      <div>
+        <strong class="govuk-body-s govuk-!-margin-bottom-0">Total extended</strong>
+        <div class="govuk-heading-m govuk-!-padding-top-0">
+          <%= calculator.extended_count %>
         </div>
-      <% end %>
+      </div>
+
+      <div>
+        <strong class="govuk-body-s govuk-!-margin-bottom-0">Total clawed back</strong>
+        <div class="govuk-heading-m govuk-!-padding-top-0">
+          <%= calculator.clawed_back_count %>
+        </div>
+      </div>
 
       <div>
         <strong class="govuk-body-s govuk-!-margin-bottom-0">Total voided</strong>

--- a/app/services/finance/ecf/statement_calculator.rb
+++ b/app/services/finance/ecf/statement_calculator.rb
@@ -139,6 +139,10 @@ module Finance
         end
       end
 
+      def clawed_back_count
+        statement.participant_declarations.clawed_back.count
+      end
+
       def voided_count
         voided_declarations.count
       end

--- a/spec/components/finance/statements/payment_breakdown/ecf_spec.rb
+++ b/spec/components/finance/statements/payment_breakdown/ecf_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Finance::Statements::PaymentBreakdown::ECF, type: :component do
       completed_count: 30,
       extended_count:,
       voided_count: 50,
+      clawed_back_count: 12,
     )
   end
   let(:extended_count) { 0 }
@@ -86,29 +87,14 @@ RSpec.describe Finance::Statements::PaymentBreakdown::ECF, type: :component do
     expect(counts_list[2][0]).to eq("Total completed")
     expect(counts_list[2][1]).to eq("30")
 
-    expect(counts_list[3][0]).to eq("Total voided")
-    expect(counts_list[3][1]).to eq("50")
-  end
+    expect(counts_list[3][0]).to eq("Total extended")
+    expect(counts_list[3][1]).to eq("0")
 
-  describe "with extended count" do
-    let(:extended_count) { 40 }
+    expect(counts_list[4][0]).to eq("Total clawed back")
+    expect(counts_list[4][1]).to eq("12")
 
-    it "has correct declaration counts" do
-      expect(counts_list[0][0]).to eq("Total starts")
-      expect(counts_list[0][1]).to eq("10")
-
-      expect(counts_list[1][0]).to eq("Total retained")
-      expect(counts_list[1][1]).to eq("20")
-
-      expect(counts_list[2][0]).to eq("Total completed")
-      expect(counts_list[2][1]).to eq("30")
-
-      expect(counts_list[3][0]).to eq("Total extended")
-      expect(counts_list[3][1]).to eq("40")
-
-      expect(counts_list[4][0]).to eq("Total voided")
-      expect(counts_list[4][1]).to eq("50")
-    end
+    expect(counts_list[5][0]).to eq("Total voided")
+    expect(counts_list[5][1]).to eq("50")
   end
 
   it "has link to voided declarations" do


### PR DESCRIPTION
[Jira-4047](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-4047)

### Context

Following a review of the screens with the contracts and assurance teams there are some small changes to make to the current front end for 2024 and earlier cohorts.

We want to display the clawed back declarations count in the finance statement summary. We also want to always show the extended declaration counts, even when 0.

### Changes proposed in this pull request

- Add clawed back count to finance statements

### Guidance to review

The clawed back declarations are fudged due to the factory not playing ball; getting them on the November statement was turning into a lot of test setup, so I opted to manually transition submitted declarations (the count functionality is tested independently in the calculator).