### PR TITLE
Update `VoidParticipantDeclaration` to support `voided_by_user`

### DIFF
--- a/app/controllers/api/v1/participant_declarations_controller.rb
+++ b/app/controllers/api/v1/participant_declarations_controller.rb
@@ -37,7 +37,7 @@ module Api
       end
 
       def void
-        render json: serializer_class.new(VoidParticipantDeclaration.new(participant_declaration_for_lead_provider).call).serializable_hash.to_json
+        render json: serializer_class.new(VoidParticipantDeclaration.new(participant_declaration_for_lead_provider, voided_by_user: nil).call).serializable_hash.to_json
       end
 
     private

--- a/app/controllers/api/v3/participant_declarations_controller.rb
+++ b/app/controllers/api/v3/participant_declarations_controller.rb
@@ -41,7 +41,7 @@ module Api
       # PUT /api/v3/participant-declarations/:id/void
       #
       def void
-        render json: serializer_class.new(VoidParticipantDeclaration.new(participant_declaration_for_lead_provider).call).serializable_hash.to_json
+        render json: serializer_class.new(VoidParticipantDeclaration.new(participant_declaration_for_lead_provider, voided_by_user: nil).call).serializable_hash.to_json
       end
 
     private

--- a/app/services/importers/clawbacks.rb
+++ b/app/services/importers/clawbacks.rb
@@ -25,7 +25,7 @@ module Importers
           next
         end
 
-        service = Finance::ClawbackDeclaration.new(participant_declaration:)
+        service = Finance::ClawbackDeclaration.new(participant_declaration, voided_by_user: nil)
 
         begin
           service.call

--- a/lib/participant_profile_deduplicator.rb
+++ b/lib/participant_profile_deduplicator.rb
@@ -233,7 +233,7 @@ private
     return unless declaration.voidable? || declaration.paid?
 
     record_info("Voided declaration: #{declaration.declaration_type}, #{declaration.state} (#{declaration.id}).")
-    VoidParticipantDeclaration.new(declaration).call
+    VoidParticipantDeclaration.new(declaration, voided_by_user: nil).call
   end
 
   def conflicting_declaration(declaration)

--- a/spec/factories/participant_declaration.rb
+++ b/spec/factories/participant_declaration.rb
@@ -83,7 +83,7 @@ FactoryBot.define do
 
     trait :voided do
       after(:create) do |participant_declaration|
-        VoidParticipantDeclaration.new(participant_declaration).call
+        VoidParticipantDeclaration.new(participant_declaration, voided_by_user: nil).call
         participant_declaration.reload
       end
     end
@@ -119,7 +119,7 @@ FactoryBot.define do
           cohort: participant_declaration.cohort
         )
 
-        service = Finance::ClawbackDeclaration.new(participant_declaration)
+        service = Finance::ClawbackDeclaration.new(participant_declaration, voided_by_user: nil)
         raise ArgumentError, service.errors.full_messages unless service.valid?
 
         service.call

--- a/spec/services/finance/ecf/banding_calculator_spec.rb
+++ b/spec/services/finance/ecf/banding_calculator_spec.rb
@@ -310,7 +310,7 @@ RSpec.describe Finance::ECF::BandingCalculator do
           # Create clawbacks for this month statement from declarations 1 month ago
           travel_to statement.deadline_date - 1.day do
             declarations_one_month_ago.sample(2).each do |dec|
-              Finance::ClawbackDeclaration.new(dec.reload).call
+              Finance::ClawbackDeclaration.new(dec.reload, voided_by_user: nil).call
             end
           end
         end
@@ -365,7 +365,7 @@ RSpec.describe Finance::ECF::BandingCalculator do
           travel_to statement.deadline_date - 1.day do
             # Create clawbacks for this month statement from declarations 1 month ago
             declarations_one_month_ago.sample(2).each do |dec|
-              Finance::ClawbackDeclaration.new(dec.reload).call
+              Finance::ClawbackDeclaration.new(dec.reload, voided_by_user: nil).call
             end
 
             # Create declarations for this month statement
@@ -426,7 +426,7 @@ RSpec.describe Finance::ECF::BandingCalculator do
           declarations_one_month_ago
           # Create 1 clawback for statement 1 month ago from declarations 2 months ago
           travel_to statement_one_month_ago.deadline_date - 1.day do
-            Finance::ClawbackDeclaration.new(declarations_two_months_ago[0].reload).call
+            Finance::ClawbackDeclaration.new(declarations_two_months_ago[0].reload, voided_by_user: nil).call
           end
           # Mark statement 1 months ago as paid
           Statements::MarkAsPayable.new(statement_one_month_ago).call
@@ -438,10 +438,10 @@ RSpec.describe Finance::ECF::BandingCalculator do
             create_list(:mentor_participant_declaration, 2, :eligible, cpd_lead_provider:, declaration_type:)
 
             # Create 1 clawback for this month statement from declarations 2 months ago
-            Finance::ClawbackDeclaration.new(declarations_two_months_ago[1].reload).call
+            Finance::ClawbackDeclaration.new(declarations_two_months_ago[1].reload, voided_by_user: nil).call
 
             # Create 1 clawback for this month statement from declarations 1 month ago
-            Finance::ClawbackDeclaration.new(declarations_one_month_ago[0].reload).call
+            Finance::ClawbackDeclaration.new(declarations_one_month_ago[0].reload, voided_by_user: nil).call
           end
         end
 
