### PR TITLE
[CPDLP-4054] Relax Content Security Policy in the app

### DIFF
--- a/app/controllers/concerns/relaxed_content_security_policy.rb
+++ b/app/controllers/concerns/relaxed_content_security_policy.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module RelaxedContentSecurityPolicy
+  extend ActiveSupport::Concern
+
+  included do
+    include ActionController::ContentSecurityPolicy
+
+    # More relaxad policy specific for some pages that requires inline javascripts to run
+    content_security_policy do |policy|
+      script_src = policy.script_src || %i[self]
+      policy.script_src_elem(*script_src.concat(["'unsafe-inline'"]))
+      policy.script_src_attr(*script_src.concat(["'unsafe-inline'"]))
+    end
+  end
+end

--- a/app/controllers/finance/ecf/statements_controller.rb
+++ b/app/controllers/finance/ecf/statements_controller.rb
@@ -3,6 +3,8 @@
 module Finance
   module ECF
     class StatementsController < BaseController
+      include RelaxedContentSecurityPolicy
+
       def show
         @ecf_lead_provider = lead_provider_scope.find(params[:payment_breakdown_id])
         @statement = @ecf_lead_provider.statements.find(params[:id])

--- a/app/controllers/privacy_policies_controller.rb
+++ b/app/controllers/privacy_policies_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class PrivacyPoliciesController < ApplicationController
+  include RelaxedContentSecurityPolicy
+
   skip_before_action :check_privacy_policy_accepted
 
   def show

--- a/app/controllers/schools/cohort_setup_controller.rb
+++ b/app/controllers/schools/cohort_setup_controller.rb
@@ -2,6 +2,8 @@
 
 module Schools
   class CohortSetupController < BaseController
+    include RelaxedContentSecurityPolicy
+
     skip_before_action :redirect_to_setup_cohort
     before_action :initialize_wizard
     before_action :data_check

--- a/app/views/layouts/_width_container.html.erb
+++ b/app/views/layouts/_width_container.html.erb
@@ -46,7 +46,7 @@
 <% if FeatureFlag.active?(:zendesk_widget) %>
   <% if current_user.present? && !Rails.env.test? %>
     <!-- Start of teachercpdhelp Zendesk Widget script -->
-    <script id="ze-snippet" src="https://static.zdassets.com/ekr/snippet.js?key=3544292a-5b38-4f45-bd16-98efeaa11ae9"> </script>
+    <script nonce="<%= content_security_policy_nonce %>" id="ze-snippet" src="https://static.zdassets.com/ekr/snippet.js?key=3544292a-5b38-4f45-bd16-98efeaa11ae9"> </script>
     <!-- End of teachercpdhelp Zendesk Widget script -->
   <% end %>
 <% end %>

--- a/app/views/schools/cohort_setup/appropriate_body.html.erb
+++ b/app/views/schools/cohort_setup/appropriate_body.html.erb
@@ -25,7 +25,7 @@
             <div class="govuk-form-group">
               <h1 class="govuk-label-wrapper">
                 <span class="govuk-caption-l"><%= @wizard.school.name %></span>
-                <label class="govuk-label govuk-label--l" for="whichTSH">
+                <label class="govuk-label govuk-label--l" for="schools-cohorts-setup-wizard-appropriate-body-id-field">
                   <%= title %>
                 </label>
               </h1>
@@ -55,7 +55,7 @@
             <div class="govuk-form-group">
               <h1 class="govuk-label-wrapper">
                 <span class="govuk-caption-l"><%= @wizard.school.name %></span>
