### PR TITLE
Prevent mentors changing cohort due to payments frozen

### DIFF
--- a/app/services/change_schedule.rb
+++ b/app/services/change_schedule.rb
@@ -78,7 +78,7 @@ class ChangeSchedule
 private
 
   def changing_cohort_due_to_payments_frozen?
-    return false unless participant_profile
+    return false unless participant_profile&.ect?
     return false unless allow_change_to_from_frozen_cohort
     return true if participant_profile.unfinished_with_billable_declaration?(cohort:)
 


### PR DESCRIPTION
[Jira-4130](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-4130)

### Context

Currently we allow both ECTs and mentors to change schedule from a payments frozen cohort to the active registration cohort if they have billable declarations in the frozen cohort.

Going forward we will be marking these mentors as complete which will exclude them from being eligible to transfer from a payments frozen cohort, but for a belt and braces approach we also want to guard against this explicitly in the `ChangeSchedule` service.

### Changes proposed in this pull request

- Prevent mentors changing cohort due to payments frozen

Add guard clause to prevent mentors from transferring due to payments being frozen. We will still allow transferring out of a payments frozen cohort if there are no billable declarations against the participant (though they won't be flagged as `cohort_changed_after_payments_frozen` in this scenario).

### Guidance to review

Depends on the updated scopes in #5629.