### PR TITLE
[CPDLP-4149] Pin chromedriver version locally

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -191,8 +191,6 @@ jobs:
       CI: true
       CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
       CI_NODE_INDEX: ${{ matrix.ci_node_index }}
-      DISPLAY: "=:99"
-      CHROME_VERSION: "127.0.6533.119"
 
     services:
       postgres:
@@ -205,23 +203,6 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-      - name: Install Chrome
-        run: |
-          # Download specific Chrome version
-          # due a possible race condition between newer versions of chromedriver and selenium
-          # causing some specs to fail intermittently on CI with the failure Net::ReadTimeout
-          # See https://github.com/teamcapybara/capybara/issues/2770
-          wget https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}-1_amd64.deb
-          # Install Chrome
-          sudo apt-get install -y --allow-downgrades ./google-chrome-stable_${CHROME_VERSION}-1_amd64.deb
-
-      - uses: nanasess/setup-chromedriver@v2
-      - name: Start chromedriver
-        run: |
-          set -x
-          chromedriver --url-base=/wd/hub &
-          sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
-
       - name: Checkout code
         uses: actions/checkout@v4
 

--- a/spec/features_helper.rb
+++ b/spec/features_helper.rb
@@ -15,10 +15,13 @@ Capybara.register_driver :chrome_headless do |app|
   http_client.read_timeout = 120
   http_client.open_timeout = 120
 
+  # Pin Chrome version due a possible race condition between newer versions of chromedriver and selenium
+  # causing some specs to fail intermittently on CI with the failure Net::ReadTimeout
+  # See https://github.com/teamcapybara/capybara/issues/2770
   Capybara::Selenium::Driver.new(
     app,
     browser: :chrome,
-    options: Selenium::WebDriver::Options.chrome(args:),
+    options: Selenium::WebDriver::Options.chrome(args:, browser_version: "127.0.6533.119"),
     http_client:,
   )
 end

--- a/spec/features_helper.rb
+++ b/spec/features_helper.rb
@@ -7,29 +7,31 @@ require "selenium-webdriver"
 require "site_prism"
 require "site_prism/all_there" # Optional but needed to perform more complex matching
 
-Capybara.register_driver :chrome_headless do |app|
-  args = %w[disable-build-check disable-dev-shm-usage disable-gpu no-sandbox window-size=1400,1400 enable-features=NetworkService,NetworkServiceInProcess disable-features=VizDisplayCompositor]
-  args << "headless" unless ENV["NOT_HEADLESS"]
-
+Capybara.register_driver :headless_firefox do |app|
   http_client = Selenium::WebDriver::Remote::Http::Default.new
   http_client.read_timeout = 120
   http_client.open_timeout = 120
 
-  # Pin Chrome version due a possible race condition between newer versions of chromedriver and selenium
-  # causing some specs to fail intermittently on CI with the failure Net::ReadTimeout
-  # See https://github.com/teamcapybara/capybara/issues/2770
+  options = Selenium::WebDriver::Firefox::Options.new
+  options.args << "--headless" unless ENV["NOT_HEADLESS"]
+  options.args << "--width=1400"
+  options.args << "--height=1400"
+
   Capybara::Selenium::Driver.new(
     app,
-    browser: :chrome,
-    options: Selenium::WebDriver::Options.chrome(args:, browser_version: "127.0.6533.119"),
+    browser: :firefox,
+    options:,
     http_client:,
   )
 end
 
 Capybara.server_port = 9887 + ENV["TEST_ENV_NUMBER"].to_i
-Capybara.javascript_driver = :chrome_headless
+Capybara.javascript_driver = :headless_firefox
 Capybara.automatic_label_click = true
 Capybara.default_max_wait_time = 10
+
+# Silence deprecation warnings until upstream Capybara version is updated https://github.com/teamcapybara/capybara/issues/2779
+Selenium::WebDriver.logger.ignore(:clear_local_storage, :clear_session_storage)
 
 RSpec.configure do |config|
   config.include AxeHelper, type: :feature


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-4149

A possible race condition between newer versions of chromedriver and selenium is causing some specs to fail intermittently on CI with the failure `Net::ReadTimeout` and locally with `Selenium::WebDriver::Error::UnknownError`.

### Changes proposed in this pull request

Move chromeversion pin to features helper file instead, so feature specs will pass locally as well on the CI, without the errors described above.