### PR TITLE
[CPDLP-4019] Tech debt - Move banding logic into a banding calculator

### DIFF
--- a/app/services/finance/ecf/banding_calculator.rb
+++ b/app/services/finance/ecf/banding_calculator.rb
@@ -52,7 +52,7 @@ module Finance
 
       def banding
         @banding ||=
-          bands.zip(:a..:z).map do |band, letter|
+          bands.zip(:a..:d).map do |band, letter|
             # minimum band should always be 1 or more, otherwise band a will go over its max limit
             band_min = band.min.to_i.zero? ? 1 : band.min
             {

--- a/app/services/finance/ecf/banding_calculator.rb
+++ b/app/services/finance/ecf/banding_calculator.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+module Finance
+  module ECF
+    class BandingCalculator
+      attr_reader :statement, :declaration_type
+
+      def initialize(statement:, declaration_type:)
+        @statement = statement
+        @declaration_type = declaration_type
+        calculate
+      end
+
+      def calculate
+        add_previous_count
+        add_billables
+        remaining_refundables_count = adjust_for_refundables
+        adjust_remaining_refundables(remaining_refundables_count)
+
+        banding
+      end
+
+      def min(letter)
+        banding_by_letter(letter)[:min]
+      end
+
+      def max(letter)
+        banding_by_letter(letter)[:max]
+      end
+
+      def previous_count(letter)
+        banding_by_letter(letter)[:previous_count]
+      end
+
+      def count(letter)
+        banding_by_letter(letter)[:count]
+      end
+
+      def additions(letter)
+        banding_by_letter(letter)[:additions]
+      end
+
+      def subtractions(letter)
+        banding_by_letter(letter)[:subtractions]
+      end
+
+    private
+
+      def bands
+        @bands ||= statement.contract.bands.order(max: :asc)
+      end
+
+      def banding
+        @banding ||=
+          bands.zip(:a..:z).map do |band, letter|
+            # minimum band should always be 1 or more, otherwise band a will go over its max limit
+            band_min = band.min.to_i.zero? ? 1 : band.min
+            {
+              band: letter,
+              min: band_min,
+              max: band.max,
+            }
+          end
+      end
+
+      def banding_by_letter(letter)
+        @banding_by_letter ||= banding.index_by do |hash|
+          hash[:band]
+        end
+
+        @banding_by_letter[letter] || {}
+      end
+
+      def add_previous_count
+        pot_size = previous_fill_level
+
+        banding.each do |hash|
+          band_capacity = hash[:max] - hash[:min] + 1
+
+          fill_level = [pot_size, band_capacity].min
+          hash[:previous_count] = fill_level
+
+          pot_size -= fill_level
+        end
+      end
+
+      def add_billables
+        pot_size = current_billable_count
+
+        banding.each do |hash|
+          band_capacity = hash[:max] - (hash[:min] - 1) - hash[:previous_count]
+          fill_level = [pot_size, band_capacity].min
+          pot_size -= fill_level
+
+          hash[:count] = fill_level
+          hash[:additions] = fill_level
+        end
+      end
+
+      def adjust_for_refundables
+        pot_size = current_refundable_count
+
+        banding.reverse.each do |hash|
+          fill_level = hash[:count]
+          available = [fill_level, pot_size].min
+          pot_size -= available
+
+          hash[:count] = fill_level - available
+          hash[:subtractions] = available
+        end
+
+        pot_size
+      end
+
+      def adjust_remaining_refundables(remaining_pot_size)
+        return unless remaining_pot_size.positive?
+
+        banding.reverse.each do |hash|
+          available = hash[:previous_count]
+          next if available.zero?
+
+          reduction = [remaining_pot_size, available].min
+          remaining_pot_size -= reduction
+
+          hash[:count] = -reduction
+          hash[:subtractions] = (hash[:subtractions] || 0) + reduction
+        end
+      end
+
+      def previous_fill_level
+        previous_billable_count - previous_refundable_count
+      end
+
+      def previous_billable_count
+        Finance::StatementLineItem
+          .where(statement: statement.previous_statements)
+          .billable
+          .joins(:participant_declaration)
+          .merge!(ParticipantDeclaration.for_declaration(declaration_type))
+          .count
+      end
+
+      def previous_refundable_count
+        Finance::StatementLineItem
+          .where(statement: statement.previous_statements)
+          .refundable
+          .joins(:participant_declaration)
+          .merge!(ParticipantDeclaration.for_declaration(declaration_type))
+          .count
+      end
+
+      def current_billable_count
+        statement
+          .billable_statement_line_items
+          .joins(:participant_declaration)
+          .merge!(ParticipantDeclaration.for_declaration(declaration_type))
+          .count
+      end
+
+      def current_refundable_count
+        statement
+          .refundable_statement_line_items
+          .joins(:participant_declaration)
+          .merge!(ParticipantDeclaration.for_declaration(declaration_type))
+          .count
+      end
+    end
+  end
+end

--- a/app/services/finance/ecf/ect/banding_calculator.rb
+++ b/app/services/finance/ecf/ect/banding_calculator.rb
@@ -6,42 +6,12 @@ module Finance
       class BandingCalculator < Finance::ECF::BandingCalculator
       private
 
-        def previous_billable_count
-          Finance::StatementLineItem
-            .where(statement: statement.previous_statements)
-            .billable
-            .joins(:participant_declaration)
-            .merge!(ParticipantDeclaration.for_declaration(declaration_type))
-            .merge!(ParticipantDeclaration.ect)
-            .count
+        def previous_statement_line_items
+          super.merge!(ParticipantDeclaration.ect)
         end
 
-        def previous_refundable_count
-          Finance::StatementLineItem
-            .where(statement: statement.previous_statements)
-            .refundable
-            .joins(:participant_declaration)
-            .merge!(ParticipantDeclaration.for_declaration(declaration_type))
-            .merge!(ParticipantDeclaration.ect)
-            .count
-        end
-
-        def current_billable_count
-          statement
-            .billable_statement_line_items
-            .joins(:participant_declaration)
-            .merge!(ParticipantDeclaration.for_declaration(declaration_type))
-            .merge!(ParticipantDeclaration.ect)
-            .count
-        end
-
-        def current_refundable_count
-          statement
-            .refundable_statement_line_items
-            .joins(:participant_declaration)
-            .merge!(ParticipantDeclaration.for_declaration(declaration_type))
-            .merge!(ParticipantDeclaration.ect)
-            .count
+        def current_statement_line_items
+          super.merge!(ParticipantDeclaration.ect)
         end
       end
     end

--- a/app/services/finance/ecf/ect/banding_calculator.rb
+++ b/app/services/finance/ecf/ect/banding_calculator.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Finance
+  module ECF
+    module ECT
+      class BandingCalculator < Finance::ECF::BandingCalculator
+      private
+
+        def previous_billable_count
+          Finance::StatementLineItem
+            .where(statement: statement.previous_statements)
+            .billable
+            .joins(:participant_declaration)
+            .merge!(ParticipantDeclaration.for_declaration(declaration_type))
+            .merge!(ParticipantDeclaration.ect)
+            .count
+        end
+
+        def previous_refundable_count
+          Finance::StatementLineItem
+            .where(statement: statement.previous_statements)
+            .refundable
+            .joins(:participant_declaration)
+            .merge!(ParticipantDeclaration.for_declaration(declaration_type))
+            .merge!(ParticipantDeclaration.ect)
+            .count
+        end
+
+        def current_billable_count
+          statement
+            .billable_statement_line_items
+            .joins(:participant_declaration)
+            .merge!(ParticipantDeclaration.for_declaration(declaration_type))
+            .merge!(ParticipantDeclaration.ect)
+            .count
+        end
+
+        def current_refundable_count
+          statement
+            .refundable_statement_line_items
+            .joins(:participant_declaration)
+            .merge!(ParticipantDeclaration.for_declaration(declaration_type))
+            .merge!(ParticipantDeclaration.ect)
+            .count
+        end
+      end
+    end
+  end
+end

--- a/app/services/finance/ecf/ect/output_calculator.rb
+++ b/app/services/finance/ecf/ect/output_calculator.rb
@@ -6,26 +6,6 @@ module Finance
       class OutputCalculator < Finance::ECF::OutputCalculator
       private
 
-        def previous_fill_level_for_declaration_type(declaration_type)
-          billable = Finance::StatementLineItem
-            .where(statement: statement.previous_statements)
-            .billable
-            .joins(:participant_declaration)
-            .merge!(ParticipantDeclaration.for_declaration(declaration_type))
-            .merge!(ParticipantDeclaration.ect)
-            .count
-
-          refundable = Finance::StatementLineItem
-            .where(statement: statement.previous_statements)
-            .refundable
-            .joins(:participant_declaration)
-            .merge!(ParticipantDeclaration.for_declaration(declaration_type))
-            .merge!(ParticipantDeclaration.ect)
-            .count
-
-          billable - refundable
-        end
-
         def previous_fill_level_for_uplift
           billable = Finance::StatementLineItem
             .where(statement: statement.previous_statements)
@@ -46,24 +26,6 @@ module Finance
             .count
 
           billable - refundable
-        end
-
-        def current_billable_count_for_declaration_type(declaration_type)
-          statement
-            .billable_statement_line_items
-            .joins(:participant_declaration)
-            .merge!(ParticipantDeclaration.for_declaration(declaration_type))
-            .merge!(ParticipantDeclaration.ect)
-            .count
-        end
-
-        def current_refundable_count_declaration_type(declaration_type)
-          statement
-            .refundable_statement_line_items
-            .joins(:participant_declaration)
-            .merge!(ParticipantDeclaration.for_declaration(declaration_type))
-            .merge!(ParticipantDeclaration.ect)
-            .count
         end
 
         def current_billable_count_for_uplift

--- a/app/services/finance/ecf/ect/statement_calculator.rb
+++ b/app/services/finance/ecf/ect/statement_calculator.rb
@@ -6,12 +6,14 @@ module Finance
   module ECF
     module ECT
       class StatementCalculator < Finance::ECF::StatementCalculator
-        def voided_declarations
-          statement.participant_declarations.voided.merge!(ParticipantDeclaration.ect)
-        end
-
         def ect?
           true
+        end
+
+      private
+
+        def participant_declarations
+          super.merge!(ParticipantDeclaration.ect)
         end
       end
     end

--- a/app/services/finance/ecf/ect/statement_calculator.rb
+++ b/app/services/finance/ecf/ect/statement_calculator.rb
@@ -13,12 +13,6 @@ module Finance
         def ect?
           true
         end
-
-      private
-
-        def output_calculator
-          @output_calculator ||= OutputCalculator.new(statement:)
-        end
       end
     end
   end

--- a/app/services/finance/ecf/mentor/output_calculator.rb
+++ b/app/services/finance/ecf/mentor/output_calculator.rb
@@ -15,10 +15,12 @@ module Finance
           @statement = statement
         end
 
-        def output_breakdown
-          @output_breakdown ||= declaration_types.map do |declaration_type|
-            current_output_for_declaration_type(declaration_type)
-          end
+        def additions(declaration_type)
+          output_breakdown["#{declaration_type}_additions"]
+        end
+
+        def subtractions(declaration_type)
+          output_breakdown["#{declaration_type}_subtractions"]
         end
 
         def fee_for_declaration(type:)
@@ -29,17 +31,17 @@ module Finance
       private
 
         def declaration_types
-          DECLARATION_TYPE_FEE_PROPORTIONS.stringify_keys.keys
+          DECLARATION_TYPE_FEE_PROPORTIONS.keys
         end
 
-        def current_output_for_declaration_type(declaration_type)
-          current_output_count = current_billable_count_for_declaration_type(declaration_type)
-          refundable_output_count = current_refundable_count_declaration_type(declaration_type)
+        def output_breakdown
+          @output_breakdown ||= declaration_types.each_with_object({}) do |declaration_type, hash|
+            current_output_count = current_billable_count_for_declaration_type(declaration_type)
+            refundable_output_count = current_refundable_count_declaration_type(declaration_type)
 
-          hash = {}
-          hash[:"#{declaration_type.underscore}_additions"] = current_output_count
-          hash[:"#{declaration_type.underscore}_subtractions"] = refundable_output_count
-          hash
+            hash["#{declaration_type}_additions"] = current_output_count
+            hash["#{declaration_type}_subtractions"] = refundable_output_count
+          end
         end
 
         def current_billable_count_for_declaration_type(declaration_type)

--- a/app/services/finance/ecf/mentor/statement_calculator.rb
+++ b/app/services/finance/ecf/mentor/statement_calculator.rb
@@ -40,15 +40,15 @@ module Finance
           end
 
           define_method "additions_for_#{declaration_type}" do
-            output_calculator.output_breakdown.sum do |hash|
-              hash[:"#{declaration_type}_additions"].to_i * output_calculator.fee_for_declaration(type: declaration_type)
-            end
+            additions = output_calculator.additions(declaration_type)
+            fee = output_calculator.fee_for_declaration(type: declaration_type)
+            additions * fee
           end
 
           define_method "deductions_for_#{declaration_type}" do
-            output_calculator.output_breakdown.sum do |hash|
-              hash[:"#{declaration_type}_subtractions"].to_i * output_calculator.fee_for_declaration(type: declaration_type)
-            end
+            subtractions = output_calculator.subtractions(declaration_type)
+            fee = output_calculator.fee_for_declaration(type: declaration_type)
+            subtractions * fee
           end
         end
 
@@ -57,15 +57,11 @@ module Finance
         end
 
         def started_count
-          output_calculator.output_breakdown.sum do |hash|
-            hash[:started_additions].to_i
-          end
+          output_calculator.additions("started")
         end
 
         def completed_count
-          output_calculator.output_breakdown.sum do |hash|
-            hash[:completed_additions].to_i
-          end
+          output_calculator.additions("completed")
         end
 
         def voided_count
@@ -102,8 +98,7 @@ module Finance
           result = []
 
           declaration_types.each do |declaration_type|
-            hash = output_calculator.output_breakdown.find { |b| b.key?(:"#{declaration_type}_subtractions") }
-            count = hash[:"#{declaration_type}_subtractions"]
+            count = output_calculator.subtractions(declaration_type)
 
             next if count.zero?
 

--- a/app/services/finance/ecf/mentor/statement_calculator.rb
+++ b/app/services/finance/ecf/mentor/statement_calculator.rb
@@ -30,10 +30,6 @@ module Finance
           total * vat_rate
         end
 
-        def voided_declarations
-          statement.participant_declarations.voided.merge!(ParticipantDeclaration.mentor)
-        end
-
         declaration_types.each do |declaration_type|
           define_method "#{declaration_type}_fee_per_declaration" do
             fee_for_declaration(type: declaration_type)
@@ -65,7 +61,7 @@ module Finance
         end
 
         def voided_count
-          voided_declarations.count
+          participant_declarations.voided.count
         end
 
         def adjustments_total
@@ -131,6 +127,10 @@ module Finance
 
         def declaration_types
           self.class.declaration_types
+        end
+
+        def participant_declarations
+          statement.participant_declarations.voided.merge!(ParticipantDeclaration.mentor)
         end
 
         def vat_rate

--- a/app/services/finance/ecf/mentor/statement_calculator.rb
+++ b/app/services/finance/ecf/mentor/statement_calculator.rb
@@ -130,7 +130,7 @@ module Finance
         end
 
         def participant_declarations
-          statement.participant_declarations.voided.merge!(ParticipantDeclaration.mentor)
+          statement.participant_declarations.merge!(ParticipantDeclaration.mentor)
         end
 
         def vat_rate

--- a/app/services/finance/ecf/output_calculator.rb
+++ b/app/services/finance/ecf/output_calculator.rb
@@ -3,6 +3,18 @@
 module Finance
   module ECF
     class OutputCalculator
+      DECLARATION_TYPE_FEE_PROPORTIONS = {
+        started: 0.2,
+        completed: 0.2,
+        retained_1: 0.15,
+        retained_2: 0.15,
+        retained_3: 0.15,
+        retained_4: 0.15,
+        extended_1: 0.15,
+        extended_2: 0.15,
+        extended_3: 0.15,
+      }.freeze
+
       attr_reader :statement
 
       def initialize(statement:)
@@ -23,17 +35,7 @@ module Finance
       end
 
       def fee_for_declaration(band_letter:, type:)
-        percentage = case type
-                     when :started
-                       started_event_percentage
-                     when :completed
-                       completed_event_percentage
-                     when :retained_1, :retained_2, :retained_3, :retained_4
-                       retained_event_percentage
-                     when :extended_1, :extended_2, :extended_3
-                       extended_event_percentage
-                     end
-
+        percentage = DECLARATION_TYPE_FEE_PROPORTIONS[type]
         percentage * band_for_letter(band_letter).output_payment_per_participant
       end
 
@@ -41,29 +43,13 @@ module Finance
 
       def bandings
         @bandings ||= declaration_types.index_with do |declaration_type|
-          BandingCalculator.new(statement:, declaration_type:)
+          self.class.module_parent::BandingCalculator.new(statement:, declaration_type:)
         end
       end
 
       def band_for_letter(letter)
         @band_for_letters ||= bands.zip(:a..:d).each_with_object({}) { |(band, lettr), hash| hash[lettr] = band }
         @band_for_letters[letter]
-      end
-
-      def started_event_percentage
-        0.2
-      end
-
-      def completed_event_percentage
-        0.2
-      end
-
-      def retained_event_percentage
-        0.15
-      end
-
-      def extended_event_percentage
-        0.15
       end
 
       def declaration_types

--- a/app/services/finance/ecf/output_calculator.rb
+++ b/app/services/finance/ecf/output_calculator.rb
@@ -9,23 +9,8 @@ module Finance
         @statement = statement
       end
 
-      def banding_breakdown
-        @banding_breakdown ||= begin
-          bandings = declaration_types.map do |declaration_type|
-            current_banding_for_declaration_type(declaration_type)
-          end
-
-          result = bandings[0]
-
-          band_letters.each do |letter|
-            bandings[1..].each do |banding|
-              new_chunk = banding.find { |e| e[:band] == letter }
-              result.find { |e| e[:band] == letter }.merge!(new_chunk)
-            end
-          end
-
-          result
-        end
+      def banding_for(declaration_type:)
+        bandings[declaration_type]
       end
 
       def uplift_breakdown
@@ -54,8 +39,15 @@ module Finance
 
     private
 
+      def bandings
+        @bandings ||= declaration_types.index_with do |declaration_type|
+          BandingCalculator.new(statement:, declaration_type:)
+        end
+      end
+
       def band_for_letter(letter)
-        bands.zip(:a..:z).find { |e| e[1] == letter }[0]
+        @band_for_letters ||= bands.zip(:a..:d).each_with_object({}) { |(band, lettr), hash| hash[lettr] = band }
+        @band_for_letters[letter]
       end
 
       def started_event_percentage
@@ -88,110 +80,8 @@ module Finance
         ]
       end
 
