### PR TITLE
fix backup and restore snapshot

### DIFF
--- a/.github/actions/backup-and-restore-snapshot-database/action.yml
+++ b/.github/actions/backup-and-restore-snapshot-database/action.yml
@@ -59,6 +59,11 @@ runs:
       shell: bash
       run: make install-konduit
 
+    - name: Get key vault token
+      shell: bash
+      run: |
+        az account get-access-token --scope 'https://vault.azure.net/.default' --output none
+
     - name: Backup database
       shell: bash
       run: |


### PR DESCRIPTION
### Context

The restore_snapshot_database.yml workflow fails with error

`ERROR: AADSTS700024: Client assertion is not within its valid time range. Current time: 2025-03-11T14:01:24.5652190Z, assertion valid from 2025-03-11T13:48:26.0000000Z, expiry time of assertion 2025-03-11T13:53:26.0000000Z. Review the documentation at https://learn.microsoft.com/entra/identity-platform/certificate-credentials . Trace ID: nnnnnnn Correlation ID: nnnnnnnnnnn Timestamp: 2025-03-11 14:01:24Z`

The id token is only valid for 5 minutes, and although az login retrieves a 60 minute token it's only valid at the arm scope.
As the konduit restore after the backup uses keyvault, the az keyvault command can't generate a token as the id token has expired.

### Changes proposed in this pull request

Request a keyvault token (60 minutes) before starting the backup & restore.

### Guidance to review

full test run: https://github.com/DFE-Digital/early-careers-framework/actions/runs/13811034281