@@ -524,7 +524,7 @@ RSpec.describe Finance::ECF::BandingCalculator do
 
           travel_to statement_one_month_ago.deadline_date - 1.day do
             # Create clawback for statement 1 month ago for participant_declaration
-            Finance::ClawbackDeclaration.new(participant_declaration.reload).call
+            Finance::ClawbackDeclaration.new(participant_declaration.reload, voided_by_user: nil).call
 
             # Mark statement 1 month ago as paid
             Statements::MarkAsPayable.new(statement_one_month_ago).call

--- a/spec/services/finance/ecf/ect/banding_calculator_spec.rb
+++ b/spec/services/finance/ecf/ect/banding_calculator_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Finance::ECF::ECT::BandingCalculator do
       # Create clawbacks for statement 1 month ago from declarations 2 months ago
       travel_to statement_one_month_ago.deadline_date - 1.day do
         declarations.each do |dec|
-          Finance::ClawbackDeclaration.new(dec.reload).call
+          Finance::ClawbackDeclaration.new(dec.reload, voided_by_user: nil).call
         end
       end
       # Mark statement 1 months ago as paid
@@ -97,7 +97,7 @@ RSpec.describe Finance::ECF::ECT::BandingCalculator do
       # Create clawbacks for statement 1 month ago from declarations 2 months ago
       travel_to statement_one_month_ago.deadline_date - 1.day do
         declarations.each do |dec|
-          Finance::ClawbackDeclaration.new(dec.reload).call
+          Finance::ClawbackDeclaration.new(dec.reload, voided_by_user: nil).call
         end
       end
 
@@ -119,7 +119,7 @@ RSpec.describe Finance::ECF::ECT::BandingCalculator do
 
         # Create clawbacks for this month statement from declarations 1 month ago
         declarations.each do |dec|
-          Finance::ClawbackDeclaration.new(dec.reload).call
+          Finance::ClawbackDeclaration.new(dec.reload, voided_by_user: nil).call
         end
       end
     end

--- a/spec/services/finance/ecf/mentor/output_calculator_spec.rb
+++ b/spec/services/finance/ecf/mentor/output_calculator_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe Finance::ECF::Mentor::OutputCalculator, mid_cohort: true do
 
       before do
         travel_to second_statement.deadline_date do
-          Finance::ClawbackDeclaration.new(participant_declaration.reload).call
+          Finance::ClawbackDeclaration.new(participant_declaration.reload, voided_by_user: nil).call
         end
 
         participant_declaration.clawed_back!

--- a/spec/services/importers/clawbacks_spec.rb
+++ b/spec/services/importers/clawbacks_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Importers::Clawbacks do
       end
 
       it "delegates to service class" do
-        expect(Finance::ClawbackDeclaration).to receive(:new).with(participant_declaration:).and_return(mock_service)
+        expect(Finance::ClawbackDeclaration).to receive(:new).with(participant_declaration, voided_by_user: nil).and_return(mock_service)
 
         subject.call
 

--- a/spec/services/record_declaration_spec.rb
+++ b/spec/services/record_declaration_spec.rb
@@ -613,7 +613,7 @@ RSpec.describe RecordDeclaration do
       service = ParticipantDeclarations::MarkAsPaid.new(statement)
       service.call(participant_declaration)
 
-      Finance::ClawbackDeclaration.new(participant_declaration).call
+      Finance::ClawbackDeclaration.new(participant_declaration, voided_by_user: nil).call
 
       params[:declaration_date] = (declaration_date + 1.second).rfc3339
 

--- a/spec/services/statements/mark_as_paid_spec.rb
+++ b/spec/services/statements/mark_as_paid_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Statements::MarkAsPaid do
 
     travel_to statement.deadline_date - 1.day do
       create(:ect_participant_declaration, :eligible, cpd_lead_provider:)
-      VoidParticipantDeclaration.new(create(:ect_participant_declaration, :eligible, cpd_lead_provider:)).call
+      VoidParticipantDeclaration.new(create(:ect_participant_declaration, :eligible, cpd_lead_provider:), voided_by_user: nil).call
     end
 
     Statements::MarkAsPayable.new(statement).call


### PR DESCRIPTION
> ⚠️ depends on #5580

### Context

When we void a declaration manually via the admin interface we want to track the user that performed the void and the time that it was voided. 

### Changes proposed in this pull request

- Update `VoidParticipantDeclaration` to support `voided_by_user`

We have `voided_at` and `voided_by_user` as attributes on the `ParticipantDeclaration` model that we can use.

Add a `voided_by_user` required parameter to the `VoidParticipantDeclaration` service initializer and update current usage of the service to pass `nil` (to retain current behaviour).

When we come to expose this in the admin interface we can pass the currently signed in user. If a user is provided we will populated `voided_by_user` and set `voided_at` to the current time.

### Guidance to review

In the ticket and during our discussion we agreed to wrap this in a form object model, but on implementing it I don't think this is worthwhile. When we come to expose this in the front end we're not going to be sending any data from the browser and having an extra form model will just create confusion (if we forgot to use this model in the console we would end up losing the voided by user details).

By keeping it in the `VoidParticipantDeclaration` service it means we only have a single service/point of use and we can call this service from the action that processes the web link, passing in the `current_user`.

I thought about extracting the `track_voiding_user` and its tests to a concern/shared context, but decided it was probably more hassle than its worth.