### PR TITLE
Upgrade to Puma v6 (take #2)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem "pg", "~> 1.5"
 gem "ar-uuid", "~> 0.2.3"
 
 # Use Puma as the app server
-gem "puma", "< 7"
+gem "puma", "~> 6.0"
 
 # Soft delete
 gem "discard", "~> 1.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -417,7 +417,7 @@ GEM
       date
       stringio
     public_suffix (6.0.1)
-    puma (5.6.9)
+    puma (6.6.0)
       nio4r (~> 2.0)
     pundit (2.5.0)
       activesupport (>= 3.0.0)
@@ -791,7 +791,7 @@ DEPENDENCIES
   pg (~> 1.5)
   pretender (>= 0.4.0)
   pry-byebug
-  puma (< 7)
+  puma (~> 6.0)
   pundit
   pundit-matchers (~> 1.9.0)
   rack-attack (~> 6.7)


### PR DESCRIPTION
The last attempt (#5640) didn't force an upgrade and it remained on v5.

