### PR TITLE
Closing 2022 cohort

### DIFF
--- a/app/forms/schools/add_participants/base_wizard.rb
+++ b/app/forms/schools/add_participants/base_wizard.rb
@@ -493,7 +493,7 @@ module Schools
       end
 
       def cohort_for_transfer
-        cohort = Cohort.active_registration_cohort
+        cohort = Cohort.destination_from_frozen_cohort
         return cohort if existing_participant_profile&.unfinished?(cohort:)
 
         existing_participant_cohort || existing_participant_profile&.schedule&.cohort

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -3,6 +3,7 @@
 class Cohort < ApplicationRecord
   has_paper_trail
 
+  DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT = 2024
   START_YEAR_2020 = 2020
 
   INITIAL_COHORT_START_DATE = Date.new(2021, 9, 1)
@@ -29,6 +30,10 @@ class Cohort < ApplicationRecord
 
   def self.current
     starting_within(Date.current - 1.year + 1.day, Date.current)
+  end
+
+  def self.destination_from_frozen_cohort
+    where(start_year: DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT).first
   end
 
   def self.next

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -33,7 +33,7 @@ class Cohort < ApplicationRecord
   end
 
   def self.destination_from_frozen_cohort
-    where(start_year: DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT).first
+    find_by!(start_year: DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT)
   end
 
   def self.next

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -182,7 +182,7 @@ class ParticipantProfile::ECF < ParticipantProfile
     return false unless cohort&.start_year == Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT
     return false unless schedule&.cohort&.payments_frozen?
 
-    participant_declarations.none? { |declaration| declaration.billable? }
+    participant_declarations.none?(&:billable?)
   end
 
   def unfinished?(cohort: Cohort.destination_from_frozen_cohort)

--- a/app/services/early_career_teachers/create.rb
+++ b/app/services/early_career_teachers/create.rb
@@ -56,7 +56,7 @@ module EarlyCareerTeachers
     def amend_mentor_cohort
       Induction::AmendParticipantCohort.new(participant_profile: mentor_profile,
                                             source_cohort_start_year: mentor_profile.schedule.cohort.start_year,
-                                            target_cohort_start_year: Cohort.active_registration_cohort.start_year,
+                                            target_cohort_start_year:,
                                             force_from_frozen_cohort: true).save
     end
 
@@ -93,6 +93,10 @@ module EarlyCareerTeachers
 
     def participant_profile_exists?
       teacher_profile.participant_profiles.ects.exists? || user.participant_identities.joins(:participant_profiles).where(participant_profiles: { type: "ParticipantProfile::ECT" }).exists?
+    end
+
+    def target_cohort_start_year
+      Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT
     end
   end
 end

--- a/app/services/early_career_teachers/create.rb
+++ b/app/services/early_career_teachers/create.rb
@@ -56,7 +56,7 @@ module EarlyCareerTeachers
     def amend_mentor_cohort
       Induction::AmendParticipantCohort.new(participant_profile: mentor_profile,
                                             source_cohort_start_year: mentor_profile.schedule.cohort.start_year,
-                                            target_cohort_start_year:,
+                                            target_cohort_start_year: Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT,
                                             force_from_frozen_cohort: true).save
     end
 
@@ -93,10 +93,6 @@ module EarlyCareerTeachers
 
     def participant_profile_exists?
       teacher_profile.participant_profiles.ects.exists? || user.participant_identities.joins(:participant_profiles).where(participant_profiles: { type: "ParticipantProfile::ECT" }).exists?
-    end
-
-    def target_cohort_start_year
-      Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT
     end
   end
 end

--- a/app/services/early_career_teachers/reactivate.rb
+++ b/app/services/early_career_teachers/reactivate.rb
@@ -49,7 +49,7 @@ module EarlyCareerTeachers
     def amend_mentor_cohort
       Induction::AmendParticipantCohort.new(participant_profile: mentor_profile,
                                             source_cohort_start_year: mentor_profile.schedule.cohort.start_year,
-                                            target_cohort_start_year:,
+                                            target_cohort_start_year: Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT,
                                             force_from_frozen_cohort: true).save
     end
 
@@ -78,10 +78,6 @@ module EarlyCareerTeachers
         status: :active,
         schedule: Finance::Schedule::ECF.default_for(cohort:),
       )
-    end
-
-    def target_cohort_start_year
-      Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT
     end
 
     def update_participant_profile_email

--- a/app/services/early_career_teachers/reactivate.rb
+++ b/app/services/early_career_teachers/reactivate.rb
@@ -49,7 +49,7 @@ module EarlyCareerTeachers
     def amend_mentor_cohort
       Induction::AmendParticipantCohort.new(participant_profile: mentor_profile,
                                             source_cohort_start_year: mentor_profile.schedule.cohort.start_year,
-                                            target_cohort_start_year: Cohort.active_registration_cohort.start_year,
+                                            target_cohort_start_year:,
                                             force_from_frozen_cohort: true).save
     end
 
@@ -78,6 +78,10 @@ module EarlyCareerTeachers
         status: :active,
         schedule: Finance::Schedule::ECF.default_for(cohort:),
       )
+    end
+
+    def target_cohort_start_year
+      Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT
     end
 
     def update_participant_profile_email

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -25,6 +25,7 @@ class FeatureFlag
     school_participant_status_language
     registration_pilot_school
     programme_type_changes_2025
