### PR TITLE
[CPDLP-4106] Accept only 2024 cohort when moving participants to from a frozen cohort

### DIFF
--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -52,8 +52,11 @@ class ParticipantProfile::ECF < ParticipantProfile
     %w[cohort participant_identity school user teacher_profile induction_records]
   end
 
-  def self.unfinished_with_billable_declaration(cohort: Cohort.active_registration_cohort, restrict_to_participant_ids: [])
-    return none if cohort.blank?
+  def self.unfinished_with_billable_declaration(cohort:, restrict_to_participant_ids: [])
+    # We need to replace Cohort.active_registration_cohort (currently 2024) with hardcoded 2024
+    # because for 2025 registration we still want these participants to continue training in 2024 not 2025
+    # which will be the value of Cohort.active_registration_cohort when we open 2025 registration.
+    return none unless cohort&.start_year == 2024
 
     completed_billable_declarations = ParticipantDeclaration.billable.for_declaration(:completed)
     completed_billable_declarations = completed_billable_declarations.where(participant_profile_id: restrict_to_participant_ids) if restrict_to_participant_ids.any?

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -11,6 +11,7 @@ class ParticipantProfile::ECF < ParticipantProfile
     school-left-fip
     other
   ].freeze
+  DESTINATION_COHORT_WHEN_MOVING_PARTICIPANTS_TO_FROM_A_FROZEN_COHORT = 2024
 
   enum profile_duplicity: {
     single: "single",
@@ -56,7 +57,7 @@ class ParticipantProfile::ECF < ParticipantProfile
     # We need to replace Cohort.active_registration_cohort (currently 2024) with hardcoded 2024
     # because for 2025 registration we still want these participants to continue training in 2024 not 2025
     # which will be the value of Cohort.active_registration_cohort when we open 2025 registration.
-    return none unless cohort&.start_year == 2024
+    return none unless cohort&.start_year == DESTINATION_COHORT_WHEN_MOVING_PARTICIPANTS_TO_FROM_A_FROZEN_COHORT
 
     completed_billable_declarations = ParticipantDeclaration.billable.for_declaration(:completed)
     completed_billable_declarations = completed_billable_declarations.where(participant_profile_id: restrict_to_participant_ids) if restrict_to_participant_ids.any?

--- a/spec/services/change_schedule_spec.rb
+++ b/spec/services/change_schedule_spec.rb
@@ -66,7 +66,7 @@ end
 
 RSpec.shared_examples "changing cohort and continuing training" do
   let(:cohort) { new_cohort.previous }
-  let(:new_cohort) { Cohort.active_registration_cohort }
+  let(:new_cohort) { create(:cohort, start_year: 2024) }
 
   it { expect(new_cohort).not_to eq(cohort) }
 
@@ -116,6 +116,12 @@ RSpec.shared_examples "changing cohort and continuing training" do
 
           it { is_expected.to be_valid }
           it { expect { service.call }.to change { participant_profile.reload.cohort_changed_after_payments_frozen }.to(true) }
+
+          context "when new cohort is not 2024" do
+            let(:new_cohort) { create(:cohort, start_year: 2022) }
+
+            it { is_expected.to be_invalid }
+          end
         end
       end
 
@@ -343,14 +349,6 @@ RSpec.describe ChangeSchedule do
 
         it_behaves_like "changing cohort and continuing training" do
           let!(:new_schedule) { Finance::Schedule::ECF.find_by(cohort: new_cohort, schedule_identifier:) }
-        end
-
-        it_behaves_like "changing cohort and continuing training" do
-          let(:new_cohort) { Cohort.previous }
-        end
-
-        it_behaves_like "changing cohort and continuing training" do
-          let(:new_cohort) { Cohort.next }
         end
 
         context "when there are no submitted/eligible/payable/paid declarations" do

--- a/spec/services/change_schedule_spec.rb
+++ b/spec/services/change_schedule_spec.rb
@@ -345,6 +345,14 @@ RSpec.describe ChangeSchedule do
           let!(:new_schedule) { Finance::Schedule::ECF.find_by(cohort: new_cohort, schedule_identifier:) }
         end
 
+        it_behaves_like "changing cohort and continuing training" do
+          let(:new_cohort) { Cohort.previous }
+        end
+
+        it_behaves_like "changing cohort and continuing training" do
+          let(:new_cohort) { Cohort.next }
+        end
+
         context "when there are no submitted/eligible/payable/paid declarations" do
           context "when changing to another cohort" do
             describe ".call" do

--- a/spec/support/shared_examples/change_cohort_and_continue_training_support.rb
+++ b/spec/support/shared_examples/change_cohort_and_continue_training_support.rb
@@ -9,7 +9,7 @@ RSpec.shared_examples "can change cohort and continue training" do |participant_
     let(:cpd_lead_provider) { eligible_participant.lead_provider.cpd_lead_provider }
     let(:eligible_participants) { create_list(declaration_type, 3, :payable, declaration_type: :started, cohort: Cohort.previous).map(&:participant_profile) }
     let(:eligible_participant) { eligible_participants.first }
-    let(:cohort) { Cohort.active_registration_cohort }
+    let(:cohort) { create(:cohort, start_year: 2024) }
 
     before do
       current_cohort.freeze_payments!
@@ -49,13 +49,19 @@ RSpec.shared_examples "can change cohort and continue training" do |participant_
 
       it { is_expected.to be_none }
     end
+
+    context "when the cohort is not 2024" do
+      let(:cohort) { create(:cohort, start_year: 2023) }
+
+      it { is_expected.to be_none }
+    end
   end
 
   describe "#unfinished_with_billable_declaration?" do
     let(:declaration) { create(declaration_type, :paid, declaration_type: :started, cohort: Cohort.previous) }
     let(:participant_profile) { declaration.participant_profile }
     let(:current_cohort) { participant_profile.schedule.cohort }
-    let(:cohort) { Cohort.active_registration_cohort }
+    let(:cohort) { create(:cohort, start_year: 2024) }
 
     before { current_cohort.freeze_payments! }
 
@@ -70,10 +76,10 @@ RSpec.shared_examples "can change cohort and continue training" do |participant_
       it { is_expected.not_to be_unfinished_with_billable_declaration(cohort:) }
     end
 
-    context "when the cohort they intend to continue training in is not the active registration cohort" do
-      let(:cohort) { Cohort.active_registration_cohort.previous }
+    context "when the cohort they intend to continue training in is not 2024" do
+      let(:cohort) { create(:cohort, start_year: 2023) }
 
-      it { is_expected.to be_unfinished_with_billable_declaration(cohort:) }
+      it { is_expected.not_to be_unfinished_with_billable_declaration(cohort:) }
     end
 
     %i[paid payable eligible].each do |billable_declaration_type|
@@ -109,6 +115,12 @@ RSpec.shared_examples "can change cohort and continue training" do |participant_
 
         context "when the cohort is not present" do
           let(:cohort) { nil }
+
+          it { is_expected.not_to be_unfinished_with_billable_declaration(cohort:) }
+        end
+
+        context "when the cohort is not 2024" do
+          let(:cohort) { create(:cohort, start_year: 2023) }
 
           it { is_expected.not_to be_unfinished_with_billable_declaration(cohort:) }
         end

--- a/spec/support/shared_examples/change_cohort_and_continue_training_support.rb
+++ b/spec/support/shared_examples/change_cohort_and_continue_training_support.rb
@@ -67,7 +67,7 @@ RSpec.shared_examples "can change cohort and continue training" do |participant_
     context "when the cohort they intend to continue training in is not the active registration cohort" do
       let(:cohort) { Cohort.active_registration_cohort.previous }
 
-      it { is_expected.not_to be_unfinished_with_billable_declaration(cohort:) }
+      it { is_expected.to be_unfinished_with_billable_declaration(cohort:) }
     end
 
     %i[paid payable eligible].each do |billable_declaration_type|

--- a/spec/support/shared_examples/change_cohort_and_continue_training_support.rb
+++ b/spec/support/shared_examples/change_cohort_and_continue_training_support.rb
@@ -43,6 +43,12 @@ RSpec.shared_examples "can change cohort and continue training" do |participant_
 
       it { is_expected.to contain_exactly(eligible_participants.first) }
     end
+
+    context "when the cohort is not present" do
+      let(:cohort) { nil }
+
+      it { is_expected.to be_none }
+    end
   end
 
   describe "#unfinished_with_billable_declaration?" do
@@ -85,6 +91,27 @@ RSpec.shared_examples "can change cohort and continue training" do |participant_
         end
 
         it { is_expected.not_to be_unfinished_with_billable_declaration(cohort:) }
+      end
+
+      context "when the participant has a not completed, #{billable_declaration_type} declaration" do
+        before do
+          milestone_date = participant_profile.schedule.milestones.find_by(declaration_type: "retained-1").start_date
+          travel_to(milestone_date) do
+            create(declaration_type,
+                   billable_declaration_type,
+                   declaration_type: "retained-1",
+                   participant_profile:,
+                   cpd_lead_provider: participant_profile.lead_provider.cpd_lead_provider)
+          end
+        end
+
+        it { is_expected.to be_unfinished_with_billable_declaration(cohort:) }
+
+        context "when the cohort is not present" do
+          let(:cohort) { nil }
+
+          it { is_expected.not_to be_unfinished_with_billable_declaration(cohort:) }
+        end
       end
     end
 


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-4106](https://dfedigital.atlassian.net/browse/CPDLP-4106)

Last year when freezing cohort 2021 we moved participants to the active registration cohort which was 2024. This year freezing cohort 2022 will also move to 2024 and NOT the active registration cohort.

### Changes proposed in this pull request

-  Replace `Cohort.active_registration_cohort` (currently 2024) with hardcoded 2024, so when 2025 registration period opens, we only accept 2024 cohort when moving participants to from a frozen cohort;

[CPDLP-4106]: https://dfedigital.atlassian.net/browse/CPDLP-4106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