-                <label class="govuk-label govuk-label--l" for="whichTSH">
+                <label class="govuk-label govuk-label--l" for="schools-cohorts-setup-wizard-appropriate-body-id-field">
                   Which teaching school hub have you appointed?
                 </label>
               </h1>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -16,10 +16,7 @@ Rails.application.configure do
   gtm_script_src     = %w[https://www.googletagmanager.com/gtm.js https://www.googletagmanager.com/gtag/js]
   gtm_img_src        = %w[https://www.googletagmanager.com/td]
   ga_connect_src     = %w[*.google-analytics.com]
-  zd_script_src      = %w[https://static.zdassets.com/ekr/snippet.js
-                          https://static.zdassets.com/ekr/sentry-browser.min.js
-                          https://ekr.zdassets.com/compose/
-                          https://static.zdassets.com/web_widget/classic/latest/]
+  zd_script_src      = %w[*.zdassets.com]
   sentry_connect_src = %w[*.ingest.sentry.io]
 
   config.content_security_policy do |policy|

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
     policy.font_src(*self_base.concat(data, gfonts_src))
     policy.img_src(*self_base.concat(data, blob, gtm_src))
     policy.object_src :none
-    policy.script_src(*self_base.concat(gtm_src, zd_script_src))
+    policy.script_src(*self_base.concat(gtm_src, zd_script_src, ["'unsafe-eval'"]))
     policy.style_src(*self_base)
     policy.connect_src(*self_base.concat(ga_connect_src, zd_script_src, sentry_connect_src))
     policy.frame_src(*self_base.concat(gtm_src))

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -12,22 +12,22 @@ Rails.application.configure do
   self_base          = %i[self]
   data               = %i[data]
   blob               = %i[blob]
-  gtm_frame_src      = %w[https://www.googletagmanager.com/ns.html]
-  gtm_script_src     = %w[https://www.googletagmanager.com/gtm.js https://www.googletagmanager.com/gtag/js]
-  gtm_img_src        = %w[https://www.googletagmanager.com/td]
+  gtm_src            = %w[*.googletagmanager.com]
   ga_connect_src     = %w[*.google-analytics.com]
   zd_script_src      = %w[*.zdassets.com]
+  gfonts_src         = %w[*.fonts.gstatic.com]
   sentry_connect_src = %w[*.ingest.sentry.io]
 
   config.content_security_policy do |policy|
     policy.default_src(*self_base)
-    policy.font_src(*self_base.concat(data))
-    policy.img_src(*self_base.concat(data, blob, gtm_img_src))
+    policy.font_src(*self_base.concat(data, gfonts_src))
+    policy.img_src(*self_base.concat(data, blob, gtm_src))
     policy.object_src :none
-    policy.script_src(*self_base.concat(gtm_script_src, zd_script_src))
+    policy.script_src(*self_base.concat(gtm_src, zd_script_src))
     policy.style_src(*self_base)
     policy.connect_src(*self_base.concat(ga_connect_src, zd_script_src, sentry_connect_src))
-    policy.frame_src(*self_base.concat(gtm_frame_src))
+    policy.frame_src(*self_base.concat(gtm_src))
+    policy.script_src_elem(*self_base.concat(["'unsafe-inline'"]))
     policy.style_src_elem(*self_base.concat(["'unsafe-inline'"]))
 
     # The report-uri seems to make the feature specs flakey when ran in

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -9,14 +9,17 @@
 Rails.application.configure do
   # Default policy for the application; covers static pages and the
   # admin/finance dashboards.
-  self_base          = %i[self]
-  data               = %i[data]
-  blob               = %i[blob]
-  gtm_frame_src      = %w[https://www.googletagmanager.com/ns.html]
-  gtm_script_src     = %w[https://www.googletagmanager.com/gtm.js https://www.googletagmanager.com/gtag/js]
-  gtm_img_src        = %w[https://www.googletagmanager.com/td]
-  ga_connect_src     = %w[*.google-analytics.com]
-  zd_script_src      = %w[https://static.zdassets.com/ekr/snippet.js]
+  self_base       = %i[self]
+  data            = %i[data]
+  blob            = %i[blob]
+  gtm_frame_src   = %w[https://www.googletagmanager.com/ns.html]
+  gtm_script_src  = %w[https://www.googletagmanager.com/gtm.js https://www.googletagmanager.com/gtag/js]
+  gtm_img_src     = %w[https://www.googletagmanager.com/td]
+  ga_connect_src  = %w[*.google-analytics.com]
+  zd_script_src   = %w[https://static.zdassets.com/ekr/snippet.js
+                       https://static.zdassets.com/ekr/sentry-browser.min.js
+                       https://ekr.zdassets.com/compose/
+                       https://static.zdassets.com/web_widget/classic/latest/]
   sentry_connect_src = %w[*.ingest.sentry.io]
 
   config.content_security_policy do |policy|
@@ -28,6 +31,7 @@ Rails.application.configure do
     policy.style_src(*self_base)
     policy.connect_src(*self_base.concat(ga_connect_src, sentry_connect_src))
     policy.frame_src(*self_base.concat(gtm_frame_src))
+    policy.style_src_elem(*self_base.concat(["'unsafe-inline'"]))
 
     # The report-uri seems to make the feature specs flakey when ran in
     # CI. I'm not sure why - disabling for now.
@@ -39,7 +43,7 @@ Rails.application.configure do
   config.content_security_policy_nonce_directives = %w[script-src style-src]
 
   # Report violations without enforcing the policy.
-  config.content_security_policy_report_only = false
+  # config.content_security_policy_report_only = true
 
   # Security-related HTTP headers.
   config.action_dispatch.default_headers = {

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -39,7 +39,7 @@ Rails.application.configure do
   config.content_security_policy_nonce_directives = %w[script-src style-src]
 
   # Report violations without enforcing the policy.
-  config.content_security_policy_report_only = true
+  config.content_security_policy_report_only = false
 
   # Security-related HTTP headers.
   config.action_dispatch.default_headers = {

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -9,17 +9,17 @@
 Rails.application.configure do
   # Default policy for the application; covers static pages and the
   # admin/finance dashboards.
-  self_base       = %i[self]
-  data            = %i[data]
-  blob            = %i[blob]
-  gtm_frame_src   = %w[https://www.googletagmanager.com/ns.html]
-  gtm_script_src  = %w[https://www.googletagmanager.com/gtm.js https://www.googletagmanager.com/gtag/js]
-  gtm_img_src     = %w[https://www.googletagmanager.com/td]
-  ga_connect_src  = %w[*.google-analytics.com]
-  zd_script_src   = %w[https://static.zdassets.com/ekr/snippet.js
-                       https://static.zdassets.com/ekr/sentry-browser.min.js
-                       https://ekr.zdassets.com/compose/
-                       https://static.zdassets.com/web_widget/classic/latest/]
+  self_base          = %i[self]
+  data               = %i[data]
+  blob               = %i[blob]
+  gtm_frame_src      = %w[https://www.googletagmanager.com/ns.html]
+  gtm_script_src     = %w[https://www.googletagmanager.com/gtm.js https://www.googletagmanager.com/gtag/js]
+  gtm_img_src        = %w[https://www.googletagmanager.com/td]
+  ga_connect_src     = %w[*.google-analytics.com]
+  zd_script_src      = %w[https://static.zdassets.com/ekr/snippet.js
+                          https://static.zdassets.com/ekr/sentry-browser.min.js
+                          https://ekr.zdassets.com/compose/
+                          https://static.zdassets.com/web_widget/classic/latest/]
   sentry_connect_src = %w[*.ingest.sentry.io]
 
   config.content_security_policy do |policy|
@@ -29,7 +29,7 @@ Rails.application.configure do
     policy.object_src :none
     policy.script_src(*self_base.concat(gtm_script_src, zd_script_src))
     policy.style_src(*self_base)
-    policy.connect_src(*self_base.concat(ga_connect_src, sentry_connect_src))
+    policy.connect_src(*self_base.concat(ga_connect_src, zd_script_src, sentry_connect_src))
     policy.frame_src(*self_base.concat(gtm_frame_src))
     policy.style_src_elem(*self_base.concat(["'unsafe-inline'"]))
 

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -27,7 +27,6 @@ Rails.application.configure do
     policy.style_src(*self_base)
     policy.connect_src(*self_base.concat(ga_connect_src, zd_script_src, sentry_connect_src))
     policy.frame_src(*self_base.concat(gtm_src))
-    policy.script_src_elem(*self_base.concat(["'unsafe-inline'"]))
     policy.style_src_elem(*self_base.concat(["'unsafe-inline'"]))
 
     # The report-uri seems to make the feature specs flakey when ran in
@@ -40,7 +39,7 @@ Rails.application.configure do
   config.content_security_policy_nonce_directives = %w[script-src style-src]
 
   # Report violations without enforcing the policy.
-  # config.content_security_policy_report_only = true
+  config.content_security_policy_report_only = true
 
   # Security-related HTTP headers.
   config.action_dispatch.default_headers = {


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-4054](https://dfedigital.atlassian.net/browse/CPDLP-4054)

As part of [this ticket](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-4053) we updated the CSP report-only header for the API and documentation/admin pages.
Now that time has passed with this in production - assuming there are no reported violations in Sentry - we want to enforce the changes by enabling the CSP header.

### Changes proposed in this pull request

- Relax CSP policy;
- The CSP header is being served and matches the report only configuration;

### Guidance to review



[CPDLP-4054]: https://dfedigital.atlassian.net/browse/CPDLP-4054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