### PR TITLE
Enable voiding of declarations via the finance dashboard

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -63,3 +63,8 @@ $govuk-new-link-styles: true;
 .govuk-summary-list__key--align-top {
   vertical-align: top;
 }
+
+.govuk-error-summary__list li {
+  color: #d4351c;
+  font-weight: bold;
+}

--- a/app/controllers/admin/participants/change_name_controller.rb
+++ b/app/controllers/admin/participants/change_name_controller.rb
@@ -28,7 +28,7 @@ module Admin::Participants
 
     def check_gai_status
       if @participant_profile.user.get_an_identity_id.present?
-        flash[:alert] = "Get an Identity registered users must change their names via the Get an Identity service."
+        set_alert_message(content: "Get an Identity registered users must change their names via the Get an Identity service.")
 
         redirect_to admin_participants_path
       end

--- a/app/controllers/admin/participants/induction_records_controller.rb
+++ b/app/controllers/admin/participants/induction_records_controller.rb
@@ -44,7 +44,7 @@ module Admin::Participants
         set_success_message(heading: "The induction records has been updated")
         redirect_to admin_participant_school_path(@participant_profile)
       else
-        flash.now[:alert] = "The induction records could not be updated"
+        set_alert_message(content: "The induction records could not be updated", now: true)
         render "admin/participants/induction_records/edit_training_status"
       end
     end

--- a/app/controllers/admin/participants/school_transfer_controller.rb
+++ b/app/controllers/admin/participants/school_transfer_controller.rb
@@ -77,7 +77,7 @@ module Admin::Participants
     def handle_form_error(error)
       clear_session_data
       Sentry.capture_exception(error)
-      flash[:alert] = "There was a problem processing your request. If this problem persists please contact an administrator."
+      set_alert_message(content: "There was a problem processing your request. If this problem persists please contact an administrator.")
       redirect_to admin_participants_path
     end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -51,6 +51,14 @@ private
     flash[:notice] = { title:, heading:, content: }
   end
 
+  def set_alert_message(title: "There is a problem", content: "", now: false)
+    if now
+      flash.now[:alert] = { title:, content: }
+    else
+      flash[:alert] = { title:, content: }
+    end
+  end
+
 protected
 
   def release_version

--- a/app/controllers/finance/ecf/participant_declarations/void_controller.rb
+++ b/app/controllers/finance/ecf/participant_declarations/void_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Finance
+  module ECF
+    module ParticipantDeclarations
+      class VoidController < BaseController
+        before_action :set_participant_profile_and_declaration
+
+        def new; end
+
+        def create
+          VoidParticipantDeclaration.new(@declaration, voided_by_user: current_user).call
+          set_success_message(**I18n.t("finance.void_declaration.success"))
+        rescue Api::Errors::InvalidTransitionError
+          set_important_message(**I18n.t("finance.void_declaration.failure"))
+        ensure
+          redirect_to finance_participant_path(@participant_profile.user)
+        end
+
+      private
+
+        def set_participant_profile_and_declaration
+          @participant_profile = ParticipantProfile.find(params[:participant_profile_id])
+          @declaration = @participant_profile.participant_declarations.includes(:cpd_lead_provider).find(params[:participant_declaration_id])
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/finance/ecf/participant_declarations/void_controller.rb
+++ b/app/controllers/finance/ecf/participant_declarations/void_controller.rb
@@ -12,7 +12,7 @@ module Finance
           VoidParticipantDeclaration.new(@declaration, voided_by_user: current_user).call
           set_success_message(**I18n.t("finance.void_declaration.success"))
         rescue Api::Errors::InvalidTransitionError
-          set_important_message(**I18n.t("finance.void_declaration.failure"))
+          set_alert_message(**I18n.t("finance.void_declaration.failure"))
         ensure
           redirect_to finance_participant_path(@participant_profile.user)
         end

--- a/app/controllers/finance/participants_controller.rb
+++ b/app/controllers/finance/participants_controller.rb
@@ -9,7 +9,7 @@ module Finance
         if @user
           redirect_to finance_participant_path(@user)
         else