+    closing_2022
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).index_with { |name|

--- a/app/services/induction/amend_cohort_after_eligibility_checks.rb
+++ b/app/services/induction/amend_cohort_after_eligibility_checks.rb
@@ -18,9 +18,13 @@ module Induction
     def amend_participant_cohort
       Induction::AmendParticipantCohort.new(participant_profile:,
                                             source_cohort_start_year: participant_profile.schedule&.cohort&.start_year,
-                                            target_cohort_start_year: Cohort.active_registration_cohort.start_year,
+                                            target_cohort_start_year:,
                                             force_from_frozen_cohort: true)
                                        .save
+    end
+
+    def target_cohort_start_year
+      Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT
     end
 
     def unfinished_eligible_participant?

--- a/app/services/induction/amend_cohort_after_eligibility_checks.rb
+++ b/app/services/induction/amend_cohort_after_eligibility_checks.rb
@@ -18,13 +18,9 @@ module Induction
     def amend_participant_cohort
       Induction::AmendParticipantCohort.new(participant_profile:,
                                             source_cohort_start_year: participant_profile.schedule&.cohort&.start_year,
-                                            target_cohort_start_year:,
+                                            target_cohort_start_year: Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT,
                                             force_from_frozen_cohort: true)
                                        .save
-    end
-
-    def target_cohort_start_year
-      Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT
     end
 
     def unfinished_eligible_participant?

--- a/app/services/induction/amend_participant_cohort.rb
+++ b/app/services/induction/amend_participant_cohort.rb
@@ -23,7 +23,7 @@
 #                                             schedule:).save
 #
 #  - For cohort changes on participants whose current cohort has been payments_frozen and are transferred to
-#    the active registration cohort, it will automatically flag the participant_profile as
+#    the Cohort.destination_from_frozen_cohort, it will automatically flag the participant_profile as
 #    cohort_changed_after_payments_frozen: true
 #
 module Induction
@@ -251,7 +251,7 @@ module Induction
     end
 
     def transfer_from_payments_frozen_cohort?
-      source_cohort&.payments_frozen? && target_cohort == Cohort.active_registration_cohort
+      source_cohort&.payments_frozen? && target_cohort == Cohort.destination_from_frozen_cohort
     end
 
     def cohort_changed_after_payments_frozen

--- a/app/services/induction/change_mentor.rb
+++ b/app/services/induction/change_mentor.rb
@@ -27,7 +27,7 @@ private
   def amend_mentor_cohort
     Induction::AmendParticipantCohort.new(participant_profile: mentor_profile,
                                           source_cohort_start_year: mentor_profile.schedule.cohort.start_year,
-                                          target_cohort_start_year:,
+                                          target_cohort_start_year: Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT,
                                           force_from_frozen_cohort: true).save
   end
 
@@ -63,9 +63,5 @@ private
 
   def sit_name
     induction_record.school.induction_tutor&.full_name
-  end
-
-  def target_cohort_start_year
-    Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT
   end
 end

--- a/app/services/induction/change_mentor.rb
+++ b/app/services/induction/change_mentor.rb
@@ -27,7 +27,7 @@ private
   def amend_mentor_cohort
     Induction::AmendParticipantCohort.new(participant_profile: mentor_profile,
                                           source_cohort_start_year: mentor_profile.schedule.cohort.start_year,
-                                          target_cohort_start_year: Cohort.active_registration_cohort.start_year,
+                                          target_cohort_start_year:,
                                           force_from_frozen_cohort: true).save
   end
 
@@ -63,5 +63,9 @@ private
 
   def sit_name
     induction_record.school.induction_tutor&.full_name
+  end
+
+  def target_cohort_start_year
+    Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT
   end
 end

--- a/app/services/induction/transfer_and_continue_existing_fip.rb
+++ b/app/services/induction/transfer_and_continue_existing_fip.rb
@@ -34,7 +34,7 @@ private
   def amend_mentor_cohort
     Induction::AmendParticipantCohort.new(participant_profile: mentor_profile,
                                           source_cohort_start_year: mentor_profile.schedule.cohort.start_year,
-                                          target_cohort_start_year: Cohort.active_registration_cohort.start_year,
+                                          target_cohort_start_year:,
                                           force_from_frozen_cohort: true).save
   end
 
@@ -118,5 +118,9 @@ private
     @schedule ||= Induction::ScheduleForNewCohort.call(cohort:,
                                                        induction_record: latest_induction_record,
                                                        extended_schedule: cohort_changed_after_payments_frozen)
+  end
+
+  def target_cohort_start_year
+    Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT
   end
 end

--- a/app/services/induction/transfer_and_continue_existing_fip.rb
+++ b/app/services/induction/transfer_and_continue_existing_fip.rb
@@ -34,7 +34,7 @@ private
   def amend_mentor_cohort
     Induction::AmendParticipantCohort.new(participant_profile: mentor_profile,
                                           source_cohort_start_year: mentor_profile.schedule.cohort.start_year,
-                                          target_cohort_start_year:,
+                                          target_cohort_start_year: Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT,
                                           force_from_frozen_cohort: true).save
   end
 
@@ -118,9 +118,5 @@ private
     @schedule ||= Induction::ScheduleForNewCohort.call(cohort:,
                                                        induction_record: latest_induction_record,
                                                        extended_schedule: cohort_changed_after_payments_frozen)
-  end
-
-  def target_cohort_start_year
-    Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT
   end
 end

--- a/app/services/induction/transfer_to_schools_programme.rb
+++ b/app/services/induction/transfer_to_schools_programme.rb
@@ -55,7 +55,7 @@ private
   def amend_mentor_cohort
     Induction::AmendParticipantCohort.new(participant_profile: mentor_profile,
                                           source_cohort_start_year: mentor_profile.schedule.cohort.start_year,
-                                          target_cohort_start_year: Cohort.active_registration_cohort.start_year,
+                                          target_cohort_start_year:,
                                           force_from_frozen_cohort: true).save
   end
 
@@ -79,5 +79,9 @@ private
     @schedule ||= Induction::ScheduleForNewCohort.call(cohort:,
                                                        induction_record: latest_induction_record,
                                                        extended_schedule: cohort_changed_after_payments_frozen)
+  end
+
+  def target_cohort_start_year
+    Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT
   end
 end

--- a/app/services/induction/transfer_to_schools_programme.rb
+++ b/app/services/induction/transfer_to_schools_programme.rb
@@ -55,7 +55,7 @@ private
   def amend_mentor_cohort
     Induction::AmendParticipantCohort.new(participant_profile: mentor_profile,
                                           source_cohort_start_year: mentor_profile.schedule.cohort.start_year,
-                                          target_cohort_start_year:,
+                                          target_cohort_start_year: Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT,
                                           force_from_frozen_cohort: true).save
   end
 
@@ -79,9 +79,5 @@ private
     @schedule ||= Induction::ScheduleForNewCohort.call(cohort:,
                                                        induction_record: latest_induction_record,
                                                        extended_schedule: cohort_changed_after_payments_frozen)
-  end
-
-  def target_cohort_start_year
-    Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT
   end
 end

--- a/app/services/participants/check_and_set_completion_date.rb
+++ b/app/services/participants/check_and_set_completion_date.rb
@@ -117,11 +117,8 @@ module Participants
       Participants::SyncDQTInductionStartDate.call(start_date, participant_profile)
     end
 
-    def target_cohort
-      Cohort.active_registration_cohort
+    def target_cohort_start_year
+      Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT
     end
-
-    # target_cohort_start_year
-    delegate :start_year, to: :target_cohort, prefix: true
   end
 end

--- a/db/new_seeds/base/add_testing_scenarios_for_closing_2021.rb
+++ b/db/new_seeds/base/add_testing_scenarios_for_closing_2021.rb
@@ -7,354 +7,356 @@ cohort_2024 = Cohort.find_by_start_year(2024)
 cohort_2025 = Cohort.find_by_start_year(2025)
 
 ActiveRecord::Base.transaction do
-  (1..4).each do |school_number|
-    school = NewSeeds::Scenarios::Schools::School.new(name: "Closing 2021 School #{school_number}", urn: "20210#{school_number}")
-                                                 .build
-                                                 .with_an_induction_tutor(full_name: "SIT Closing 2021 School #{school_number}", email: "sit-closing-2021-school-#{school_number}@example.com")
-                                                 .chosen_fip_and_partnered_in(cohort: cohort_2021)
-                                                 .chosen_fip_and_partnered_in(cohort: cohort_2022)
-                                                 .chosen_fip_and_partnered_in(cohort: cohort_2023)
-                                                 .chosen_fip_and_partnered_in(cohort: cohort_2024)
-                                                 .chosen_fip_and_partnered_in(cohort: cohort_2025)
-    (2021..2025).each do |start_year|
-      school_cohort = school.school_cohorts[start_year]
-      cpd_lead_provider = FactoryBot.create(:seed_cpd_lead_provider,
-                                            name: school_cohort.default_induction_programme.partnership.lead_provider.name)
+  (2021..2022).each do |cohort_to_close|
+    (1..4).each do |school_number|
+      school = NewSeeds::Scenarios::Schools::School.new(name: "Closing #{cohort_to_close} School #{school_number}", urn: "#{cohort_to_close}0#{school_number}")
+                                                   .build
+                                                   .with_an_induction_tutor(full_name: "SIT Closing #{cohort_to_close} School #{school_number}", email: "sit-closing-#{cohort_to_close}-school-#{school_number}@example.com")
+                                                   .chosen_fip_and_partnered_in(cohort: cohort_2021)
+                                                   .chosen_fip_and_partnered_in(cohort: cohort_2022)
+                                                   .chosen_fip_and_partnered_in(cohort: cohort_2023)
+                                                   .chosen_fip_and_partnered_in(cohort: cohort_2024)
+                                                   .chosen_fip_and_partnered_in(cohort: cohort_2025)
+      (2021..2025).each do |start_year|
+        school_cohort = school.school_cohorts[start_year]
+        cpd_lead_provider = FactoryBot.create(:seed_cpd_lead_provider,
+                                              name: school_cohort.default_induction_programme.partnership.lead_provider.name)
 
-      { "Mentor" => NewSeeds::Scenarios::Participants::Mentors::MentorWithNoEcts,
-        "Ect" => NewSeeds::Scenarios::Participants::Ects::Ect }.each do |participant_type, scenario_klass|
-        # #{participant_type} with only completed billable declaration
-        declaration_factory_type = participant_type == "Mentor" ? :seed_mentor_participant_declaration : :seed_ect_participant_declaration
+        { "Mentor" => NewSeeds::Scenarios::Participants::Mentors::MentorWithNoEcts,
+          "Ect" => NewSeeds::Scenarios::Participants::Ects::Ect }.each do |participant_type, scenario_klass|
+          # #{participant_type} with only completed billable declaration
+          declaration_factory_type = participant_type == "Mentor" ? :seed_mentor_participant_declaration : :seed_ect_participant_declaration
 
-        scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with completed billable declaration")
-        .build
-        .with_induction_record(induction_programme: school_cohort.default_induction_programme)
-        .with_validation_data
-        .with_eligibility.tap do |scenario|
-          FactoryBot.create(declaration_factory_type,
-                            participant_profile: scenario.participant_profile,
-                            cohort: school_cohort.cohort,
-                            user: scenario.user,
-                            cpd_lead_provider:,
-                            declaration_type: "completed",
-                            state: "eligible")
+          scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with completed billable declaration")
+          .build
+          .with_induction_record(induction_programme: school_cohort.default_induction_programme)
+          .with_validation_data
+          .with_eligibility.tap do |scenario|
+            FactoryBot.create(declaration_factory_type,
+                              participant_profile: scenario.participant_profile,
+                              cohort: school_cohort.cohort,
+                              user: scenario.user,
+                              cpd_lead_provider:,
+                              declaration_type: "completed",
+                              state: "eligible")
+          end
+
+          # #{participant_type} with only completed non-billable declaration
+          scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with completed non-billable declaration")
+          .build
+          .with_induction_record(induction_programme: school_cohort.default_induction_programme)
+          .with_validation_data
+          .with_eligibility.tap do |scenario|
+            FactoryBot.create(declaration_factory_type,
+                              participant_profile: scenario.participant_profile,
+                              cohort: school_cohort.cohort,
+                              user: scenario.user,
+                              cpd_lead_provider:,
+                              declaration_type: "completed",
+                              state: "submitted")
+          end
+
+          # #{participant_type} with only non-completed billable declaration
+          scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with non-completed billable declaration")
+          .build
+          .with_induction_record(induction_programme: school_cohort.default_induction_programme)
+          .with_validation_data
+          .with_eligibility.tap do |scenario|
+            FactoryBot.create(declaration_factory_type,
+                              participant_profile: scenario.participant_profile,
+                              cohort: school_cohort.cohort,
+                              user: scenario.user,
+                              cpd_lead_provider:,
+                              declaration_type: "started",
+                              state: "eligible")
+          end
+
+          completion_date = Date.new(start_year + 1, 8, 31)
+          build_params = if participant_type == "Mentor"
+                           { mentor_completion_date: completion_date }
+                         else
+                           { induction_completion_date: completion_date }
+                         end
+
+          # #{participant_type} with only non-completed billable declaration and completion date
+          scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with non-completed billable declaration and completion date")
+          .build(**build_params)
+          .with_induction_record(induction_programme: school_cohort.default_induction_programme)
+          .with_validation_data
+          .with_eligibility.tap do |scenario|
+            FactoryBot.create(declaration_factory_type,
+                              participant_profile: scenario.participant_profile,
+                              cohort: school_cohort.cohort,
+                              user: scenario.user,
+                              cpd_lead_provider:,
+                              declaration_type: "started",
+                              state: "eligible")
+          end
+
+          # #{participant_type} with only non-completed non-billable(submitted) declaration
+          scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with non-completed non-billable(submitted) declaration")
+          .build
+          .with_induction_record(induction_programme: school_cohort.default_induction_programme)
+          .with_validation_data
+          .with_eligibility.tap do |scenario|
+            FactoryBot.create(declaration_factory_type,
+                              participant_profile: scenario.participant_profile,
+                              cohort: school_cohort.cohort,
+                              user: scenario.user,
+                              cpd_lead_provider:,
+                              declaration_type: "retained-1",
+                              state: "submitted")
+          end
+
+          # #{participant_type} with only non-completed non-billable not submitted declaration
+          scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with non-completed non-billable not submitted declaration")
+          .build
+          .with_induction_record(induction_programme: school_cohort.default_induction_programme)
+          .with_validation_data
+          .with_eligibility.tap do |scenario|
+            FactoryBot.create(declaration_factory_type,
+                              participant_profile: scenario.participant_profile,
+                              cohort: school_cohort.cohort,
+                              user: scenario.user,
+                              cpd_lead_provider:,
+                              declaration_type: "retained-1",
+                              state: "voided")
+          end
+
+          # #{participant_type} with only completion date
+          scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} only with completion date")
+                        .build(**build_params)
+                        .with_induction_record(induction_programme: school_cohort.default_induction_programme)
+                        .with_validation_data
+                        .with_eligibility
+
+          # #{participant_type}
+          scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number}")
+                        .build
+                        .with_induction_record(induction_programme: school_cohort.default_induction_programme)
+                        .with_validation_data
+                        .with_eligibility
+
+          # #{participant_type} Ineligible no ISD
+          scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} Ineligible for funding and no induction start date First")
+                        .build(induction_start_date: nil)
+                        .with_induction_record(induction_programme: school_cohort.default_induction_programme)
+                        .with_validation_data
+                        .with_eligibility(status: "ineligible", reason: "no_induction")
+
+          scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} Ineligible for funding and no induction start date Second")
+                        .build(induction_start_date: nil)
+                        .with_induction_record(induction_programme: school_cohort.default_induction_programme)
+                        .with_validation_data
+                        .with_eligibility(status: "ineligible", reason: "no_induction")
+
+          scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} Ineligible for funding and no induction start date Third")
+                        .build(induction_start_date: nil)
+                        .with_induction_record(induction_programme: school_cohort.default_induction_programme)
+                        .with_validation_data
+                        .with_eligibility(status: "ineligible", reason: "no_induction")
+
+          # #{participant_type} Ineligible no ISD  with only non-completed non-billable declaration
+          scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with non-completed non-billable declaration and Ineligible for funding and no induction start date First")
+          .build(induction_start_date: nil)
+          .with_induction_record(induction_programme: school_cohort.default_induction_programme)
+          .with_validation_data
+          .with_eligibility(status: "ineligible", reason: "no_induction").tap do |scenario|
+            FactoryBot.create(declaration_factory_type,
+                              participant_profile: scenario.participant_profile,
+                              cohort: school_cohort.cohort,
+                              user: scenario.user,
+                              cpd_lead_provider:,
+                              declaration_type: "started",
+                              state: "voided")
+          end
+
+          # #{participant_type} Ineligible no ISD  with only non-completed non-billable declaration
+          scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with non-completed non-billable declaration and Ineligible for funding and no induction start date Second")
+          .build(induction_start_date: nil)
+          .with_induction_record(induction_programme: school_cohort.default_induction_programme)
+          .with_validation_data
+          .with_eligibility(status: "ineligible", reason: "no_induction").tap do |scenario|
+            FactoryBot.create(declaration_factory_type,
+                              participant_profile: scenario.participant_profile,
+                              cohort: school_cohort.cohort,
+                              user: scenario.user,
+                              cpd_lead_provider:,
+                              declaration_type: "started",
+                              state: "voided")
+          end
+
+          # #{participant_type} Ineligible no ISD  with only non-completed non-billable declaration
+          scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with non-completed non-billable declaration and Ineligible for funding and no induction start date Third")
+          .build(induction_start_date: nil)
+          .with_induction_record(induction_programme: school_cohort.default_induction_programme)
+          .with_validation_data
+          .with_eligibility(status: "ineligible", reason: "no_induction").tap do |scenario|
+            FactoryBot.create(declaration_factory_type,
+                              participant_profile: scenario.participant_profile,
+                              cohort: school_cohort.cohort,
+                              user: scenario.user,
+                              cpd_lead_provider:,
+                              declaration_type: "started",
+                              state: "voided")
+          end
+
+          # #{participant_type} Ineligible no ISD  with only non-completed billable declaration
+          scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with non-completed billable declaration and Ineligible for funding and no induction start date First")
+          .build(induction_start_date: nil)
+          .with_induction_record(induction_programme: school_cohort.default_induction_programme)
+          .with_validation_data
+          .with_eligibility(status: "ineligible", reason: "no_induction").tap do |scenario|
+            FactoryBot.create(declaration_factory_type,
+                              participant_profile: scenario.participant_profile,
+                              cohort: school_cohort.cohort,
+                              user: scenario.user,
+                              cpd_lead_provider:,
+                              declaration_type: "started",
+                              state: "eligible")
+          end
+
+          # #{participant_type} Ineligible no ISD  with only non-completed billable declaration
+          scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with non-completed billable declaration and Ineligible for funding and no induction start date Second")
+          .build(induction_start_date: nil)
+          .with_induction_record(induction_programme: school_cohort.default_induction_programme)
+          .with_validation_data
+          .with_eligibility(status: "ineligible", reason: "no_induction").tap do |scenario|
+            FactoryBot.create(declaration_factory_type,
+                              participant_profile: scenario.participant_profile,
+                              cohort: school_cohort.cohort,
+                              user: scenario.user,
+                              cpd_lead_provider:,
+                              declaration_type: "started",
+                              state: "eligible")
+          end
+
+          # #{participant_type} Ineligible no ISD  with only non-completed billable declaration
+          scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with non-completed billable declaration and Ineligible for funding and no induction start date Third")
+          .build(induction_start_date: nil)
+          .with_induction_record(induction_programme: school_cohort.default_induction_programme)
+          .with_validation_data
+          .with_eligibility(status: "ineligible", reason: "no_induction").tap do |scenario|
+            FactoryBot.create(declaration_factory_type,
+                              participant_profile: scenario.participant_profile,
+                              cohort: school_cohort.cohort,
+                              user: scenario.user,
+                              cpd_lead_provider:,
+                              declaration_type: "started",
+                              state: "eligible")
+          end
+
+          # #{participant_type} Ineligible no ISD  with only completed non-billable declaration
+          scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with completed non-billable declaration and Ineligible for funding and no induction start date First")
+          .build(induction_start_date: nil)
+          .with_induction_record(induction_programme: school_cohort.default_induction_programme)
+          .with_validation_data
+          .with_eligibility(status: "ineligible", reason: "no_induction").tap do |scenario|
+            FactoryBot.create(declaration_factory_type,
+                              participant_profile: scenario.participant_profile,
+                              cohort: school_cohort.cohort,
+                              user: scenario.user,
+                              cpd_lead_provider:,
+                              declaration_type: "completed",
+                              state: "voided")
+          end
+
+          # #{participant_type} Ineligible no ISD  with only completed non-billable declaration
+          scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with completed non-billable declaration and Ineligible for funding and no induction start date Second")
+          .build(induction_start_date: nil)
+          .with_induction_record(induction_programme: school_cohort.default_induction_programme)
+          .with_validation_data
+          .with_eligibility(status: "ineligible", reason: "no_induction").tap do |scenario|
+            FactoryBot.create(declaration_factory_type,
+                              participant_profile: scenario.participant_profile,
+                              cohort: school_cohort.cohort,
+                              user: scenario.user,
+                              cpd_lead_provider:,
+                              declaration_type: "completed",
+                              state: "voided")
+          end
+
+          # #{participant_type} Ineligible no ISD  with only completed non-billable declaration
+          scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with completed non-billable declaration and Ineligible for funding and no induction start date Third")
+          .build(induction_start_date: nil)
+          .with_induction_record(induction_programme: school_cohort.default_induction_programme)
+          .with_validation_data
+          .with_eligibility(status: "ineligible", reason: "no_induction").tap do |scenario|
+            FactoryBot.create(declaration_factory_type,
+                              participant_profile: scenario.participant_profile,
+                              cohort: school_cohort.cohort,
+                              user: scenario.user,
+                              cpd_lead_provider:,
+                              declaration_type: "completed",
+                              state: "voided")
+          end
+
+          # #{participant_type} Ineligible no ISD  with only completed billable declaration
+          scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with completed billable declaration and Ineligible for funding and no induction start date First")
+          .build(induction_start_date: nil)
+          .with_induction_record(induction_programme: school_cohort.default_induction_programme)
+          .with_validation_data
+          .with_eligibility(status: "ineligible", reason: "no_induction").tap do |scenario|
+            FactoryBot.create(declaration_factory_type,
+                              participant_profile: scenario.participant_profile,
+                              cohort: school_cohort.cohort,
+                              user: scenario.user,
+                              cpd_lead_provider:,
+                              declaration_type: "completed",
+                              state: "paid")
+          end
+
+          # #{participant_type} Ineligible no ISD with only completed billable declaration
+          scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with completed billable declaration and Ineligible for funding and no induction start date Second")
+          .build(induction_start_date: nil)
+          .with_induction_record(induction_programme: school_cohort.default_induction_programme)
+          .with_validation_data
+          .with_eligibility(status: "ineligible", reason: "no_induction").tap do |scenario|
+            FactoryBot.create(declaration_factory_type,
+                              participant_profile: scenario.participant_profile,
+                              cohort: school_cohort.cohort,
+                              user: scenario.user,
+                              cpd_lead_provider:,
+                              declaration_type: "completed",
+                              state: "paid")
+          end
+
+          # #{participant_type} Ineligible no ISD with only completed billable declaration
+          scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with completed billable declaration and Ineligible for funding and no induction start date Third")
+          .build(induction_start_date: nil)
+          .with_induction_record(induction_programme: school_cohort.default_induction_programme)
+          .with_validation_data
+          .with_eligibility(status: "ineligible", reason: "no_induction").tap do |scenario|
+            FactoryBot.create(declaration_factory_type,
+                              participant_profile: scenario.participant_profile,
+                              cohort: school_cohort.cohort,
+                              user: scenario.user,
+                              cpd_lead_provider:,
+                              declaration_type: "completed",
+                              state: "paid")
+          end
+
+          # #{participant_type} Ineligible no ISD with only completion date
+          scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} Ineligible with only completion date and no induction start date First")
+                        .build(induction_start_date: nil, **build_params)
+                        .with_induction_record(induction_programme: school_cohort.default_induction_programme)
+                        .with_validation_data
+                        .with_eligibility(status: "ineligible", reason: "no_induction")
+
+          # #{participant_type} Ineligible no ISD with only completion date
+          scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} Ineligible with only completion date and no induction start date Second")
+                        .build(induction_start_date: nil, **build_params)
+                        .with_induction_record(induction_programme: school_cohort.default_induction_programme)
+                        .with_validation_data
+                        .with_eligibility(status: "ineligible", reason: "no_induction")
+
+          # #{participant_type} Ineligible no ISD with only completion date
+          scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} Ineligible with only completion date and no induction start date Third")
+                        .build(induction_start_date: nil, **build_params)
+                        .with_induction_record(induction_programme: school_cohort.default_induction_programme)
+                        .with_validation_data
+                        .with_eligibility(status: "ineligible", reason: "no_induction")
         end
