### PR TITLE
Upgrade Puma to v6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem "pg", "~> 1.5"
 gem "ar-uuid", "~> 0.2.3"
 
 # Use Puma as the app server
-gem "puma", "~> 5.6"
+gem "puma", "< 7"
 
 # Soft delete
 gem "discard", "~> 1.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -791,7 +791,7 @@ DEPENDENCIES
   pg (~> 1.5)
   pretender (>= 0.4.0)
   pry-byebug
-  puma (~> 5.6)
+  puma (< 7)
   pundit
   pundit-matchers (~> 1.9.0)
   rack-attack (~> 6.7)


### PR DESCRIPTION
In order to upgrade `rack` we need to also upgrade `puma` to the latest version.

Looking at the upgrade guide we shouldn't need to make any changes:

https://github.com/puma/puma/blob/master/6.0-Upgrade.md

