### PR TITLE
Optimize `ParticipantsFilter` query

### DIFF
--- a/app/services/delivery_partners/induction_records_query.rb
+++ b/app/services/delivery_partners/induction_records_query.rb
@@ -35,7 +35,7 @@ module DeliveryPartners
           :school,
           user: :teacher_profile,
           induction_programme: [partnership: :lead_provider],
-          participant_profile: %i[ecf_participant_eligibility ecf_participant_validation_data],
+          participant_profile: %i[teacher_profile ecf_participant_eligibility ecf_participant_validation_data],
         )
         .select(
           "induction_records.*",

--- a/app/services/delivery_partners/participants_filter.rb
+++ b/app/services/delivery_partners/participants_filter.rb
@@ -60,10 +60,18 @@ module DeliveryPartners
     end
 
     def filter_academic_year(scoped, academic_year)
-      return scoped.joins(:cohort).where("start_year <= ?", LATEST_COHORT_TO_RETURN) if academic_year.blank?
+      return scoped.where.not(induction_programme: induction_programmes_to_ignore) if academic_year.blank?
       return scoped.none unless academic_year.to_i.in?(academic_year_options.map(&:id))
 
-      scoped.includes(:cohort).where(cohort: { start_year: academic_year })
+      scoped.where(induction_programme: induction_programmes_to_include(academic_year))
+    end
+
+    def induction_programmes_to_ignore
+      InductionProgramme.joins(school_cohort: :cohort).where("cohorts.start_year > ?", LATEST_COHORT_TO_RETURN)
+    end
+
+    def induction_programmes_to_include(academic_year)
+      InductionProgramme.joins(school_cohort: :cohort).where(cohort: { start_year: academic_year })
     end
 
     def filter_status(scoped, status)


### PR DESCRIPTION
[Jira-4129](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-4129)

### Context

Since updating the `ParticipantsFilter` to filter on cohort by default (to exclude 2025 and later) we have noticed timeouts on the corresponding page in the dashboard. We want to make this query more performant so that we no longer see timeouts in Sentry.

### Changes proposed in this pull request

- Optimize `ParticipantsFilter` query

It looks like when we join on `cohort` it ends up pulling in a bunch of other tables (as it has to go through induction programme -> school cohort -> cohort) and the query that active record ends up with is quite large and slow.

To avoid this, we can instead use a subquery to find the induction programmes that are associated with relevant cohorts and then filter on those, avoiding the many joins.

### Guidance to review

This appears to be more performant; the underlying query is much smaller and on doing some contrived performance testing against sandbox it seems to take less time:

- Without cohort filtering; ~2.3s
- With joining on cohort to filter: ~3.2s
- Using a subquery on induction programme: ~2.5s

Benchmark script:

```
require 'benchmark'

include Pagy::Backend

results = Benchmark.measure {
  delivery_partner = DeliveryPartner.find("****")
  induction_records = DeliveryPartners::InductionRecordsQuery.new(delivery_partner:).induction_records
  training_record_states = DetermineTrainingRecordState.call(induction_records:)
  filter = DeliveryPartners::ParticipantsFilter.new(collection: induction_records, params: {}, training_record_states:)

  pagy(filter.scope.order(updated_at: :desc), page: 1, limit: 3000)
}

puts results.real
```

Test to verify before/after changes don't alter results:

```
delivery_partners = DeliveryPartner.all

results = {}

delivery_partners.each do |delivery_partner|
  induction_records = DeliveryPartners::InductionRecordsQuery.new(delivery_partner:).induction_records
  training_record_states = DetermineTrainingRecordState.call(induction_records:)

  filter_old = DeliveryPartners::ParticipantsFilter.new(collection: induction_records, params: {}, training_record_states:, new_logic: false)
  filter_new = DeliveryPartners::ParticipantsFilter.new(collection: induction_records, params: {}, training_record_states:, new_logic: true)

  old_ids = filter_old.scope.pluck(:id)
  new_ids = filter_new.scope.pluck(:id)

  results[delivery_partner.name] = old_ids == new_ids
end

results.values.uniq

irb(main):068> results.values.uniq
=> [true]
```