-      # this is a 3 pass algorithm
-      # first pass adds billable declarations
-      # second pass subtracts refunds
-      # third pass further subtracts refunds if statement is net negative
-      def current_banding_for_declaration_type(declaration_type)
-        pot_size = current_billable_count_for_declaration_type(declaration_type)
-
-        banding = previous_banding_for_declaration_type(declaration_type).map do |hash|
-          band_capacity = hash[:max] - (hash[:min] - 1) - hash[:"previous_#{declaration_type.underscore}_count"]
-
-          fill_level = [pot_size, band_capacity].min
-
-          pot_size -= fill_level
-
-          hash[:"#{declaration_type.underscore}_count"] = fill_level
-          hash[:"#{declaration_type.underscore}_additions"] = fill_level
-
-          hash
-        end
-
-        pot_size = current_refundable_count_declaration_type(declaration_type)
-
-        banding = banding.reverse.map do |hash|
-          fill_level = hash[:"#{declaration_type.underscore}_count"]
-
-          available = [fill_level, pot_size].min
-
-          hash[:"#{declaration_type.underscore}_count"] = fill_level - available
-          hash[:"#{declaration_type.underscore}_subtractions"] = available
-
-          pot_size -= available
-
-          hash
-        end
-
-        if pot_size.positive?
-          banding = banding.map do |hash|
-            available = hash[:"previous_#{declaration_type.underscore}_count"]
-
-            unless available.zero?
-              reduction = [pot_size, available].min
-
-              hash[:"#{declaration_type.underscore}_count"] = -reduction
-              hash[:"#{declaration_type.underscore}_subtractions"] += reduction
-
-              pot_size -= reduction
-            end
-
-            hash
-          end
-        end
-
-        banding.reverse
-      end
-
-      def previous_banding_for_declaration_type(declaration_type)
-        pot_size = previous_fill_level_for_declaration_type(declaration_type)
-
-        bands.zip(:a..:z).map do |band, letter|
-          # minimum band should always be 1 or more, otherwise band a will go over
-          # its max limit
-          band_min = band.min.to_i.zero? ? 1 : band.min
-
-          band_capacity = band.max - band_min + 1
-
-          fill_level = [pot_size, band_capacity].min
-
-          pot_size -= fill_level
-
-          key_name = "previous_#{declaration_type.underscore}_count".to_sym
-
-          {
-            band: letter,
-            min: band_min,
-            max: band.max,
-            key_name => fill_level,
-          }
-        end
-      end
-
       def bands
         statement.contract.bands.order(max: :asc)
-      end
-
-      def band_letters
-        bands.zip(:a..:z).map { |e| e[1] }
-      end
-
-      def previous_fill_level_for_declaration_type(declaration_type)
-        billable = Finance::StatementLineItem
-          .where(statement: statement.previous_statements)
-          .billable
-          .joins(:participant_declaration)
-          .merge!(ParticipantDeclaration.for_declaration(declaration_type))
-          .count
-
-        refundable = Finance::StatementLineItem
-          .where(statement: statement.previous_statements)
-          .refundable
-          .joins(:participant_declaration)
-          .merge!(ParticipantDeclaration.for_declaration(declaration_type))
-          .count
-
-        billable - refundable
       end
 
       def previous_fill_level_for_uplift
@@ -212,22 +102,6 @@ module Finance
           .count
 
         billable - refundable
-      end
-
-      def current_billable_count_for_declaration_type(declaration_type)
-        statement
-          .billable_statement_line_items
-          .joins(:participant_declaration)
-          .merge!(ParticipantDeclaration.for_declaration(declaration_type))
-          .count
-      end
-
-      def current_refundable_count_declaration_type(declaration_type)
-        statement
-          .refundable_statement_line_items
-          .joins(:participant_declaration)
-          .merge!(ParticipantDeclaration.for_declaration(declaration_type))
-          .count
       end
 
       def current_billable_count_for_uplift

--- a/app/services/finance/ecf/statement_calculator.rb
+++ b/app/services/finance/ecf/statement_calculator.rb
@@ -284,7 +284,7 @@ module Finance
       end
 
       def output_calculator
-        @output_calculator ||= OutputCalculator.new(statement:)
+        @output_calculator ||= self.class.module_parent::OutputCalculator.new(statement:)
       end
 
       def event_types

--- a/app/services/finance/ecf/statement_calculator.rb
+++ b/app/services/finance/ecf/statement_calculator.rb
@@ -59,10 +59,6 @@ module Finance
         total * vat_rate
       end
 
-      def voided_declarations
-        statement.participant_declarations.voided
-      end
-
       event_types.each do |event_type|
         declaration_type = event_type.to_s.dasherize
 
@@ -158,11 +154,11 @@ module Finance
       end
 
       def clawed_back_count
-        statement.participant_declarations.clawed_back.count
+        participant_declarations.clawed_back.count
       end
 
       def voided_count
-        voided_declarations.count
+        participant_declarations.voided.count
       end
 
       def uplift_count
@@ -278,6 +274,8 @@ module Finance
       end
 
     private
+
+      delegate :participant_declarations, to: :statement
 
       def calculated_service_fee
         PaymentCalculator::ECF::ServiceFees.new(contract:).call.sum { |hash| hash[:monthly] }

--- a/app/services/finance/ecf/statement_calculator.rb
+++ b/app/services/finance/ecf/statement_calculator.rb
@@ -64,17 +64,19 @@ module Finance
       end
 
       event_types.each do |event_type|
+        declaration_type = event_type.to_s.dasherize
+
         band_mapping.each_key do |letter|
           define_method "#{event_type}_band_#{letter}_count" do
-            output_calculator.banding_breakdown.find { |e| e[:band] == letter }[:"#{event_type}_count"]
+            output_calculator.banding_for(declaration_type:).count(letter)
           end
 
           define_method "#{event_type}_band_#{letter}_additions" do
-            output_calculator.banding_breakdown.find { |e| e[:band] == letter }[:"#{event_type}_additions"]
+            output_calculator.banding_for(declaration_type:).additions(letter)
           end
 
           define_method "#{event_type}_band_#{letter}_subtractions" do
-            output_calculator.banding_breakdown.find { |e| e[:band] == letter }[:"#{event_type}_subtractions"]
+            output_calculator.banding_for(declaration_type:).subtractions(letter)
           end
 
           define_method "#{event_type}_band_#{letter}_fee_per_declaration" do
@@ -83,14 +85,18 @@ module Finance
         end
 
         define_method "additions_for_#{event_type}" do
-          output_calculator.banding_breakdown.sum do |hash|
-            hash[:"#{event_type}_additions"] * output_calculator.fee_for_declaration(band_letter: hash[:band], type: event_type)
+          band_letters.sum do |letter|
+            additions = output_calculator.banding_for(declaration_type:).additions(letter)
+            fee = output_calculator.fee_for_declaration(band_letter: letter, type: event_type)
+            additions * fee
           end
         end
 
         define_method "deductions_for_#{event_type}" do
-          output_calculator.banding_breakdown.sum do |hash|
-            hash[:"#{event_type}_subtractions"] * output_calculator.fee_for_declaration(band_letter: hash[:band], type: event_type)
+          band_letters.sum do |letter|
+            subtractions = output_calculator.banding_for(declaration_type:).subtractions(letter)
+            fee = output_calculator.fee_for_declaration(band_letter: letter, type: event_type)
+            subtractions * fee
           end
         end
       end
@@ -116,26 +122,38 @@ module Finance
       end
 
       def started_count
-        output_calculator.banding_breakdown.sum do |hash|
-          hash[:started_additions]
+        band_letters.sum do |letter|
+          output_calculator.banding_for(declaration_type: "started").additions(letter)
         end
       end
 
+      def retained_types
+        event_types.select { |t| t.starts_with?("retained_") }
+      end
+
       def retained_count
-        output_calculator.banding_breakdown.sum do |hash|
-          hash.select { |k, _| k.match(/retained_\d_additions/) }.values.sum
+        band_letters.sum do |letter|
+          retained_types.sum do |event_type|
+            output_calculator.banding_for(declaration_type: event_type.to_s.dasherize).additions(letter)
+          end
         end
       end
 
       def completed_count
-        output_calculator.banding_breakdown.sum do |hash|
-          hash[:completed_additions]
+        band_letters.sum do |letter|
+          output_calculator.banding_for(declaration_type: "completed").additions(letter)
         end
       end
 
+      def extended_types
+        event_types.select { |t| t.starts_with?("extended_") }
+      end
+
       def extended_count
-        output_calculator.banding_breakdown.sum do |hash|
-          hash.select { |k, _| k.match(/extended_\d_additions/) }.values.sum
+        band_letters.sum do |letter|
+          extended_types.sum do |event_type|
+            output_calculator.banding_for(declaration_type: event_type.to_s.dasherize).additions(letter)
+          end
         end
       end
 

--- a/spec/factories/finance/statements.rb
+++ b/spec/factories/finance/statements.rb
@@ -21,6 +21,18 @@ FactoryBot.define do
       end
     end
 
+    trait :one_month_ago do
+      name { 1.month.ago.strftime "%B %Y" }
+      deadline_date { 2.months.ago.end_of_month }
+      payment_date { 1.month.ago.end_of_month }
+    end
+
+    trait :two_months_ago do
+      name { 2.months.ago.strftime "%B %Y" }
+      deadline_date { 3.months.ago.end_of_month }
+      payment_date { 2.months.ago.end_of_month }
+    end
+
     trait :output_fee do
       output_fee { true }
     end

