### PR TITLE
[CPDLP-4157] Improve training record states seeds data

### DIFF
--- a/db/new_seeds/scenarios/participants/training_record_states.rb
+++ b/db/new_seeds/scenarios/participants/training_record_states.rb
@@ -22,6 +22,7 @@ module NewSeeds
             .new(name: "FIP School for Training Record States")
             .build
             .with_an_induction_tutor(full_name: "FIP School for Training Record States SIT", email: "fip-training-states@example.com")
+            .with_partnership_in(cohort:)
             .chosen_fip_and_partnered_in(cohort:)
         end
 
@@ -38,6 +39,8 @@ module NewSeeds
                                                      .new(name: "FIP School with previous FIP induction programme cohort")
                                                      .build
                                                      .with_an_induction_tutor(full_name: "FIP School with previous FIP induction programme cohort SIT", email: "fip-previous-fip-programme-cohort@example.com")
+                                                     .with_partnership_in(cohort: previous_cohort)
+                                                     .with_partnership_in(cohort:)
                                                      .chosen_fip_and_partnered_in(cohort: previous_cohort)
                                                      .chosen_fip_and_partnered_in(cohort:)
         end


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-4157](https://dfedigital.atlassian.net/browse/CPDLP-4157)

A school had partnerships in both 2024 and 2025 cohorts, when participants (ECTs and Mentors) were being created some were created without a populated Lead Provider and Delivery Partner.

### Changes proposed in this pull request

- Add partnership to the training record states seeds;
- Confirm that ECT/Mentor is linked up to DPs/LPs when created via FE school journey;

### Guidance to review

Review app

[CPDLP-4157]: https://dfedigital.atlassian.net/browse/CPDLP-4157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