### PR TITLE
Exclude 2025 and later participants from delivery partners

### DIFF
--- a/spec/features/delivery_partners/participants_spec.rb
+++ b/spec/features/delivery_partners/participants_spec.rb
@@ -4,7 +4,8 @@ require "rails_helper"
 
 RSpec.feature "Delivery partner users participants", type: :feature do
   let(:school) { create(:school) }
-  let(:school_cohort) { create(:school_cohort, school:) }
+  let(:cohort) { create(:cohort, start_year: DeliveryPartners::ParticipantsFilter::LATEST_COHORT_TO_RETURN) }
+  let(:school_cohort) { create(:school_cohort, school:, cohort:) }
   let(:participant_profile) { create(:ect_participant_profile, school_cohort:, training_status: "withdrawn") }
 
   let(:delivery_partner_user) { create(:user, :delivery_partner) }
@@ -40,6 +41,15 @@ RSpec.feature "Delivery partner users participants", type: :feature do
     then_i_see("Participants")
     when_i_click_on("Download (csv)")
     and_i_see_participant_details_csv_export
+  end
+
+  context "when the participant is in a cohort that we exclude" do
+    let(:cohort) { create(:cohort, start_year: DeliveryPartners::ParticipantsFilter::LATEST_COHORT_TO_RETURN + 1) }
+
+    scenario "Visit participants page" do
+      then_i_see("Participants")
+      and_i_see_no_participant_details
+    end
   end
 
   context "Search query" do
@@ -134,6 +144,11 @@ RSpec.feature "Delivery partner users participants", type: :feature do
   def and_i_see_participant_details
     expect(page).to have_content(participant_profile.user.full_name)
     expect(page).to have_content(participant_profile.user.email)
+  end
+
+  def and_i_see_no_participant_details
+    expect(page).not_to have_content(participant_profile.user.full_name)
+    expect(page).not_to have_content(participant_profile.user.email)
   end
 
   def and_i_do_not_see_participant_details

--- a/spec/features/scenarios/participants/ect_doing_fip/in_training_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_fip/in_training_spec.rb
@@ -154,21 +154,25 @@ RSpec.feature "ECT doing FIP: in training", type: :feature do
     expect(participant_endpoint).to have_schedule_identifier schedule_identifier
   end
 
-  scenario "The current delivery partner can locate a record for the ECT" do
-    given_i_sign_in_as_the_user_with_the_full_name delivery_partner_name
+  context "when the participant cohort is #{DeliveryPartners::ParticipantsFilter::LATEST_COHORT_TO_RETURN} or earlier" do
+    let(:start_year) { DeliveryPartners::ParticipantsFilter::LATEST_COHORT_TO_RETURN }
 
-    delivery_partner_portal = Pages::DeliveryPartnerPortal.loaded
-    delivery_partner_portal.get_participant(participant_full_name)
+    scenario "The current delivery partner can locate a record for the ECT" do
+      given_i_sign_in_as_the_user_with_the_full_name delivery_partner_name
 
-    expect(delivery_partner_portal).to have_full_name participant_full_name
-    expect(delivery_partner_portal).to have_email_address participant_email
-    expect(delivery_partner_portal).to have_teacher_reference_number teacher_reference_number
-    expect(delivery_partner_portal).to have_participant_type long_participant_type
-    expect(delivery_partner_portal).to have_lead_provider_name lead_provider_name
-    expect(delivery_partner_portal).to have_school_name school_name
-    expect(delivery_partner_portal).to have_school_urn school.urn
-    expect(delivery_partner_portal).to have_academic_year start_year
-    expect(delivery_partner_portal).to have_training_record_status delivery_partner_record_state
+      delivery_partner_portal = Pages::DeliveryPartnerPortal.loaded
+      delivery_partner_portal.get_participant(participant_full_name)
+
+      expect(delivery_partner_portal).to have_full_name participant_full_name
+      expect(delivery_partner_portal).to have_email_address participant_email
+      expect(delivery_partner_portal).to have_teacher_reference_number teacher_reference_number
+      expect(delivery_partner_portal).to have_participant_type long_participant_type
+      expect(delivery_partner_portal).to have_lead_provider_name lead_provider_name
+      expect(delivery_partner_portal).to have_school_name school_name
+      expect(delivery_partner_portal).to have_school_urn school.urn
+      expect(delivery_partner_portal).to have_academic_year start_year
+      expect(delivery_partner_portal).to have_training_record_status delivery_partner_record_state
+    end
   end
 
   scenario "The Support for ECTs service can locate a record for the ECT" do