-
-        # #{participant_type} with only completed non-billable declaration
-        scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with completed non-billable declaration")
-        .build
-        .with_induction_record(induction_programme: school_cohort.default_induction_programme)
-        .with_validation_data
-        .with_eligibility.tap do |scenario|
-          FactoryBot.create(declaration_factory_type,
-                            participant_profile: scenario.participant_profile,
-                            cohort: school_cohort.cohort,
-                            user: scenario.user,
-                            cpd_lead_provider:,
-                            declaration_type: "completed",
-                            state: "submitted")
-        end
-
-        # #{participant_type} with only non-completed billable declaration
-        scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with non-completed billable declaration")
-        .build
-        .with_induction_record(induction_programme: school_cohort.default_induction_programme)
-        .with_validation_data
-        .with_eligibility.tap do |scenario|
-          FactoryBot.create(declaration_factory_type,
-                            participant_profile: scenario.participant_profile,
-                            cohort: school_cohort.cohort,
-                            user: scenario.user,
-                            cpd_lead_provider:,
-                            declaration_type: "started",
-                            state: "eligible")
-        end
-
-        completion_date = Date.new(start_year + 1, 8, 31)
-        build_params = if participant_type == "Mentor"
-                         { mentor_completion_date: completion_date }
-                       else
-                         { induction_completion_date: completion_date }
-                       end
-
-        # #{participant_type} with only non-completed billable declaration and completion date
-        scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with non-completed billable declaration and completion date")
-        .build(**build_params)
-        .with_induction_record(induction_programme: school_cohort.default_induction_programme)
-        .with_validation_data
-        .with_eligibility.tap do |scenario|
-          FactoryBot.create(declaration_factory_type,
-                            participant_profile: scenario.participant_profile,
-                            cohort: school_cohort.cohort,
-                            user: scenario.user,
-                            cpd_lead_provider:,
-                            declaration_type: "started",
-                            state: "eligible")
-        end
-
-        # #{participant_type} with only non-completed non-billable(submitted) declaration
-        scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with non-completed non-billable(submitted) declaration")
-        .build
-        .with_induction_record(induction_programme: school_cohort.default_induction_programme)
-        .with_validation_data
-        .with_eligibility.tap do |scenario|
-          FactoryBot.create(declaration_factory_type,
-                            participant_profile: scenario.participant_profile,
-                            cohort: school_cohort.cohort,
-                            user: scenario.user,
-                            cpd_lead_provider:,
-                            declaration_type: "retained-1",
-                            state: "submitted")
-        end
-
-        # #{participant_type} with only non-completed non-billable not submitted declaration
-        scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with non-completed non-billable not submitted declaration")
-        .build
-        .with_induction_record(induction_programme: school_cohort.default_induction_programme)
-        .with_validation_data
-        .with_eligibility.tap do |scenario|
-          FactoryBot.create(declaration_factory_type,
-                            participant_profile: scenario.participant_profile,
-                            cohort: school_cohort.cohort,
-                            user: scenario.user,
-                            cpd_lead_provider:,
-                            declaration_type: "retained-1",
-                            state: "voided")
-        end
-
-        # #{participant_type} with only completion date
-        scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} only with completion date")
-                      .build(**build_params)
-                      .with_induction_record(induction_programme: school_cohort.default_induction_programme)
-                      .with_validation_data
-                      .with_eligibility
-
-        # #{participant_type}
-        scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number}")
-                      .build
-                      .with_induction_record(induction_programme: school_cohort.default_induction_programme)
-                      .with_validation_data
-                      .with_eligibility
-
-        # #{participant_type} Ineligible no ISD
-        scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} Ineligible for funding and no induction start date First")
-                      .build(induction_start_date: nil)
-                      .with_induction_record(induction_programme: school_cohort.default_induction_programme)
-                      .with_validation_data
-                      .with_eligibility(status: "ineligible", reason: "no_induction")
-
-        scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} Ineligible for funding and no induction start date Second")
-                      .build(induction_start_date: nil)
-                      .with_induction_record(induction_programme: school_cohort.default_induction_programme)
-                      .with_validation_data
-                      .with_eligibility(status: "ineligible", reason: "no_induction")
-
-        scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} Ineligible for funding and no induction start date Third")
-                      .build(induction_start_date: nil)
-                      .with_induction_record(induction_programme: school_cohort.default_induction_programme)
-                      .with_validation_data
-                      .with_eligibility(status: "ineligible", reason: "no_induction")
-
-        # #{participant_type} Ineligible no ISD  with only non-completed non-billable declaration
-        scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with non-completed non-billable declaration and Ineligible for funding and no induction start date First")
-        .build(induction_start_date: nil)
-        .with_induction_record(induction_programme: school_cohort.default_induction_programme)
-        .with_validation_data
-        .with_eligibility(status: "ineligible", reason: "no_induction").tap do |scenario|
-          FactoryBot.create(declaration_factory_type,
-                            participant_profile: scenario.participant_profile,
-                            cohort: school_cohort.cohort,
-                            user: scenario.user,
-                            cpd_lead_provider:,
-                            declaration_type: "started",
-                            state: "voided")
-        end
-
-        # #{participant_type} Ineligible no ISD  with only non-completed non-billable declaration
-        scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with non-completed non-billable declaration and Ineligible for funding and no induction start date Second")
-        .build(induction_start_date: nil)
-        .with_induction_record(induction_programme: school_cohort.default_induction_programme)
-        .with_validation_data
-        .with_eligibility(status: "ineligible", reason: "no_induction").tap do |scenario|
-          FactoryBot.create(declaration_factory_type,
-                            participant_profile: scenario.participant_profile,
-                            cohort: school_cohort.cohort,
-                            user: scenario.user,
-                            cpd_lead_provider:,
-                            declaration_type: "started",
-                            state: "voided")
-        end
-
-        # #{participant_type} Ineligible no ISD  with only non-completed non-billable declaration
-        scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with non-completed non-billable declaration and Ineligible for funding and no induction start date Third")
-        .build(induction_start_date: nil)
-        .with_induction_record(induction_programme: school_cohort.default_induction_programme)
-        .with_validation_data
-        .with_eligibility(status: "ineligible", reason: "no_induction").tap do |scenario|
-          FactoryBot.create(declaration_factory_type,
-                            participant_profile: scenario.participant_profile,
-                            cohort: school_cohort.cohort,
-                            user: scenario.user,
-                            cpd_lead_provider:,
-                            declaration_type: "started",
-                            state: "voided")
-        end
-
-        # #{participant_type} Ineligible no ISD  with only non-completed billable declaration
-        scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with non-completed billable declaration and Ineligible for funding and no induction start date First")
-        .build(induction_start_date: nil)
-        .with_induction_record(induction_programme: school_cohort.default_induction_programme)
-        .with_validation_data
-        .with_eligibility(status: "ineligible", reason: "no_induction").tap do |scenario|
-          FactoryBot.create(declaration_factory_type,
-                            participant_profile: scenario.participant_profile,
-                            cohort: school_cohort.cohort,
-                            user: scenario.user,
-                            cpd_lead_provider:,
-                            declaration_type: "started",
-                            state: "eligible")
-        end
-
-        # #{participant_type} Ineligible no ISD  with only non-completed billable declaration
-        scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with non-completed billable declaration and Ineligible for funding and no induction start date Second")
-        .build(induction_start_date: nil)
-        .with_induction_record(induction_programme: school_cohort.default_induction_programme)
-        .with_validation_data
-        .with_eligibility(status: "ineligible", reason: "no_induction").tap do |scenario|
-          FactoryBot.create(declaration_factory_type,
-                            participant_profile: scenario.participant_profile,
-                            cohort: school_cohort.cohort,
-                            user: scenario.user,
-                            cpd_lead_provider:,
-                            declaration_type: "started",
-                            state: "eligible")
-        end
-
-        # #{participant_type} Ineligible no ISD  with only non-completed billable declaration
-        scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with non-completed billable declaration and Ineligible for funding and no induction start date Third")
-        .build(induction_start_date: nil)
-        .with_induction_record(induction_programme: school_cohort.default_induction_programme)
-        .with_validation_data
-        .with_eligibility(status: "ineligible", reason: "no_induction").tap do |scenario|
-          FactoryBot.create(declaration_factory_type,
-                            participant_profile: scenario.participant_profile,
-                            cohort: school_cohort.cohort,
-                            user: scenario.user,
-                            cpd_lead_provider:,
-                            declaration_type: "started",
-                            state: "eligible")
-        end
-
-        # #{participant_type} Ineligible no ISD  with only completed non-billable declaration
-        scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with completed non-billable declaration and Ineligible for funding and no induction start date First")
-        .build(induction_start_date: nil)
-        .with_induction_record(induction_programme: school_cohort.default_induction_programme)
-        .with_validation_data
-        .with_eligibility(status: "ineligible", reason: "no_induction").tap do |scenario|
-          FactoryBot.create(declaration_factory_type,
-                            participant_profile: scenario.participant_profile,
-                            cohort: school_cohort.cohort,
-                            user: scenario.user,
-                            cpd_lead_provider:,
-                            declaration_type: "completed",
-                            state: "voided")
-        end
-
-        # #{participant_type} Ineligible no ISD  with only completed non-billable declaration
-        scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with completed non-billable declaration and Ineligible for funding and no induction start date Second")
-        .build(induction_start_date: nil)
-        .with_induction_record(induction_programme: school_cohort.default_induction_programme)
-        .with_validation_data
-        .with_eligibility(status: "ineligible", reason: "no_induction").tap do |scenario|
-          FactoryBot.create(declaration_factory_type,
-                            participant_profile: scenario.participant_profile,
-                            cohort: school_cohort.cohort,
-                            user: scenario.user,
-                            cpd_lead_provider:,
-                            declaration_type: "completed",
-                            state: "voided")
-        end
-
-        # #{participant_type} Ineligible no ISD  with only completed non-billable declaration
-        scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with completed non-billable declaration and Ineligible for funding and no induction start date Third")
-        .build(induction_start_date: nil)
-        .with_induction_record(induction_programme: school_cohort.default_induction_programme)
-        .with_validation_data
-        .with_eligibility(status: "ineligible", reason: "no_induction").tap do |scenario|
-          FactoryBot.create(declaration_factory_type,
-                            participant_profile: scenario.participant_profile,
-                            cohort: school_cohort.cohort,
-                            user: scenario.user,
-                            cpd_lead_provider:,
-                            declaration_type: "completed",
-                            state: "voided")
-        end
-
-        # #{participant_type} Ineligible no ISD  with only completed billable declaration
-        scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with completed billable declaration and Ineligible for funding and no induction start date First")
-        .build(induction_start_date: nil)
-        .with_induction_record(induction_programme: school_cohort.default_induction_programme)
-        .with_validation_data
-        .with_eligibility(status: "ineligible", reason: "no_induction").tap do |scenario|
-          FactoryBot.create(declaration_factory_type,
-                            participant_profile: scenario.participant_profile,
-                            cohort: school_cohort.cohort,
-                            user: scenario.user,
-                            cpd_lead_provider:,
-                            declaration_type: "completed",
-                            state: "paid")
-        end
-
-        # #{participant_type} Ineligible no ISD with only completed billable declaration
-        scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with completed billable declaration and Ineligible for funding and no induction start date Second")
-        .build(induction_start_date: nil)
-        .with_induction_record(induction_programme: school_cohort.default_induction_programme)
-        .with_validation_data
-        .with_eligibility(status: "ineligible", reason: "no_induction").tap do |scenario|
-          FactoryBot.create(declaration_factory_type,
-                            participant_profile: scenario.participant_profile,
-                            cohort: school_cohort.cohort,
-                            user: scenario.user,
-                            cpd_lead_provider:,
-                            declaration_type: "completed",
-                            state: "paid")
-        end
-
-        # #{participant_type} Ineligible no ISD with only completed billable declaration
-        scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} with completed billable declaration and Ineligible for funding and no induction start date Third")
-        .build(induction_start_date: nil)
-        .with_induction_record(induction_programme: school_cohort.default_induction_programme)
-        .with_validation_data
-        .with_eligibility(status: "ineligible", reason: "no_induction").tap do |scenario|
-          FactoryBot.create(declaration_factory_type,
-                            participant_profile: scenario.participant_profile,
-                            cohort: school_cohort.cohort,
-                            user: scenario.user,
-                            cpd_lead_provider:,
-                            declaration_type: "completed",
-                            state: "paid")
-        end
-
-        # #{participant_type} Ineligible no ISD with only completion date
-        scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} Ineligible with only completion date and no induction start date First")
-                      .build(induction_start_date: nil, **build_params)
-                      .with_induction_record(induction_programme: school_cohort.default_induction_programme)
-                      .with_validation_data
-                      .with_eligibility(status: "ineligible", reason: "no_induction")
-
-        # #{participant_type} Ineligible no ISD with only completion date
-        scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} Ineligible with only completion date and no induction start date Second")
-                      .build(induction_start_date: nil, **build_params)
-                      .with_induction_record(induction_programme: school_cohort.default_induction_programme)
-                      .with_validation_data
-                      .with_eligibility(status: "ineligible", reason: "no_induction")
-
-        # #{participant_type} Ineligible no ISD with only completion date
-        scenario_klass.new(school_cohort:, full_name: "#{participant_type} #{start_year} School #{school_number} Ineligible with only completion date and no induction start date Third")
-                      .build(induction_start_date: nil, **build_params)
-                      .with_induction_record(induction_programme: school_cohort.default_induction_programme)
-                      .with_validation_data
-                      .with_eligibility(status: "ineligible", reason: "no_induction")
       end
     end
   end

