### PR TITLE
Update to latest ubuntu image as ubuntu 20 has been deprecated

### DIFF
--- a/.github/workflows/refresh_knapsack_manifest.yml
+++ b/.github/workflows/refresh_knapsack_manifest.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   refresh_manifest:
     name: Refresh Knapsack manifest
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     env:
       RAILS_ENV: test

--- a/.github/workflows/refresh_migration_database.yml
+++ b/.github/workflows/refresh_migration_database.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   refresh-migration-db:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/restore_snapshot_database.yml
+++ b/.github/workflows/restore_snapshot_database.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   backup-and-restore-production:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     environment: production
     steps:
       - name: Checkout code

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -113,7 +113,7 @@ jobs:
 
   tests:
     name: Run rspec
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -179,7 +179,7 @@ jobs:
 
   feature-tests:
     name: Run rspec (features)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -265,7 +265,7 @@ jobs:
   e2e-scenarios:
     if: ${{ inputs.run-end-to-end-tests }}
     name: Run end to end scenarios
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -314,7 +314,7 @@ jobs:
 
   sonar-scanner:
     name: Sonar Scanner
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: [ tests, feature-tests, ruby-linting ]
     if: github.ref != 'refs/heads/main' && github.actor != 'dependabot[bot]'
     permissions:


### PR DESCRIPTION

### Context

Ubuntu 20 image has been deprecated https://github.com/actions/runner-images/issues/11101 this is causing failures on our workflows as they use a mix of latest and different versions

- Ticket: n/a

### Changes proposed in this pull request
Update all workflow ubuntu images to latest to avoid failures


### Guidance to review
thanks @mooktakim for finding the issue and @leandroalemao for flagging :)