--- a/spec/features/scenarios/participants/ect_doing_fip/no_validation_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_fip/no_validation_spec.rb
@@ -155,21 +155,25 @@ RSpec.feature "ECT doing FIP: no validation", type: :feature do
     expect(participant_endpoint).to have_schedule_identifier schedule_identifier
   end
 
-  scenario "The current delivery partner can locate a record for the ECT" do
-    given_i_sign_in_as_the_user_with_the_full_name delivery_partner_name
+  context "when the participant cohort is #{DeliveryPartners::ParticipantsFilter::LATEST_COHORT_TO_RETURN} or earlier" do
+    let(:start_year) { DeliveryPartners::ParticipantsFilter::LATEST_COHORT_TO_RETURN }
 
-    delivery_partner_portal = Pages::DeliveryPartnerPortal.loaded
-    delivery_partner_portal.get_participant(participant_full_name)
+    scenario "The current delivery partner can locate a record for the ECT" do
+      given_i_sign_in_as_the_user_with_the_full_name delivery_partner_name
 
-    expect(delivery_partner_portal).to have_full_name participant_full_name
-    expect(delivery_partner_portal).to have_email_address participant_email
-    expect(delivery_partner_portal).to have_teacher_reference_number teacher_reference_number
-    expect(delivery_partner_portal).to have_participant_type long_participant_type
-    expect(delivery_partner_portal).to have_lead_provider_name lead_provider_name
-    expect(delivery_partner_portal).to have_school_name school_name
-    expect(delivery_partner_portal).to have_school_urn school.urn
-    expect(delivery_partner_portal).to have_academic_year start_year
-    expect(delivery_partner_portal).to have_training_record_status delivery_partner_record_state
+      delivery_partner_portal = Pages::DeliveryPartnerPortal.loaded
+      delivery_partner_portal.get_participant(participant_full_name)
+
+      expect(delivery_partner_portal).to have_full_name participant_full_name
+      expect(delivery_partner_portal).to have_email_address participant_email
+      expect(delivery_partner_portal).to have_teacher_reference_number teacher_reference_number
+      expect(delivery_partner_portal).to have_participant_type long_participant_type
+      expect(delivery_partner_portal).to have_lead_provider_name lead_provider_name
+      expect(delivery_partner_portal).to have_school_name school_name
+      expect(delivery_partner_portal).to have_school_urn school.urn
+      expect(delivery_partner_portal).to have_academic_year start_year
+      expect(delivery_partner_portal).to have_training_record_status delivery_partner_record_state
+    end
   end
 
   scenario "The Support for ECTs service can locate a record for the CIP ECT" do

--- a/spec/services/delivery_partners/participants_filter_spec.rb
+++ b/spec/services/delivery_partners/participants_filter_spec.rb
@@ -3,25 +3,36 @@
 require "rails_helper"
 
 RSpec.describe DeliveryPartners::ParticipantsFilter do
-  let(:school_cohort1) { create(:school_cohort, cohort: Cohort.current) }
+  let(:latest_start_year_returned) { DeliveryPartners::ParticipantsFilter::LATEST_COHORT_TO_RETURN }
+  let(:excluded_start_year) { latest_start_year_returned + 1 }
+
+  let(:school_cohort1) { create(:school_cohort, cohort: Cohort.find_by!(start_year: latest_start_year_returned - 1)) }
   let(:partnership1) { create(:partnership, lead_provider: create(:lead_provider, name: "LP1")) }
   let(:induction_programme1) { create(:induction_programme, partnership: partnership1) }
   let(:participant_profile1) { create(:mentor_participant_profile) }
   let!(:induction_record1) { create(:induction_record, participant_profile: participant_profile1, induction_programme: induction_programme1, school_cohort: school_cohort1) }
 
-  let(:school_cohort2) { create(:school_cohort, cohort: Cohort.next) }
+  let(:school_cohort2) { create(:school_cohort, cohort: Cohort.find_by!(start_year: latest_start_year_returned)) }
   let(:partnership2) { create(:partnership, lead_provider: create(:lead_provider, name: "LP2")) }
   let(:induction_programme2) { create(:induction_programme, partnership: partnership2) }
   let(:participant_profile2) { create(:ect_participant_profile, training_status: "deferred") }
   let!(:induction_record2) { create(:induction_record, participant_profile: participant_profile2, induction_programme: induction_programme2, school_cohort: school_cohort2, training_status: "deferred") }
 
