### PR TITLE
[CPDLP-4172] Spike Option 1 - user feature flag to show old/new reason and backfill existing data with new value

### DIFF
--- a/app/serializers/api/v3/ecf/participant_serializer.rb
+++ b/app/serializers/api/v3/ecf/participant_serializer.rb
@@ -41,7 +41,7 @@ module Api
                 .find { |pps| pps.state == ParticipantProfileState.states[:withdrawn] && pps.cpd_lead_provider_id == cpd_lead_provider.id }
               if latest_participant_profile_state.present?
                 {
-                  reason: latest_participant_profile_state.reason,
+                  reason: reason_type(latest_participant_profile_state.reason),
                   date: latest_participant_profile_state.created_at.rfc3339,
                 }
               end
@@ -58,10 +58,18 @@ module Api
                 .find { |pps| pps.state == ParticipantProfileState.states[:deferred] && pps.cpd_lead_provider_id == cpd_lead_provider.id }
               if latest_participant_profile_state.present?
                 {
-                  reason: latest_participant_profile_state.reason,
+                  reason: reason_type(latest_participant_profile_state.reason),
                   date: latest_participant_profile_state.created_at.rfc3339,
                 }
               end
+            end
+          end
+
+          def reason_type(reason)
+            if FeatureFlag.active?(:new_programme_types)
+              reason == "school-left-fip" ? "school-left-provider-led" : reason
+            else
+              reason == "school-left-provider-led" ? "school-left-fip" : reason
             end
           end
 

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -25,6 +25,7 @@ class FeatureFlag
     school_participant_status_language
     registration_pilot_school
     programme_type_changes_2025
+    new_programme_types
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).index_with { |name|

--- a/app/services/withdraw_participant.rb
+++ b/app/services/withdraw_participant.rb
@@ -19,7 +19,7 @@ class WithdrawParticipant
   validates :reason,
             presence: { message: I18n.t(:missing_reason) },
             inclusion: {
-              in: ->(klass) { klass.participant_profile.class::WITHDRAW_REASONS },
+              in: :withdraw_reason_types,
               message: I18n.t(:invalid_reason),
             }, if: ->(klass) { klass.participant_profile.present? }
   validate :not_already_withdrawn
@@ -103,5 +103,16 @@ private
         training_status: ParticipantProfileState.states[:withdrawn],
       },
     )
+  end
+
+  def withdraw_reason_types
+    types = ParticipantProfile::ECF::WITHDRAW_REASONS.dup
+
+    if FeatureFlag.active?(:new_programme_types)
+      types.delete("school-left-fip")
+      types << "school-left-provider-led"
+    end
+
+    types
   end
 end

--- a/db/migrate/20250328163442_change_reason_to_new_fip_name.rb
+++ b/db/migrate/20250328163442_change_reason_to_new_fip_name.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangeReasonToNewFipName < ActiveRecord::Migration[7.1]
+  def change
+    ParticipantProfileState.where(reason: "school-left-fip").update_all(reason: "school-left-provider-led")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_02_28_135429) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_28_163442) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"

--- a/spec/services/withdraw_participant_spec.rb
+++ b/spec/services/withdraw_participant_spec.rb
@@ -23,6 +23,48 @@ RSpec.shared_examples "validating a participant to be withdrawn" do
     end
   end
 
+  context "when new_programme_types feature on" do
+    before { FeatureFlag.activate(:new_programme_types) }
+
+    context "when the reason is 'school-left-provider-led'" do
+      let(:reason) { "school-left-provider-led" }
+
+      it "reason is valid" do
+        is_expected.to be_valid
+        expect(service.reason).to eq("school-left-provider-led")
+      end
+    end
+
+    context "when the reason is 'school-left-fip'" do
+      let(:reason) { "school-left-fip" }
+
+      it "reason is invalid" do
+        is_expected.to be_invalid
+      end
+    end
+  end
+
+  context "when new_programme_types feature off" do
+    before { FeatureFlag.deactivate(:new_programme_types) }
+
+    context "when the reason is 'school-left-provider-led'" do
+      let(:reason) { "school-left-provider-led" }
+
+      it "reason is invalid" do
+        is_expected.to be_invalid
+      end
+    end
+
+    context "when the reason is 'school-left-fip'" do
+      let(:reason) { "school-left-fip" }
+
+      it "reason is valid" do
+        is_expected.to be_valid
+        expect(service.reason).to eq("school-left-fip")
+      end
+    end
+  end
+
   context "when the course identifier is missing" do
     let(:course_identifier) {}
 

--- a/spec/support/shared_examples/participant_actions_withdraw_support.rb
+++ b/spec/support/shared_examples/participant_actions_withdraw_support.rb
@@ -34,4 +34,62 @@ RSpec.shared_examples "JSON Participant Withdrawal endpoint" do
       end
     end
   end
+
+  context "when new_programme_types feature on" do
+    let(:params) { { data: { attributes: { course_identifier: "ecf-induction", reason: } } } }
+    before { FeatureFlag.activate(:new_programme_types) }
+
+    context "when reason is 'school-left-fip'" do
+      let(:reason) { "school-left-fip" }
+
+      it "participant is withdrawn with correct reason" do
+        put(url, params:)
+
+        expect(response).not_to be_successful
+        expect(parsed_response.dig("errors", 0, "detail")).to include("The property '#/reason' must be a valid reason")
+      end
+    end
+
+    context "when reason is 'school-left-provider-led'" do
+      let(:reason) { "school-left-provider-led" }
+
+      it "participant is withdrawn with correct reason" do
+        put(url, params:)
+
+        expect(response).to be_successful
+        if url.match?("/v3/")
+          expect(parsed_response.dig("data", "attributes", "ecf_enrolments", 0, "withdrawal", "reason")).to eql("school-left-provider-led")
+        end
+      end
+    end
+  end
+
+  context "when new_programme_types feature off" do
+    let(:params) { { data: { attributes: { course_identifier: "ecf-induction", reason: } } } }
+    before { FeatureFlag.deactivate(:new_programme_types) }
+
+    context "when reason is 'school-left-fip'" do
+      let(:reason) { "school-left-fip" }
+
+      it "participant is withdrawn with correct reason" do
+        put(url, params:)
+
+        expect(response).to be_successful
+        if url.match?("/v3/")
+          expect(parsed_response.dig("data", "attributes", "ecf_enrolments", 0, "withdrawal", "reason")).to eql("school-left-fip")
+        end
+      end
+    end
+
+    context "when reason is 'school-left-provider-led'" do
+      let(:reason) { "school-left-provider-led" }
+
+      it "participant is withdrawn with correct reason" do
+        put(url, params:)
+
+        expect(response).not_to be_successful
+        expect(parsed_response.dig("errors", 0, "detail")).to include("The property '#/reason' must be a valid reason")
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-4172

### Changes proposed in this pull request

* New feature flag `new_programme_types`
* When feature on, change validate types to include `school-left-provider-led`
* Serializer show new provider-led value if feature is on
* Backfill existing values with provider-led value

### Guidance to review