--- a/spec/services/finance/ecf/banding_calculator_spec.rb
+++ b/spec/services/finance/ecf/banding_calculator_spec.rb
@@ -1,0 +1,642 @@
+# frozen_string_literal: true
+
+RSpec.describe Finance::ECF::BandingCalculator do
+  let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
+  let(:lead_provider) { cpd_lead_provider.lead_provider }
+  let!(:call_off_contract) { create(:call_off_contract, :with_minimal_bands, lead_provider:) }
+  let(:bands) { call_off_contract.bands }
+
+  let!(:statement) { create(:ecf_statement, :output_fee, cpd_lead_provider:) }
+  let(:statement_one_month_ago) { create(:ecf_statement, :one_month_ago, cpd_lead_provider:) }
+  let(:statement_two_months_ago) { create(:ecf_statement, :two_months_ago, cpd_lead_provider:) }
+  let(:declaration_type) { "started" }
+
+  let(:calculator_one_month_ago) { described_class.new(statement: statement_one_month_ago, declaration_type:) }
+  let(:calculator_two_months_ago) { described_class.new(statement: statement_two_months_ago, declaration_type:) }
+  subject { described_class.new(statement:, declaration_type:) }
+
+  describe "#min" do
+    it "returns min for all the bands" do
+      expect(subject.min(:a)).to eq(1)
+      expect(subject.min(:b)).to eq(bands[1].min)
+      expect(subject.min(:c)).to eq(bands[2].min)
+      expect(subject.min(:d)).to eq(bands[3].min)
+      expect(subject.min(:e)).to be_nil
+    end
+  end
+
+  describe "#max" do
+    it "returns max for all the bands" do
+      expect(subject.max(:a)).to eq(bands[0].max)
+      expect(subject.max(:b)).to eq(bands[1].max)
+      expect(subject.max(:c)).to eq(bands[2].max)
+      expect(subject.max(:d)).to eq(bands[3].max)
+      expect(subject.max(:e)).to be_nil
+    end
+  end
+
+  describe "#calculate" do
+    let(:letters) { %i[a b c d] }
+
+    context "when there are no declarations" do
+      it "returns zero" do
+        letters.each do |letter|
+          expect(subject.previous_count(letter)).to eq(0)
+          expect(subject.count(letter)).to eq(0)
+          expect(subject.additions(letter)).to eq(0)
+          expect(subject.subtractions(letter)).to eq(0)
+        end
+      end
+    end
+
+    context "when there are declarations attached to another statement for different provider" do
+      let(:other_cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
+
+      let!(:other_statement) { create(:ecf_statement, cpd_lead_provider: other_cpd_lead_provider, payment_date: 1.week.ago) }
+
+      before do
+        create(:call_off_contract, :with_minimal_bands, lead_provider: other_cpd_lead_provider.lead_provider)
+
+        travel_to other_statement.deadline_date - 1.day do
+          create(:ect_participant_declaration, :eligible, cpd_lead_provider: other_cpd_lead_provider)
+        end
+      end
+
+      it "returns zero" do
+        letters.each do |letter|
+          expect(subject.previous_count(letter)).to eq(0)
+          expect(subject.count(letter)).to eq(0)
+          expect(subject.additions(letter)).to eq(0)
+          expect(subject.subtractions(letter)).to eq(0)
+        end
+      end
+    end
+
+    context "when band A is partially filled" do
+      before do
+        travel_to statement.deadline_date do
+          create(:ect_participant_declaration, :eligible, cpd_lead_provider:)
+        end
+      end
+
+      it "returns the number of declarations" do
+        expect(subject.previous_count(:a)).to eq(0)
+        expect(subject.count(:a)).to eq(1)
+        expect(subject.additions(:a)).to eq(1)
+        expect(subject.subtractions(:a)).to eq(0)
+
+        (letters - [:a]).each do |letter|
+          expect(subject.previous_count(letter)).to eq(0)
+          expect(subject.count(letter)).to eq(0)
+          expect(subject.additions(letter)).to eq(0)
+          expect(subject.subtractions(letter)).to eq(0)
+        end
+      end
+    end
+
+    context "when band A overflows to band B" do
+      before do
+        travel_to statement.deadline_date - 1.day do
+          create_list(:ect_participant_declaration, 1, :eligible, cpd_lead_provider:, declaration_type:)
+          create_list(:mentor_participant_declaration, 2, :eligible, cpd_lead_provider:, declaration_type:)
+        end
+      end
+
+      it "returns the maximum number allowed in the band" do
+        expect(subject.previous_count(:a)).to eq(0)
+        expect(subject.count(:a)).to eq(2)
+        expect(subject.additions(:a)).to eq(2)
+        expect(subject.subtractions(:a)).to eq(0)
+
+        expect(subject.previous_count(:b)).to eq(0)
+        expect(subject.count(:b)).to eq(1)
+        expect(subject.additions(:b)).to eq(1)
+        expect(subject.subtractions(:b)).to eq(0)
+
+        (letters - %i[a b]).each do |letter|
+          expect(subject.previous_count(letter)).to eq(0)
+          expect(subject.count(letter)).to eq(0)
+          expect(subject.additions(letter)).to eq(0)
+          expect(subject.subtractions(letter)).to eq(0)
+        end
+      end
+    end
+
+    context "when overfilled all bands" do
+      before do
+        travel_to statement.deadline_date - 1.day do
+          create_list(:ect_participant_declaration, 4, :eligible, cpd_lead_provider:, declaration_type:)
+          create_list(:mentor_participant_declaration, 5, :eligible, cpd_lead_provider:, declaration_type:)
+        end
+      end
+
+      it "returns the maximum fill for all bands" do
+        letters.each do |letter|
+          expect(subject.previous_count(letter)).to eq(0)
+          expect(subject.count(letter)).to eq(2)
+          expect(subject.additions(letter)).to eq(2)
+          expect(subject.subtractions(letter)).to eq(0)
+        end
+      end
+    end
+
+    context "when there is a previous statement partially filling the band" do
+      before do
+        travel_to statement_one_month_ago.deadline_date - 1.day do
+          create_list(:ect_participant_declaration, 1, :eligible, cpd_lead_provider:, declaration_type:)
+        end
+      end
+
+      context "there are no declarations on this statement" do
+        it "returns previous count" do
+          expect(subject.previous_count(:a)).to eq(1)
+          expect(subject.count(:a)).to eq(0)
+          expect(subject.additions(:a)).to eq(0)
+          expect(subject.subtractions(:a)).to eq(0)
+
+          (letters - %i[a]).each do |letter|
+            expect(subject.previous_count(letter)).to eq(0)
+            expect(subject.count(letter)).to eq(0)
+            expect(subject.additions(letter)).to eq(0)
+            expect(subject.subtractions(letter)).to eq(0)
+          end
+        end
+      end
+
+      context "there are declarations on this statement, partly filling it" do
+        before do
+          travel_to statement.deadline_date - 1.day do
+            create_list(:mentor_participant_declaration, 1, :eligible, cpd_lead_provider:, declaration_type:)
+          end
+        end
+
+        it "returns previous count and current count" do
+          expect(subject.previous_count(:a)).to eq(1)
+          expect(subject.count(:a)).to eq(1)
+          expect(subject.additions(:a)).to eq(1)
+          expect(subject.subtractions(:a)).to eq(0)
+
+          (letters - %i[a]).each do |letter|
+            expect(subject.previous_count(letter)).to eq(0)
+            expect(subject.count(letter)).to eq(0)
+            expect(subject.additions(letter)).to eq(0)
+            expect(subject.subtractions(letter)).to eq(0)
+          end
+        end
+      end
+
+      context "there are declarations on this statement, over filling it" do
+        before do
+          travel_to statement.deadline_date - 1.day do
+            create_list(:mentor_participant_declaration, 2, :eligible, cpd_lead_provider:, declaration_type:)
+          end
+        end
+
+        it "returns previous count and current count, filling into band B" do
+          expect(subject.previous_count(:a)).to eq(1)
+          expect(subject.count(:a)).to eq(1)
+          expect(subject.additions(:a)).to eq(1)
+          expect(subject.subtractions(:a)).to eq(0)
+
+          expect(subject.previous_count(:b)).to eq(0)
+          expect(subject.count(:b)).to eq(1)
+          expect(subject.additions(:b)).to eq(1)
+          expect(subject.subtractions(:b)).to eq(0)
+
+          (letters - %i[a b]).each do |letter|
+            expect(subject.previous_count(letter)).to eq(0)
+            expect(subject.count(letter)).to eq(0)
+            expect(subject.additions(letter)).to eq(0)
+            expect(subject.subtractions(letter)).to eq(0)
+          end
+        end
+      end
+    end
+
+    context "when there is a previous statement totally filling the band" do
+      before do
+        travel_to statement_one_month_ago.deadline_date - 1.day do
+          create_list(:ect_participant_declaration, 1, :eligible, cpd_lead_provider:, declaration_type:)
+          create_list(:mentor_participant_declaration, 1, :eligible, cpd_lead_provider:, declaration_type:)
+        end
+        travel_to statement.deadline_date - 1.day do
+          create_list(:mentor_participant_declaration, 1, :eligible, cpd_lead_provider:, declaration_type:)
+        end
+      end
+
+      it "returns previous count filled and current count overflows to band B" do
+        expect(subject.previous_count(:a)).to eq(2)
+        expect(subject.count(:a)).to eq(0)
+        expect(subject.additions(:a)).to eq(0)
+        expect(subject.subtractions(:a)).to eq(0)
+
+        expect(subject.previous_count(:b)).to eq(0)
+        expect(subject.count(:b)).to eq(1)
+        expect(subject.additions(:b)).to eq(1)
+        expect(subject.subtractions(:b)).to eq(0)
+
+        (letters - %i[a b]).each do |letter|
+          expect(subject.previous_count(letter)).to eq(0)
+          expect(subject.count(letter)).to eq(0)
+          expect(subject.additions(letter)).to eq(0)
+          expect(subject.subtractions(letter)).to eq(0)
+        end
+      end
+    end
+
+    context "when previous statement filled band A and B, current statement overfilling to band C and D" do
+      before do
+        travel_to statement_one_month_ago.deadline_date - 1.day do
+          create_list(:ect_participant_declaration, 2, :eligible, cpd_lead_provider:, declaration_type:)
+          create_list(:mentor_participant_declaration, 2, :eligible, cpd_lead_provider:, declaration_type:)
+        end
+        travel_to statement.deadline_date - 1.day do
+          create_list(:mentor_participant_declaration, 1, :eligible, cpd_lead_provider:, declaration_type:)
+          create_list(:mentor_participant_declaration, 2, :eligible, cpd_lead_provider:, declaration_type:)
+        end
+      end
+
+      it "returns band values" do
+        expect(subject.previous_count(:a)).to eq(2)
+        expect(subject.count(:a)).to eq(0)
+        expect(subject.additions(:a)).to eq(0)
+        expect(subject.subtractions(:a)).to eq(0)
+
+        expect(subject.previous_count(:b)).to eq(2)
+        expect(subject.count(:b)).to eq(0)
+        expect(subject.additions(:b)).to eq(0)
+        expect(subject.subtractions(:b)).to eq(0)
+
+        expect(subject.previous_count(:c)).to eq(0)
+        expect(subject.count(:c)).to eq(2)
+        expect(subject.additions(:c)).to eq(2)
+        expect(subject.subtractions(:c)).to eq(0)
+
+        expect(subject.previous_count(:d)).to eq(0)
+        expect(subject.count(:d)).to eq(1)
+        expect(subject.additions(:d)).to eq(1)
+        expect(subject.subtractions(:d)).to eq(0)
+      end
+    end
+
+    context "when there are clawbacks" do
+      let(:declarations_one_month_ago) do
+        # Create declarations for statement 1 month ago
+        declarations = []
+        travel_to statement_one_month_ago.deadline_date - 1.day do
+          declarations += create_list(:ect_participant_declaration, 2, :eligible, cpd_lead_provider:, declaration_type:)
+          declarations += create_list(:mentor_participant_declaration, 2, :eligible, cpd_lead_provider:, declaration_type:)
+        end
+        declarations
+      end
+      let(:declarations_two_months_ago) do
+        # Create declarations for statement 2 months ago
+        declarations = []
+        travel_to statement_two_months_ago.deadline_date - 1.day do
+          declarations += create_list(:ect_participant_declaration, 2, :eligible, cpd_lead_provider:, declaration_type:)
+          declarations += create_list(:mentor_participant_declaration, 2, :eligible, cpd_lead_provider:, declaration_type:)
+        end
+        declarations
+      end
+
+      context "when there are no additions" do
+        before do
+          declarations_one_month_ago
+
+          # Mark statement 1 month ago as paid
+          Statements::MarkAsPayable.new(statement_one_month_ago).call
+          Statements::MarkAsPaid.new(statement_one_month_ago).call
+
+          # Create clawbacks for this month statement from declarations 1 month ago
+          travel_to statement.deadline_date - 1.day do
+            declarations_one_month_ago.sample(2).each do |dec|
+              Finance::ClawbackDeclaration.new(dec.reload).call
+            end
+          end
+        end
+
+        it "returns values for statement 1 month ago" do
+          expect(calculator_one_month_ago.previous_count(:a)).to eq(0)
+          expect(calculator_one_month_ago.count(:a)).to eq(2)
+          expect(calculator_one_month_ago.additions(:a)).to eq(2)
+          expect(calculator_one_month_ago.subtractions(:a)).to eq(0)
+
+          expect(calculator_one_month_ago.previous_count(:b)).to eq(0)
+          expect(calculator_one_month_ago.count(:b)).to eq(2)
+          expect(calculator_one_month_ago.additions(:b)).to eq(2)
+          expect(calculator_one_month_ago.subtractions(:b)).to eq(0)
+
+          (letters - %i[a b]).each do |letter|
+            expect(calculator_one_month_ago.previous_count(letter)).to eq(0)
+            expect(calculator_one_month_ago.count(letter)).to eq(0)
+            expect(calculator_one_month_ago.additions(letter)).to eq(0)
+            expect(calculator_one_month_ago.subtractions(letter)).to eq(0)
+          end
+        end
+
+        it "returns values with clawbacks for this month statement" do
+          expect(subject.previous_count(:a)).to eq(2)
+          expect(subject.count(:a)).to eq(0)
+          expect(subject.additions(:a)).to eq(0)
+          expect(subject.subtractions(:a)).to eq(0)
+
+          expect(subject.previous_count(:b)).to eq(2)
+          expect(subject.count(:b)).to eq(-2)
+          expect(subject.additions(:b)).to eq(0)
+          expect(subject.subtractions(:b)).to eq(2)
+
+          (letters - %i[a b]).each do |letter|
+            expect(subject.previous_count(letter)).to eq(0)
+            expect(subject.count(letter)).to eq(0)
+            expect(subject.additions(letter)).to eq(0)
+            expect(subject.subtractions(letter)).to eq(0)
+          end
+        end
+      end
+
+      context "when there are 3 additions" do
+        before do
+          declarations_one_month_ago
+
+          # Mark statement 1 month ago as paid
+          Statements::MarkAsPayable.new(statement_one_month_ago).call
+          Statements::MarkAsPaid.new(statement_one_month_ago).call
+
+          travel_to statement.deadline_date - 1.day do
+            # Create clawbacks for this month statement from declarations 1 month ago
+            declarations_one_month_ago.sample(2).each do |dec|
+              Finance::ClawbackDeclaration.new(dec.reload).call
+            end
+
+            # Create declarations for this month statement
+            create_list(:ect_participant_declaration, 1, :eligible, cpd_lead_provider:, declaration_type:)
+            create_list(:mentor_participant_declaration, 2, :eligible, cpd_lead_provider:, declaration_type:)
+          end
+        end
+
+        it "returns values for statement 1 month ago" do
+          expect(calculator_one_month_ago.previous_count(:a)).to eq(0)
+          expect(calculator_one_month_ago.count(:a)).to eq(2)
+          expect(calculator_one_month_ago.additions(:a)).to eq(2)
+          expect(calculator_one_month_ago.subtractions(:a)).to eq(0)
+
+          expect(calculator_one_month_ago.previous_count(:b)).to eq(0)
+          expect(calculator_one_month_ago.count(:b)).to eq(2)
+          expect(calculator_one_month_ago.additions(:b)).to eq(2)
+          expect(calculator_one_month_ago.subtractions(:b)).to eq(0)
+
+          (letters - %i[a b]).each do |letter|
+            expect(calculator_one_month_ago.previous_count(letter)).to eq(0)
+            expect(calculator_one_month_ago.count(letter)).to eq(0)
+            expect(calculator_one_month_ago.additions(letter)).to eq(0)
+            expect(calculator_one_month_ago.subtractions(letter)).to eq(0)
+          end
+        end
+
+        it "returns values with clawbacks for this month statement" do
+          expect(subject.previous_count(:a)).to eq(2)
+          expect(subject.count(:a)).to eq(0)
+          expect(subject.additions(:a)).to eq(0)
+          expect(subject.subtractions(:a)).to eq(0)
+
+          expect(subject.previous_count(:b)).to eq(2)
+          expect(subject.count(:b)).to eq(0)
+          expect(subject.additions(:b)).to eq(0)
+          expect(subject.subtractions(:b)).to eq(0)
+
+          expect(subject.previous_count(:c)).to eq(0)
+          expect(subject.count(:c)).to eq(1)
+          expect(subject.additions(:c)).to eq(2)
+          expect(subject.subtractions(:c)).to eq(1)
+
+          expect(subject.previous_count(:d)).to eq(0)
+          expect(subject.count(:d)).to eq(0)
+          expect(subject.additions(:d)).to eq(1)
+          expect(subject.subtractions(:d)).to eq(1)
+        end
+      end
+
+      context "when clawbacks present in 3 consecutive statements" do
+        before do
+          declarations_two_months_ago
+          # Mark statement 2 months ago as paid
+          Statements::MarkAsPayable.new(statement_two_months_ago).call
+          Statements::MarkAsPaid.new(statement_two_months_ago).call
+
+          declarations_one_month_ago
+          # Create 1 clawback for statement 1 month ago from declarations 2 months ago
+          travel_to statement_one_month_ago.deadline_date - 1.day do
+            Finance::ClawbackDeclaration.new(declarations_two_months_ago[0].reload).call
+          end
+          # Mark statement 1 months ago as paid
+          Statements::MarkAsPayable.new(statement_one_month_ago).call
+          Statements::MarkAsPaid.new(statement_one_month_ago).call
+
+          travel_to statement.deadline_date - 1.day do
+            # Create declarations for this month statement
+            create_list(:ect_participant_declaration, 2, :eligible, cpd_lead_provider:, declaration_type:)
+            create_list(:mentor_participant_declaration, 2, :eligible, cpd_lead_provider:, declaration_type:)
+
+            # Create 1 clawback for this month statement from declarations 2 months ago
+            Finance::ClawbackDeclaration.new(declarations_two_months_ago[1].reload).call
+
+            # Create 1 clawback for this month statement from declarations 1 month ago
+            Finance::ClawbackDeclaration.new(declarations_one_month_ago[0].reload).call
+          end
+        end
+
+        it "returns values for statement 2 months ago" do
+          expect(calculator_two_months_ago.previous_count(:a)).to eq(0)
+          expect(calculator_two_months_ago.count(:a)).to eq(2)
+          expect(calculator_two_months_ago.additions(:a)).to eq(2)
+          expect(calculator_two_months_ago.subtractions(:a)).to eq(0)
+
+          expect(calculator_two_months_ago.previous_count(:b)).to eq(0)
+          expect(calculator_two_months_ago.count(:b)).to eq(2)
+          expect(calculator_two_months_ago.additions(:b)).to eq(2)
+          expect(calculator_two_months_ago.subtractions(:b)).to eq(0)
+
+          (letters - %i[a b]).each do |letter|
+            expect(calculator_two_months_ago.previous_count(letter)).to eq(0)
+            expect(calculator_two_months_ago.count(letter)).to eq(0)
+            expect(calculator_two_months_ago.additions(letter)).to eq(0)
+            expect(calculator_two_months_ago.subtractions(letter)).to eq(0)
+          end
+        end
+
+        it "returns values for statement 1 month ago" do
+          expect(calculator_one_month_ago.previous_count(:a)).to eq(2)
+          expect(calculator_one_month_ago.count(:a)).to eq(0)
+          expect(calculator_one_month_ago.additions(:a)).to eq(0)
+          expect(calculator_one_month_ago.subtractions(:a)).to eq(0)
+
+          expect(calculator_one_month_ago.previous_count(:b)).to eq(2)
+          expect(calculator_one_month_ago.count(:b)).to eq(0)
+          expect(calculator_one_month_ago.additions(:b)).to eq(0)
+          expect(calculator_one_month_ago.subtractions(:b)).to eq(0)
+
+          expect(calculator_one_month_ago.previous_count(:c)).to eq(0)
+          expect(calculator_one_month_ago.count(:c)).to eq(2)
+          expect(calculator_one_month_ago.additions(:c)).to eq(2)
+          expect(calculator_one_month_ago.subtractions(:c)).to eq(0)
+
+          expect(calculator_one_month_ago.previous_count(:d)).to eq(0)
+          expect(calculator_one_month_ago.count(:d)).to eq(1)
+          expect(calculator_one_month_ago.additions(:d)).to eq(2)
+          expect(calculator_one_month_ago.subtractions(:d)).to eq(1)
+        end
+
+        it "returns values for this month statement" do
+          expect(subject.previous_count(:a)).to eq(2)
+          expect(subject.count(:a)).to eq(0)
+          expect(subject.additions(:a)).to eq(0)
+          expect(subject.subtractions(:a)).to eq(0)
+
+          expect(subject.previous_count(:b)).to eq(2)
+          expect(subject.count(:b)).to eq(0)
+          expect(subject.additions(:b)).to eq(0)
+          expect(subject.subtractions(:b)).to eq(0)
+
+          expect(subject.previous_count(:c)).to eq(2)
+          expect(subject.count(:c)).to eq(0)
+          expect(subject.additions(:c)).to eq(0)
+          expect(subject.subtractions(:c)).to eq(0)
+
+          expect(subject.previous_count(:d)).to eq(1)
+          expect(subject.count(:d)).to eq(-1)
+          expect(subject.additions(:d)).to eq(1)
+          expect(subject.subtractions(:d)).to eq(2)
+        end
+      end
+
+      context "when there is a clawback followed by a declaration again" do
+        let!(:participant_declaration) do
+          travel_to statement_two_months_ago.deadline_date - 1.day do
+            create(:ect_participant_declaration, :eligible, cpd_lead_provider:, declaration_type:)
+          end
+        end
+        let(:participant_profile) { participant_declaration.participant_profile }
+
+        before do
+          # Mark statement 2 months ago as paid
+          Statements::MarkAsPayable.new(statement_two_months_ago).call
+          Statements::MarkAsPaid.new(statement_two_months_ago).call
+
+          travel_to statement_one_month_ago.deadline_date - 1.day do
+            # Create clawback for statement 1 month ago for participant_declaration
+            Finance::ClawbackDeclaration.new(participant_declaration.reload).call
+
+            # Mark statement 1 month ago as paid
+            Statements::MarkAsPayable.new(statement_one_month_ago).call
+            Statements::MarkAsPaid.new(statement_one_month_ago).call
+          end
+
+          # Create declaration for this month statement with existing participant_profile
+          travel_to statement.deadline_date - 1.day do
+            create(:ect_participant_declaration, :payable, participant_profile:, cpd_lead_provider:)
+          end
+        end
+
+        it "returns values for statement 2 months ago" do
+          expect(calculator_two_months_ago.previous_count(:a)).to eq(0)
+          expect(calculator_two_months_ago.count(:a)).to eq(1)
+          expect(calculator_two_months_ago.additions(:a)).to eq(1)
+          expect(calculator_two_months_ago.subtractions(:a)).to eq(0)
+
+          (letters - %i[a]).each do |letter|
+            expect(calculator_two_months_ago.previous_count(letter)).to eq(0)
+            expect(calculator_two_months_ago.count(letter)).to eq(0)
+            expect(calculator_two_months_ago.additions(letter)).to eq(0)
+            expect(calculator_two_months_ago.subtractions(letter)).to eq(0)
+          end
+        end
+
+        it "returns values for statement 1 month ago" do
+          expect(calculator_one_month_ago.previous_count(:a)).to eq(1)
+          expect(calculator_one_month_ago.count(:a)).to eq(-1)
+          expect(calculator_one_month_ago.additions(:a)).to eq(0)
+          expect(calculator_one_month_ago.subtractions(:a)).to eq(1)
+
+          (letters - %i[a]).each do |letter|
+            expect(calculator_one_month_ago.previous_count(letter)).to eq(0)
+            expect(calculator_one_month_ago.count(letter)).to eq(0)
+            expect(calculator_one_month_ago.additions(letter)).to eq(0)
+            expect(calculator_one_month_ago.subtractions(letter)).to eq(0)
+          end
+        end
+
+        it "returns values for this month statement" do
+          expect(subject.previous_count(:a)).to eq(0)
+          expect(subject.count(:a)).to eq(1)
+          expect(subject.additions(:a)).to eq(1)
+          expect(subject.subtractions(:a)).to eq(0)
+
+          (letters - %i[a]).each do |letter|
+            expect(subject.previous_count(letter)).to eq(0)
+            expect(subject.count(letter)).to eq(0)
+            expect(subject.additions(letter)).to eq(0)
+            expect(subject.subtractions(letter)).to eq(0)
+          end
+        end
+      end
+
+      %w[started retained-1 retained-2 retained-3 retained-4 completed].each do |dec_type|
+        context "with #{dec_type} declaration type" do
+          let(:declaration_type) { dec_type }
+
+          before do
+            travel_to statement.deadline_date - 1.day do
+              # Forces declaration type to be within cutoff
+              Finance::Milestone.update_all(start_date: Date.yesterday, milestone_date: Date.tomorrow)
+
+              create(:ect_participant_declaration, :eligible, cpd_lead_provider:, declaration_type:)
+              create(:mentor_participant_declaration, :eligible, cpd_lead_provider:, declaration_type:)
+            end
+          end
+
+          it "returns values for this month statement" do
+            expect(subject.previous_count(:a)).to eq(0)
+            expect(subject.count(:a)).to eq(2)
+            expect(subject.additions(:a)).to eq(2)
+            expect(subject.subtractions(:a)).to eq(0)
+
+            (letters - %i[a]).each do |letter|
+              expect(subject.previous_count(letter)).to eq(0)
+              expect(subject.count(letter)).to eq(0)
+              expect(subject.additions(letter)).to eq(0)
+              expect(subject.subtractions(letter)).to eq(0)
+            end
+          end
+        end
+      end
+
+      %w[extended-1 extended-2 extended-3].each do |dec_type|
+        context "with #{dec_type} declaration type" do
+          let!(:schedule) { create(:ecf_extended_schedule) }
+          let(:declaration_type) { dec_type }
+
+          before do
+            travel_to statement.deadline_date - 1.day do
+              create(:ect_participant_declaration, :extended, cpd_lead_provider:, declaration_type:)
+              create(:mentor_participant_declaration, :extended, cpd_lead_provider:, declaration_type:)
+            end
+          end
+
+          it "returns values for this month statement" do
+            expect(subject.previous_count(:a)).to eq(0)
+            expect(subject.count(:a)).to eq(2)
+            expect(subject.additions(:a)).to eq(2)
+            expect(subject.subtractions(:a)).to eq(0)
+
+            (letters - %i[a]).each do |letter|
+              expect(subject.previous_count(letter)).to eq(0)
+              expect(subject.count(letter)).to eq(0)
+              expect(subject.additions(letter)).to eq(0)
+              expect(subject.subtractions(letter)).to eq(0)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/finance/ecf/banding_calculator_spec.rb
+++ b/spec/services/finance/ecf/banding_calculator_spec.rb
@@ -251,7 +251,7 @@ RSpec.describe Finance::ECF::BandingCalculator do
           create_list(:mentor_participant_declaration, 2, :eligible, cpd_lead_provider:, declaration_type:)
         end
         travel_to statement.deadline_date - 1.day do
-          create_list(:mentor_participant_declaration, 1, :eligible, cpd_lead_provider:, declaration_type:)
+          create_list(:ect_participant_declaration, 1, :eligible, cpd_lead_provider:, declaration_type:)
           create_list(:mentor_participant_declaration, 2, :eligible, cpd_lead_provider:, declaration_type:)
         end
       end

--- a/spec/services/finance/ecf/ect/banding_calculator_spec.rb
+++ b/spec/services/finance/ecf/ect/banding_calculator_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+RSpec.describe Finance::ECF::ECT::BandingCalculator do
+  let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
+  let(:lead_provider) { cpd_lead_provider.lead_provider }
+  let!(:call_off_contract) { create(:call_off_contract, :with_minimal_bands, lead_provider:) }
+
+  let!(:statement) { create(:ecf_statement, :output_fee, cpd_lead_provider:) }
+  let(:statement_one_month_ago) { create(:ecf_statement, :one_month_ago, cpd_lead_provider:) }
+  let(:statement_two_months_ago) { create(:ecf_statement, :two_months_ago, cpd_lead_provider:) }
+  let(:declaration_type) { "started" }
+
+  subject { described_class.new(statement:, declaration_type:) }
+
+  describe "#previous_billable_count" do
+    before do
+      travel_to statement_one_month_ago.deadline_date - 1.day do
+        create_list(:ect_participant_declaration, 2, :eligible, cpd_lead_provider:, declaration_type:)
+        create_list(:mentor_participant_declaration, 1, :eligible, cpd_lead_provider:, declaration_type:)
+      end
+      travel_to statement.deadline_date - 1.day do
+        create_list(:ect_participant_declaration, 3, :eligible, cpd_lead_provider:, declaration_type:)
+        create_list(:mentor_participant_declaration, 1, :eligible, cpd_lead_provider:, declaration_type:)
+      end
+    end
+
+    it "returns ECT only previous billable count for this months statement" do
+      expect(subject.send(:previous_billable_count)).to eq(2)
+    end
+  end
+
+  describe "#previous_refundable_count" do
+    before do
+      # Create declarations for statement 2 months ago
+      declarations = []
+      travel_to statement_two_months_ago.deadline_date - 1.day do
+        declarations += create_list(:ect_participant_declaration, 2, :eligible, cpd_lead_provider:, declaration_type:)
+        declarations += create_list(:mentor_participant_declaration, 2, :eligible, cpd_lead_provider:, declaration_type:)
+      end
+
+      # Mark statement 2 months ago as paid
+      Statements::MarkAsPayable.new(statement_two_months_ago).call
+      Statements::MarkAsPaid.new(statement_two_months_ago).call
+
+      # Create clawbacks for statement 1 month ago from declarations 2 months ago
+      travel_to statement_one_month_ago.deadline_date - 1.day do
+        declarations.each do |dec|
+          Finance::ClawbackDeclaration.new(dec.reload).call
+        end
+      end
+      # Mark statement 1 months ago as paid
+      Statements::MarkAsPayable.new(statement_one_month_ago).call
+      Statements::MarkAsPaid.new(statement_one_month_ago).call
+
+      travel_to statement.deadline_date - 1.day do
+        # Create declarations for this month statement
+        create_list(:ect_participant_declaration, 1, :eligible, cpd_lead_provider:, declaration_type:)
+        create_list(:mentor_participant_declaration, 1, :eligible, cpd_lead_provider:, declaration_type:)
+      end
+    end
+
+    it "returns ECT only previous refundable count for this months statement" do
+      expect(subject.send(:previous_refundable_count)).to eq(2)
+    end
+  end
+
+  describe "#current_billable_count" do
+    before do
+      travel_to statement_one_month_ago.deadline_date - 1.day do
+        create_list(:ect_participant_declaration, 2, :eligible, cpd_lead_provider:, declaration_type:)
+        create_list(:mentor_participant_declaration, 1, :eligible, cpd_lead_provider:, declaration_type:)
+      end
+      travel_to statement.deadline_date - 1.day do
+        create_list(:ect_participant_declaration, 3, :eligible, cpd_lead_provider:, declaration_type:)
+        create_list(:mentor_participant_declaration, 1, :eligible, cpd_lead_provider:, declaration_type:)
+      end
+    end
+
+    it "returns ECT only current billable count for this months statement" do
+      expect(subject.send(:current_billable_count)).to eq(3)
+    end
+  end
+
+  describe "#current_refundable_count" do
+    before do
+      # Create declarations for statement 2 months ago
+      declarations = []
+      travel_to statement_two_months_ago.deadline_date - 1.day do
+        declarations += create_list(:ect_participant_declaration, 2, :eligible, cpd_lead_provider:, declaration_type:)
+        declarations += create_list(:mentor_participant_declaration, 2, :eligible, cpd_lead_provider:, declaration_type:)
+      end
+
+      # Mark statement 2 months ago as paid
+      Statements::MarkAsPayable.new(statement_two_months_ago).call
+      Statements::MarkAsPaid.new(statement_two_months_ago).call
+
+      # Create clawbacks for statement 1 month ago from declarations 2 months ago
+      travel_to statement_one_month_ago.deadline_date - 1.day do
+        declarations.each do |dec|
+          Finance::ClawbackDeclaration.new(dec.reload).call
+        end
+      end
+
+      # Create declarations for statement 1 month ago
+      declarations = []
+      travel_to statement_one_month_ago.deadline_date - 1.day do
+        declarations += create_list(:ect_participant_declaration, 3, :eligible, cpd_lead_provider:, declaration_type:)
+        declarations += create_list(:mentor_participant_declaration, 1, :eligible, cpd_lead_provider:, declaration_type:)
+      end
+
+      # Mark statement 1 months ago as paid
+      Statements::MarkAsPayable.new(statement_one_month_ago).call
+      Statements::MarkAsPaid.new(statement_one_month_ago).call
+
+      travel_to statement.deadline_date - 1.day do
+        # Create declarations for this month statement
+        create_list(:ect_participant_declaration, 1, :eligible, cpd_lead_provider:, declaration_type:)
+        create_list(:mentor_participant_declaration, 1, :eligible, cpd_lead_provider:, declaration_type:)
+
+        # Create clawbacks for this month statement from declarations 1 month ago
+        declarations.each do |dec|
+          Finance::ClawbackDeclaration.new(dec.reload).call
+        end
+      end
+    end
+
+    it "returns ECT only current refundable count for this months statement" do
+      expect(subject.send(:current_refundable_count)).to eq(3)
+    end
+  end
+end

--- a/spec/services/finance/ecf/ect/output_calculator_spec.rb
+++ b/spec/services/finance/ecf/ect/output_calculator_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe Finance::ECF::ECT::OutputCalculator do
   let(:first_statement) { create(:ecf_statement, cpd_lead_provider:, payment_date: 6.months.ago) }
   let(:second_statement) { create(:ecf_statement, cpd_lead_provider:, payment_date: 4.months.ago) }
   let(:third_statement) { create(:ecf_statement, cpd_lead_provider:, payment_date: 2.months.ago) }
-  let(:fourth_statement) { create(:ecf_statement, cpd_lead_provider:, payment_date: 0.months.ago) }
 
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
   let(:lead_provider) { cpd_lead_provider.lead_provider }
@@ -13,23 +12,54 @@ RSpec.describe Finance::ECF::ECT::OutputCalculator do
   let(:first_statement_calc) { described_class.new(statement: first_statement) }
   let(:second_statement_calc) { described_class.new(statement: second_statement) }
   let(:third_statement_calc) { described_class.new(statement: third_statement) }
-  let(:fourth_statement_calc) { described_class.new(statement: fourth_statement) }
 
-  let(:relevant_started_keys) do
-    %i[
-      band
-      min
-      max
-      previous_started_count
-      started_count
-      started_additions
-      started_subtractions
-    ]
+  subject { first_statement_calc }
+
+  describe "#band_for" do
+    let(:letters) { %i[a b c d] }
+    let(:declaration_types) do
+      %w[
+        started
+        retained-1
+        retained-2
+        retained-3
+        retained-4
+        completed
+        extended-1
+        extended-2
+        extended-3
+      ]
+    end
+
+    before do
+      declaration_types.each do |declaration_type|
+        mock_banding = instance_double(
+          Finance::ECF::ECT::BandingCalculator,
+          previous_count: 5,
+          count: 10,
+          additions: 15,
+          subtractions: 5,
+        )
+
+        expect(Finance::ECF::ECT::BandingCalculator).to receive(:new)
+          .with(statement: first_statement, declaration_type:)
+          .and_return(mock_banding)
+      end
+    end
+
+    it "correctly delegates to ECT banding calculator" do
+      declaration_types.each do |declaration_type|
+        letters.each do |letter|
+          expect(subject.banding_for(declaration_type:).previous_count(letter)).to eq(5)
+          expect(subject.banding_for(declaration_type:).count(letter)).to eq(10)
+          expect(subject.banding_for(declaration_type:).additions(letter)).to eq(15)
+          expect(subject.banding_for(declaration_type:).subtractions(letter)).to eq(5)
+        end
+      end
+    end
   end
 
   describe "#fee_for_declaration" do
-    subject { first_statement_calc }
-
     it "returns correct fees" do
       expect(subject.fee_for_declaration(band_letter: :a, type: :started)).to eql(48)
       expect(subject.fee_for_declaration(band_letter: :a, type: :retained_1)).to eql(36)
@@ -73,333 +103,104 @@ RSpec.describe Finance::ECF::ECT::OutputCalculator do
     end
   end
 
-  describe "#banding_breakdown" do
-    context "when nada declarations" do
-      it "returns empty bands" do
-        expected = [
-          {
-            band: :a,
-            min: 1,
-            max: 2,
-            previous_started_count: 0,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-          {
-            band: :b,
-            min: 3,
-            max: 4,
-            previous_started_count: 0,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-          {
-            band: :c,
-            min: 5,
-            max: 6,
-            previous_started_count: 0,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-          {
-            band: :d,
-            min: 7,
-            max: 8,
-            previous_started_count: 0,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-        ]
+  describe "#uplift_breakdown" do
+    context "when there an no uplifts" do
+      let(:expected) do
+        {
+          previous_count: 0,
+          count: 0,
+          additions: 0,
+          subtractions: 0,
+        }
+      end
 
-        expect(first_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(expected)
+      it "returns zero current and previous uplifts" do
+        expect(first_statement_calc.uplift_breakdown).to eql(expected)
       end
     end
 
-    context "when partially filled bands" do
-      let!(:to_be_paid_participant_declaration) do
-        travel_to first_statement.deadline_date - 1.day do
-          create(:ect_participant_declaration, :payable, cpd_lead_provider:)
-          create(:mentor_participant_declaration, :payable, cpd_lead_provider:)
-        end
-      end
-
-      before do
-        travel_to first_statement.deadline_date do
-          Statements::MarkAsPaid.new(first_statement).call
-        end
-      end
-
-      it "returns correct bands" do
-        expected = [
-          {
-            band: :a,
-            min: 1,
-            max: 2,
-            previous_started_count: 0,
-            started_count: 1,
-            started_additions: 1,
-            started_subtractions: 0,
-          },
-          {
-            band: :b,
-            min: 3,
-            max: 4,
-            previous_started_count: 0,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-          {
-            band: :c,
-            min: 5,
-            max: 6,
-            previous_started_count: 0,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-          {
-            band: :d,
-            min: 7,
-            max: 8,
-            previous_started_count: 0,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-        ]
-
-        expect(first_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(expected)
-      end
-    end
-
-    context "when fully filled bands" do
-      let!(:to_be_paid_declarations) do
-        travel_to first_statement.deadline_date do
-          create_list(:ect_participant_declaration, 2, :eligible, cpd_lead_provider:)
-          create_list(:mentor_participant_declaration, 2, :eligible, cpd_lead_provider:)
-        end
-      end
-      before do
-        Statements::MarkAsPayable.new(first_statement).call
-        Statements::MarkAsPaid.new(first_statement).call
-      end
-
-      it "returns correct bands" do
-        expected = [
-          {
-            band: :a,
-            min: 1,
-            max: 2,
-            previous_started_count: 0,
-            started_count: 2,
-            started_additions: 2,
-            started_subtractions: 0,
-          },
-          {
-            band: :b,
-            min: 3,
-            max: 4,
-            previous_started_count: 0,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-          {
-            band: :c,
-            min: 5,
-            max: 6,
-            previous_started_count: 0,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-          {
-            band: :d,
-            min: 7,
-            max: 8,
-            previous_started_count: 0,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-        ]
-        expect(first_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(expected)
-      end
-
-      context "when band a min is set to zero" do
-        before do
-          contract.participant_bands.find_by!(min: nil).update(min: 0)
-        end
-
-        it "returns correct bands" do
-          expected = [
-            {
-              band: :a,
-              min: 1,
-              max: 2,
-              previous_started_count: 0,
-              started_count: 2,
-              started_additions: 2,
-              started_subtractions: 0,
-            },
-            {
-              band: :b,
-              min: 3,
-              max: 4,
-              previous_started_count: 0,
-              started_count: 0,
-              started_additions: 0,
-              started_subtractions: 0,
-            },
-            {
-              band: :c,
-              min: 5,
-              max: 6,
-              previous_started_count: 0,
-              started_count: 0,
-              started_additions: 0,
-              started_subtractions: 0,
-            },
-            {
-              band: :d,
-              min: 7,
-              max: 8,
-              previous_started_count: 0,
-              started_count: 0,
-              started_additions: 0,
-              started_subtractions: 0,
-            },
-          ]
-          expect(first_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(expected)
-        end
-      end
-    end
-
-    context "when multiple bands" do
-      let!(:to_be_paid_declarations) do
-        travel_to first_statement.deadline_date do
-          create_list(:ect_participant_declaration, 7, :eligible, cpd_lead_provider:)
-          create_list(:mentor_participant_declaration, 7, :eligible, cpd_lead_provider:)
-        end
-      end
-      before do
-        Statements::MarkAsPayable.new(first_statement).call
-        Statements::MarkAsPaid.new(first_statement).call
-      end
-
-      it "returns correct bands" do
-        expected = [
-          {
-            band: :a,
-            min: 1,
-            max: 2,
-            previous_started_count: 0,
-            started_count: 2,
-            started_additions: 2,
-            started_subtractions: 0,
-          },
-          {
-            band: :b,
-            min: 3,
-            max: 4,
-            previous_started_count: 0,
-            started_count: 2,
-            started_additions: 2,
-            started_subtractions: 0,
-          },
-          {
-            band: :c,
-            min: 5,
-            max: 6,
-            previous_started_count: 0,
-            started_count: 2,
-            started_additions: 2,
-            started_subtractions: 0,
-          },
-          {
-            band: :d,
-            min: 7,
-            max: 8,
-            previous_started_count: 0,
-            started_count: 1,
-            started_additions: 1,
-            started_subtractions: 0,
-          },
-        ]
-
-        expect(first_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(expected)
-      end
-    end
-
-    context "when overfilled all bands" do
-      let!(:to_be_paid_declarations) do
-        travel_to first_statement.deadline_date do
-          create_list(:ect_participant_declaration, 9, :eligible, cpd_lead_provider:)
-          create_list(:mentor_participant_declaration, 9, :eligible, cpd_lead_provider:)
-        end
-      end
-      before do
-        Statements::MarkAsPayable.new(first_statement).call
-        Statements::MarkAsPaid.new(first_statement).call
-      end
-
-      it "does not count extra declarations" do
-        expected = [
-          {
-            band: :a,
-            min: 1,
-            max: 2,
-            previous_started_count: 0,
-            started_count: 2,
-            started_additions: 2,
-            started_subtractions: 0,
-          },
-          {
-            band: :b,
-            min: 3,
-            max: 4,
-            previous_started_count: 0,
-            started_count: 2,
-            started_additions: 2,
-            started_subtractions: 0,
-          },
-          {
-            band: :c,
-            min: 5,
-            max: 6,
-            previous_started_count: 0,
-            started_count: 2,
-            started_additions: 2,
-            started_subtractions: 0,
-          },
-          {
-            band: :d,
-            min: 7,
-            max: 8,
-            previous_started_count: 0,
-            started_count: 2,
-            started_additions: 2,
-            started_subtractions: 0,
-          },
-        ]
-
-        expect(first_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(expected)
-      end
-    end
-
-    context "next statement is present" do
+    context "when there are uplifts" do
       before do
         declarations = create_list(
-          :ect_participant_declaration, 3,
-          state: :paid
+          :ect_participant_declaration, 2,
+          state: :paid,
+          pupil_premium_uplift: true
         ) + create_list(
-          :mentor_participant_declaration, 3,
-          state: :paid
+          :mentor_participant_declaration, 2,
+          state: :paid,
+          pupil_premium_uplift: true
+        )
+
+        declarations.each do |dec|
+          Finance::StatementLineItem.create!(
+            statement: first_statement,
+            participant_declaration: dec,
+            state: dec.state,
+          )
+        end
+      end
+
+      let(:expected) do
+        {
+          previous_count: 0,
+          count: 2,
+          additions: 2,
+          subtractions: 0,
+        }
+      end
+
+      it "returns current uplifts" do
+        expect(first_statement_calc.uplift_breakdown).to eql(expected)
+      end
+    end
+
+    context "when there are uplifts but not on started declarations" do
+      before do
+        declarations = create_list(
+          :ect_participant_declaration, 2,
+          state: :paid,
+          pupil_premium_uplift: true,
+          declaration_type: "retained-1"
+        ) + create_list(
+          :mentor_participant_declaration, 2,
+          state: :paid,
+          pupil_premium_uplift: true,
+          declaration_type: "retained-1"
+        )
+
+        declarations.each do |dec|
+          Finance::StatementLineItem.create!(
+            statement: first_statement,
+            participant_declaration: dec,
+            state: dec.state,
+          )
+        end
+      end
+
+      let(:expected) do
+        {
+          previous_count: 0,
+          count: 0,
+          additions: 0,
+          subtractions: 0,
+        }
+      end
+
+      it "does not count them" do
+        expect(first_statement_calc.uplift_breakdown).to eql(expected)
+      end
+    end
+
+    context "when there is net negative of uplifts on a single statement" do
+      before do
+        declarations = create_list(
+          :ect_participant_declaration, 2,
+          state: :paid,
+          pupil_premium_uplift: true
+        ) + create_list(
+          :mentor_participant_declaration, 2,
+          state: :paid,
+          pupil_premium_uplift: true
         )
 
         declarations.each do |dec|
@@ -410,183 +211,40 @@ RSpec.describe Finance::ECF::ECT::OutputCalculator do
           )
         end
 
-        declarations = create_list(
-          :ect_participant_declaration, 3,
-          state: :payable
-        ) + create_list(
-          :mentor_participant_declaration, 3,
-          state: :payable
-        )
+        clawback_line_items = first_statement
+          .billable_statement_line_items
+          .joins(:participant_declaration)
+          .where(participant_declarations: { state: "paid" })
+          .order(Arel.sql("RANDOM()"))
+          .merge!(ParticipantDeclaration.ect)
+          .limit(1)
 
-        declarations.each do |dec|
+        clawback_line_items.each do |line_item|
           Finance::StatementLineItem.create!(
             statement: second_statement,
-            participant_declaration: dec,
-            state: dec.state,
+            participant_declaration: line_item.participant_declaration,
+            state: "awaiting_clawback",
           )
+
+          line_item.participant_declaration.update!(state: "awaiting_clawback")
         end
       end
 
-      it "counts bands from where it left off" do
-        expected = [
-          {
-            band: :a,
-            min: 1,
-            max: 2,
-            previous_started_count: 2,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-          {
-            band: :b,
-            min: 3,
-            max: 4,
-            previous_started_count: 1,
-            started_count: 1,
-            started_additions: 1,
-            started_subtractions: 0,
-          },
-          {
-            band: :c,
-            min: 5,
-            max: 6,
-            previous_started_count: 0,
-            started_count: 2,
-            started_additions: 2,
-            started_subtractions: 0,
-          },
-          {
-            band: :d,
-            min: 7,
-            max: 8,
-            previous_started_count: 0,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-        ]
+      let(:expected) do
+        {
+          previous_count: 2,
+          count: -1,
+          additions: 0,
+          subtractions: 1,
+        }
+      end
 
-        expect(second_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(expected)
+      it "returns negative uplifts" do
+        expect(second_statement_calc.uplift_breakdown).to eql(expected)
       end
     end
 
-    context "when clawbacks present in 2 consecutive statements" do
-      before do
-        declarations = create_list(
-          :ect_participant_declaration, 5,
-          state: :paid
-        ) + create_list(
-          :mentor_participant_declaration, 5,
-          state: :paid
-        )
-
-        declarations.each do |dec|
-          Finance::StatementLineItem.create!(
-            statement: first_statement,
-            participant_declaration: dec,
-            state: dec.state,
-          )
-        end
-
-        clawback_declarations = declarations.first(3).sample(2)
-
-        clawback_declarations.each do |dec|
-          dec.update!(state: "awaiting_clawback")
-
-          Finance::StatementLineItem.create!(
-            statement: second_statement,
-            participant_declaration: dec,
-            state: dec.state,
-          )
-        end
-      end
-
-      it "can calculate refunds when current statement is empty" do
-        first_statement_expectation = [
-          {
-            band: :a,
-            min: 1,
-            max: 2,
-            previous_started_count: 0,
-            started_count: 2,
-            started_additions: 2,
-            started_subtractions: 0,
-          },
-          {
-            band: :b,
-            min: 3,
-            max: 4,
-            previous_started_count: 0,
-            started_count: 2,
-            started_additions: 2,
-            started_subtractions: 0,
-          },
-          {
-            band: :c,
-            min: 5,
-            max: 6,
-            previous_started_count: 0,
-            started_count: 1,
-            started_additions: 1,
-            started_subtractions: 0,
-          },
-          {
-            band: :d,
-            min: 7,
-            max: 8,
-            previous_started_count: 0,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-        ]
-
-        second_statement_expectation = [
-          {
-            band: :a,
-            min: 1,
-            max: 2,
-            previous_started_count: 2,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-          {
-            band: :b,
-            min: 3,
-            max: 4,
-            previous_started_count: 2,
-            started_count: -1,
-            started_additions: 0,
-            started_subtractions: 1,
-          },
-          {
-            band: :c,
-            min: 5,
-            max: 6,
-            previous_started_count: 1,
-            started_count: -1,
-            started_additions: 0,
-            started_subtractions: 1,
-          },
-          {
-            band: :d,
-            min: 7,
-            max: 8,
-            previous_started_count: 0,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-        ]
-
-        expect(first_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(first_statement_expectation)
-        expect(second_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(second_statement_expectation)
-      end
-    end
-
-    context "when clawbacks present in 3 consecutive statements" do
+    context "when there are previous uplifts" do
       before do
         setup_statement_one
         setup_statement_two
@@ -596,10 +254,12 @@ RSpec.describe Finance::ECF::ECT::OutputCalculator do
       def setup_statement_one
         declarations = create_list(
           :ect_participant_declaration, 3,
-          state: :paid
+          state: :paid,
+          pupil_premium_uplift: true
         ) + create_list(
           :mentor_participant_declaration, 3,
-          state: :paid
+          state: :paid,
+          pupil_premium_uplift: true
         )
 
         declarations.each do |dec|
@@ -614,10 +274,12 @@ RSpec.describe Finance::ECF::ECT::OutputCalculator do
       def setup_statement_two
         declarations = create_list(
           :ect_participant_declaration, 3,
-          state: :paid
+          state: :paid,
+          pupil_premium_uplift: true
         ) + create_list(
           :mentor_participant_declaration, 3,
-          state: :paid
+          state: :paid,
+          pupil_premium_uplift: true
         )
 
         declarations.each do |dec|
@@ -650,10 +312,12 @@ RSpec.describe Finance::ECF::ECT::OutputCalculator do
       def setup_statement_three
         declarations = create_list(
           :ect_participant_declaration, 3,
-          state: :payable
+          state: :payable,
+          pupil_premium_uplift: true
         ) + create_list(
           :mentor_participant_declaration, 3,
-          state: :payable
+          state: :payable,
+          pupil_premium_uplift: true
         )
 
         declarations.each do |dec|
@@ -701,614 +365,37 @@ RSpec.describe Finance::ECF::ECT::OutputCalculator do
         end
       end
 
-      it "can calculate refunds for typical use case" do
-        first_statement_expectation = [
-          {
-            band: :a,
-            min: 1,
-            max: 2,
-            previous_started_count: 0,
-            started_count: 2,
-            started_additions: 2,
-            started_subtractions: 0,
-          },
-          {
-            band: :b,
-            min: 3,
-            max: 4,
-            previous_started_count: 0,
-            started_count: 1,
-            started_additions: 1,
-            started_subtractions: 0,
-          },
-          {
-            band: :c,
-            min: 5,
-            max: 6,
-            previous_started_count: 0,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-          {
-            band: :d,
-            min: 7,
-            max: 8,
-            previous_started_count: 0,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-        ]
-
-        second_statement_expectation = [
-          {
-            band: :a,
-            min: 1,
-            max: 2,
-            previous_started_count: 2,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-          {
-            band: :b,
-            min: 3,
-            max: 4,
-            previous_started_count: 1,
-            started_count: 1,
-            started_additions: 1,
-            started_subtractions: 0,
-          },
-          {
-            band: :c,
-            min: 5,
-            max: 6,
-            previous_started_count: 0,
-            started_count: 1,
-            started_additions: 2,
-            started_subtractions: 1,
-          },
-          {
-            band: :d,
-            min: 7,
-            max: 8,
-            previous_started_count: 0,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-        ]
-
-        third_statement_expectation = [
-          {
-            band: :a,
-            min: 1,
-            max: 2,
-            previous_started_count: 2,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-          {
-            band: :b,
-            min: 3,
-            max: 4,
-            previous_started_count: 2,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-          {
-            band: :c,
-            min: 5,
-            max: 6,
-            previous_started_count: 1,
-            started_count: 1,
-            started_additions: 1,
-            started_subtractions: 0,
-          },
-          {
-            band: :d,
-            min: 7,
-            max: 8,
-            previous_started_count: 0,
-            started_count: 0,
-            started_additions: 2,
-            started_subtractions: 2,
-          },
-        ]
-
-        expect(first_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(first_statement_expectation)
-        expect(second_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(second_statement_expectation)
-        expect(third_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(third_statement_expectation)
-      end
-    end
-
-    context "when there is a clawback followed by a declaration again" do
-      let!(:participant_declaration) do
-        travel_to first_statement.deadline_date do
-          create(:ect_participant_declaration, :paid, cpd_lead_provider:)
-        end
-      end
-      let(:participant_profile) { participant_declaration.participant_profile }
-
-      before do
-        travel_to second_statement.deadline_date do
-          Finance::ClawbackDeclaration.new(participant_declaration.reload).call
-        end
-
-        participant_declaration.clawed_back!
-        participant_declaration
-          .statement_line_items
-          .awaiting_clawback
-          .first
-          .clawed_back!
-
-        travel_to second_statement.deadline_date do
-          create(:ect_participant_declaration, :payable, participant_profile:, cpd_lead_provider:)
-        end
+      let(:statement_one_expectation) do
+        {
+          previous_count: 0,
+          count: 3,
+          additions: 3,
+          subtractions: 0,
+        }
       end
 
-      it "pays out the following declaration" do
-        third_statement_expectation = [
-          {
-            band: :a,
-            min: 1,
-            max: 2,
-            previous_started_count: 1,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-          {
-            band: :b,
-            min: 3,
-            max: 4,
-            previous_started_count: 0,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-          {
-            band: :c,
-            min: 5,
-            max: 6,
-            previous_started_count: 0,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-          {
-            band: :d,
-            min: 7,
-            max: 8,
-            previous_started_count: 0,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-        ]
-
-        expect(third_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(third_statement_expectation)
-      end
-    end
-
-    context "uplifts" do
-      context "when there an no uplifts" do
-        let(:expected) do
-          {
-            previous_count: 0,
-            count: 0,
-            additions: 0,
-            subtractions: 0,
-          }
-        end
-
-        it "returns zero current and previous uplifts" do
-          expect(first_statement_calc.uplift_breakdown).to eql(expected)
-        end
+      let(:statement_two_expectation) do
+        {
+          previous_count: 3,
+          count: 2,
+          additions: 3,
+          subtractions: 1,
+        }
       end
 
-      context "when there are uplifts" do
-        before do
-          declarations = create_list(
-            :ect_participant_declaration, 2,
-            state: :paid,
-            pupil_premium_uplift: true
-          ) + create_list(
-            :mentor_participant_declaration, 2,
-            state: :paid,
-            pupil_premium_uplift: true
-          )
-
-          declarations.each do |dec|
-            Finance::StatementLineItem.create!(
-              statement: first_statement,
-              participant_declaration: dec,
-              state: dec.state,
-            )
-          end
-        end
-
-        let(:expected) do
-          {
-            previous_count: 0,
-            count: 2,
-            additions: 2,
-            subtractions: 0,
-          }
-        end
-
-        it "returns current uplifts" do
-          expect(first_statement_calc.uplift_breakdown).to eql(expected)
-        end
+      let(:statement_three_expectation) do
+        {
+          previous_count: 5,
+          count: 1,
+          additions: 3,
+          subtractions: 2,
+        }
       end
 
-      context "when there are uplifts but not on started declarations" do
-        before do
-          declarations = create_list(
-            :ect_participant_declaration, 2,
-            state: :paid,
-            pupil_premium_uplift: true,
-            declaration_type: "retained-1"
-          ) + create_list(
-            :mentor_participant_declaration, 2,
-            state: :paid,
-            pupil_premium_uplift: true,
-            declaration_type: "retained-1"
-          )
-
-          declarations.each do |dec|
-            Finance::StatementLineItem.create!(
-              statement: first_statement,
-              participant_declaration: dec,
-              state: dec.state,
-            )
-          end
-        end
-
-        let(:expected) do
-          {
-            previous_count: 0,
-            count: 0,
-            additions: 0,
-            subtractions: 0,
-          }
-        end
-
-        it "does not count them" do
-          expect(first_statement_calc.uplift_breakdown).to eql(expected)
-        end
-      end
-
-      context "when there is net negative of uplifts on a single statement" do
-        before do
-          declarations = create_list(
-            :ect_participant_declaration, 2,
-            state: :paid,
-            pupil_premium_uplift: true
-          ) + create_list(
-            :mentor_participant_declaration, 2,
-            state: :paid,
-            pupil_premium_uplift: true
-          )
-
-          declarations.each do |dec|
-            Finance::StatementLineItem.create!(
-              statement: first_statement,
-              participant_declaration: dec,
-              state: dec.state,
-            )
-          end
-
-          clawback_line_items = first_statement
-            .billable_statement_line_items
-            .joins(:participant_declaration)
-            .where(participant_declarations: { state: "paid" })
-            .order(Arel.sql("RANDOM()"))
-            .merge!(ParticipantDeclaration.ect)
-            .limit(1)
-
-          clawback_line_items.each do |line_item|
-            Finance::StatementLineItem.create!(
-              statement: second_statement,
-              participant_declaration: line_item.participant_declaration,
-              state: "awaiting_clawback",
-            )
-
-            line_item.participant_declaration.update!(state: "awaiting_clawback")
-          end
-        end
-
-        let(:expected) do
-          {
-            previous_count: 2,
-            count: -1,
-            additions: 0,
-            subtractions: 1,
-          }
-        end
-
-        it "returns negative uplifts" do
-          expect(second_statement_calc.uplift_breakdown).to eql(expected)
-        end
-      end
-
-      context "when there are previous uplifts" do
-        before do
-          setup_statement_one
-          setup_statement_two
-          setup_statement_three
-        end
-
-        def setup_statement_one
-          declarations = create_list(
-            :ect_participant_declaration, 3,
-            state: :paid,
-            pupil_premium_uplift: true
-          ) + create_list(
-            :mentor_participant_declaration, 3,
-            state: :paid,
-            pupil_premium_uplift: true
-          )
-
-          declarations.each do |dec|
-            Finance::StatementLineItem.create!(
-              statement: first_statement,
-              participant_declaration: dec,
-              state: dec.state,
-            )
-          end
-        end
-
-        def setup_statement_two
-          declarations = create_list(
-            :ect_participant_declaration, 3,
-            state: :paid,
-            pupil_premium_uplift: true
-          ) + create_list(
-            :mentor_participant_declaration, 3,
-            state: :paid,
-            pupil_premium_uplift: true
-          )
-
-          declarations.each do |dec|
-            Finance::StatementLineItem.create!(
-              statement: second_statement,
-              participant_declaration: dec,
-              state: dec.state,
-            )
-          end
-
-          clawback_line_items = first_statement
-            .billable_statement_line_items
-            .joins(:participant_declaration)
-            .where(participant_declarations: { state: "paid" })
-            .order(Arel.sql("RANDOM()"))
-            .merge!(ParticipantDeclaration.ect)
-            .limit(1)
-
-          clawback_line_items.each do |line_item|
-            Finance::StatementLineItem.create!(
-              statement: second_statement,
-              participant_declaration: line_item.participant_declaration,
-              state: "clawed_back",
-            )
-
-            line_item.participant_declaration.update!(state: "clawed_back")
-          end
-        end
-
-        def setup_statement_three
-          declarations = create_list(
-            :ect_participant_declaration, 3,
-            state: :payable,
-            pupil_premium_uplift: true
-          ) + create_list(
-            :mentor_participant_declaration, 3,
-            state: :payable,
-            pupil_premium_uplift: true
-          )
-
-          declarations.each do |dec|
-            Finance::StatementLineItem.create!(
-              statement: third_statement,
-              participant_declaration: dec,
-              state: dec.state,
-            )
-          end
-
-          clawback_line_items = first_statement
-            .billable_statement_line_items
-            .joins(:participant_declaration)
-            .where(participant_declarations: { state: "paid" })
-            .order(Arel.sql("RANDOM()"))
-            .merge!(ParticipantDeclaration.ect)
-            .limit(1)
-
-          clawback_line_items.each do |line_item|
-            Finance::StatementLineItem.create!(
-              statement: third_statement,
-              participant_declaration: line_item.participant_declaration,
-              state: "awaiting_clawback",
-            )
-
-            line_item.participant_declaration.update!(state: "awaiting_clawback")
-          end
-
-          clawback_line_items = second_statement
-            .billable_statement_line_items
-            .order(Arel.sql("RANDOM()"))
-            .joins(:participant_declaration)
-            .where(participant_declarations: { state: "paid" })
-            .merge!(ParticipantDeclaration.ect)
-            .limit(1)
-
-          clawback_line_items.each do |line_item|
-            Finance::StatementLineItem.create!(
-              statement: third_statement,
-              participant_declaration: line_item.participant_declaration,
-              state: "awaiting_clawback",
-            )
-
-            line_item.participant_declaration.update!(state: "awaiting_clawback")
-          end
-        end
-
-        let(:statement_one_expectation) do
-          {
-            previous_count: 0,
-            count: 3,
-            additions: 3,
-            subtractions: 0,
-          }
-        end
-
-        let(:statement_two_expectation) do
-          {
-            previous_count: 3,
-            count: 2,
-            additions: 3,
-            subtractions: 1,
-          }
-        end
-
-        let(:statement_three_expectation) do
-          {
-            previous_count: 5,
-            count: 1,
-            additions: 3,
-            subtractions: 2,
-          }
-        end
-
-        it "returns correct uplifts" do
-          expect(first_statement_calc.uplift_breakdown).to eql(statement_one_expectation)
-          expect(second_statement_calc.uplift_breakdown).to eql(statement_two_expectation)
-          expect(third_statement_calc.uplift_breakdown).to eql(statement_three_expectation)
-        end
-      end
-    end
-
-    context "extended" do
-      let!(:schedule) { create(:ecf_extended_schedule) }
-
-      let!(:extended_participant_declaration) do
-        travel_to first_statement.deadline_date - 1.day do
-          create(:ect_participant_declaration, :extended, declaration_type: "extended-1", cpd_lead_provider:)
-          create(:ect_participant_declaration, :extended, declaration_type: "extended-2", cpd_lead_provider:)
-          create(:ect_participant_declaration, :extended, declaration_type: "extended-3", cpd_lead_provider:)
-          create(:mentor_participant_declaration, :extended, declaration_type: "extended-1", cpd_lead_provider:)
-        end
-      end
-
-      it "returns correct bands" do
-        extended_keys = %i[
-          band
-          min
-          max
-
-          previous_extended_1_count
-          extended_1_count
-          extended_1_additions
-          extended_1_subtractions
-
-          previous_extended_2_count
-          extended_2_count
-          extended_2_additions
-          extended_2_subtractions
-
-          previous_extended_3_count
-          extended_3_count
-          extended_3_additions
-          extended_3_subtractions
-        ]
-
-        expected = [
-          {
-            band: :a,
-            min: 1,
-            max: 2,
-
-            previous_extended_1_count: 0,
-            extended_1_additions: 1,
-            extended_1_count: 1,
-            extended_1_subtractions: 0,
-
-            previous_extended_2_count: 0,
-            extended_2_additions: 1,
-            extended_2_count: 1,
-            extended_2_subtractions: 0,
-
-            previous_extended_3_count: 0,
-            extended_3_additions: 1,
-            extended_3_count: 1,
-            extended_3_subtractions: 0,
-          },
-          {
-            band: :b,
-            min: 3,
-            max: 4,
-
-            previous_extended_1_count: 0,
-            extended_1_additions: 0,
-            extended_1_count: 0,
-            extended_1_subtractions: 0,
-
-            previous_extended_2_count: 0,
-            extended_2_additions: 0,
-            extended_2_count: 0,
-            extended_2_subtractions: 0,
-
-            previous_extended_3_count: 0,
-            extended_3_additions: 0,
-            extended_3_count: 0,
-            extended_3_subtractions: 0,
-          },
-          {
-            band: :c,
-            min: 5,
-            max: 6,
-
-            previous_extended_1_count: 0,
-            extended_1_additions: 0,
-            extended_1_count: 0,
-            extended_1_subtractions: 0,
-
-            previous_extended_2_count: 0,
-            extended_2_additions: 0,
-            extended_2_count: 0,
-            extended_2_subtractions: 0,
-
-            previous_extended_3_count: 0,
-            extended_3_additions: 0,
-            extended_3_count: 0,
-            extended_3_subtractions: 0,
-          },
-          {
-            band: :d,
-            min: 7,
-            max: 8,
-
-            previous_extended_1_count: 0,
-            extended_1_additions: 0,
-            extended_1_count: 0,
-            extended_1_subtractions: 0,
-
-            previous_extended_2_count: 0,
-            extended_2_additions: 0,
-            extended_2_count: 0,
-            extended_2_subtractions: 0,
-
-            previous_extended_3_count: 0,
-            extended_3_additions: 0,
-            extended_3_count: 0,
-            extended_3_subtractions: 0,
-          },
-        ]
-
-        expect(first_statement_calc.banding_breakdown.map { |e| e.slice(*extended_keys) }).to eql(expected)
+      it "returns correct uplifts" do
+        expect(first_statement_calc.uplift_breakdown).to eql(statement_one_expectation)
+        expect(second_statement_calc.uplift_breakdown).to eql(statement_two_expectation)
+        expect(third_statement_calc.uplift_breakdown).to eql(statement_three_expectation)
       end
     end
   end

--- a/spec/services/finance/ecf/ect/statement_calculator_spec.rb
+++ b/spec/services/finance/ecf/ect/statement_calculator_spec.rb
@@ -2,25 +2,15 @@
 
 RSpec.describe Finance::ECF::ECT::StatementCalculator do
   it_behaves_like "a Finance ECF statement calculator" do
-    describe "#total" do
-      let(:uplift_breakdown) do
-        {
-          previous_count: 0,
-          count: 2,
-          additions: 4,
-          subtractions: 2,
-        }
-      end
-      let(:output_calculator) { instance_double("Finance::ECF::ECT::OutputCalculator", uplift_breakdown:, banding_breakdown: []) }
+    describe "#output_calculator" do
+      let(:output_calculator) { subject.send(:output_calculator) }
 
-      before do
-        allow(Finance::ECF::ECT::OutputCalculator).to receive(:new).with(statement:).and_return(output_calculator)
+      it "delegates to the correct OutputCalculator" do
+        expect(output_calculator.class).to eq(Finance::ECF::ECT::OutputCalculator)
       end
 
-      it "calls OutputCalculator with correct params" do
-        subject.total
-
-        expect(Finance::ECF::ECT::OutputCalculator).to have_received(:new).with(statement:)
+      it "delegates to the correct BandingCalculator" do
+        expect(output_calculator.banding_for(declaration_type: "started").class).to eq(Finance::ECF::ECT::BandingCalculator)
       end
     end
 
@@ -55,7 +45,7 @@ RSpec.describe Finance::ECF::ECT::StatementCalculator do
         end
       end
 
-      it "returns all voided declarations" do
+      it "returns ECT only voided declarations" do
         expect(subject.voided_declarations.size).to eql(5)
         expect(subject.voided_declarations.pluck(:state).uniq).to eql(%w[voided])
       end

--- a/spec/services/finance/ecf/mentor/statement_calculator_spec.rb
+++ b/spec/services/finance/ecf/mentor/statement_calculator_spec.rb
@@ -125,41 +125,6 @@ RSpec.describe Finance::ECF::Mentor::StatementCalculator, mid_cohort: true do
     end
   end
 
-  describe "#voided_declarations" do
-    before do
-      declarations = create_list(
-        :mentor_participant_declaration, 5,
-        state: :voided
-      )
-
-      declarations.each do |dec|
-        Finance::StatementLineItem.create!(
-          statement:,
-          participant_declaration: dec,
-          state: dec.state,
-        )
-      end
-
-      declarations = create_list(
-        :ect_participant_declaration, 5,
-        state: :voided
-      )
-
-      declarations.each do |dec|
-        Finance::StatementLineItem.create!(
-          statement:,
-          participant_declaration: dec,
-          state: dec.state,
-        )
-      end
-    end
-
-    it "returns only voided mentor declarations" do
-      expect(subject.voided_declarations.size).to eql(5)
-      expect(subject.voided_declarations.pluck(:state, :type).uniq.flatten).to eql(["voided", "ParticipantDeclaration::Mentor"])
-    end
-  end
-
   describe "#voided_count" do
     before do
       declarations = create_list(

--- a/spec/services/finance/ecf/mentor/statement_calculator_spec.rb
+++ b/spec/services/finance/ecf/mentor/statement_calculator_spec.rb
@@ -9,25 +9,31 @@ RSpec.describe Finance::ECF::Mentor::StatementCalculator, mid_cohort: true do
 
   subject { described_class.new(statement:) }
 
-  describe "#total" do
-    let(:output_breakdown) do
-      [
-        {
-          started_additions: 5,
-          started_subtractions: 2,
-        },
-        {
-          completed_additions: 3,
-          completed_subtractions: 1,
-        },
-      ]
-    end
-    let(:output_calculator) { instance_double("Finance::ECF::Mentor::OutputCalculator", output_breakdown:) }
+  before do
+    output_calculator = subject.send(:output_calculator)
 
-    before do
-      allow(Finance::ECF::Mentor::OutputCalculator).to receive(:new).with(statement:).and_return(output_calculator)
-      allow(output_calculator).to receive(:fee_for_declaration).and_return(500)
+    # Mock output_breakdown values
+    if defined?(mock_output_breakdown)
+      allow(output_calculator).to receive(:output_breakdown).and_return(mock_output_breakdown.stringify_keys)
     end
+
+    # Mock fee_for_declaration
+    if defined?(mock_fee_for_declaration)
+      allow(output_calculator).to receive(:fee_for_declaration).and_return(*mock_fee_for_declaration)
+    end
+  end
+
+  describe "#total" do
+    let(:mock_output_breakdown) do
+      {
+        started_additions: 5,
+        started_subtractions: 2,
+
+        completed_additions: 3,
+        completed_subtractions: 1,
+      }
+    end
+    let(:mock_fee_for_declaration) { 500 }
 
     context "when VAT is not applicable" do
       it "calculates the total" do
@@ -43,26 +49,16 @@ RSpec.describe Finance::ECF::Mentor::StatementCalculator, mid_cohort: true do
   end
 
   describe "#started_fee_per_declaration" do
-    let(:output_breakdown) do
-      [
-        {
-          started_additions: 4,
-          started_subtractions: 0,
-        },
-        {
-          completed_additions: 2,
-          completed_subtractions: 1,
-        },
-      ]
-    end
+    let(:mock_output_breakdown) do
+      {
+        started_additions: 4,
+        started_subtractions: 0,
 
-    let(:output_calculator) { instance_double("Finance::ECF::Mentor::OutputCalculator") }
-
-    before do
-      allow(Finance::ECF::Mentor::OutputCalculator).to receive(:new).and_return(output_calculator)
-      allow(output_calculator).to receive(:output_breakdown).and_return(output_breakdown)
-      allow(output_calculator).to receive(:fee_for_declaration).and_return(500)
+        completed_additions: 2,
+        completed_subtractions: 1,
+      }
     end
+    let(:mock_fee_for_declaration) { 500 }
 
     it "returns correct value" do
       expect(subject.started_fee_per_declaration).to eql(500)
@@ -70,26 +66,16 @@ RSpec.describe Finance::ECF::Mentor::StatementCalculator, mid_cohort: true do
   end
 
   describe "#additions_for_started" do
-    let(:output_breakdown) do
-      [
-        {
-          started_additions: 4,
-          started_subtractions: 0,
-        },
-        {
-          completed_additions: 2,
-          completed_subtractions: 1,
-        },
-      ]
-    end
+    let(:mock_output_breakdown) do
+      {
+        started_additions: 4,
+        started_subtractions: 0,
 
-    let(:output_calculator) { instance_double("Finance::ECF::Mentor::OutputCalculator") }
-
-    before do
-      allow(Finance::ECF::Mentor::OutputCalculator).to receive(:new).and_return(output_calculator)
-      allow(output_calculator).to receive(:output_breakdown).and_return(output_breakdown)
-      allow(output_calculator).to receive(:fee_for_declaration).and_return(500)
+        completed_additions: 2,
+        completed_subtractions: 1,
+      }
     end
+    let(:mock_fee_for_declaration) { 500 }
 
     it "returns correct value" do
       expect(subject.additions_for_started).to eql(2000)
@@ -97,22 +83,14 @@ RSpec.describe Finance::ECF::Mentor::StatementCalculator, mid_cohort: true do
   end
 
   describe "#started_count" do
-    let(:output_breakdown) do
-      [
-        {
-          started_additions: 10,
-          started_subtractions: 0,
-        },
-        {
-          completed_additions: 2,
-          completed_subtractions: 1,
-        },
-      ]
-    end
-    let(:output_calculator) { instance_double("Finance::ECF::Mentor::OutputCalculator", output_breakdown:) }
+    let(:mock_output_breakdown) do
+      {
+        started_additions: 10,
+        started_subtractions: 0,
 
-    before do
-      allow(Finance::ECF::Mentor::OutputCalculator).to receive(:new).and_return(output_calculator)
+        completed_additions: 2,
+        completed_subtractions: 1,
+      }
     end
 
     it "returns correct value" do
@@ -121,22 +99,14 @@ RSpec.describe Finance::ECF::Mentor::StatementCalculator, mid_cohort: true do
   end
 
   describe "#completed_count" do
-    let(:output_breakdown) do
-      [
-        {
-          started_additions: 10,
-          started_subtractions: 0,
-        },
-        {
-          completed_additions: 20,
-          completed_subtractions: 1,
-        },
-      ]
-    end
-    let(:output_calculator) { instance_double("Finance::ECF::Mentor::OutputCalculator", output_breakdown:) }
+    let(:mock_output_breakdown) do
+      {
+        started_additions: 10,
+        started_subtractions: 0,
 
-    before do
-      allow(Finance::ECF::Mentor::OutputCalculator).to receive(:new).and_return(output_calculator)
+        completed_additions: 20,
+        completed_subtractions: 1,
+      }
     end
 
     it "returns correct value" do
@@ -225,38 +195,27 @@ RSpec.describe Finance::ECF::Mentor::StatementCalculator, mid_cohort: true do
   end
 
   describe "#fee_for_declaration" do
-    let(:output_calculator) { instance_double("Finance::ECF::Mentor::OutputCalculator", output_breakdown: []) }
-
-    before do
-      allow(Finance::ECF::Mentor::OutputCalculator).to receive(:new).with(statement:).and_return(output_calculator)
-    end
+    let(:output_calculator) { subject.send(:output_calculator) }
+    let(:mock_fee_for_declaration) { 100.0 }
 
     it "calls OutputCalculator#fee_for_declaration with correct params" do
       expect(output_calculator).to receive(:fee_for_declaration).with(type: "started")
 
-      subject.fee_for_declaration(type: "started")
+      expect(subject.fee_for_declaration(type: "started")).to eq(100.0)
     end
   end
 
   describe "#clawbacks_breakdown" do
-    let(:output_breakdown) do
-      [
-        {
-          started_additions: 0,
-          started_subtractions: 2,
-        },
-        {
-          completed_additions: 0,
-          completed_subtractions: 3,
-        },
-      ]
-    end
+    let(:mock_output_breakdown) do
+      {
+        started_additions: 0,
+        started_subtractions: 2,
 
-    let(:output_calculator) { instance_double("Finance::ECF::Mentor::OutputCalculator", output_breakdown:, fee_for_declaration: 100.0) }
-
-    before do
-      allow(Finance::ECF::Mentor::OutputCalculator).to receive(:new).with(statement:).and_return(output_calculator)
+        completed_additions: 0,
+        completed_subtractions: 3,
+      }
     end
+    let(:mock_fee_for_declaration) { 100.0 }
 
     it "returns clawbacks breakdown" do
       expect(subject.clawbacks_breakdown).to eq([

--- a/spec/services/finance/ecf/output_calculator_spec.rb
+++ b/spec/services/finance/ecf/output_calculator_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe Finance::ECF::OutputCalculator do
   let(:first_statement) { create(:ecf_statement, cpd_lead_provider:, payment_date: 6.months.ago) }
   let(:second_statement) { create(:ecf_statement, cpd_lead_provider:, payment_date: 4.months.ago) }
   let(:third_statement) { create(:ecf_statement, cpd_lead_provider:, payment_date: 2.months.ago) }
-  let(:fourth_statement) { create(:ecf_statement, cpd_lead_provider:, payment_date: 0.months.ago) }
 
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
   let(:lead_provider) { cpd_lead_provider.lead_provider }
@@ -13,23 +12,54 @@ RSpec.describe Finance::ECF::OutputCalculator do
   let(:first_statement_calc) { described_class.new(statement: first_statement) }
   let(:second_statement_calc) { described_class.new(statement: second_statement) }
   let(:third_statement_calc) { described_class.new(statement: third_statement) }
-  let(:fourth_statement_calc) { described_class.new(statement: fourth_statement) }
 
-  let(:relevant_started_keys) do
-    %i[
-      band
-      min
-      max
-      previous_started_count
-      started_count
-      started_additions
-      started_subtractions
-    ]
+  subject { first_statement_calc }
+
+  describe "#band_for" do
+    let(:letters) { %i[a b c d] }
+    let(:declaration_types) do
+      %w[
+        started
+        retained-1
+        retained-2
+        retained-3
+        retained-4
+        completed
+        extended-1
+        extended-2
+        extended-3
+      ]
+    end
+
+    before do
+      declaration_types.each do |declaration_type|
+        mock_banding = instance_double(
+          Finance::ECF::BandingCalculator,
+          previous_count: 5,
+          count: 10,
+          additions: 15,
+          subtractions: 5,
+        )
+
+        expect(Finance::ECF::BandingCalculator).to receive(:new)
+          .with(statement: first_statement, declaration_type:)
+          .and_return(mock_banding)
+      end
+    end
+
+    it "correctly delegates to banding calculator" do
+      declaration_types.each do |declaration_type|
+        letters.each do |letter|
+          expect(subject.banding_for(declaration_type:).previous_count(letter)).to eq(5)
+          expect(subject.banding_for(declaration_type:).count(letter)).to eq(10)
+          expect(subject.banding_for(declaration_type:).additions(letter)).to eq(15)
+          expect(subject.banding_for(declaration_type:).subtractions(letter)).to eq(5)
+        end
+      end
+    end
   end
 
   describe "#fee_for_declaration" do
-    subject { first_statement_calc }
-
     it "returns correct fees" do
       expect(subject.fee_for_declaration(band_letter: :a, type: :started)).to eql(48)
       expect(subject.fee_for_declaration(band_letter: :a, type: :retained_1)).to eql(36)
@@ -73,333 +103,104 @@ RSpec.describe Finance::ECF::OutputCalculator do
     end
   end
 
-  describe "#banding_breakdown" do
-    context "when nada declarations" do
-      it "returns empty bands" do
-        expected = [
-          {
-            band: :a,
-            min: 1,
-            max: 2,
-            previous_started_count: 0,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-          {
-            band: :b,
-            min: 3,
-            max: 4,
-            previous_started_count: 0,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-          {
-            band: :c,
-            min: 5,
-            max: 6,
-            previous_started_count: 0,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-          {
-            band: :d,
-            min: 7,
-            max: 8,
-            previous_started_count: 0,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-        ]
+  describe "#uplift_breakdown" do
+    context "when there an no uplifts" do
+      let(:expected) do
+        {
+          previous_count: 0,
+          count: 0,
+          additions: 0,
+          subtractions: 0,
+        }
+      end
 
-        expect(first_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(expected)
+      it "returns zero current and previous uplifts" do
+        expect(first_statement_calc.uplift_breakdown).to eql(expected)
       end
     end
 
-    context "when partially filled bands" do
-      let!(:to_be_paid_participant_declaration) do
-        travel_to first_statement.deadline_date - 1.day do
-          create(:ect_participant_declaration, :payable, cpd_lead_provider:)
-          create(:mentor_participant_declaration, :payable, cpd_lead_provider:)
-        end
-      end
-
-      before do
-        travel_to first_statement.deadline_date do
-          Statements::MarkAsPaid.new(first_statement).call
-        end
-      end
-
-      it "returns correct bands" do
-        expected = [
-          {
-            band: :a,
-            min: 1,
-            max: 2,
-            previous_started_count: 0,
-            started_count: 1,
-            started_additions: 1,
-            started_subtractions: 0,
-          },
-          {
-            band: :b,
-            min: 3,
-            max: 4,
-            previous_started_count: 0,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-          {
-            band: :c,
-            min: 5,
-            max: 6,
-            previous_started_count: 0,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-          {
-            band: :d,
-            min: 7,
-            max: 8,
-            previous_started_count: 0,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-        ]
-
-        expect(first_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(expected)
-      end
-    end
-
-    context "when fully filled bands" do
-      let!(:to_be_paid_declarations) do
-        travel_to first_statement.deadline_date do
-          create_list(:ect_participant_declaration, 2, :eligible, cpd_lead_provider:)
-          create_list(:mentor_participant_declaration, 2, :eligible, cpd_lead_provider:)
-        end
-      end
-      before do
-        Statements::MarkAsPayable.new(first_statement).call
-        Statements::MarkAsPaid.new(first_statement).call
-      end
-
-      it "returns correct bands" do
-        expected = [
-          {
-            band: :a,
-            min: 1,
-            max: 2,
-            previous_started_count: 0,
-            started_count: 2,
-            started_additions: 2,
-            started_subtractions: 0,
-          },
-          {
-            band: :b,
-            min: 3,
-            max: 4,
-            previous_started_count: 0,
-            started_count: 2,
-            started_additions: 2,
-            started_subtractions: 0,
-          },
-          {
-            band: :c,
-            min: 5,
-            max: 6,
-            previous_started_count: 0,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-          {
-            band: :d,
-            min: 7,
-            max: 8,
-            previous_started_count: 0,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-        ]
-        expect(first_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(expected)
-      end
-
-      context "when band a min is set to zero" do
-        before do
-          contract.participant_bands.find_by!(min: nil).update(min: 0)
-        end
-
-        it "returns correct bands" do
-          expected = [
-            {
-              band: :a,
-              min: 1,
-              max: 2,
-              previous_started_count: 0,
-              started_count: 2,
-              started_additions: 2,
-              started_subtractions: 0,
-            },
-            {
-              band: :b,
-              min: 3,
-              max: 4,
-              previous_started_count: 0,
-              started_count: 2,
-              started_additions: 2,
-              started_subtractions: 0,
-            },
-            {
-              band: :c,
-              min: 5,
-              max: 6,
-              previous_started_count: 0,
-              started_count: 0,
-              started_additions: 0,
-              started_subtractions: 0,
-            },
-            {
-              band: :d,
-              min: 7,
-              max: 8,
-              previous_started_count: 0,
-              started_count: 0,
-              started_additions: 0,
-              started_subtractions: 0,
-            },
-          ]
-          expect(first_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(expected)
-        end
-      end
-    end
-
-    context "when multiple bands" do
-      let!(:to_be_paid_declarations) do
-        travel_to first_statement.deadline_date do
-          create_list(:ect_participant_declaration, 7, :eligible, cpd_lead_provider:)
-          create(:mentor_participant_declaration, :eligible, cpd_lead_provider:)
-        end
-      end
-      before do
-        Statements::MarkAsPayable.new(first_statement).call
-        Statements::MarkAsPaid.new(first_statement).call
-      end
-
-      it "returns correct bands" do
-        expected = [
-          {
-            band: :a,
-            min: 1,
-            max: 2,
-            previous_started_count: 0,
-            started_count: 2,
-            started_additions: 2,
-            started_subtractions: 0,
-          },
-          {
-            band: :b,
-            min: 3,
-            max: 4,
-            previous_started_count: 0,
-            started_count: 2,
-            started_additions: 2,
-            started_subtractions: 0,
-          },
-          {
-            band: :c,
-            min: 5,
-            max: 6,
-            previous_started_count: 0,
-            started_count: 2,
-            started_additions: 2,
-            started_subtractions: 0,
-          },
-          {
-            band: :d,
-            min: 7,
-            max: 8,
-            previous_started_count: 0,
-            started_count: 2,
-            started_additions: 2,
-            started_subtractions: 0,
-          },
-        ]
-
-        expect(first_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(expected)
-      end
-    end
-
-    context "when overfilled all bands" do
-      let!(:to_be_paid_declarations) do
-        travel_to first_statement.deadline_date do
-          create_list(:ect_participant_declaration, 9, :eligible, cpd_lead_provider:)
-          create(:mentor_participant_declaration, :eligible, cpd_lead_provider:)
-        end
-      end
-      before do
-        Statements::MarkAsPayable.new(first_statement).call
-        Statements::MarkAsPaid.new(first_statement).call
-      end
-
-      it "does not count extra declarations" do
-        expected = [
-          {
-            band: :a,
-            min: 1,
-            max: 2,
-            previous_started_count: 0,
-            started_count: 2,
-            started_additions: 2,
-            started_subtractions: 0,
-          },
-          {
-            band: :b,
-            min: 3,
-            max: 4,
-            previous_started_count: 0,
-            started_count: 2,
-            started_additions: 2,
-            started_subtractions: 0,
-          },
-          {
-            band: :c,
-            min: 5,
-            max: 6,
-            previous_started_count: 0,
-            started_count: 2,
-            started_additions: 2,
-            started_subtractions: 0,
-          },
-          {
-            band: :d,
-            min: 7,
-            max: 8,
-            previous_started_count: 0,
-            started_count: 2,
-            started_additions: 2,
-            started_subtractions: 0,
-          },
-        ]
-
-        expect(first_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(expected)
-      end
-    end
-
-    context "next statement is present" do
+    context "when there are uplifts" do
       before do
         declarations = create_list(
-          :ect_participant_declaration, 3,
-          state: :paid
-        ) << create(
-          :mentor_participant_declaration,
+          :ect_participant_declaration, 2,
           state: :paid,
+          pupil_premium_uplift: true
+        ) + create_list(
+          :mentor_participant_declaration, 2,
+          state: :paid,
+          pupil_premium_uplift: true
+        )
+
+        declarations.each do |dec|
+          Finance::StatementLineItem.create!(
+            statement: first_statement,
+            participant_declaration: dec,
+            state: dec.state,
+          )
+        end
+      end
+
+      let(:expected) do
+        {
+          previous_count: 0,
+          count: 4,
+          additions: 4,
+          subtractions: 0,
+        }
+      end
+
+      it "returns current uplifts" do
+        expect(first_statement_calc.uplift_breakdown).to eql(expected)
+      end
+    end
+
+    context "when there are uplifts but not on started declarations" do
+      before do
+        declarations = create_list(
+          :ect_participant_declaration, 2,
+          state: :paid,
+          pupil_premium_uplift: true,
+          declaration_type: "retained-1"
+        ) + create_list(
+          :mentor_participant_declaration, 2,
+          state: :paid,
+          pupil_premium_uplift: true,
+          declaration_type: "retained-1"
+        )
+
+        declarations.each do |dec|
+          Finance::StatementLineItem.create!(
+            statement: first_statement,
+            participant_declaration: dec,
+            state: dec.state,
+          )
+        end
+      end
+
+      let(:expected) do
+        {
+          previous_count: 0,
+          count: 0,
+          additions: 0,
+          subtractions: 0,
+        }
+      end
+
+      it "does not count them" do
+        expect(first_statement_calc.uplift_breakdown).to eql(expected)
+      end
+    end
+
+    context "when there is net negative of uplifts on a single statement" do
+      before do
+        declarations = create_list(
+          :ect_participant_declaration, 2,
+          state: :paid,
+          pupil_premium_uplift: true
+        ) + create_list(
+          :mentor_participant_declaration, 2,
+          state: :paid,
+          pupil_premium_uplift: true
         )
 
         declarations.each do |dec|
@@ -410,183 +211,39 @@ RSpec.describe Finance::ECF::OutputCalculator do
           )
         end
 
-        declarations = create_list(
-          :ect_participant_declaration, 3,
-          state: :payable
-        ) << create(
-          :mentor_participant_declaration,
-          state: :payable,
-        )
+        clawback_line_items = first_statement
+          .billable_statement_line_items
+          .joins(:participant_declaration)
+          .where(participant_declarations: { state: "paid" })
+          .order(Arel.sql("RANDOM()"))
+          .limit(1)
 
-        declarations.each do |dec|
+        clawback_line_items.each do |line_item|
           Finance::StatementLineItem.create!(
             statement: second_statement,
-            participant_declaration: dec,
-            state: dec.state,
+            participant_declaration: line_item.participant_declaration,
+            state: "awaiting_clawback",
           )
+
+          line_item.participant_declaration.update!(state: "awaiting_clawback")
         end
       end
 
-      it "counts bands from where it left off" do
-        expected = [
-          {
-            band: :a,
-            min: 1,
-            max: 2,
-            previous_started_count: 2,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-          {
-            band: :b,
-            min: 3,
-            max: 4,
-            previous_started_count: 2,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-          {
-            band: :c,
-            min: 5,
-            max: 6,
-            previous_started_count: 0,
-            started_count: 2,
-            started_additions: 2,
-            started_subtractions: 0,
-          },
-          {
-            band: :d,
-            min: 7,
-            max: 8,
-            previous_started_count: 0,
-            started_count: 2,
-            started_additions: 2,
-            started_subtractions: 0,
-          },
-        ]
+      let(:expected) do
+        {
+          previous_count: 4,
+          count: -1,
+          additions: 0,
+          subtractions: 1,
+        }
+      end
 
-        expect(second_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(expected)
+      it "returns negative uplifts" do
+        expect(second_statement_calc.uplift_breakdown).to eql(expected)
       end
     end
 
-    context "when clawbacks present in 2 consecutive statements" do
-      before do
-        declarations = create_list(
-          :ect_participant_declaration, 5,
-          state: :paid
-        ) << create(
-          :mentor_participant_declaration,
-          state: :paid,
-        )
-
-        declarations.each do |dec|
-          Finance::StatementLineItem.create!(
-            statement: first_statement,
-            participant_declaration: dec,
-            state: dec.state,
-          )
-        end
-
-        clawback_declarations = declarations.sample(2)
-
-        clawback_declarations.each do |dec|
-          dec.update!(state: "awaiting_clawback")
-
-          Finance::StatementLineItem.create!(
-            statement: second_statement,
-            participant_declaration: dec,
-            state: dec.state,
-          )
-        end
-      end
-
-      it "can calculate refunds when current statement is empty" do
-        first_statement_expectation = [
-          {
-            band: :a,
-            min: 1,
-            max: 2,
-            previous_started_count: 0,
-            started_count: 2,
-            started_additions: 2,
-            started_subtractions: 0,
-          },
-          {
-            band: :b,
-            min: 3,
-            max: 4,
-            previous_started_count: 0,
-            started_count: 2,
-            started_additions: 2,
-            started_subtractions: 0,
-          },
-          {
-            band: :c,
-            min: 5,
-            max: 6,
-            previous_started_count: 0,
-            started_count: 2,
-            started_additions: 2,
-            started_subtractions: 0,
-          },
-          {
-            band: :d,
-            min: 7,
-            max: 8,
-            previous_started_count: 0,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-        ]
-
-        second_statement_expectation = [
-          {
-            band: :a,
-            min: 1,
-            max: 2,
-            previous_started_count: 2,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-          {
-            band: :b,
-            min: 3,
-            max: 4,
-            previous_started_count: 2,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-          {
-            band: :c,
-            min: 5,
-            max: 6,
-            previous_started_count: 2,
-            started_count: -2,
-            started_additions: 0,
-            started_subtractions: 2,
-          },
-          {
-            band: :d,
-            min: 7,
-            max: 8,
-            previous_started_count: 0,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-        ]
-
-        expect(first_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(first_statement_expectation)
-        expect(second_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(second_statement_expectation)
-      end
-    end
-
-    context "when clawbacks present in 3 consecutive statements" do
+    context "when there are previous uplifts" do
       before do
         setup_statement_one
         setup_statement_two
@@ -596,10 +253,12 @@ RSpec.describe Finance::ECF::OutputCalculator do
       def setup_statement_one
         declarations = create_list(
           :ect_participant_declaration, 3,
-          state: :paid
-        ) << create(
-          :mentor_participant_declaration,
-          state: :payable,
+          state: :paid,
+          pupil_premium_uplift: true
+        ) + create_list(
+          :mentor_participant_declaration, 3,
+          state: :paid,
+          pupil_premium_uplift: true
         )
 
         declarations.each do |dec|
@@ -614,10 +273,12 @@ RSpec.describe Finance::ECF::OutputCalculator do
       def setup_statement_two
         declarations = create_list(
           :ect_participant_declaration, 3,
-          state: :paid
-        ) << create(
-          :mentor_participant_declaration,
           state: :paid,
+          pupil_premium_uplift: true
+        ) + create_list(
+          :mentor_participant_declaration, 3,
+          state: :paid,
+          pupil_premium_uplift: true
         )
 
         declarations.each do |dec|
@@ -648,10 +309,12 @@ RSpec.describe Finance::ECF::OutputCalculator do
       def setup_statement_three
         declarations = create_list(
           :ect_participant_declaration, 3,
-          state: :payable
-        ) << create(
-          :mentor_participant_declaration,
           state: :payable,
+          pupil_premium_uplift: true
+        ) + create_list(
+          :mentor_participant_declaration, 3,
+          state: :payable,
+          pupil_premium_uplift: true
         )
 
         declarations.each do |dec|
@@ -697,608 +360,37 @@ RSpec.describe Finance::ECF::OutputCalculator do
         end
       end
 
-      it "can calculate refunds for typical use case" do
-        first_statement_expectation = [
-          {
-            band: :a,
-            min: 1,
-            max: 2,
-            previous_started_count: 0,
-            started_count: 2,
-            started_additions: 2,
-            started_subtractions: 0,
-          },
-          {
-            band: :b,
-            min: 3,
-            max: 4,
-            previous_started_count: 0,
-            started_count: 2,
-            started_additions: 2,
-            started_subtractions: 0,
-          },
-          {
-            band: :c,
-            min: 5,
-            max: 6,
-            previous_started_count: 0,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-          {
-            band: :d,
-            min: 7,
-            max: 8,
-            previous_started_count: 0,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-        ]
-
-        second_statement_expectation = [
-          {
-            band: :a,
-            min: 1,
-            max: 2,
-            previous_started_count: 2,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-          {
-            band: :b,
-            min: 3,
-            max: 4,
-            previous_started_count: 2,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-          {
-            band: :c,
-            min: 5,
-            max: 6,
-            previous_started_count: 0,
-            started_count: 2,
-            started_additions: 2,
-            started_subtractions: 0,
-          },
-          {
-            band: :d,
-            min: 7,
-            max: 8,
-            previous_started_count: 0,
-            started_count: 1,
-            started_additions: 2,
-            started_subtractions: 1,
-          },
-        ]
-
-        third_statement_expectation = [
-          {
-            band: :a,
-            min: 1,
-            max: 2,
-            previous_started_count: 2,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-          {
-            band: :b,
-            min: 3,
-            max: 4,
-            previous_started_count: 2,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-          {
-            band: :c,
-            min: 5,
-            max: 6,
-            previous_started_count: 2,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-          {
-            band: :d,
-            min: 7,
-            max: 8,
-            previous_started_count: 1,
-            started_count: -1,
-            started_additions: 1,
-            started_subtractions: 2,
-          },
-        ]
-
-        expect(first_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(first_statement_expectation)
-        expect(second_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(second_statement_expectation)
-        expect(third_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(third_statement_expectation)
-      end
-    end
-
-    context "when there is a clawback followed by a declaration again" do
-      let!(:participant_declaration) do
-        travel_to first_statement.deadline_date do
-          create(:ect_participant_declaration, :paid, cpd_lead_provider:)
-        end
-      end
-      let(:participant_profile) { participant_declaration.participant_profile }
-
-      before do
-        travel_to second_statement.deadline_date do
-          Finance::ClawbackDeclaration.new(participant_declaration.reload).call
-        end
-
-        participant_declaration.clawed_back!
-        participant_declaration
-          .statement_line_items
-          .awaiting_clawback
-          .first
-          .clawed_back!
-
-        travel_to second_statement.deadline_date do
-          create(:ect_participant_declaration, :payable, participant_profile:, cpd_lead_provider:)
-        end
+      let(:statement_one_expectation) do
+        {
+          previous_count: 0,
+          count: 6,
+          additions: 6,
+          subtractions: 0,
+        }
       end
 
-      it "pays out the following declaration" do
-        third_statement_expectation = [
-          {
-            band: :a,
-            min: 1,
-            max: 2,
-            previous_started_count: 1,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-          {
-            band: :b,
-            min: 3,
-            max: 4,
-            previous_started_count: 0,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-          {
-            band: :c,
-            min: 5,
-            max: 6,
-            previous_started_count: 0,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-          {
-            band: :d,
-            min: 7,
-            max: 8,
-            previous_started_count: 0,
-            started_count: 0,
-            started_additions: 0,
-            started_subtractions: 0,
-          },
-        ]
-
-        expect(third_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(third_statement_expectation)
-      end
-    end
-
-    context "uplifts" do
-      context "when there an no uplifts" do
-        let(:expected) do
-          {
-            previous_count: 0,
-            count: 0,
-            additions: 0,
-            subtractions: 0,
-          }
-        end
-
-        it "returns zero current and previous uplifts" do
-          expect(first_statement_calc.uplift_breakdown).to eql(expected)
-        end
+      let(:statement_two_expectation) do
+        {
+          previous_count: 6,
+          count: 5,
+          additions: 6,
+          subtractions: 1,
+        }
       end
 
-      context "when there are uplifts" do
-        before do
-          declarations = create_list(
-            :ect_participant_declaration, 2,
-            state: :paid,
-            pupil_premium_uplift: true
-          ) + create_list(
-            :mentor_participant_declaration, 2,
-            state: :paid,
-            pupil_premium_uplift: true
-          )
-
-          declarations.each do |dec|
-            Finance::StatementLineItem.create!(
-              statement: first_statement,
-              participant_declaration: dec,
-              state: dec.state,
-            )
-          end
-        end
-
-        let(:expected) do
-          {
-            previous_count: 0,
-            count: 4,
-            additions: 4,
-            subtractions: 0,
-          }
-        end
-
-        it "returns current uplifts" do
-          expect(first_statement_calc.uplift_breakdown).to eql(expected)
-        end
+      let(:statement_three_expectation) do
+        {
+          previous_count: 11,
+          count: 4,
+          additions: 6,
+          subtractions: 2,
+        }
       end
 
-      context "when there are uplifts but not on started declarations" do
-        before do
-          declarations = create_list(
-            :ect_participant_declaration, 2,
-            state: :paid,
-            pupil_premium_uplift: true,
-            declaration_type: "retained-1"
-          ) + create_list(
-            :mentor_participant_declaration, 2,
-            state: :paid,
-            pupil_premium_uplift: true,
-            declaration_type: "retained-1"
-          )
-
-          declarations.each do |dec|
-            Finance::StatementLineItem.create!(
-              statement: first_statement,
-              participant_declaration: dec,
-              state: dec.state,
-            )
-          end
-        end
-
-        let(:expected) do
-          {
-            previous_count: 0,
-            count: 0,
-            additions: 0,
-            subtractions: 0,
-          }
-        end
-
-        it "does not count them" do
-          expect(first_statement_calc.uplift_breakdown).to eql(expected)
-        end
-      end
-
-      context "when there is net negative of uplifts on a single statement" do
-        before do
-          declarations = create_list(
-            :ect_participant_declaration, 2,
-            state: :paid,
-            pupil_premium_uplift: true
-          ) + create_list(
-            :mentor_participant_declaration, 2,
-            state: :paid,
-            pupil_premium_uplift: true
-          )
-
-          declarations.each do |dec|
-            Finance::StatementLineItem.create!(
-              statement: first_statement,
-              participant_declaration: dec,
-              state: dec.state,
-            )
-          end
-
-          clawback_line_items = first_statement
-            .billable_statement_line_items
-            .joins(:participant_declaration)
-            .where(participant_declarations: { state: "paid" })
-            .order(Arel.sql("RANDOM()"))
-            .limit(1)
-
-          clawback_line_items.each do |line_item|
-            Finance::StatementLineItem.create!(
-              statement: second_statement,
-              participant_declaration: line_item.participant_declaration,
-              state: "awaiting_clawback",
-            )
-
-            line_item.participant_declaration.update!(state: "awaiting_clawback")
-          end
-        end
-
-        let(:expected) do
-          {
-            previous_count: 4,
-            count: -1,
-            additions: 0,
-            subtractions: 1,
-          }
-        end
-
-        it "returns negative uplifts" do
-          expect(second_statement_calc.uplift_breakdown).to eql(expected)
-        end
-      end
-
-      context "when there are previous uplifts" do
-        before do
-          setup_statement_one
-          setup_statement_two
-          setup_statement_three
-        end
-
-        def setup_statement_one
-          declarations = create_list(
-            :ect_participant_declaration, 3,
-            state: :paid,
-            pupil_premium_uplift: true
-          ) + create_list(
-            :mentor_participant_declaration, 3,
-            state: :paid,
-            pupil_premium_uplift: true
-          )
-
-          declarations.each do |dec|
-            Finance::StatementLineItem.create!(
-              statement: first_statement,
-              participant_declaration: dec,
-              state: dec.state,
-            )
-          end
-        end
-
-        def setup_statement_two
-          declarations = create_list(
-            :ect_participant_declaration, 3,
-            state: :paid,
-            pupil_premium_uplift: true
-          ) + create_list(
-            :mentor_participant_declaration, 3,
-            state: :paid,
-            pupil_premium_uplift: true
-          )
-
-          declarations.each do |dec|
-            Finance::StatementLineItem.create!(
-              statement: second_statement,
-              participant_declaration: dec,
-              state: dec.state,
-            )
-          end
-
-          clawback_line_items = first_statement
-            .billable_statement_line_items
-            .joins(:participant_declaration)
-            .where(participant_declarations: { state: "paid" })
-            .order(Arel.sql("RANDOM()")).limit(1)
-
-          clawback_line_items.each do |line_item|
-            Finance::StatementLineItem.create!(
-              statement: second_statement,
-              participant_declaration: line_item.participant_declaration,
-              state: "clawed_back",
-            )
-
-            line_item.participant_declaration.update!(state: "clawed_back")
-          end
-        end
-
-        def setup_statement_three
-          declarations = create_list(
-            :ect_participant_declaration, 3,
-            state: :payable,
-            pupil_premium_uplift: true
-          ) + create_list(
-            :mentor_participant_declaration, 3,
-            state: :payable,
-            pupil_premium_uplift: true
-          )
-
-          declarations.each do |dec|
-            Finance::StatementLineItem.create!(
-              statement: third_statement,
-              participant_declaration: dec,
-              state: dec.state,
-            )
-          end
-
-          clawback_line_items = first_statement
-            .billable_statement_line_items
-            .joins(:participant_declaration)
-            .where(participant_declarations: { state: "paid" })
-            .order(Arel.sql("RANDOM()"))
-            .limit(1)
-
-          clawback_line_items.each do |line_item|
-            Finance::StatementLineItem.create!(
-              statement: third_statement,
-              participant_declaration: line_item.participant_declaration,
-              state: "awaiting_clawback",
-            )
-
-            line_item.participant_declaration.update!(state: "awaiting_clawback")
-          end
-
-          clawback_line_items = second_statement
-            .billable_statement_line_items
-            .order(Arel.sql("RANDOM()"))
-            .joins(:participant_declaration)
-            .where(participant_declarations: { state: "paid" })
-            .limit(1)
-
-          clawback_line_items.each do |line_item|
-            Finance::StatementLineItem.create!(
-              statement: third_statement,
-              participant_declaration: line_item.participant_declaration,
-              state: "awaiting_clawback",
-            )
-
-            line_item.participant_declaration.update!(state: "awaiting_clawback")
-          end
-        end
-
-        let(:statement_one_expectation) do
-          {
-            previous_count: 0,
-            count: 6,
-            additions: 6,
-            subtractions: 0,
-          }
-        end
-
-        let(:statement_two_expectation) do
-          {
-            previous_count: 6,
-            count: 5,
-            additions: 6,
-            subtractions: 1,
-          }
-        end
-
-        let(:statement_three_expectation) do
-          {
-            previous_count: 11,
-            count: 4,
-            additions: 6,
-            subtractions: 2,
-          }
-        end
-
-        it "returns correct uplifts" do
-          expect(first_statement_calc.uplift_breakdown).to eql(statement_one_expectation)
-          expect(second_statement_calc.uplift_breakdown).to eql(statement_two_expectation)
-          expect(third_statement_calc.uplift_breakdown).to eql(statement_three_expectation)
-        end
-      end
-    end
-
-    context "extended" do
-      let!(:schedule) { create(:ecf_extended_schedule) }
-
-      let!(:extended_participant_declaration) do
-        travel_to first_statement.deadline_date - 1.day do
-          create(:ect_participant_declaration, :extended, declaration_type: "extended-1", cpd_lead_provider:)
-          create(:ect_participant_declaration, :extended, declaration_type: "extended-2", cpd_lead_provider:)
-          create(:mentor_participant_declaration, :extended, declaration_type: "extended-3", cpd_lead_provider:)
-        end
-      end
-
-      it "returns correct bands" do
-        extended_keys = %i[
-          band
-          min
-          max
-
-          previous_extended_1_count
-          extended_1_count
-          extended_1_additions
-          extended_1_subtractions
-
-          previous_extended_2_count
-          extended_2_count
-          extended_2_additions
-          extended_2_subtractions
-
-          previous_extended_3_count
-          extended_3_count
-          extended_3_additions
-          extended_3_subtractions
-        ]
-
-        expected = [
-          {
-            band: :a,
-            min: 1,
-            max: 2,
-
-            previous_extended_1_count: 0,
-            extended_1_additions: 1,
-            extended_1_count: 1,
-            extended_1_subtractions: 0,
-
-            previous_extended_2_count: 0,
-            extended_2_additions: 1,
-            extended_2_count: 1,
-            extended_2_subtractions: 0,
-
-            previous_extended_3_count: 0,
-            extended_3_additions: 1,
-            extended_3_count: 1,
-            extended_3_subtractions: 0,
-          },
-          {
-            band: :b,
-            min: 3,
-            max: 4,
-
-            previous_extended_1_count: 0,
-            extended_1_additions: 0,
-            extended_1_count: 0,
-            extended_1_subtractions: 0,
-
-            previous_extended_2_count: 0,
-            extended_2_additions: 0,
-            extended_2_count: 0,
-            extended_2_subtractions: 0,
-
-            previous_extended_3_count: 0,
-            extended_3_additions: 0,
-            extended_3_count: 0,
-            extended_3_subtractions: 0,
-          },
-          {
-            band: :c,
-            min: 5,
-            max: 6,
-
-            previous_extended_1_count: 0,
-            extended_1_additions: 0,
-            extended_1_count: 0,
-            extended_1_subtractions: 0,
-
-            previous_extended_2_count: 0,
-            extended_2_additions: 0,
-            extended_2_count: 0,
-            extended_2_subtractions: 0,
-
-            previous_extended_3_count: 0,
-            extended_3_additions: 0,
-            extended_3_count: 0,
-            extended_3_subtractions: 0,
-          },
-          {
-            band: :d,
-            min: 7,
-            max: 8,
-
-            previous_extended_1_count: 0,
-            extended_1_additions: 0,
-            extended_1_count: 0,
-            extended_1_subtractions: 0,
-
-            previous_extended_2_count: 0,
-            extended_2_additions: 0,
-            extended_2_count: 0,
-            extended_2_subtractions: 0,
-
-            previous_extended_3_count: 0,
-            extended_3_additions: 0,
-            extended_3_count: 0,
-            extended_3_subtractions: 0,
-          },
-        ]
-
-        expect(first_statement_calc.banding_breakdown.map { |e| e.slice(*extended_keys) }).to eql(expected)
+      it "returns correct uplifts" do
+        expect(first_statement_calc.uplift_breakdown).to eql(statement_one_expectation)
+        expect(second_statement_calc.uplift_breakdown).to eql(statement_two_expectation)
+        expect(third_statement_calc.uplift_breakdown).to eql(statement_three_expectation)
       end
     end
   end

--- a/spec/services/finance/ecf/statement_calculator_spec.rb
+++ b/spec/services/finance/ecf/statement_calculator_spec.rb
@@ -2,25 +2,15 @@
 
 RSpec.describe Finance::ECF::StatementCalculator, mid_cohort: true do
   it_behaves_like "a Finance ECF statement calculator" do
-    describe "#total" do
-      let(:uplift_breakdown) do
-        {
-          previous_count: 0,
-          count: 2,
-          additions: 4,
-          subtractions: 2,
-        }
-      end
-      let(:output_calculator) { instance_double("Finance::ECF::OutputCalculator", uplift_breakdown:, banding_breakdown: []) }
+    describe "#output_calculator" do
+      let(:output_calculator) { subject.send(:output_calculator) }
 
-      before do
-        allow(Finance::ECF::OutputCalculator).to receive(:new).with(statement:).and_return(output_calculator)
+      it "delegates to the correct OutputCalculator" do
+        expect(output_calculator.class).to eq(Finance::ECF::OutputCalculator)
       end
 
-      it "calls OutputCalculator with correct params" do
-        subject.total
-
-        expect(Finance::ECF::OutputCalculator).to have_received(:new).with(statement:)
+      it "delegates to the correct BandingCalculator" do
+        expect(output_calculator.banding_for(declaration_type: "started").class).to eq(Finance::ECF::BandingCalculator)
       end
     end
 

--- a/spec/services/finance/ecf/statement_calculator_spec.rb
+++ b/spec/services/finance/ecf/statement_calculator_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Finance::ECF::StatementCalculator, mid_cohort: true do
       it { expect(subject.clawed_back_count).to eql(7) }
     end
 
-    describe "#voided_declarations" do
+    describe "#voided_count" do
       before do
         create_declarations(:ect_participant_declaration, :voided, 5)
         create_declarations(:mentor_participant_declaration, :voided, 5)
@@ -43,7 +43,6 @@ RSpec.describe Finance::ECF::StatementCalculator, mid_cohort: true do
 
       it "returns all voided declarations" do
         expect(subject.voided_count).to eql(10)
-        expect(subject.voided_declarations).to all(be_voided)
       end
     end
   end

--- a/spec/support/shared_examples/finance_statement_calculators_support.rb
+++ b/spec/support/shared_examples/finance_statement_calculators_support.rb
@@ -27,8 +27,10 @@ RSpec.shared_examples "a Finance ECF statement calculator", mid_cohort: true do
   before do
     # Mock banding calculator with mocked methods
     if defined?(mock_bandings)
+      banding_calculator_klass = described_class.module_parent::BandingCalculator
+
       declaration_types.each do |declaration_type|
-        mock_banding = instance_double(Finance::ECF::BandingCalculator)
+        mock_banding = instance_double(banding_calculator_klass)
         %i[previous_count count additions subtractions].each do |action|
           dec_values = mock_bandings[declaration_type] || {}
           action_values = dec_values[action] || {}
@@ -40,7 +42,7 @@ RSpec.shared_examples "a Finance ECF statement calculator", mid_cohort: true do
           end
         end
 
-        allow(Finance::ECF::BandingCalculator).to receive(:new)
+        expect(banding_calculator_klass).to receive(:new)
           .with(statement:, declaration_type:)
           .and_return(mock_banding)
       end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-4019

### Changes proposed in this pull request

* New `BandingCalculator` for ECF and ECT
* Output calculators updated to use `BandingCalculator`
* Some refactoring to maintain consistency between ECF, ECT and Mentor output calculators
* Most of the calculation tests moved to banding calculator spec
* Output and statement calculators refactored and simplified

### Guidance to review