--- a/spec/features/scenarios/onboarding_a_deferred_participant/cip_to_fip_spec.rb
+++ b/spec/features/scenarios/onboarding_a_deferred_participant/cip_to_fip_spec.rb
@@ -42,6 +42,7 @@ RSpec.feature "CIP to FIP - Onboard a deferred participant",
       allow(Cohort).to receive(:current).and_return(cohort)
       allow(Cohort).to receive(:next).and_return(cohort)
       allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
+      allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
       allow(cohort).to receive(:next).and_return(cohort)
       allow(cohort).to receive(:previous).and_return(cohort)
       cohort

--- a/spec/features/scenarios/onboarding_a_deferred_participant/fip_to_cip_spec.rb
+++ b/spec/features/scenarios/onboarding_a_deferred_participant/fip_to_cip_spec.rb
@@ -42,6 +42,7 @@ RSpec.feature "FIP to CIP - Onboard a deferred participant",
       allow(Cohort).to receive(:current).and_return(cohort)
       allow(Cohort).to receive(:next).and_return(cohort)
       allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
+      allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
       allow(cohort).to receive(:next).and_return(cohort)
       allow(cohort).to receive(:previous).and_return(cohort)
       cohort

--- a/spec/features/scenarios/onboarding_a_deferred_participant/fip_to_fip_with_different_provider_spec.rb
+++ b/spec/features/scenarios/onboarding_a_deferred_participant/fip_to_fip_with_different_provider_spec.rb
@@ -42,6 +42,7 @@ RSpec.feature "FIP to FIP with different provider - Onboard a deferred participa
       allow(Cohort).to receive(:current).and_return(cohort)
       allow(Cohort).to receive(:next).and_return(cohort)
       allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
