### PR TITLE
[CPDLP-3943] Create eligible schools and partnerships on the mentor/ect valid test data generators

### DIFF
--- a/app/services/valid_test_data_generators/ecf_lead_provider_populater.rb
+++ b/app/services/valid_test_data_generators/ecf_lead_provider_populater.rb
@@ -209,6 +209,10 @@ module ValidTestDataGenerators
         s.name = Faker::Company.name
         s.address_line1 = Faker::Address.street_address
         s.postcode = Faker::Address.postcode
+        s.primary_contact_email = "school-info-#{s.urn}@example.com"
+        s.school_status_code = 1
+        s.school_type_code = 1
+        s.administrative_district_code = "E123"
       end
       school_cohort = school_cohort(school:)
       partnership = attach_partnership_to_school(school:)

--- a/app/services/valid_test_data_generators/mentor_ect_generator.rb
+++ b/app/services/valid_test_data_generators/mentor_ect_generator.rb
@@ -51,13 +51,17 @@ module ValidTestDataGenerators
 
     def find_or_create_school_cohort
       school = partnership.school
-      school_cohort = SchoolCohort.find_or_create_by!(school:, cohort:, induction_programme_choice: "full_induction_programme")
-      InductionProgramme.find_or_create_by!(school_cohort:, partnership:, training_programme: "full_induction_programme")
+      school_cohort = SchoolCohort.find_or_create_by!(school:, cohort:) do |sc|
+        sc.induction_programme_choice = "full_induction_programme"
+      end
+      school.school_local_authorities.create!(local_authority: LocalAuthority.all.sample, start_year: cohort.start_year)
+      Induction::SetCohortInductionProgramme.call(school_cohort:,
+                                                  programme_choice: "full_induction_programme")
       school_cohort
     end
 
     def partnership
-      lead_provider.partnerships.find_by(cohort:)
+      lead_provider.partnerships.joins(:school).merge!(School.eligible_or_cip_only).find_by(cohort:)
     end
   end
 end

--- a/spec/services/valid_test_data_generators/mentor_ect_generator_spec.rb
+++ b/spec/services/valid_test_data_generators/mentor_ect_generator_spec.rb
@@ -18,7 +18,10 @@ RSpec.describe ValidTestDataGenerators::MentorECTGenerator do
     end
 
     context "when the cohort has a default schedule and the lead provider has a school" do
-      before { create(:partnership, cohort:, lead_provider:) }
+      before do
+        create(:local_authority)
+        create(:partnership, cohort:, lead_provider:)
+      end
 
       it { expect { generate }.to change(ParticipantProfile::ECT, :count).by(number) }
       it { expect { generate }.to change(ParticipantProfile::Mentor, :count).by(number) }


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-3943

We want to create participants linked to eligible schools as only eligible schools are visible in the admin dashboards and returned in the API responses.

### Changes proposed in this pull request

- Create eligible schools when running the mentor/ect valid test data generators;
- Make sure we select the eligible school when creating the school cohort in the generator;

### Guidance to review

```
ActiveRecord::Base.transaction do
  names = [
    "Ambition Institute",
  ]
  cohorts = Cohort.between_years(2021, 2025)

  names.product(cohorts) do |name, cohort|
    ValidTestDataGenerators::ECFLeadProviderPopulater.call(name:, cohort:, total_schools: 1, participants_per_school: 0)
    ValidTestDataGenerators::MentorECTGenerator.call(name:, cohort:, number: 5)
  end
end
```
