### PR TITLE
Add feature flag for 2025 programme type changes

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -24,6 +24,7 @@ class FeatureFlag
     prevent_2023_ect_registrations
     school_participant_status_language
     registration_pilot_school
+    programme_type_changes_2025
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).index_with { |name|


### PR DESCRIPTION
### Context

We are starting work on changes to programme naming for 2025 that will need to be hidden behind a feature flag until fully ready.

Both Schools and LPDOB need to make changes that will be synchronised together so this PR adds a feature flag we can all share.

### Changes proposed in this pull request

Add a new `:programme_type_changes_2025` feature flag
