### PR TITLE
Add service to mark call off contracts as unused

### DIFF
--- a/app/models/call_off_contract.rb
+++ b/app/models/call_off_contract.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 class CallOffContract < ApplicationRecord
+  UNUSED_VERSION_PREFIX = "unused_"
+
   belongs_to :lead_provider
   belongs_to :cohort
 
   has_many :participant_bands
+
+  scope :not_flagged_as_unused, -> { where.not("version LIKE ?", "#{UNUSED_VERSION_PREFIX}%") }
 
   def total_contract_value
     participant_bands.map(&:contract_value).sum

--- a/app/services/oneoffs/mark_contracts_as_unused.rb
+++ b/app/services/oneoffs/mark_contracts_as_unused.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "has_recordable_information"
+
+module Oneoffs
+  class MarkContractsAsUnused
+    include HasRecordableInformation
+
+    DUPLICATE_ATTRIBUTES = %w[lead_provider_id cohort_id version].freeze
+    EQUALITY_CHECK_IGNORE = {
+      call_off_contract: %w[id raw created_at updated_at],
+      participant_bands: %w[id call_off_contract_id created_at updated_at],
+    }.freeze
+
+    def perform_change(dry_run: true)
+      reset_recorded_info
+
+      record_info("~~~ DRY RUN ~~~") if dry_run
+
+      ActiveRecord::Base.transaction do
+        mark_as_unused!(orphans, "no associated finance statement")
+        mark_as_unused!(confirmed_duplicates, "duplicates")
+
+        record_divergent_duplicate_info
+
+        raise ActiveRecord::Rollback if dry_run
+      end
+
+      recorded_info
+    end
+
+  private
+
+    def mark_as_unused!(call_off_contracts, reason)
+      record_info("Marking #{call_off_contracts.size} contracts as unused (#{reason})")
+
+      call_off_contracts.each do |call_off_contract|
+        call_off_contract.update!(version: "#{CallOffContract::UNUSED_VERSION_PREFIX}#{call_off_contract.version}")
+      end
+    end
+
+    def orphans
+      @orphans ||= call_off_contracts
+        .joins(:lead_provider)
+        .joins("LEFT JOIN statements ON
+          statements.cpd_lead_provider_id = lead_providers.cpd_lead_provider_id
+          AND statements.cohort_id = call_off_contracts.cohort_id
+          AND statements.contract_version = call_off_contracts.version")
+        .where(statements: { id: nil })
+    end
+
+    def confirmed_duplicates
+      @confirmed_duplicates ||= potential_duplicates.flat_map do |original, duplicates|
+        duplicates.select { |dup| call_off_contract_equal?(original, dup) }
+      end
+    end
+
+    def divergent_duplicates
+      @divergent_duplicates ||= potential_duplicates.values.flatten - confirmed_duplicates
+    end
+
+    def record_divergent_duplicate_info
+      divergent_duplicates.each do |divergent_duplicate|
+        original = potential_duplicates.find { |_, duplicates| duplicates.include?(divergent_duplicate) }.first
+        record_info("Skipping duplicate (#{divergent_duplicate.id}) due to attributes differing with original (#{original.id})")
+      end
+    end
+
+    def potential_duplicates
+      @potential_duplicates ||= duplicated_attributes.each_with_object({}) do |duplicate_condition, hash|
+        duplicates = call_off_contracts.where(duplicate_condition).order(:created_at).to_a
+        original = duplicates.shift
+        hash[original] = duplicates
+      end
+    end
+
+    def call_off_contract_equal?(original, duplicate)
+      contracts_equal = attributes_equal?(original, duplicate, :call_off_contract)
+
+      original_bands = original.participant_bands.min_nulls_first
+      duplicate_bands = duplicate.participant_bands.min_nulls_first
+      bands_equal = original_bands.zip(duplicate_bands).all? do |original_band, duplicate_band|
+        attributes_equal?(original_band, duplicate_band, :participant_bands)
+      end
+
+      contracts_equal && bands_equal
+    end
+
+    def attributes_equal?(original, duplicate, ignore_key)
+      original_attributes = original.attributes.except(*EQUALITY_CHECK_IGNORE[ignore_key])
+      duplicate_attributes = duplicate.attributes.except(*EQUALITY_CHECK_IGNORE[ignore_key])
+
+      original_attributes == duplicate_attributes
+    end
+
+    def duplicated_attributes
+      @duplicated_attributes ||= call_off_contracts
+        .group(*DUPLICATE_ATTRIBUTES)
+        .having("COUNT(*) > 1")
+        .pluck(*DUPLICATE_ATTRIBUTES)
+        .map { |values| DUPLICATE_ATTRIBUTES.zip(values).to_h.symbolize_keys }
+    end
+
+    def call_off_contracts
+      @call_off_contracts ||= CallOffContract.not_flagged_as_unused
+    end
+  end
+end

--- a/spec/factories/call_off_contract.rb
+++ b/spec/factories/call_off_contract.rb
@@ -33,6 +33,10 @@ FactoryBot.define do
       }.to_json
     end
 
