### PR TITLE
[CPDLP-4108] tests added for change schedule to move frozen 2022 to 2024

### DIFF
--- a/spec/services/change_schedule_spec.rb
+++ b/spec/services/change_schedule_spec.rb
@@ -410,6 +410,31 @@ RSpec.describe ChangeSchedule do
             expect(service.errors.messages_for(:cohort)).to include("You cannot change a participant to this cohort as you do not have a partnership with the school for the cohort. Contact the DfE for assistance.")
           end
         end
+
+        context "when changing from frozen cohort with billable declarations" do
+          let(:allow_change_to_from_frozen_cohort) { true }
+          let(:cohort) { create(:cohort, :payments_frozen, start_year: 2022) }
+
+          before { create(:participant_declaration, participant_profile:, state: "payable", course_identifier:, cpd_lead_provider:) }
+
+          context "when changing from 2022 to 2024" do
+            let(:new_cohort) { create(:cohort, start_year: 2024) }
+
+            it "is valid" do
+              is_expected.to be_valid
+            end
+          end
+
+          context "when changing from 2022 to 2025" do
+            let(:new_cohort) { create(:cohort, start_year: 2025) }
+
+            it "is invalid and returns an error message" do
+              is_expected.to be_invalid
+
+              expect(service.errors.messages_for(:cohort)).to include("You cannot change the '#/cohort' field")
+            end
+          end
+        end
       end
 
       context "when the participant does not belong to the CPD lead provider" do

--- a/spec/services/change_schedule_spec.rb
+++ b/spec/services/change_schedule_spec.rb
@@ -417,8 +417,8 @@ RSpec.describe ChangeSchedule do
 
           before { create(:participant_declaration, participant_profile:, state: "payable", course_identifier:, cpd_lead_provider:) }
 
-          context "when changing from 2022 to 2024" do
-            let(:new_cohort) { create(:cohort, start_year: 2024) }
+          context "when changing from 2022 to #{ParticipantProfile::ECF::DESTINATION_COHORT_WHEN_MOVING_PARTICIPANTS_TO_FROM_A_FROZEN_COHORT}" do
+            let(:new_cohort) { create(:cohort, start_year: ParticipantProfile::ECF::DESTINATION_COHORT_WHEN_MOVING_PARTICIPANTS_TO_FROM_A_FROZEN_COHORT) }
 
             it "is valid" do
               is_expected.to be_valid


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-4108

### Changes proposed in this pull request

* The work has already been done in model scopes, this PR just adds tests.
* Added test to `ChangeSchedule` service
* Added test to v1,v2,v3 `change-schedule` endpoint
* Test for changing frozen cohort from 2022 to 2024 and stop 2022 to 2025

### Guidance to review

