### PR TITLE
Clear evidence_held if not applicable when recording declaration

### DIFF
--- a/app/validators/evidence_held_validator.rb
+++ b/app/validators/evidence_held_validator.rb
@@ -54,7 +54,7 @@ class EvidenceHeldValidator < ActiveModel::Validator
       evidence_held_present?(record)
       valid_detailed_evidence_held?(record)
     else
-      return unless validate_evidence_held?(record)
+      return record.evidence_held = nil unless validate_evidence_held?(record)
 
       evidence_held_present?(record)
       valid_evidence_held?(record)

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -394,14 +394,15 @@ RSpec.describe "participant-declarations endpoint spec", type: :request, mid_coh
               .to include({ "title" => "participant_id", "detail" => "Your update cannot be made as the '#/participant_id' is not recognised. Check participant details and try again." })
           end
         end
-        context "with unpermitted parameter" do
+
+        context "with parameter that is not required" do
           before { params[:data][:attributes][:evidence_held] = "test" }
 
-          it "creates the declaration" do
+          it "ignores a parameter that is not required" do
             post "/api/v1/participant-declarations", params: params.to_json
 
             expect(response).to be_successful
-            expect(ParticipantDeclaration.order(created_at: :desc).first.evidence_held).to eq("test")
+            expect(ParticipantDeclaration.order(created_at: :desc).first.evidence_held).to be_nil
           end
         end
 

--- a/spec/requests/api/v2/participant_declarations_spec.rb
+++ b/spec/requests/api/v2/participant_declarations_spec.rb
@@ -222,11 +222,11 @@ RSpec.describe "participant-declarations endpoint spec", type: :request, mid_coh
           )
       end
 
-      it "ignores an unpermitted parameter" do
+      it "ignores a parameter that is not required" do
         post "/api/v2/participant-declarations", params: build_params(valid_params.merge(evidence_held: "test"))
 
         expect(response.status).to eq 200
-        expect(ParticipantDeclaration.order(created_at: :desc).first.evidence_held).to eq("test")
+        expect(ParticipantDeclaration.order(created_at: :desc).first.evidence_held).to be_nil
       end
 
       it "returns 422 when supplied an incorrect course type" do

--- a/spec/requests/api/v3/participant_declarations_spec.rb
+++ b/spec/requests/api/v3/participant_declarations_spec.rb
@@ -446,11 +446,11 @@ RSpec.describe "API Participant Declarations", type: :request, mid_cohort: true 
           ])
       end
 
-      it "ignores an unpermitted parameter" do
+      it "ignores a parameter that is not required" do
         post "/api/v3/participant-declarations", params: build_params(valid_params.merge(evidence_held: "test"))
 
         expect(response.status).to eq 200
-        expect(ParticipantDeclaration.order(created_at: :desc).first.evidence_held).to eq("test")
+        expect(ParticipantDeclaration.order(created_at: :desc).first.evidence_held).to be_nil
       end
 
       it "returns 422 when supplied an incorrect course type" do

--- a/spec/validators/evidence_held_validator_spec.rb
+++ b/spec/validators/evidence_held_validator_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe EvidenceHeldValidator do
 
       validates :evidence_held, evidence_held: true
 
-      attr_reader :participant_profile, :schedule, :cohort, :declaration_type, :evidence_held
+      attr_accessor :participant_profile, :schedule, :cohort, :declaration_type, :evidence_held
 
       def self.model_name
         ActiveModel::Name.new(self, nil, "temp")
@@ -116,6 +116,15 @@ RSpec.describe EvidenceHeldValidator do
 
             it "is valid" do
               expect(subject).to be_valid
+            end
+          end
+
+          context "when `evidence_held` is present" do
+            let(:evidence_held) { "other" }
+
+            it "is valid (sets the `evidence_held` to `nil`)" do
+              expect(subject).to be_valid
+              expect(subject.evidence_held).to be_nil
             end
           end
 


### PR DESCRIPTION
[Jira-4140](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-4140)

### Context

The `EvidenceHeldValidator` will only validate the evidence held if it applies to the declaration being recorded.

It applies for detailed evidence types if the declaration type is not `started` or the `evidence_held` value is provided.

It applies for normal evidence types if the declaration type is not `started`.

This means if the declaration is started and for normal evidence types and the `evidence_held` value is provided it will not be validated but it will end up being persisted against the declaration.

We want to prevent lead providers persisting bad/incorrect `evidence_held` values against declarations.

### Changes proposed in this pull request

- Clear evidence_held if not applicable when recording declaration

We can avoid this by either returning a new error message when an `evidence_held` is provided or by sanitizing the field as part of the validation process (clearing it if it is not required).

I opted for the latter in this commit in order to keep the behaviour of the API consistent with what lead providers expect at the moment. Its not ideal as the validator shouldn't be modifying the value in my opinion, but its the most pragmatic solution (a better solution would require a larger refactoring of the validator).

### Guidance to review

Checking the snapshot database we will have some clean up work to do after this goes in:

```
ParticipantDeclaration
  .joins(:cohort)
  .where(cohort: { detailed_evidence_types: false }, declaration_type: :started)
  .where.not(evidence_held: nil)
  .group(:evidence_held)
  .count

  => 
  {""=>11166,
   "other"=>408,
   "self-study-material completed"=>6,
   "self-study-material-completed"=>14141,
   "training_event_attendance"=>1,
   "training-event-attended"=>13455,
   "yes"=>143}
```