### PR TITLE
[CPDLP-4090] Set participants start date as now on the valid test data generators

### DIFF
--- a/app/services/valid_test_data_generators/completed_mentor_generator.rb
+++ b/app/services/valid_test_data_generators/completed_mentor_generator.rb
@@ -81,7 +81,7 @@ module ValidTestDataGenerators
         induction_programme = profile.school_cohort.induction_programmes.first
         raise unless induction_programme
 
-        Induction::Enrol.call(participant_profile: profile, induction_programme:)
+        Induction::Enrol.call(participant_profile: profile, induction_programme:, start_date: Time.zone.now)
 
         return profile unless profile.active_record?
 
@@ -130,7 +130,7 @@ module ValidTestDataGenerators
         induction_programme = profile.school_cohort.induction_programmes.first
         raise unless induction_programme
 
-        Induction::Enrol.call(participant_profile: profile, induction_programme:)
+        Induction::Enrol.call(participant_profile: profile, induction_programme:, start_date: Time.zone.now)
 
         return profile unless profile.active_record?
 

--- a/app/services/valid_test_data_generators/ecf_lead_provider_populater.rb
+++ b/app/services/valid_test_data_generators/ecf_lead_provider_populater.rb
@@ -96,7 +96,7 @@ module ValidTestDataGenerators
         induction_programme = profile.school_cohort.induction_programmes.first
         raise unless induction_programme
 
-        Induction::Enrol.call(participant_profile: profile, induction_programme:)
+        Induction::Enrol.call(participant_profile: profile, induction_programme:, start_date: Time.zone.now)
 
         return unless profile.active_record?
 
@@ -145,7 +145,7 @@ module ValidTestDataGenerators
         induction_programme = profile.school_cohort.induction_programmes.first
         raise unless induction_programme
 
-        Induction::Enrol.call(participant_profile: profile, induction_programme:)
+        Induction::Enrol.call(participant_profile: profile, induction_programme:, start_date: Time.zone.now)
 
         return profile unless profile.active_record?
 

--- a/app/services/valid_test_data_generators/mentor_ect_generator.rb
+++ b/app/services/valid_test_data_generators/mentor_ect_generator.rb
@@ -42,7 +42,7 @@ module ValidTestDataGenerators
       participant_profile = klass.create!(teacher_profile:, school_cohort:, status: :active, schedule:, participant_identity:)
       ParticipantProfileState.create!(participant_profile:)
       ECFParticipantEligibility.create!(participant_profile:).eligible_status!
-      Induction::Enrol.call(participant_profile:, induction_programme: school_cohort.induction_programmes.first)
+      Induction::Enrol.call(participant_profile:, induction_programme: school_cohort.induction_programmes.first, start_date: Time.zone.now)
     end
 
     def schedule


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-4090

When generating test data in sandbox. The participants start date is being set in the future as the service `Induction::Enrol` sets the start date as the default schedule start date.

### Changes proposed in this pull request

Add `start_date: Time.zone.now` to the params, so participants start date won't be in the future.