### PR TITLE
Support tagging in release notes

### DIFF
--- a/docs/config.rb
+++ b/docs/config.rb
@@ -3,6 +3,7 @@
 require "govuk_tech_docs"
 require "lib/govuk_tech_docs/table_of_contents/custom_helpers"
 require "lib/govuk_tech_docs/open_api/extension"
+require "lib/markdown_renderer"
 
 GovukTechDocs.configure(self)
 
@@ -15,6 +16,15 @@ activate :open_api
 set :css_dir, "api-reference/stylesheets"
 set :js_dir, "api-reference/javascripts"
 set :images_dir, "api-reference/javascripts"
+set :markdown,
+    renderer: MarkdownRenderer.new(
+      with_toc_data: true,
+      api: true,
+      context: self,
+    ),
+    fenced_code_blocks: true,
+    tables: true,
+    no_intra_emphasis: true
 
 set :relative_links, true
 

--- a/docs/lib/markdown_renderer.rb
+++ b/docs/lib/markdown_renderer.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class MarkdownRenderer < GovukTechDocs::TechDocsHTMLRenderer
+  class UnknownTagError < StandardError; end
+
+  # Expects tags in the format: [#tag-1 #tag-2 #tag-3]
+  INDIVIDUAL_TAG_PATTERN = /#([\w-]+)/
+  TAGS_PATTEN = /\[(#{INDIVIDUAL_TAG_PATTERN}(?:\s+#{INDIVIDUAL_TAG_PATTERN})*)\]/
+
+  TAG_MAPPINGS = {
+    "breaking-change" => "red",
+    "new-feature" => "green",
+    "bug-fix" => "yellow",
+    "new-field" => "turquoise",
+    "data-update" => "blue",
+    "contract-closure" => "orange",
+    "new-course" => "pink",
+    "production-release" => "purple",
+    "sandbox-release" => "grey",
+  }.freeze
+
+  def preprocess(document)
+    document.gsub(TAGS_PATTEN) do
+      tags = Regexp.last_match(1).scan(INDIVIDUAL_TAG_PATTERN).flatten.map(&:downcase)
+      sorted_tags = tags.sort_by { |tag| TAG_MAPPINGS.keys.index(tag) }
+      %(<div class="tag-group">#{sorted_tags.map { |tag| render_tag(tag) }.join}</div>)
+    end
+  end
+
+private
+
+  def render_tag(tag)
+    color = TAG_MAPPINGS[tag] or raise UnknownTagError, "Tag not recognised: #{tag}"
+    text = tag.gsub("-", " ")
+
+    "<strong class=\"govuk-tag govuk-tag--#{color}\">#{text}</strong>"
+  end
+end

--- a/docs/source/api-reference/stylesheets/screen.css.scss
+++ b/docs/source/api-reference/stylesheets/screen.css.scss
@@ -14,6 +14,17 @@ $govuk-assets-path: "/api-reference/assets/govuk/assets/";
   padding: 3px 0;
 }
 
+body.release-notes .technical-documentation {
+  .tag-group {
+    margin: -22px 0 22px 0;
+  
+    .govuk-tag {
+      font-size: 0.8em;
+      margin: 0 10px 8px 0;
+    }
+  }
+}
+
 @include govuk-media-query(desktop) {
   .flexbox {
     .app-pane__toc {

--- a/docs/source/layouts/custom_core.erb
+++ b/docs/source/layouts/custom_core.erb
@@ -23,7 +23,7 @@
     <%= yield_content :head %>
   </head>
 
-  <body class="govuk-template__body">
+  <body class="govuk-template__body <%= current_page.data.title.parameterize %>">
     <div class="app-pane">
       <div class="app-pane__header toc-open-disabled">
         <a href="#content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>

--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -9,6 +9,8 @@ If you have any questions or comments about these notes, please contact DfE via 
 
 ## 19 February 2025
 
+[#new-feature #sandbox-release]
+
 We’ve added the schedules and contract data for the 2025/26 intake of early career teachers (ECTs) and mentors to the test (sandbox) environment.
 
 Lead providers can either add participants via the ECF interface or by using the seed data we’ve created. This will allow them to test the full end-to-end process and ensure smooth integration for any upcoming changes.
@@ -38,6 +40,8 @@ This is because there’ll only be 2 mentor declarations from the 2025/26 academ
 These changes align with the updated frameworks and payment guidelines shared with lead providers.
 
 ## 8 January 2025
+
+[#bug-fix]
 
 Lead providers getting participant declarations via the API endpoints will now see previous declarations attached to completed participants rather than just active participants.
 

--- a/docs/spec/lib/markdown_renderer_spec.rb
+++ b/docs/spec/lib/markdown_renderer_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "markdown_renderer"
+
+RSpec.describe MarkdownRenderer, type: :model do
+  let(:context) { instance_double("Middleman::ConfigContext", app: nil) }
+
+  let(:instance) { described_class.new(context:) }
+
+  describe "#preprocess" do
+    subject(:preprocess) { instance.preprocess(document) }
+
+    described_class::TAG_MAPPINGS.each do |tag, color|
+      context "when the document contains a #{tag} tag" do
+        let(:document) { "[##{tag}]" }
+        let(:expected_text) { tag.gsub("-", " ") }
+
+        it { is_expected.to eq(%(<div class="tag-group"><strong class="govuk-tag govuk-tag--#{color}">#{expected_text}</strong></div>)) }
+      end
+    end
+
+    context "when the document contains an unknown tag" do
+      let(:document) { "[#unknown-tag]" }
+
+      it { expect { preprocess }.to raise_error(described_class::UnknownTagError, "Tag not recognised: unknown-tag") }
+    end
+
+    context "when the tags are malformed (missing hash)" do
+      let(:document) { "[#new feature]" }
+
+      it { is_expected.to eq(document) }
+    end
+
+    context "when the tags are malformed (leading/trailing white space)" do
+      let(:document) { "[ #new-feature ]" }
+
+      it { is_expected.to eq(document) }
+    end
+
+    context "when the tags are in a different case" do
+      let(:document) { "[#NeW-FeAtUrE]" }
+
+      it { is_expected.to eq(%(<div class="tag-group"><strong class="govuk-tag govuk-tag--green">new feature</strong></div>)) }
+    end
+
+    context "when there are multiple sets of tags" do
+      let(:document) { "[#new-feature][#bug-fix]" }
+
+      it { is_expected.to eq(%(<div class="tag-group"><strong class="govuk-tag govuk-tag--green">new feature</strong></div><div class="tag-group"><strong class="govuk-tag govuk-tag--yellow">bug fix</strong></div>)) }
+    end
+
+    context "when there are multiple tags in the same group" do
+      let(:document) { "[#new-feature #bug-fix]" }
+
+      it { is_expected.to eq(%(<div class="tag-group"><strong class="govuk-tag govuk-tag--green">new feature</strong><strong class="govuk-tag govuk-tag--yellow">bug fix</strong></div>)) }
+    end
+
+    context "when there is other content mixed in with tags" do
+      let(:document) { "[#bug-fix] [link](http://link.com)" }
+
+      it { is_expected.to eq(%(<div class="tag-group"><strong class="govuk-tag govuk-tag--yellow">bug fix</strong></div> [link](http://link.com))) }
+    end
+
+    context "when the document contains multiple tags" do
+      let(:tags) { described_class::TAG_MAPPINGS.keys.map { |key| "##{key}" } }
+      let(:document) { "[#{tags.shuffle.join(' ')}]" }
+      let(:rendered_tag_regex) { />([\w\s]+)</ }
+
+      it "renders the tags in the correct order" do
+        rendered_tags = preprocess.scan(rendered_tag_regex).flatten.map(&:parameterize)
+
+        expect(rendered_tags).to eq(described_class::TAG_MAPPINGS.keys)
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Jira-4076](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-4076)

### Context

We want the ability to tag release notes so that providers can easily distinguish the type of change being released.

### Changes proposed in this pull request

- Support tagging in release notes

Add custom `MarkdownRenderer` that can interpret our tag syntax, for example: `[#tag-1 #tag-2]`.

Update Middleman config to use our custom markdown rendering.

Add CSS for slightly smaller govuk-style tags.

Add page title to body class so that we can easily add targetted CWSS.

Update latest release notes with tags.

### Guidance to review

Example of all tags (review app only has tags on the latest two release notes, as per the ticket):

<img width="1342" alt="Screenshot 2025-02-27 at 10 55 09" src="https://github.com/user-attachments/assets/df07e58a-cf32-498c-b7b6-23dcd363f0ca" />