-  let(:delivery_partner) { create(:delivery_partner, partnerships: [partnership1, partnership2]) }
+  let(:school_cohort3) { create(:school_cohort, cohort: Cohort.find_by!(start_year: excluded_start_year)) }
+  let(:partnership3) { create(:partnership, lead_provider: create(:lead_provider, name: "LP3")) }
+  let(:induction_programme3) { create(:induction_programme, partnership: partnership3) }
+  let(:participant_profile3) { create(:ect_participant_profile, training_status: "deferred") }
+  let!(:induction_record3) { create(:induction_record, participant_profile: participant_profile3, induction_programme: induction_programme3, school_cohort: school_cohort3) }
+
+  let(:delivery_partner) { create(:delivery_partner, partnerships: [partnership1, partnership2, partnership3]) }
 
   let(:collection) { DeliveryPartners::InductionRecordsQuery.new(delivery_partner:).induction_records }
   let(:params) { {} }
   let(:training_record_states) { DetermineTrainingRecordState.call(induction_records: collection) }
 
-  subject { described_class.new(collection:, params:, training_record_states:).scope.to_a }
+  let(:instance) { described_class.new(collection:, params:, training_record_states:) }
+
+  subject { instance.scope.to_a }
 
   context "when there are no filters provided" do
     it { is_expected.to contain_exactly(induction_record1, induction_record2) }
@@ -98,7 +109,13 @@ RSpec.describe DeliveryPartners::ParticipantsFilter do
       it { is_expected.to be_empty }
     end
 
-    context "with academic_year" do
+    context "with academic_year not present in the options" do
+      let(:params) { { academic_year: excluded_start_year } }
+
+      it { is_expected.to be_empty }
+    end
+
+    context "with academic_year present in the options" do
       let(:params) { { academic_year: school_cohort1.start_year } }
 
       it { is_expected.to contain_exactly(induction_record1) }
@@ -123,5 +140,32 @@ RSpec.describe DeliveryPartners::ParticipantsFilter do
 
       it { is_expected.to contain_exactly(induction_record1) }
     end
+  end
+
+  describe "#role_options" do
+    subject(:options) { instance.role_options }
+
+    it { expect(options.map(&:id)).to eq(["", "ect", "mentor"]) }
+    it { expect(options.map(&:name)).to eq(["", "Early career teacher", "Mentor"]) }
+  end
+
+  describe "#academic_year_options" do
+    before { expect(Cohort.where(start_year: excluded_start_year)).to be_exists }
+
+    subject(:options) { instance.academic_year_options }
+
+    let(:expected_values) { [""] + Cohort.order(:start_year).pluck(:start_year).excluding(excluded_start_year) }
+
+    it { expect(options.map(&:id)).to eq(expected_values) }
+    it { expect(options.map(&:name)).to eq(expected_values) }
+  end
+
+  describe "#status_options" do
+    subject(:options) { instance.status_options }
+
+    let(:expected_values) { I18n.t("status_tags.delivery_partner_participant_status").values.uniq }
+
+    it { expect(options.map(&:id)).to eq([""] + expected_values.pluck(:id)) }
+    it { expect(options.map(&:name)).to eq([""] + expected_values.pluck(:label)) }
   end
 end


### PR DESCRIPTION
[Jira-4060](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-4060)

### Context

We want to exclude participants in the 2025 cohort from the delivery partners participants view. We also want to hide the 2025 and later cohorts from the academic year dropdown.

This is intended to encourage lead providers to carry out their contractual duties and ensure there is no ownness on the DfE to share details of participants in 2025 and later cohorts.

### Changes proposed in this pull request

- Exclude 2025 and later participants from delivery partners

### Guidance to review

Participant created in 2025 cohort for `Koelpin-Homenick` DP:

```
school_cohort = FactoryBot.create(:school_cohort, cohort: Cohort.find_by!(start_year: 2025))
delivery_partner = DeliveryPartner.find("8d2875ca-4727-48b7-8adf-9a47fa9debdc")
lead_provider = LeadProvider.find_by(name: "Ambition Institute")
partnership = FactoryBot.create(:partnership, lead_provider: FactoryBot.create(:lead_provider, name: "LP3"), delivery_partner:)
induction_programme = FactoryBot.create(:induction_programme, partnership:)
participant_profile = FactoryBot.create(:ect_participant_profile, training_status: "deferred")
FactoryBot.create(:induction_record, participant_profile:, induction_programme:, school_cohort:)
```