### PR TITLE
Change wording of error when already clawing/clawed back

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -88,7 +88,7 @@ en:
   missing_school_cohort_default_partnership: You cannot change a participant to this cohort as you do not have a partnership with the school for the cohort. Contact the DfE for assistance.
   withdrawn_participant: Cannot perform actions on a withdrawn participant
   declaration_already_voided: "This declaration has already been voided."
-  declaration_not_voidable: "This declaration cannot be voided. Contact the DfE if you have any questions about why you cannot void it."
+  declaration_not_voidable: "This declaration has been clawed-back, so you can only view it."
   schedule_missing: "The participant does not have a schedule"
   declaration_before_milestone_start: "Enter a '#/declaration_date' that's on or after the milestone start."
   declaration_after_milestone_cutoff: "Enter a '#/declaration_date' that's before the milestone end date."

--- a/spec/services/void_participant_declaration_spec.rb
+++ b/spec/services/void_participant_declaration_spec.rb
@@ -97,6 +97,24 @@ RSpec.describe VoidParticipantDeclaration do
       end
     end
 
+    context "when the declaration is already clawed back" do
+      let(:participant_declaration) { create(:ect_participant_declaration, :clawed_back, participant_profile:, cpd_lead_provider:) }
+
+      it { expect { subject.call }.to raise_error(Api::Errors::InvalidTransitionError, "This declaration has been clawed-back, so you can only view it.") }
+    end
+
+    context "when the declaration is awaiting clawback" do
+      let(:participant_declaration) { create(:ect_participant_declaration, :awaiting_clawback, participant_profile:, cpd_lead_provider:) }
+
+      it { expect { subject.call }.to raise_error(Api::Errors::InvalidTransitionError, "This declaration has been clawed-back, so you can only view it.") }
+    end
+
+    context "when the declaration is already voided" do
+      let(:participant_declaration) { create(:ect_participant_declaration, :voided, participant_profile:, cpd_lead_provider:) }
+
+      it { expect { subject.call }.to raise_error(Api::Errors::InvalidTransitionError, "This declaration has already been voided.") }
+    end
+
     context "when declaration is submitted" do
       let(:participant_declaration) do
         create(:ect_participant_declaration, cpd_lead_provider:, participant_profile:)


### PR DESCRIPTION
[Jira-4091](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-4091)

### Context

The error message we serve to lead providers when they try and clawback a declaration that is either `clawed_back` or `awaiting_clawback` already is not clear. We want to update it to improve the messaging to lead providers.

### Changes proposed in this pull request

- Change wording of error when already clawing/clawed back

Update the error to be clearer and add test coverage.

### Guidance to review

I checked to see if any states that aren't `clawed_back` or `awaiting_clawback` could end up hitting this error message, but the only other state that gets here is `voided` and that is picked up by the earlier check and raise.