### PR TITLE
Optimise the appropriate body participants query

### DIFF
--- a/app/controllers/appropriate_bodies/participants_controller.rb
+++ b/app/controllers/appropriate_bodies/participants_controller.rb
@@ -13,14 +13,14 @@ module AppropriateBodies
       respond_to do |format|
         format.html do
           @pagy, @induction_records = pagy(
-            @filter.scope.order(updated_at: :desc),
+            @filter.scope,
             page: params[:page],
             limit: 50,
           )
         end
 
         format.csv do
-          serializer = InductionRecordsSerializer.new(@filter.scope.order(updated_at: :desc), params: { training_record_states: @training_record_states })
+          serializer = InductionRecordsSerializer.new(@filter.scope, params: { training_record_states: @training_record_states })
           render body: to_csv(serializer.serializable_hash)
         end
       end

--- a/app/services/appropriate_bodies/participants_filter.rb
+++ b/app/services/appropriate_bodies/participants_filter.rb
@@ -23,7 +23,7 @@ module AppropriateBodies
         scoped = filter_status(scoped, params[:status])
       end
 
-      scoped
+      scoped.order(updated_at: :desc)
     end
 
     def filter_query(scoped, query)

--- a/spec/services/appropriate_bodies/participants_filter_spec.rb
+++ b/spec/services/appropriate_bodies/participants_filter_spec.rb
@@ -31,7 +31,9 @@ RSpec.describe AppropriateBodies::ParticipantsFilter do
   subject { described_class.new(collection:, params:, training_record_states:).scope.to_a }
 
   context "No filter" do
-    it { is_expected.to match_array([induction_record1, induction_record2]) }
+    before { induction_record1.update(updated_at: 1.day.from_now) }
+
+    it { is_expected.to eq([induction_record1, induction_record2]) }
   end
 
   context "Search filter" do


### PR DESCRIPTION
> ⚠️ WIP

### Context

We are seeing timeouts in Sentry from the appropriate body participants page. This is down to the underlying query being inefficient. We want to optimise the query to prevent timeouts.

### Changes proposed in this pull request

- Shift ordering of AB participants into query

Instead of ordering in the controller we can shift the sort into the query, which makes more sense and enables us to more easily test it.

### Guidance to review