+      allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
       allow(cohort).to receive(:next).and_return(cohort)
       allow(cohort).to receive(:previous).and_return(cohort)
       cohort

--- a/spec/features/scenarios/onboarding_a_deferred_participant/fip_to_fip_with_same_provider_spec.rb
+++ b/spec/features/scenarios/onboarding_a_deferred_participant/fip_to_fip_with_same_provider_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature "FIP to FIP with same provider - Onboard a deferred participant",
       allow(Cohort).to receive(:current).and_return(cohort)
       allow(Cohort).to receive(:next).and_return(cohort)
       allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
-
+      allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
       allow(cohort).to receive(:next).and_return(cohort)
       allow(cohort).to receive(:previous).and_return(cohort)
       cohort

--- a/spec/features/scenarios/onboarding_a_withdrawn_participant/cip_to_fip_spec.rb
+++ b/spec/features/scenarios/onboarding_a_withdrawn_participant/cip_to_fip_spec.rb
@@ -42,6 +42,7 @@ RSpec.feature "CIP to FIP - Onboarding a withdrawn participant",
       allow(Cohort).to receive(:current).and_return(cohort)
       allow(Cohort).to receive(:next).and_return(cohort)
       allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
+      allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
       allow(cohort).to receive(:next).and_return(cohort)
       allow(cohort).to receive(:previous).and_return(cohort)
       cohort

--- a/spec/features/scenarios/onboarding_a_withdrawn_participant/fip_to_cip_spec.rb
+++ b/spec/features/scenarios/onboarding_a_withdrawn_participant/fip_to_cip_spec.rb
@@ -42,6 +42,7 @@ RSpec.feature "FIP to CIP - Onboarding a withdrawn participant",
       allow(Cohort).to receive(:current).and_return(cohort)
       allow(Cohort).to receive(:next).and_return(cohort)
       allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
+      allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
       allow(cohort).to receive(:next).and_return(cohort)
       allow(cohort).to receive(:previous).and_return(cohort)
       cohort

--- a/spec/features/scenarios/onboarding_a_withdrawn_participant/fip_to_fip_with_different_provider_spec.rb
+++ b/spec/features/scenarios/onboarding_a_withdrawn_participant/fip_to_fip_with_different_provider_spec.rb
@@ -42,6 +42,7 @@ RSpec.feature "FIP to FIP with different provider - Onboarding a withdrawn parti
       allow(Cohort).to receive(:current).and_return(cohort)
       allow(Cohort).to receive(:next).and_return(cohort)
       allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
+      allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
       allow(cohort).to receive(:next).and_return(cohort)
       allow(cohort).to receive(:previous).and_return(cohort)
       cohort

--- a/spec/features/scenarios/onboarding_a_withdrawn_participant/fip_to_fip_with_same_provider_spec.rb
+++ b/spec/features/scenarios/onboarding_a_withdrawn_participant/fip_to_fip_with_same_provider_spec.rb
@@ -42,6 +42,7 @@ RSpec.feature "FIP to FIP with same provider - Onboarding a withdrawn participan
       allow(Cohort).to receive(:current).and_return(cohort)
       allow(Cohort).to receive(:next).and_return(cohort)
       allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
+      allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
       allow(cohort).to receive(:next).and_return(cohort)
       allow(cohort).to receive(:previous).and_return(cohort)
       cohort

--- a/spec/features/scenarios/transfering_a_participant/cip_to_cip_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/cip_to_cip_spec.rb
@@ -41,6 +41,7 @@ RSpec.feature "CIP to CIP - Transfer a participant",
       allow(Cohort).to receive(:current).and_return(cohort)
       allow(Cohort).to receive(:next).and_return(cohort)
       allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
+      allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
       allow(cohort).to receive(:next).and_return(cohort)
       allow(cohort).to receive(:previous).and_return(cohort)
       cohort

--- a/spec/features/scenarios/transfering_a_participant/cip_to_fip_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/cip_to_fip_spec.rb
@@ -41,6 +41,7 @@ RSpec.feature "CIP to FIP - Transfer a participant",
       allow(Cohort).to receive(:current).and_return(cohort)
       allow(Cohort).to receive(:next).and_return(cohort)
       allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
+      allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
       allow(cohort).to receive(:next).and_return(cohort)
       allow(cohort).to receive(:previous).and_return(cohort)
       cohort

