### PR TITLE
Add `voided_at` and `voided_by_user` to `ParticipantDeclaration`

### DIFF
--- a/app/models/participant_declaration.rb
+++ b/app/models/participant_declaration.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ParticipantDeclaration < ApplicationRecord
-  self.ignored_columns = %w[statement_type statement_id voided_at temp_type]
+  self.ignored_columns = %w[statement_type statement_id temp_type]
 
   ARCHIVABLE_STATES = %w[ineligible voided submitted].freeze
 
@@ -12,6 +12,7 @@ class ParticipantDeclaration < ApplicationRecord
   belongs_to :superseded_by, class_name: "ParticipantDeclaration", optional: true
   belongs_to :delivery_partner, optional: true
   belongs_to :mentor_user, class_name: "User", optional: true
+  belongs_to :voided_by_user, class_name: "User", optional: true
 
   has_many :declaration_states
   has_many :participant_declaration_attempts, dependent: :destroy
@@ -45,6 +46,8 @@ class ParticipantDeclaration < ApplicationRecord
   delegate :fundable?, to: :participant_profile, allow_nil: true
 
   validates :course_identifier, :user, :cpd_lead_provider, :declaration_date, :declaration_type, :cohort, presence: true
+  validates :voided_by_user, presence: true, if: :voided_at
+  validates :voided_at, presence: true, if: :voided_by_user
 
   scope :for_lead_provider, ->(cpd_lead_provider) { where(cpd_lead_provider:) }
   scope :for_declaration, ->(declaration_type) { where(declaration_type:) }

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -72,6 +72,8 @@
   - delivery_partner_id
   - mentor_user_id
   - cohort_id
+  - voided_at
+  - voided_by_user_id
   :induction_records:
   - id
   - induction_programme_id

--- a/db/migrate/20250228133019_add_voided_by_and_voided_at_to_participant_declarations.rb
+++ b/db/migrate/20250228133019_add_voided_by_and_voided_at_to_participant_declarations.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddVoidedByAndVoidedAtToParticipantDeclarations < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_column :participant_declarations, :voided_at, :datetime
+    add_reference :participant_declarations, :voided_by_user, null: true, index: { algorithm: :concurrently }
+  end
+end

--- a/db/migrate/20250228135355_add_voided_by_user_foreign_key_to_participant_declarations.rb
+++ b/db/migrate/20250228135355_add_voided_by_user_foreign_key_to_participant_declarations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddVoidedByUserForeignKeyToParticipantDeclarations < ActiveRecord::Migration[7.1]
+  def change
+    add_foreign_key :participant_declarations, :users, column: :voided_by_user_id, validate: false
+  end
+end

--- a/db/migrate/20250228135429_validate_participant_declarations_voided_by_user_foreign_key.rb
+++ b/db/migrate/20250228135429_validate_participant_declarations_voided_by_user_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateParticipantDeclarationsVoidedByUserForeignKey < ActiveRecord::Migration[7.1]
+  def change
+    validate_foreign_key :participant_declarations, :users, column: :voided_by_user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_02_11_191336) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_28_135429) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -755,6 +755,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_11_191336) do
     t.uuid "delivery_partner_id"
     t.uuid "mentor_user_id"
     t.uuid "cohort_id", null: false
+    t.datetime "voided_at"
+    t.uuid "voided_by_user_id"
     t.index ["cohort_id"], name: "index_participant_declarations_on_cohort_id"
     t.index ["cpd_lead_provider_id", "participant_profile_id", "declaration_type", "course_identifier", "state"], name: "unique_declaration_index", unique: true, where: "((state)::text = ANY (ARRAY[('submitted'::character varying)::text, ('eligible'::character varying)::text, ('payable'::character varying)::text, ('paid'::character varying)::text]))"
     t.index ["cpd_lead_provider_id"], name: "index_participant_declarations_on_cpd_lead_provider_id"
@@ -765,6 +767,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_11_191336) do
     t.index ["superseded_by_id"], name: "superseded_by_index"
     t.index ["type"], name: "index_participant_declarations_on_type"
     t.index ["user_id"], name: "index_participant_declarations_on_user_id"
+    t.index ["voided_by_user_id"], name: "index_participant_declarations_on_voided_by_user_id"
   end
 
   create_table "participant_id_changes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1237,6 +1240,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_11_191336) do
   add_foreign_key "participant_declarations", "participant_profiles"
   add_foreign_key "participant_declarations", "users"
   add_foreign_key "participant_declarations", "users", column: "mentor_user_id"
+  add_foreign_key "participant_declarations", "users", column: "voided_by_user_id"
   add_foreign_key "participant_id_changes", "users"
   add_foreign_key "participant_identities", "users"
   add_foreign_key "participant_profile_completion_date_inconsistencies", "participant_profiles"

--- a/spec/models/participant_declaration_spec.rb
+++ b/spec/models/participant_declaration_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe ParticipantDeclaration, type: :model do
     it { is_expected.to belong_to(:participant_profile) }
     it { is_expected.to have_many(:declaration_states) }
     it { is_expected.to belong_to(:mentor_user).class_name("User").optional }
+    it { is_expected.to belong_to(:voided_by_user).class_name("User").optional }
     it { is_expected.to belong_to(:cohort) }
   end
 
@@ -22,6 +23,21 @@ RSpec.describe ParticipantDeclaration, type: :model do
     it { is_expected.to validate_presence_of(:declaration_date) }
     it { is_expected.to validate_presence_of(:declaration_type) }
     it { is_expected.to validate_presence_of(:cohort) }
+
+    it { is_expected.not_to validate_presence_of(:voided_at) }
+    it { is_expected.not_to validate_presence_of(:voided_by_user) }
+
+    context "when voided_at is present" do
+      before { subject.voided_at = Time.zone.now }
+
+      it { is_expected.to validate_presence_of(:voided_by_user) }
+    end
+
+    context "when voided_by_user is present" do
+      before { subject.voided_by_user = build(:user) }
+
+      it { is_expected.to validate_presence_of(:voided_at) }
+    end
   end
 
   describe "state transitions" do


### PR DESCRIPTION
[Jira-4084](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-4084)

### Context

We want to maintain a record of who voided a declaration when it happens through the user interface.

### Changes proposed in this pull request

- Add `voided_at` and `voided_by_user` to `ParticipantDeclaration` 

These will be `nil` when a lead provider has voided the declaration via the API.

### Guidance to review

The `voided_at` column appears to have been part of the model years ago, which is why it was later ignored - see #2320 - reversing that change here as we re-introduce it.