+    trait :unused do
+      version { "unused_1.0" }
+    end
+
     trait :with_monthly_service_fee do
       monthly_service_fee { 123.45 }
     end

--- a/spec/models/call_off_contract_spec.rb
+++ b/spec/models/call_off_contract_spec.rb
@@ -19,6 +19,18 @@ RSpec.describe CallOffContract, type: :model do
     end
   end
 
+  describe "scopes" do
+    describe ".not_flagged_as_unused" do
+      let!(:call_off_contract) { create(:call_off_contract) }
+
+      before { create(:call_off_contract, :unused) }
+
+      subject { described_class.not_flagged_as_unused }
+
+      it { is_expected.to contain_exactly(call_off_contract) }
+    end
+  end
+
   describe "#uplift_cap" do
     # the following makes the maths much easier
     # as there is no longer half uplifts

--- a/spec/services/oneoffs/mark_contracts_as_unused_spec.rb
+++ b/spec/services/oneoffs/mark_contracts_as_unused_spec.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+describe Oneoffs::MarkContractsAsUnused do
+  before { allow(Rails.logger).to receive(:info) }
+
+  def create_statement(call_off_contract)
+    create(
+      :ecf_statement,
+      cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider,
+      cohort: call_off_contract.cohort,
+      contract_version: call_off_contract.version,
+    )
+  end
+
+  describe "#perform_change" do
+    let(:dry_run) { false }
+    let(:instance) { described_class.new }
+
+    subject(:perform_change) { instance.perform_change(dry_run:) }
+
+    it { is_expected.to eq(instance.recorded_info) }
+
+    context "when there are call off contracts with associated statements" do
+      let(:call_off_contract) { create(:call_off_contract) }
+
+      before { create_statement(call_off_contract) }
+
+      it "does not change the contract" do
+        expect { perform_change }.not_to change { call_off_contract.reload.attributes }
+      end
+    end
+
+    context "when there are call off contracts without associated statements" do
+      let!(:call_off_contract_1) { create(:call_off_contract, version: "1.0") }
+      let!(:call_off_contract_2) { create(:call_off_contract, version: "2.0") }
+
+      it "prefixes the versions with 'unused_'" do
+        expect { perform_change }.to change { call_off_contract_1.reload.version }.from("1.0").to("unused_1.0")
+          .and change { call_off_contract_2.reload.version }.from("2.0").to("unused_2.0")
+      end
+
+      it "logs out information" do
+        perform_change
+
+        expect(instance).to have_recorded_info([
+          "Marking 2 contracts as unused (no associated finance statement)",
+        ])
+      end
+
+      context "when the call off contracts have already been marked as unused" do
+        let!(:call_off_contract) { create(:call_off_contract, :unused) }
+
+        it "does not change the contracts" do
+          expect { perform_change }.not_to change { call_off_contract.reload.attributes }
+        end
+      end
+    end
+
+    context "when there are duplicate call off contracts" do
+      let(:original) { travel_to(1.day.ago) { create(:call_off_contract, :with_minimal_bands, version: "1.0") } }
+      let!(:duplicate_1) do
+        create(
+          :call_off_contract,
+          :with_minimal_bands,
+          lead_provider: original.lead_provider,
+          cohort: original.cohort,
+          version: original.version,
+        )
+      end
+      let!(:duplicate_2) do
+        create(
+          :call_off_contract,
+          :with_minimal_bands,
+          lead_provider: original.lead_provider,
+          cohort: original.cohort,
+          version: original.version,
+        )
+      end
+
+      before { create_statement(original) }
+
+      it "prefixes the duplicate version with 'unused_'" do
+        expect { perform_change }.to change { duplicate_1.reload.version }.from("1.0").to("unused_1.0")
+          .and change { duplicate_2.reload.version }.from("1.0").to("unused_1.0")
+      end
+
+      it "does not modify the original" do
+        expect { perform_change }.not_to change { original.reload.attributes }
+      end
+
+      it "logs out information" do
+        perform_change
+
+        expect(instance).to have_recorded_info([
+          "Marking 2 contracts as unused (duplicates)",
+        ])
+      end
+
+      context "when the duplicates are not a deep-match (contract attributes differ)" do
+        before { duplicate_1.update!(set_up_fee: -123) }
+
+        it "does not modify the duplicate" do
+          expect { perform_change }.not_to change { duplicate_1.reload.attributes }
+        end
+
+        it "logs out information" do
+          perform_change
+
+          expect(instance).to have_recorded_info([
+            "Marking 1 contracts as unused (duplicates)",
+            "Skipping duplicate (#{duplicate_1.id}) due to attributes differing with original (#{original.id})",
+          ])
+        end
+      end
+
+      context "when the duplicates are not a deep-match (participant bands attributes differ)" do
+        before { duplicate_2.participant_bands.sample.update!(max: -123) }
+
+        it "does not modify the duplicate" do
+          expect { perform_change }.not_to change { duplicate_2.reload.attributes }
+        end
+
+        it "logs out information" do
+          perform_change
+
+          expect(instance).to have_recorded_info([
+            "Marking 1 contracts as unused (duplicates)",
+            "Skipping duplicate (#{duplicate_2.id}) due to attributes differing with original (#{original.id})",
+          ])
+        end
+      end
+
+      context "when the duplicates are a deep-match, but the participant bands are in a different order" do
+        before do
+          # Creating a duplicate of the first band and saving it, then destroying
+          # the original first band will cause the bands to be in a different order
+          # to the original.
+          duplicate_2_first_band = duplicate_2.participant_bands.first
+          duplicate_2_first_band.dup.save!
+          duplicate_2_first_band.destroy!
+        end
+
+        it "prefixes the duplicate version with 'unused_'" do
+          expect { perform_change }.to change { duplicate_1.reload.version }.from("1.0").to("unused_1.0")
+            .and change { duplicate_2.reload.version }.from("1.0").to("unused_1.0")
+        end
+
+        it "logs out information" do
+          perform_change
+
+          expect(instance).to have_recorded_info([
+            "Marking 2 contracts as unused (duplicates)",
+          ])
+        end
+      end
+    end
+
+    context "when dry_run is true" do
+      let(:dry_run) { true }
+      let(:call_off_contract) { create(:call_off_contract) }
+
+      it "does not make any changes, but records the changes it would make" do
+        expect { perform_change }.not_to change { call_off_contract.reload.attributes }
+
+        expect(instance).to have_recorded_info([
+          "~~~ DRY RUN ~~~",
+          "Marking 1 contracts as unused (no associated finance statement)",
+        ])
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Jira-4125](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-4125)

