### PR TITLE
Use correct serializer on v2 POST declarations endpoint

### DIFF
--- a/app/controllers/api/v1/participant_declarations_controller.rb
+++ b/app/controllers/api/v1/participant_declarations_controller.rb
@@ -15,7 +15,7 @@ module Api
 
         log_schema_validation_results
 
-        render_from_service(service, ParticipantDeclarationSerializer)
+        render_from_service(service, serializer_class)
       end
 
       def index

--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -7,6 +7,20 @@ weight: 8
 
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
 
+## 3 March 2025
+
+[#bug-fix]
+
+We’ve resolved an issue in the API where a v2 declaration endpoint was inadvertently serving the v1 schema.
+
+The fix updates the ``POST`` action to use the correct v2 schema.
+
+The following declaration endpoint has been updated:
+
+- ``POST participant-declarations``
+
+All endpoints now conform to the v2 schema specifications.
+
 ## 19 February 2025
 
 [#new-feature #sandbox-release]


### PR DESCRIPTION
> ⚠️ depends on #5575 being merged for the release note tag to work

[Jira-3728](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-3728)

### Context

We pass an explicit v1 serializer on the create action for declarations which is inherited in the v2 controller. For other actions we override with the `serializer_class` hook. This results in the wrong data being returned for the v2 create declarations endpoint.

### Changes proposed in this pull request

- Use correct serializer on v2 POST declarations endpoint

Ensure correct serializer is used in v2 create declarations action.

Add test coverage to prevent this kind of regression in the future.

### Guidance to review