--- a/spec/features/scenarios/transfering_a_participant/fip_to_cip_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/fip_to_cip_spec.rb
@@ -41,6 +41,7 @@ RSpec.feature "FIP to CIP - Transfer a participant",
       allow(Cohort).to receive(:current).and_return(cohort)
       allow(Cohort).to receive(:next).and_return(cohort)
       allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
+      allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
       allow(cohort).to receive(:next).and_return(cohort)
       allow(cohort).to receive(:previous).and_return(cohort)
       cohort

--- a/spec/features/scenarios/transfering_a_participant/fip_to_fip_with_different_provider_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/fip_to_fip_with_different_provider_spec.rb
@@ -41,6 +41,7 @@ RSpec.feature "FIP to FIP with different provider - Transfer a participant",
       allow(Cohort).to receive(:current).and_return(cohort)
       allow(Cohort).to receive(:next).and_return(cohort)
       allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
+      allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
       allow(cohort).to receive(:next).and_return(cohort)
       allow(cohort).to receive(:previous).and_return(cohort)
       cohort

--- a/spec/features/scenarios/transfering_a_participant/fip_to_fip_with_same_provider_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/fip_to_fip_with_same_provider_spec.rb
@@ -41,6 +41,7 @@ RSpec.feature "FIP to FIP with same provider - Transfer a participant",
       allow(Cohort).to receive(:current).and_return(cohort)
       allow(Cohort).to receive(:next).and_return(cohort)
       allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
+      allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
       allow(cohort).to receive(:next).and_return(cohort)
       allow(cohort).to receive(:previous).and_return(cohort)
       cohort

--- a/spec/features/schools/participants/add_participants/payments_frozen/common_steps.rb
+++ b/spec/features/schools/participants/add_participants/payments_frozen/common_steps.rb
@@ -115,3 +115,7 @@ end
 def and_the_mentor_has_been_added_to_the_active_registration_cohort
   expect(ParticipantProfile::Mentor.last.school_cohort.cohort).to eq(Cohort.active_registration_cohort)
 end
+
+def and_the_mentor_stays_in_their_current_cohort(cohort)
+  expect(ParticipantProfile::Mentor.last.school_cohort.cohort).to eq(cohort)
+end

--- a/spec/features/schools/participants/add_participants/payments_frozen/sit_adds_ect_spec.rb
+++ b/spec/features/schools/participants/add_participants/payments_frozen/sit_adds_ect_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "SIT adding an ECT", js: true, early_in_cohort: true do
     and_the_participant_has_been_added_to_the_active_registration_cohort
   end
 
-  scenario "when target cohort payments are not frozen and unfinished 2021 mentor is assigned" do
+  scenario "when target cohort payments are not frozen and unfinished 2021 mentor is assigned", with_feature_flags: { closing_2022: "active" } do
     given_there_is_a_school_that_has_chosen_fip_for_four_cohorts_and_partnered
     and_the_earliest_cohort_has_payments_frozen
     and_i_am_signed_in_as_an_induction_coordinator
@@ -93,5 +93,53 @@ RSpec.describe "SIT adding an ECT", js: true, early_in_cohort: true do
     then_i_see_confirmation_that_the_participant_has_been_added
     and_the_participant_has_been_added_to_the_active_registration_cohort
     and_the_mentor_stays_in_their_current_cohort(@mentor_school_cohort.cohort)
+  end
+
+  scenario "when target cohort payments are not frozen and unfinished 2021 mentor is assigned" do
+    given_there_is_a_school_that_has_chosen_fip_for_four_cohorts_and_partnered
+    and_the_earliest_cohort_has_payments_frozen
+    and_i_am_signed_in_as_an_induction_coordinator
+
+    and_i_have_added_a_mentor_in_cohort(earliest_cohort)
+    and_i_am_adding_a_participant_with_an_induction_start_date_in_the_cohort_with_payments_frozen
+    and_i_click_on(Cohort.current.description)
+    then_i_am_taken_to_fip_induction_dashboard
+
+    when_i_navigate_to_ect_dashboard
+    when_i_click_to_add_a_new_ect
+    then_i_should_be_on_the_who_to_add_page
+
+    when_i_select_to_add_a "ECT"
+    when_i_click_on_continue
+
+    then_i_am_taken_to_the_what_we_need_from_you_page
+
+    when_i_click_on_continue
+    then_i_am_taken_to_add_ect_name_page
+
+    when_i_add_ect_name
+    when_i_click_on_continue
+    then_i_am_taken_to_add_teachers_trn_page
+
+    when_i_add_the_trn
+    when_i_click_on_continue
+    then_i_am_taken_to_add_date_of_birth_page
+
+    when_i_add_a_date_of_birth
+    when_i_click_on_continue
+    then_i_am_taken_to_add_ect_or_mentor_email_page
+
+    when_i_add_ect_or_mentor_email(email: @participant_data[:email])
+    when_i_click_on_continue
+    then_i_am_taken_to_choose_mentor_page
+
+    when_i_select("Cohort Mentor")
+    when_i_click_on_continue
+    then_i_am_taken_to_check_details_page
+
+    when_i_click_confirm_and_add
+    then_i_see_confirmation_that_the_participant_has_been_added
+    and_the_participant_has_been_added_to_the_active_registration_cohort
+    and_the_mentor_has_been_added_to_the_active_registration_cohort
   end
 end

--- a/spec/features/schools/participants/add_participants/payments_frozen/sit_adds_ect_spec.rb
+++ b/spec/features/schools/participants/add_participants/payments_frozen/sit_adds_ect_spec.rb
@@ -92,6 +92,6 @@ RSpec.describe "SIT adding an ECT", js: true, early_in_cohort: true do
     when_i_click_confirm_and_add
     then_i_see_confirmation_that_the_participant_has_been_added
     and_the_participant_has_been_added_to_the_active_registration_cohort
-    and_the_mentor_has_been_added_to_the_active_registration_cohort
+    and_the_mentor_stays_in_their_current_cohort(@mentor_school_cohort.cohort)
   end
 end

--- a/spec/features/schools/participants/add_participants/payments_frozen/transfer_ect_to_another_school_spec.rb
+++ b/spec/features/schools/participants/add_participants/payments_frozen/transfer_ect_to_another_school_spec.rb
@@ -104,6 +104,65 @@ RSpec.describe "SIT transfers ECT to another school", js: true, early_in_cohort:
 
     and_the_participant_has_been_transfered_to_another_school
     and_the_participant_has_been_added_to_the_active_registration_cohort
+    and_the_mentor_has_been_added_to_the_active_registration_cohort
+  end
+
+  scenario "when an unfinished mentor is assigned", with_feature_flags: { closing_2022: "active" } do
+    given_there_is_a_school_that_has_chosen_fip_for_four_cohorts_and_partnered
+    and_there_is_another_school_that_has_chosen_fip_in_the_payments_frozen_cohort_and_partnered
+    and_the_earliest_cohort_has_payments_frozen
+    and_i_am_signed_in_as_an_induction_coordinator_for_the_transfer_school
+
+    and_i_have_added_a_mentor_in_cohort(earliest_cohort, school: target_school)
+    and_i_am_transfering_an_ect_in_a_cohort_with_payments_frozen_between_schools
+    and_i_click_on(Cohort.current.description)
+
+    when_i_navigate_to_ect_dashboard
+    when_i_click_to_add_a_new_ect
+    then_i_should_be_on_the_who_to_add_page
+
+    when_i_select_to_add_a "ECT"
+    when_i_click_on_continue
+
+    then_i_am_taken_to_the_what_we_need_from_you_page
+
+    when_i_click_on_continue
+    then_i_am_taken_to_add_ect_name_page
+
+    when_i_add_ect_name
+    when_i_click_on_continue
+    then_i_am_taken_to_add_teachers_trn_page
+
+    when_i_add_the_trn
+    when_i_click_on_continue
+    then_i_am_taken_to_add_date_of_birth_page
+
+    when_i_add_a_date_of_birth
+    when_i_click_on_continue
+
+    then_i_should_be_on_the_confirm_transfer_page
+    when_i_click_on_confirm
+    then_i_should_be_on_the_teacher_start_date_page
+
+    when_i_add_a_valid_start_date
+    when_i_click_on_continue
+    then_i_am_taken_to_add_ect_or_mentor_email_page
+
+    when_i_add_ect_or_mentor_email(email: @participant_data[:email])
+    when_i_click_on_continue
+    then_i_am_taken_to_choose_mentor_page
+
+    when_i_select("Cohort Mentor")
+    when_i_click_on_continue
+    when_i_choose_yes
+    when_i_click_on_continue
+    then_i_am_taken_to_check_details_page
+
+    when_i_click_confirm_and_add
+    then_i_see_confirmation_that_the_participant_has_been_added
+
+    and_the_participant_has_been_transfered_to_another_school
+    and_the_participant_has_been_added_to_the_active_registration_cohort
     and_the_mentor_stays_in_their_current_cohort(@mentor_school_cohort.cohort)
   end
 

--- a/spec/features/schools/participants/add_participants/payments_frozen/transfer_ect_to_another_school_spec.rb
+++ b/spec/features/schools/participants/add_participants/payments_frozen/transfer_ect_to_another_school_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe "SIT transfers ECT to another school", js: true, early_in_cohort:
 
     and_the_participant_has_been_transfered_to_another_school
     and_the_participant_has_been_added_to_the_active_registration_cohort
-    and_the_mentor_has_been_added_to_the_active_registration_cohort
+    and_the_mentor_stays_in_their_current_cohort(@mentor_school_cohort.cohort)
   end
 
   def and_i_am_transfering_an_ect_in_a_cohort_with_payments_frozen_between_schools

--- a/spec/features/schools/participants/add_participants/payments_frozen/transfer_mentor_to_another_school_spec.rb
+++ b/spec/features/schools/participants/add_participants/payments_frozen/transfer_mentor_to_another_school_spec.rb
@@ -45,6 +45,44 @@ RSpec.describe "SIT transfers mentor to another school", js: true, early_in_coho
     then_i_am_taken_to_mentor_added_confirmation_page
 
     and_the_mentor_has_been_transfered_to_another_school
