### PR TITLE
Remove sentry url from CSP config

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -9,15 +9,14 @@
 Rails.application.configure do
   # Default policy for the application; covers static pages and the
   # admin/finance dashboards.
-  self_base          = %i[self]
-  data               = %i[data]
-  blob               = %i[blob]
-  gtm_frame_src      = %w[https://www.googletagmanager.com/ns.html]
-  gtm_script_src     = %w[https://www.googletagmanager.com/gtm.js https://www.googletagmanager.com/gtag/js]
-  gtm_img_src        = %w[https://www.googletagmanager.com/td]
-  ga_connect_src     = %w[*.google-analytics.com]
-  zd_script_src      = %w[https://static.zdassets.com/ekr/snippet.js]
-  sentry_connect_src = %w[*.ingest.sentry.io]
+  self_base       = %i[self]
+  data            = %i[data]
+  blob            = %i[blob]
+  gtm_frame_src   = %w[https://www.googletagmanager.com/ns.html]
+  gtm_script_src  = %w[https://www.googletagmanager.com/gtm.js https://www.googletagmanager.com/gtag/js]
+  gtm_img_src     = %w[https://www.googletagmanager.com/td]
+  ga_connect_src  = %w[*.google-analytics.com]
+  zd_script_src   = %w[https://static.zdassets.com/ekr/snippet.js]
 
   config.content_security_policy do |policy|
     policy.default_src(*self_base)
@@ -26,7 +25,7 @@ Rails.application.configure do
     policy.object_src :none
     policy.script_src(*self_base.concat(gtm_script_src, zd_script_src))
     policy.style_src(*self_base)
-    policy.connect_src(*self_base.concat(ga_connect_src, sentry_connect_src))
+    policy.connect_src(*self_base.concat(ga_connect_src))
     policy.frame_src(*self_base.concat(gtm_frame_src))
 
     # The report-uri seems to make the feature specs flakey when ran in


### PR DESCRIPTION
### Context

- Ticket: N/A

PR to rollback changes made in the PR https://github.com/DFE-Digital/early-careers-framework/pull/5586

### Changes proposed in this pull request

- Remove Sentry URL from CSP `connect_src` config;

### Guidance to review