### Context

Due to historical/manual changes to contract data over the years we are in a position where we have a number of contracts that are either duplicates or are unused (i.e. not referenced by any financial statements).

### Changes proposed in this pull request

- Add not_flagged_as_unused scope to CallOffContract

We will be referencing the used/unused status of call off contracts outside the oneoff service to prefix them as `unused_`, so it makes sense to keep the scope and terminology in the model itself.

I expect when we come to migrate the contract data we will add a `not_flagged_as_unused` scope to get the contracts that are applicable to migrate over.

- Add service to mark CallOffContract records as unused

Add `Oneoffs::MarkContractsAsUnused` service to find unused/duplicated contracts and prefix their version with `unused_`. This will enable us to identify them and exclude them from the data migration to ECF 2.0.

We identify orphaned contracts by finding those without a corresponding statement (matching on lead provider, cohort and contract version).

Duplicate contracts are initially identified by comparing lead provider, cohort and version and we then perform a deep-comparison of the `CallOffContract` and `ParticipantBand` attributes.

Any contracts that match on lead provider/cohort/contract version but differ when we perform the deep comparison are not marked as unused and we instead record how many of these we encounter during the process.

### Guidance to review

```
Oneoffs::MarkContractsAsUnused.new.perform_change(dry_run: true)

["~~~ DRY RUN ~~~",
 "Marking 246 contracts as unused (no associated finance statement)",
 "Marking 86 contracts as unused (duplicates)"]
```

These numbers appear to align with Mook's original spike.
