### PR TITLE
[CPDLP-4101] Do not enable analytics in migration env

### DIFF
--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -45,7 +45,7 @@ DfE::Analytics.configure do |config|
   # enable analytics. You might want to hook this up to a feature flag or
   # environment variable.
 
-  config.enable_analytics = proc { FeatureFlag.active?(:dfe_analytics) }
+  config.enable_analytics = proc { FeatureFlag.active?(:dfe_analytics) && !Rails.env.migration? }
 
   # The environment we’re running in. This value will be attached
   # to all events we send to BigQuery.

--- a/spec/requests/dfe_analytics_spec.rb
+++ b/spec/requests/dfe_analytics_spec.rb
@@ -40,5 +40,18 @@ RSpec.describe "DfE Analytics", type: :request do
         expect { get "/api/v3/participants/ecf" }.to have_sent_analytics_event_types(:web_request)
       end
     end
+
+    context "when in the migration environment" do
+      before do
+        allow(Rails.env).to receive(:migration?).and_return(true)
+      end
+
+      it "does not send any DFE Analytics events" do
+        Cohort.create!(start_year: 2005)
+
+        expect(:create_entity).not_to have_been_enqueued_as_analytics_events
+        expect { get root_path }.not_to have_sent_analytics_event_types(:web_request)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

- Ticket:[CPDLP-4101]( https://dfedigital.atlassian.net/browse/CPDLP-4101)

When restoring migration db from production we noticed we are sending BQ events even though they should be disabled.
During the db refresh period the feature flag will be toggled on for a short period of time.. as the feature flag is copied from prod db.. up till the end of the process, when we then disable the feature flag via a command in the end of the github action.

### Changes proposed in this pull request

- Do not enable analytics in migration env;

Note: 
- There was another option in setting `enable_analytics` based in an env config. I've created a [branch](https://github.com/DFE-Digital/early-careers-framework/compare/CPDLP-4101-alternative?expand=1) with this alternative approach. Altho this option seems better as we're not hard coding the env in the config, we'd need to deploy a new version of the app every time we want to toggle on/off analytics. So keep it simple for now.

[CPDLP-4101]: https://dfedigital.atlassian.net/browse/CPDLP-4101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