-          flash.now[:alert] = "No records found"
+          set_alert_message(content: "No records found", now: true)
         end
       end
     end

--- a/app/helpers/finance_helper.rb
+++ b/app/helpers/finance_helper.rb
@@ -26,6 +26,24 @@ module FinanceHelper
     end
   end
 
+  def void_declaration_link(declaration, row)
+    return row.with_action(text: :none) unless voidable_declaration?(declaration)
+
+    participant_profile = declaration.participant_profile
+
+    row.with_action(
+      text: "Void",
+      href: new_void_finance_participant_profile_ecf_participant_declarations_path(participant_profile.id, declaration.id),
+      visually_hidden_text: "Void declaration",
+    )
+  end
+
+  def voidable_declaration?(declaration)
+    lead_provider = declaration.cpd_lead_provider.lead_provider
+    cohort = declaration.cohort
+    declaration.voidable? || (declaration.paid? && lead_provider.next_output_fee_statement(cohort))
+  end
+
   def induction_record_participant_api_response(induction_record, participant_profile)
     cpd_lead_provider = induction_record.induction_programme.partnership&.lead_provider&.cpd_lead_provider
     serializer_output = Api::V3::ECF::ParticipantSerializer.new(participant_profile.user, params: { cpd_lead_provider: }).serializable_hash

--- a/app/models/participant_declaration.rb
+++ b/app/models/participant_declaration.rb
@@ -4,6 +4,7 @@ class ParticipantDeclaration < ApplicationRecord
   self.ignored_columns = %w[statement_type statement_id temp_type]
 
   ARCHIVABLE_STATES = %w[ineligible voided submitted].freeze
+  VOIDABLE_STATES = %w[submitted eligible payable ineligible].freeze
 
   belongs_to :cpd_lead_provider
   belongs_to :user
@@ -125,7 +126,7 @@ class ParticipantDeclaration < ApplicationRecord
   end
 
   def voidable?
-    %w[submitted eligible payable ineligible].include?(state)
+    VOIDABLE_STATES.include?(state)
   end
 
   def make_submitted!