+    and_the_mentor_has_been_added_to_the_active_registration_cohort
+  end
+
+  scenario "when target cohort payments are frozen", with_feature_flags: { closing_2022: "active" } do
+    given_there_is_a_school_that_has_chosen_fip_for_four_cohorts_and_partnered
+    and_there_is_another_school_that_has_chosen_fip_in_the_payments_frozen_cohort_and_partnered
+    and_the_earliest_cohort_has_payments_frozen
+    and_i_am_signed_in_as_an_induction_coordinator_for_the_transfer_school
+    and_i_am_transfering_a_mentor_in_a_cohort_with_payments_frozen_between_schools
+    and_i_click_on(Cohort.current.description)
+
+    when_i_navigate_to_ect_dashboard
+    when_i_click_to_add_a_new_ect
+    then_i_should_be_on_the_who_to_add_page
+
+    when_i_select_to_add_a "Mentor"
+    when_i_click_on_continue
+
+    then_i_am_taken_to_the_what_we_need_from_mentor_page
+
+    when_i_click_on_continue
+    then_i_am_taken_to_add_mentor_full_name_page
+
+    when_i_add_mentor_name
+    when_i_click_on_continue
+    then_i_am_taken_to_add_teachers_trn_page
+
+    when_i_add_the_trn
+    when_i_click_on_continue
+    then_i_am_taken_to_add_date_of_birth_page
+
+    when_i_add_a_date_of_birth
+    when_i_click_on_continue
+
+    when_i_complete_transfer_steps
+    when_i_click_confirm_and_add
+    then_i_am_taken_to_mentor_added_confirmation_page
+    and_the_mentor_has_been_transfered_to_another_school
     and_the_mentor_stays_in_their_current_cohort(earliest_cohort)
   end
 

--- a/spec/features/schools/participants/add_participants/payments_frozen/transfer_mentor_to_another_school_spec.rb
+++ b/spec/features/schools/participants/add_participants/payments_frozen/transfer_mentor_to_another_school_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "SIT transfers mentor to another school", js: true, early_in_coho
     then_i_am_taken_to_mentor_added_confirmation_page
 
     and_the_mentor_has_been_transfered_to_another_school
-    and_the_mentor_has_been_added_to_the_active_registration_cohort
+    and_the_mentor_stays_in_their_current_cohort(earliest_cohort)
   end
 
   def and_i_am_transfering_a_mentor_in_a_cohort_with_payments_frozen_between_schools

--- a/spec/models/participant_profile/mentor_spec.rb
+++ b/spec/models/participant_profile/mentor_spec.rb
@@ -64,7 +64,7 @@ describe ParticipantProfile::Mentor, type: :model do
     end
   end
 
-  include_context "can change cohort and continue training", :mentor, :ect, :mentor_completion_date
+  include_context "can't change cohort and continue training", :mentor, :ect, :mentor_completion_date
 
   def build_profile(attrs = {})
     create(:mentor_participant_profile, attrs).tap do |participant_profile|

--- a/spec/models/participant_profile/mentor_spec.rb
+++ b/spec/models/participant_profile/mentor_spec.rb
@@ -64,7 +64,11 @@ describe ParticipantProfile::Mentor, type: :model do
     end
   end
 
-  include_context "can't change cohort and continue training", :mentor, :ect, :mentor_completion_date
+  context "when 2022 has been closed", with_feature_flags: { closing_2022: "active" } do
+    include_context "can't change cohort and continue training", :mentor, :ect, :mentor_completion_date
+  end
+
+  include_context "can change cohort and continue training", :mentor, :ect, :mentor_completion_date
 
   def build_profile(attrs = {})
     create(:mentor_participant_profile, attrs).tap do |participant_profile|

--- a/spec/services/change_schedule_spec.rb
+++ b/spec/services/change_schedule_spec.rb
@@ -422,8 +422,8 @@ RSpec.describe ChangeSchedule do
 
           before { create(:participant_declaration, participant_profile:, state: "payable", course_identifier:, cpd_lead_provider:) }
 
-          context "when changing from 2022 to #{ParticipantProfile::ECF::DESTINATION_COHORT_WHEN_MOVING_PARTICIPANTS_TO_FROM_A_FROZEN_COHORT}" do
-            let(:new_cohort) { create(:cohort, start_year: ParticipantProfile::ECF::DESTINATION_COHORT_WHEN_MOVING_PARTICIPANTS_TO_FROM_A_FROZEN_COHORT) }
+          context "when changing from 2022 to #{Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT}" do
+            let(:new_cohort) { create(:cohort, start_year: Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT) }
 
             it "is valid" do
               is_expected.to be_valid

--- a/spec/services/early_career_teachers/create_spec.rb
+++ b/spec/services/early_career_teachers/create_spec.rb
@@ -130,9 +130,9 @@ RSpec.describe ::EarlyCareerTeachers::Create do
       frozen_cohort.update!(payments_frozen_at: 1.month.ago)
     end
 
-    it "moves the mentor to the currently active registration cohort" do
+    it "don't move the mentor from their cohort" do
       expect { described_class.call(email: user.email, full_name: user.full_name, school_cohort: ect_school_cohort, mentor_profile_id: mentor_profile.id) }
-        .to change { mentor_profile.reload.schedule.cohort.start_year }.from(2021).to(Cohort.active_registration_cohort.start_year)
+        .not_to change { mentor_profile.reload.schedule.cohort.start_year }
     end
   end
 

--- a/spec/services/early_career_teachers/create_spec.rb
+++ b/spec/services/early_career_teachers/create_spec.rb
@@ -130,9 +130,14 @@ RSpec.describe ::EarlyCareerTeachers::Create do
       frozen_cohort.update!(payments_frozen_at: 1.month.ago)
     end
 
-    it "don't move the mentor from their cohort" do
+    it "don't move the mentor from their cohort", with_feature_flags: { closing_2022: "active" } do
       expect { described_class.call(email: user.email, full_name: user.full_name, school_cohort: ect_school_cohort, mentor_profile_id: mentor_profile.id) }
         .not_to change { mentor_profile.reload.schedule.cohort.start_year }
+    end
+
+    it "moves the mentor to the currently active registration cohort" do
+      expect { described_class.call(email: user.email, full_name: user.full_name, school_cohort: ect_school_cohort, mentor_profile_id: mentor_profile.id) }
+        .to change { mentor_profile.reload.schedule.cohort.start_year }.from(2021).to(Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT)
     end
   end
 

--- a/spec/services/induction/change_mentor_spec.rb
+++ b/spec/services/induction/change_mentor_spec.rb
@@ -76,11 +76,19 @@ RSpec.describe Induction::ChangeMentor do
 
         before do
           current_cohort.update!(payments_frozen_at: Time.current)
+        end
+
+        it "places the mentor in the destination cohort from frozen cohorts", with_feature_flags: { closing_2022: "active" } do
           allow(mentor_profile).to receive(:unfinished_with_billable_declaration?).and_return(true)
           service.call(induction_record:, mentor_profile:)
+
+          expect(current_cohort).not_to eq(cohort)
+          expect(mentor_profile.reload.schedule.cohort_id).to eq(cohort.id)
         end
 
         it "places the mentor in the destination cohort from frozen cohorts" do
+          service.call(induction_record:, mentor_profile:)
+
           expect(current_cohort).not_to eq(cohort)
           expect(mentor_profile.reload.schedule.cohort_id).to eq(cohort.id)
         end
@@ -105,11 +113,20 @@ RSpec.describe Induction::ChangeMentor do
 
         before do
           mentor_cohort.update!(payments_frozen_at: Time.current)
+        end
+
+        it "places the mentor in the currently active cohort for registration", with_feature_flags: { closing_2022: "active" } do
           allow(mentor_profile).to receive(:unfinished_with_no_billable_declaration?).and_return(true)
+
           service.call(induction_record:, mentor_profile:)
+
+          expect(mentor_cohort).not_to eq(cohort)
+          expect(mentor_profile.reload.schedule.cohort_id).to eq(cohort.id)
         end
 
         it "places the mentor in the currently active cohort for registration" do
+          service.call(induction_record:, mentor_profile:)
+
           expect(mentor_cohort).not_to eq(cohort)
           expect(mentor_profile.reload.schedule.cohort_id).to eq(cohort.id)
         end

--- a/spec/services/induction/transfer_and_continue_existing_fip_spec.rb
+++ b/spec/services/induction/transfer_and_continue_existing_fip_spec.rb
@@ -140,9 +140,16 @@ RSpec.describe Induction::TransferAndContinueExistingFip do
         frozen_cohort.update!(payments_frozen_at: 1.month.ago)
       end
 
-      it "don't move the mentor from their current cohort" do
+      it "don't move the mentor from their current cohort", with_feature_flags: { closing_2022: "active" } do
         expect { service_call }
           .not_to change { mentor_profile_2.reload.schedule.cohort.start_year }
+      end
+
+      it "moves the mentor to the currently active registration cohort" do
+        expect { service_call }
+          .to change { mentor_profile_2.reload.schedule.cohort.start_year }
+                .from(2021)
+                .to(Cohort.active_registration_cohort.start_year)
       end
     end
 

--- a/spec/services/induction/transfer_and_continue_existing_fip_spec.rb
+++ b/spec/services/induction/transfer_and_continue_existing_fip_spec.rb
@@ -140,11 +140,9 @@ RSpec.describe Induction::TransferAndContinueExistingFip do
         frozen_cohort.update!(payments_frozen_at: 1.month.ago)
       end
 
-      it "moves the mentor to the currently active registration cohort" do
+      it "don't move the mentor from their current cohort" do
         expect { service_call }
-          .to change { mentor_profile_2.reload.schedule.cohort.start_year }
-                .from(2021)
-                .to(Cohort.active_registration_cohort.start_year)
+          .not_to change { mentor_profile_2.reload.schedule.cohort.start_year }
       end
     end
 

--- a/spec/services/induction/transfer_to_schools_programme_spec.rb
+++ b/spec/services/induction/transfer_to_schools_programme_spec.rb
@@ -127,11 +127,9 @@ RSpec.describe Induction::TransferToSchoolsProgramme do
         frozen_cohort.update!(payments_frozen_at: 1.month.ago)
       end
 