--- a/app/views/finance/ecf/participant_declarations/void/new.html.erb
+++ b/app/views/finance/ecf/participant_declarations/void/new.html.erb
@@ -1,0 +1,50 @@
+<% content_for :before_content, govuk_back_link(text: "Back", href: finance_participant_path(@participant_profile.user)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Void declaration</h1>
+
+    <%= 
+      govuk_summary_list do |summary_list|
+        summary_list.with_row do |row|
+          row.with_key { "Participant ID" }
+          row.with_value { @participant_profile.user_id }
+        end
+        
+        summary_list.with_row do |row|
+          row.with_key { "Declaration ID" }
+          row.with_value { @declaration.id }
+        end
+
+        summary_list.with_row do |row|
+          row.with_key { "Declaration type" }
+          row.with_value { @declaration.declaration_type }
+        end
+
+        summary_list.with_row do |row|
+          row.with_key { "Declaration date" }
+          row.with_value { @declaration.declaration_date.to_fs(:govuk) }
+        end
+
+        summary_list.with_row do |row|
+          row.with_key { "Course identifier" }
+          row.with_value { @declaration.course_identifier }
+        end
+
+        summary_list.with_row do |row|
+          row.with_key { "Lead provider" }
+          row.with_value { @declaration.cpd_lead_provider.name }
+        end
+
+        summary_list.with_row do |row|
+          row.with_key { "State" }
+          row.with_value { @declaration.state }
+        end 
+      end
+    %>
+
+    <%= form_with url: create_void_finance_participant_profile_ecf_participant_declarations_path(@participant_profile, @declaration) do |f| %>
+      <%= f.govuk_submit "Void declaration" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/finance/participants/_declaration.html.erb
+++ b/app/views/finance/participants/_declaration.html.erb
@@ -1,49 +1,52 @@
-<%= govuk_summary_list do |summary_list| %>
-  <% summary_list.with_row do |row| %>
-    <% row.with_key { "Declaration ID" } %>
-    <% row.with_value { declaration.id } %>
-  <% end %>
+<%= 
+  govuk_summary_list do |summary_list|
+    summary_list.with_row do |row|
+      row.with_key { "Declaration ID" }
+      row.with_value { declaration.id }
+    end
 
-  <% summary_list.with_row do |row| %>
-    <% row.with_key { "Declaration type" } %>
-    <% row.with_value { declaration.declaration_type } %>
-  <% end %>
+    summary_list.with_row do |row|
+      row.with_key { "Declaration type" }
+      row.with_value { declaration.declaration_type }
+    end
 
-  <% summary_list.with_row do |row| %>
-    <% row.with_key { "Declaration date" } %>
-    <% row.with_value { declaration.declaration_date.to_fs(:govuk) } %>
-  <% end %>
+    summary_list.with_row do |row|
+      row.with_key { "Declaration date" }
+      row.with_value { declaration.declaration_date.to_fs(:govuk) }
+    end
 
-  <% summary_list.with_row do |row| %>
-    <% row.with_key { "Course identifier" } %>
-    <% row.with_value { declaration.course_identifier } %>
-  <% end %>
+    summary_list.with_row do |row|
+      row.with_key { "Course identifier" }
+      row.with_value { declaration.course_identifier }
+    end
 
-  <% summary_list.with_row do |row| %>
-    <% row.with_key { "Evidence held" } %>
-    <% row.with_value { declaration.evidence_held } %>
-  <% end %>
+    summary_list.with_row do |row|
+      row.with_key { "Evidence held" }
+      row.with_value { declaration.evidence_held }
+    end
 
-  <% summary_list.with_row do |row| %>
-    <% row.with_key { "Lead provider" } %>
-    <% row.with_value { declaration.cpd_lead_provider.name } %>
-  <% end %>
+    summary_list.with_row do |row|
+      row.with_key { "Lead provider" }
+      row.with_value { declaration.cpd_lead_provider.name }
+    end
 
-  <% summary_list.with_row do |row| %>
-    <% row.with_key { "State" } %>
-    <% row.with_value { declaration.state } %>
-  <% end %>
+    summary_list.with_row do |row|
+      row.with_key { "State" }
+      row.with_value { declaration.state }
+      void_declaration_link(declaration, row)
+    end 
 
-  <% summary_list.with_row do |row| %>
-    <% row.with_key { "Created at" } %>
-    <% row.with_value { declaration.created_at.to_fs(:govuk) } %>
-  <% end %>
+    summary_list.with_row do |row|
+      row.with_key { "Created at" }
+      row.with_value { declaration.created_at.to_fs(:govuk) }
+    end
 
-  <% summary_list.with_row do |row| %>
-    <% row.with_key { "Updated at" } %>
-    <% row.with_value { declaration.updated_at.to_fs(:govuk) } %>
-  <% end %>
-<% end %>
+    summary_list.with_row do |row|
+      row.with_key { "Updated at" }
+      row.with_value { declaration.updated_at.to_fs(:govuk) }
+    end
+  end
+%>
 
 <%=
   govuk_table do |table|

--- a/app/views/layouts/_width_container.html.erb
+++ b/app/views/layouts/_width_container.html.erb
@@ -8,8 +8,13 @@
         <% if type == "alert" %>
           <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
             <h2 class="govuk-error-summary__title" id="error-summary-title">
-              <%= msg %>
+              <%= msg[:title] %>
             </h2>
+            <div class="govuk-error-summary__body">
+              <ul class="govuk-list govuk-error-summary__list">
+                <li><%= msg[:content] %></li>
+              </ul>
+            </div>
           </div>
         <% elsif type == "success" %>
           <%= govuk_notification_banner(

--- a/app/views/layouts/_width_container_wide.html.erb
+++ b/app/views/layouts/_width_container_wide.html.erb
@@ -11,8 +11,13 @@
         <% if type == "alert" %>
           <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
             <h2 class="govuk-error-summary__title" id="error-summary-title">
-              <%= msg %>
+              <%= msg[:title] %>
             </h2>
+            <div class="govuk-error-summary__body">
+              <ul class="govuk-list govuk-error-summary__list">
+                <li><%= msg[:content] %></li>
+              </ul>
+            </div>
           </div>
         <% elsif type == "success" %>
           <%= govuk_notification_banner(

--- a/app/views/layouts/basic.html.erb
+++ b/app/views/layouts/basic.html.erb
@@ -6,8 +6,13 @@
       <% if type == "alert" %>
         <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
           <h2 class="govuk-error-summary__title" id="error-summary-title">
-            <%= msg %>
+            <%= msg[:title] %>
           </h2>
+          <div class="govuk-error-summary__body">
+            <ul class="govuk-list govuk-error-summary__list">
+              <li><%= msg[:content] %></li>
+            </ul>
+          </div>
         </div>
       <% elsif type == "success" %>
         <%= govuk_notification_banner(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -630,6 +630,12 @@ en:
     current_milestone: Current milestone
     trainees: Trainees
     view: View
+    void_declaration:
+      success:
+        heading: Declaration voided successfully.
+      failure:
+        heading: There is a problem
+        content: The declaration may have already been voided. Check its status and try again. If the problem continues, contact the lead provider team for help.
     course:
       participants: Participants
       payment_per_participant: Payment per participant

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -634,8 +634,8 @@ en:
       success:
         heading: Declaration voided successfully.
       failure:
-        heading: There is a problem
-        content: The declaration may have already been voided. Check its status and try again. If the problem continues, contact the lead provider team for help.
+        title: "This declaration may have already been voided"
+        content: Check its status and try again. If the problem continues, contact the lead provider team for help.
     course:
       participants: Participants
       payment_per_participant: Payment per participant

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -449,6 +449,11 @@ Rails.application.routes.draw do
     resources :participants, only: %i[index show]
     resources :participant_profiles, only: [] do
       namespace :ecf do
+        resource :participant_declarations, only: [] do
+          get ":participant_declaration_id/void/new", to: "participant_declarations/void#new", as: :new_void
+          post ":participant_declaration_id/void", to: "participant_declarations/void#create", as: :create_void
+        end
+
         resource :induction_records, only: [] do
           collection do
             get ":induction_record_id/change_training_status/new", to: "change_training_statuses#new", as: :new

--- a/spec/features/finance/ecf/participant_declarations/void_spec.rb
+++ b/spec/features/finance/ecf/participant_declarations/void_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Voiding declarations" do
       when_i_visit_the_void_declaration_page
       and_i_click("Void declaration")
       then_i_should_be_on_the_participant_page
-      then_there_should_be_an_important_banner(message: "The declaration may have already been voided")
+      then_there_should_be_an_alert_banner(title: "This declaration may have already been voided", message: "Check its status and try again")
     end
   end
 

--- a/spec/features/finance/ecf/participant_declarations/void_spec.rb
+++ b/spec/features/finance/ecf/participant_declarations/void_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Voiding declarations" do
+  let(:declaration) { ParticipantDeclaration.last }
+  let(:participant_profile) { declaration.participant_profile }
+
+  before do
+    given_i_am_logged_in_as_a_finance_user
+  end
+
+  context "when there are no voidable declarations" do
+    before { and_declarations_exist_but_are_not_voidable }
+
+    scenario "Link to void declaration does not appear" do
+      when_i_visit_the_participant_page
+      then_i_do_not_see_the_link("Void")
+    end
+
+    scenario "Attempting to void an already voided declaration" do
+      when_i_visit_the_void_declaration_page
+      and_i_click("Void declaration")
+      then_i_should_be_on_the_participant_page
+      then_there_should_be_an_important_banner(message: "The declaration may have already been voided")
+    end
+  end
+
+  context "when there are voidable declarations" do
+    before { and_voidable_declarations_exist }
+
+    scenario "User can void a declaration" do
+      when_i_visit_the_participant_page
+      and_i_click("Void")
+      then_i_should_be_on_the_void_declaration_page
+
+      when_i_click("Void declaration")
+      then_i_should_be_on_the_participant_page
+      and_there_should_be_a_success_banner(message: "Declaration voided successfully")
+    end
+  end
+
+  def and_declarations_exist_but_are_not_voidable
+    create(:ect_participant_declaration, :voided)
+  end
+
+  def and_voidable_declarations_exist
+    create(:ect_participant_declaration, :eligible)
+  end
+
+  def when_i_visit_the_participant_page
+    visit(finance_participant_path(participant_profile.user_id))
+  end
+
+  def then_i_do_not_see_the_link(link_text)
+    expect(page).not_to have_link(link_text)
+  end
+
+  def then_i_should_be_on_the_void_declaration_page
+    then_i_should_be_on(new_void_finance_participant_profile_ecf_participant_declarations_path(participant_profile.id, declaration.id))
+  end
+
+  def then_i_should_be_on_the_participant_page
+    finance_participant_path(participant_profile.user_id)
+  end
+
+  def when_i_visit_the_void_declaration_page
+    visit(new_void_finance_participant_profile_ecf_participant_declarations_path(participant_profile.id, declaration.id))
+  end
+end

--- a/spec/requests/finance/ecf/participant_declarations/void_spec.rb
+++ b/spec/requests/finance/ecf/participant_declarations/void_spec.rb
@@ -73,7 +73,6 @@ RSpec.describe "Voiding declarations", exceptions_app: true do
       it "shows an error message" do
         follow_redirect!
 
-        expect(response.body).to include(I18n.t("finance.void_declaration.failure.heading"))
         expect(response.body).to include(I18n.t("finance.void_declaration.failure.content"))
       end
     end

--- a/spec/requests/finance/ecf/participant_declarations/void_spec.rb
+++ b/spec/requests/finance/ecf/participant_declarations/void_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.shared_context "participant profile, declaration and access checks" do
+  context "when the participant profile does not exist" do
+    let(:participant_profile) { OpenStruct.new(id: SecureRandom.uuid) }
+
+    it { is_expected.to be_not_found }
+  end
+
+  context "when the declaration does not exist" do
+    let(:declaration) { OpenStruct.new(id: SecureRandom.uuid, participant_profile: create(:ect_participant_profile)) }
+
+    it { is_expected.to be_not_found }
+  end
+
+  context "when the declaration does not belong to the participant profile" do
+    let(:participant_profile) { create(:ect_participant_profile) }
+
+    it { is_expected.to be_not_found }
+  end
+
+  context "when not signed in" do
+    let(:user) { nil }
+
+    it { is_expected.to redirect_to(new_user_session_path) }
+  end
+end
+
+RSpec.describe "Voiding declarations", exceptions_app: true do
+  let(:user) { create(:user, :finance) }
+  let(:declaration) { create(:ect_participant_declaration, :eligible) }
+  let(:participant_profile) { declaration.participant_profile }
+
+  subject { response }
+
+  before { sign_in(user) if user }
+
+  describe "#new" do
+    before { get new_void_finance_participant_profile_ecf_participant_declarations_path(participant_profile.id, declaration.id) }
+
+    it { is_expected.to be_successful }
+
+    include_context "participant profile, declaration and access checks"
+  end
+
+  describe "#create" do
+    before { post create_void_finance_participant_profile_ecf_participant_declarations_path(participant_profile.id, declaration.id) }
+
+    it { is_expected.to redirect_to(finance_participant_path(participant_profile.user)) }
+
+    it "sets the voided_at and voided_by_user of the declaration" do
+      expect(declaration.reload).to have_attributes(
+        voided_at: be_within(5.seconds).of(Time.zone.now),
+        voided_by_user: user,
+      )
+    end
+
+    it "shows a success message" do
+      follow_redirect!
+
+      expect(response.body).to include(I18n.t("finance.void_declaration.success.heading"))
+    end
+
+    context "when the declaration cannot be voided" do
+      let(:declaration) { create(:ect_participant_declaration, :voided) }
+
+      it "does not update the declaration" do
+        expect(declaration.attributes).to eq(declaration.reload.attributes)
+      end
+
+      it "shows an error message" do
+        follow_redirect!
+
+        expect(response.body).to include(I18n.t("finance.void_declaration.failure.heading"))
+        expect(response.body).to include(I18n.t("finance.void_declaration.failure.content"))
+      end
+    end
+
+    include_context "participant profile, declaration and access checks"
+  end
+end

--- a/spec/support/features/page_assertions_helper.rb
+++ b/spec/support/features/page_assertions_helper.rb
@@ -17,6 +17,13 @@ module PageAssertionsHelper
 
   alias_method :and_there_should_be_an_important_banner, :then_there_should_be_an_important_banner
 
+  def then_there_should_be_an_alert_banner(title: "There is a problem", message: nil)
+    expect(page).to have_selector ".govuk-error-summary h2", text: title
+    expect(find(".govuk-error-summary__body")).to have_text(message) if message
+  end
+
+  alias_method :and_there_should_be_an_alert_banner, :then_there_should_be_an_alert_banner
+
   def then_i_see_an_error_message(message)
     expect(page).to have_selector(".govuk-error-summary")
     expect(page).to have_selector(".govuk-error-message", text: message)

--- a/spec/support/features/page_assertions_helper.rb
+++ b/spec/support/features/page_assertions_helper.rb
@@ -3,11 +3,19 @@
 module PageAssertionsHelper
   include Capybara::DSL
 
-  def then_there_should_be_a_success_banner
+  def then_there_should_be_a_success_banner(message: nil)
     expect(page).to have_selector ".govuk-notification-banner--success"
+    expect(find(".govuk-notification-banner--success")).to have_text(message) if message
   end
 
   alias_method :and_there_should_be_a_success_banner, :then_there_should_be_a_success_banner
+
+  def then_there_should_be_an_important_banner(message: nil)
+    expect(page).to have_selector ".govuk-notification-banner h2", text: "Important"
+    expect(find(".govuk-notification-banner")).to have_text(message) if message
+  end
+
+  alias_method :and_there_should_be_an_important_banner, :then_there_should_be_an_important_banner
 
   def then_i_see_an_error_message(message)
     expect(page).to have_selector(".govuk-error-summary")


### PR DESCRIPTION
[Jira-4088](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-4088)

### Context

At present declarations can only be voided directly by a Lead Provider or through a developer after a support request being made. This ends up causing lengthy lead times before a resolution can be reached, either delaying payment or creating need for further manual intervention.

To alleviate the issues we want to allow finance users to be able to void applicable declarations through the finance dashboard.

### Changes proposed in this pull request

- Extract voidable states into constant

Extracting and exposing as a constant as we need to be able to reference these states externally to determine if a declaration is voidable.

- Add ability to void declarations in finance dashboard

Add `Void` link to the participant declarations if they are in a voidable state (if paid they must also have an output fee statement available).

Add summary page to detail declaration prior to voiding.

On voiding, redirect to the participant page with a success message.

If there is an error when voiding, redirect to the participant page with a failure message.

- Update void error message styling

Switch to a govuk summary error type display after talking to Mark about the styling.

### Guidance to review

| Void link    | Void page | Success | Failure |
| -------- | ------- | -------- | ------- |
| <img width="1283" alt="Screenshot 2025-03-05 at 13 27 29" src="https://github.com/user-attachments/assets/4d5e9d1b-92c0-4c53-9b83-3f0c1e6128a1" />  | <img width="899" alt="Screenshot 2025-03-05 at 13 28 12" src="https://github.com/user-attachments/assets/f26e8b5b-b2b4-4878-a4d1-63ea26db6beb" />   |  <img width="1272" alt="Screenshot 2025-03-05 at 13 28 36" src="https://github.com/user-attachments/assets/f7e7aa1b-3d55-4618-bf4c-6d7e8be7c3bb" />  | <img width="1290" alt="Screenshot 2025-03-07 at 11 50 21" src="https://github.com/user-attachments/assets/55177d38-d94b-45e8-a845-0a801fbfc4db" />  |