-      it "moves the mentor to the currently active registration cohort" do
+      it "don't move the mentor from their cohort" do
         expect { service_call }
-          .to change { mentor_profile_2.reload.schedule.cohort.start_year }
-                .from(2021)
-                .to(Cohort.active_registration_cohort.start_year)
+          .not_to change { mentor_profile_2.reload.schedule.cohort.start_year }
       end
     end
 

--- a/spec/services/induction/transfer_to_schools_programme_spec.rb
+++ b/spec/services/induction/transfer_to_schools_programme_spec.rb
@@ -127,9 +127,16 @@ RSpec.describe Induction::TransferToSchoolsProgramme do
         frozen_cohort.update!(payments_frozen_at: 1.month.ago)
       end
 
-      it "don't move the mentor from their cohort" do
+      it "don't move the mentor from their cohort", with_feature_flags: { closing_2022: "active" } do
         expect { service_call }
           .not_to change { mentor_profile_2.reload.schedule.cohort.start_year }
+      end
+
+      it "moves the mentor to the currently active registration cohort" do
+        expect { service_call }
+          .to change { mentor_profile_2.reload.schedule.cohort.start_year }
+                .from(2021)
+                .to(Cohort.active_registration_cohort.start_year)
       end
     end
 

--- a/spec/support/shared_examples/change_cohort_and_continue_training_support.rb
+++ b/spec/support/shared_examples/change_cohort_and_continue_training_support.rb
@@ -190,3 +190,194 @@ RSpec.shared_examples "can change cohort and continue training" do |participant_
     end
   end
 end
+
+RSpec.shared_examples "can't change cohort and continue training" do |participant_type, other_participant_type, completed_training_at_attribute|
+  let(:declaration_type) { "#{participant_type}_participant_declaration" }
+
+  describe ".unfinished_with_billable_declaration" do
+    let(:current_cohort) { eligible_participant.schedule.cohort }
+    let(:restrict_to_participant_ids) { [] }
+    let(:cpd_lead_provider) { eligible_participant.lead_provider.cpd_lead_provider }
+    let(:eligible_participants) { create_list(declaration_type, 3, :payable, declaration_type: :started, cohort: Cohort.previous).map(&:participant_profile) }
+    let(:eligible_participant) { eligible_participants.first }
+    let(:cohort) { create(:cohort, start_year: 2024) }
+
+    before do
+      current_cohort.freeze_payments!
+
+      # Extra declaration on the same participant to ensure the results are distinct.
+      create(declaration_type, :payable, declaration_type: :"retained-1", participant_profile: eligible_participant, cpd_lead_provider:)
+
+      # Ineligible due to being a declaration for another participant type.
+      create("#{other_participant_type}_participant_declaration", :payable, declaration_type: :started)
+
+      # Ineligible due to having a billable, completed declaration.
+      create(declaration_type, :paid).tap { |d| d.update!(declaration_type: :completed) }
+
+      # Ineligible due to having the completed_training_at_attribute populated.
+      create(declaration_type, :paid, declaration_type: :started).participant_profile.update!("#{completed_training_at_attribute}": 1.month.ago)
+
+      # Ineligible due to not being in a payments frozen cohort.
+      create(declaration_type, :payable, declaration_type: :started).tap do |declaration|
+        schedule = create(:ecf_schedule, cohort: current_cohort.next)
+        declaration.participant_profile.update!(schedule:)
+      end
+    end
+
+    subject { described_class.unfinished_with_billable_declaration(cohort:, restrict_to_participant_ids:) }
+
+    it { expect(current_cohort).not_to eq(cohort) }
+    it { is_expected.to be_none }
+
+    context "when restricted to a set of participant IDs" do
+      let(:restrict_to_participant_ids) { [eligible_participants.first.id] }
+
+      it { is_expected.to be_none }
+    end
+
+    context "when the cohort is not present" do
+      let(:cohort) { nil }
+
+      it { is_expected.to be_none }
+    end
+
+    context "when the cohort is not 2024" do
+      let(:cohort) { create(:cohort, start_year: 2023) }
+
+      it { is_expected.to be_none }
+    end
+  end
+
+  describe "#unfinished_with_billable_declaration?" do
+    let(:declaration) { create(declaration_type, :paid, declaration_type: :started, cohort: Cohort.previous) }
+    let(:participant_profile) { declaration.participant_profile }
+    let(:current_cohort) { participant_profile.schedule.cohort }
+    let(:cohort) { create(:cohort, start_year: 2024) }
+
+    before { current_cohort.freeze_payments! }
+
+    subject { participant_profile }
+
+    it { expect(current_cohort).not_to eq(cohort) }
+    it { is_expected.not_to be_unfinished_with_billable_declaration(cohort:) }
+
+    context "when the participant is not in a payments frozen cohort" do
+      before { current_cohort.update!(payments_frozen_at: nil) }
+
+      it { is_expected.not_to be_unfinished_with_billable_declaration(cohort:) }
+    end
+
+    context "when the cohort they intend to continue training in is not 2024" do
+      let(:cohort) { create(:cohort, start_year: 2023) }
+
+      it { is_expected.not_to be_unfinished_with_billable_declaration(cohort:) }
+    end
+
+    %i[paid payable eligible].each do |billable_declaration_type|
+      context "when the participant has a completed, #{billable_declaration_type} declaration" do
+        before do
+          completed_milestone = participant_profile.schedule.milestones.find_by(declaration_type: :completed)
+          completed_milestone.update!(start_date: 1.month.ago, milestone_date: 1.day.from_now)
+
+          create(declaration_type,
+                 billable_declaration_type,
+                 declaration_type: :completed,
+                 declaration_date: completed_milestone.start_date,
+                 participant_profile:,
+                 cpd_lead_provider: participant_profile.lead_provider.cpd_lead_provider)
+        end
+
+        it { is_expected.not_to be_unfinished_with_billable_declaration(cohort:) }
+      end
+
+      context "when the participant has a not completed, #{billable_declaration_type} declaration" do
+        before do
+          milestone_date = participant_profile.schedule.milestones.find_by(declaration_type: "retained-1").start_date
+          travel_to(milestone_date) do
+            create(declaration_type,
+                   billable_declaration_type,
+                   declaration_type: "retained-1",
+                   participant_profile:,
+                   cpd_lead_provider: participant_profile.lead_provider.cpd_lead_provider)
+          end
+        end
+
+        it { is_expected.not_to be_unfinished_with_billable_declaration(cohort:) }
+
+        context "when the cohort is not present" do
+          let(:cohort) { nil }
+
+          it { is_expected.not_to be_unfinished_with_billable_declaration(cohort:) }
+        end
+
+        context "when the cohort is not 2024" do
+          let(:cohort) { create(:cohort, start_year: 2023) }
+
+          it { is_expected.not_to be_unfinished_with_billable_declaration(cohort:) }
+        end
+      end
+    end
+
+    context "when the participant does not have billable, not completed declarations" do
+      before { declaration.destroy }
+
+      it { is_expected.not_to be_unfinished_with_billable_declaration(cohort:) }
+    end
+
+    context "when the participant has a #{completed_training_at_attribute}" do
+      before { participant_profile.update!("#{completed_training_at_attribute}": 1.month.ago) }
+
+      it { is_expected.not_to be_unfinished_with_billable_declaration(cohort:) }
+    end
+  end
+
+  describe "#eligible_to_change_cohort_back_to_their_payments_frozen_original?" do
+    let(:declaration) { create(declaration_type, :paid, declaration_type: :started) }
+    let(:participant_profile) { declaration.participant_profile }
+    let(:current_cohort) { participant_profile.schedule.cohort }
+    let(:cohort) { create(:cohort, payments_frozen_at: 1.week.ago, start_year: to_cohort_start_year) }
+    let(:to_cohort_start_year) { current_cohort.start_year - 3 }
+
+    before do
+      declaration.update!(cohort:)
+      participant_profile.update!(cohort_changed_after_payments_frozen: true)
+      cohort.update!(payments_frozen_at: Time.zone.now)
+    end
+
+    subject { participant_profile }
+
+    it { expect(current_cohort).not_to eq(cohort) }
+    it { is_expected.to be_eligible_to_change_cohort_back_to_their_payments_frozen_original(cohort:, current_cohort:) }
+
+    context "when the participant does not have billable declarations in the previous cohort" do
+      before { declaration.update!(state: :ineligible) }
+
+      it { is_expected.not_to be_eligible_to_change_cohort_back_to_their_payments_frozen_original(cohort:, current_cohort:) }
+    end
+
+    context "when the previous cohort is not payments frozen" do
+      before { cohort.update!(payments_frozen_at: nil) }
+
+      it { is_expected.not_to be_eligible_to_change_cohort_back_to_their_payments_frozen_original(cohort:, current_cohort:) }
+    end
+
+    context "when the participant is not cohort_changed_after_payments_frozen" do
+      before { participant_profile.update!(cohort_changed_after_payments_frozen: false) }
+
+      it { is_expected.not_to be_eligible_to_change_cohort_back_to_their_payments_frozen_original(cohort:, current_cohort:) }
+    end
+
+    %i[paid payable eligible submitted].each do |billable_or_changeable_declaration_type|
+      context "when the participant has a #{billable_or_changeable_declaration_type} declaration for the current cohort" do
+        before do
+          milestone_date = participant_profile.schedule.milestones.find_by(declaration_type: "retained-1").start_date
+          travel_to(milestone_date) do
+            create(declaration_type, :payable, declaration_type: "retained-1", participant_profile:, cpd_lead_provider: participant_profile.lead_provider.cpd_lead_provider)
+          end
+        end
+
+        it { is_expected.not_to be_eligible_to_change_cohort_back_to_their_payments_frozen_original(cohort:, current_cohort:) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

[Ticket](https://dfedigital.atlassian.net/browse/CST-2850)

### Changes proposed in this pull request

- add feature flag for closing 2022 cohort
- prevent mentors in a frozen cohort from being moved by the automatic cohort change triggers
- define 2024 as the only cohort to move ECTs from a frozen cohort.
- add seed data to test participants in 2022

### Guidance to review

