### PR TITLE
[CPDLP-4182] Update school serializer to return the new programme type based on feature

### DIFF
--- a/app/serializers/api/v3/ecf/school_serializer.rb
+++ b/app/serializers/api/v3/ecf/school_serializer.rb
@@ -41,7 +41,8 @@ module Api
 
         attribute :induction_programme_choice do |school, params|
           school_cohort = school_cohort_for(school:, cohort: params[:cohort])
-          school_cohort&.induction_programme_choice.presence || "not_yet_known"
+          choice = school_cohort&.induction_programme_choice.presence || "not_yet_known"
+          ProgrammeTypeMappings.training_programme(training_programme: choice)
         end
 
         attribute :created_at do |school|

--- a/spec/serializers/api/v3/ecf/school_serializer_spec.rb
+++ b/spec/serializers/api/v3/ecf/school_serializer_spec.rb
@@ -51,16 +51,49 @@ module Api
             end
           end
 
-          context "when the school is already in the cohort" do
-            let!(:school_cohort) { create(:school_cohort, school:, cohort:) }
-            it "returns the school cohort induction_programme_choice" do
-              expect(subject.serializable_hash[:data][:attributes][:induction_programme_choice]).to eq(school_cohort.induction_programme_choice)
+          context "when 'programme_type_changes_2025' feature is disabled" do
+            before { FeatureFlag.deactivate(:programme_type_changes_2025) }
+
+            %w[core_induction_programme full_induction_programme].each do |induction_programme_choice|
+              context "when the school is already in the cohort with '#{induction_programme_choice}'" do
+                let!(:school_cohort) { create(:school_cohort, school:, cohort:, induction_programme_choice:) }
+
+                it "returns the school cohort induction_programme_choice" do
+                  expect(subject.serializable_hash[:data][:attributes][:induction_programme_choice]).to eq(induction_programme_choice)
+                end
+              end
+            end
+
+            context "when school is not yet in the cohort" do
+              it "returns the an unknown induction programme choice" do
+                expect(subject.serializable_hash[:data][:attributes][:induction_programme_choice]).to eq("not_yet_known")
+              end
             end
           end
 
-          context "when school is not yet in the cohort" do
-            it "returns the an unknown induction programme choice" do
-              expect(subject.serializable_hash[:data][:attributes][:induction_programme_choice]).to eq("not_yet_known")
+          context "when 'programme_type_changes_2025' feature is enabled" do
+            before { FeatureFlag.activate(:programme_type_changes_2025) }
+
+            context "when the school is already in the cohort with 'core_induction_programme'" do
+              let!(:school_cohort) { create(:school_cohort, school:, cohort:, induction_programme_choice: "core_induction_programme") }
+
+              it "returns the updated induction_programme_choice" do
+                expect(subject.serializable_hash[:data][:attributes][:induction_programme_choice]).to eq("school_led")
+              end
+            end
+
+            context "when the school is already in the cohort with 'full_induction_programme'" do
+              let!(:school_cohort) { create(:school_cohort, school:, cohort:, induction_programme_choice: "full_induction_programme") }
+
+              it "returns the updated induction_programme_choice" do
+                expect(subject.serializable_hash[:data][:attributes][:induction_programme_choice]).to eq("provider_led")
+              end
+            end
+
+            context "when school is not yet in the cohort" do
+              it "returns the an unknown induction programme choice" do
+                expect(subject.serializable_hash[:data][:attributes][:induction_programme_choice]).to eq("not_yet_known")
+              end
             end
           end
 

--- a/spec/serializers/api/v3/ecf/school_serializer_spec.rb
+++ b/spec/serializers/api/v3/ecf/school_serializer_spec.rb
@@ -54,7 +54,14 @@ module Api
           context "when 'programme_type_changes_2025' feature is disabled" do
             before { FeatureFlag.deactivate(:programme_type_changes_2025) }
 
-            %w[core_induction_programme full_induction_programme].each do |induction_programme_choice|
+            %w[
+              full_induction_programme
+              core_induction_programme
+              design_our_own
+              school_funded_fip
+              no_early_career_teachers
+              not_yet_known
+            ].each do |induction_programme_choice|
               context "when the school is already in the cohort with '#{induction_programme_choice}'" do
                 let!(:school_cohort) { create(:school_cohort, school:, cohort:, induction_programme_choice:) }
 
@@ -74,19 +81,42 @@ module Api
           context "when 'programme_type_changes_2025' feature is enabled" do
             before { FeatureFlag.activate(:programme_type_changes_2025) }
 
-            context "when the school is already in the cohort with 'core_induction_programme'" do
-              let!(:school_cohort) { create(:school_cohort, school:, cohort:, induction_programme_choice: "core_induction_programme") }
+            %w[
+              full_induction_programme
+              school_funded_fip
+            ].each do |induction_programme_choice|
+              context "when the school is already in the cohort with '#{induction_programme_choice}'" do
+                let!(:school_cohort) { create(:school_cohort, school:, cohort:, induction_programme_choice:) }
 
-              it "returns the updated induction_programme_choice" do
-                expect(subject.serializable_hash[:data][:attributes][:induction_programme_choice]).to eq("school_led")
+                it "returns the updated induction_programme_choice" do
+                  expect(subject.serializable_hash[:data][:attributes][:induction_programme_choice]).to eq("provider_led")
+                end
               end
             end
 
-            context "when the school is already in the cohort with 'full_induction_programme'" do
-              let!(:school_cohort) { create(:school_cohort, school:, cohort:, induction_programme_choice: "full_induction_programme") }
+            %w[
+              core_induction_programme
+              design_our_own
+            ].each do |induction_programme_choice|
+              context "when the school is already in the cohort with '#{induction_programme_choice}'" do
+                let!(:school_cohort) { create(:school_cohort, school:, cohort:, induction_programme_choice:) }
 
-              it "returns the updated induction_programme_choice" do
-                expect(subject.serializable_hash[:data][:attributes][:induction_programme_choice]).to eq("provider_led")
+                it "returns the updated induction_programme_choice" do
+                  expect(subject.serializable_hash[:data][:attributes][:induction_programme_choice]).to eq("school_led")
+                end
+              end
+            end
+
+            %w[
+              no_early_career_teachers
+              not_yet_known
+            ].each do |induction_programme_choice|
+              context "when the school is already in the cohort with '#{induction_programme_choice}'" do
+                let!(:school_cohort) { create(:school_cohort, school:, cohort:, induction_programme_choice:) }
+
+                it "returns the school cohort induction_programme_choice" do
+                  expect(subject.serializable_hash[:data][:attributes][:induction_programme_choice]).to eq(induction_programme_choice)
+                end
               end
             end
 

--- a/spec/services/programme_type_mappings_spec.rb
+++ b/spec/services/programme_type_mappings_spec.rb
@@ -56,44 +56,47 @@ RSpec.describe ProgrammeTypeMappings do
       context "when mappings are enabled" do
         let(:mappings_enabled) { true }
 
-        %i[full_induction_programme school_funded_fip].each do |induction_programme_type|
-          context "when training_programme is '#{induction_programme_type}'" do
-            let(:training_programme) { build(:induction_programme, induction_programme_type).training_programme }
+        %w[full_induction_programme school_funded_fip].each do |param|
+          context "when training_programme is '#{param}'" do
+            let(:training_programme) { param }
 
             it { is_expected.to eq("provider_led") }
           end
         end
 
-        %i[core_induction_programme design_our_own].each do |induction_programme_type|
-          context "when training_programme is '#{induction_programme_type}'" do
-            let(:training_programme) { build(:induction_programme, induction_programme_type).training_programme }
+        %w[core_induction_programme design_our_own].each do |param|
+          context "when training_programme is '#{param}'" do
+            let(:training_programme) { param }
 
             it { is_expected.to eq("school_led") }
           end
         end
 
-        context "when training_programme is anything else" do
-          let(:training_programme) { :anything_else }
+        %w[no_early_career_teachers not_yet_known].each do |param|
+          context "when training_programme is '#{param}'" do
+            let(:training_programme) { param }
 
-          it { is_expected.to eq(training_programme) }
+            it { is_expected.to eq(training_programme) }
+          end
         end
       end
 
       context "when mappings are disabled" do
         let(:mappings_enabled) { false }
 
-        %i[fip school_funded_fip cip design_our_own].each do |induction_programme_type|
-          context "when training_programme is '#{induction_programme_type}'" do
-            let(:training_programme) { build(:induction_programme, induction_programme_type).training_programme }
+        %w[
+          full_induction_programme
+          school_funded_fip
+          core_induction_programme
+          design_our_own
+          no_early_career_teachers
+          not_yet_known
+        ].each do |param|
+          context "when training_programme is '#{param}'" do
+            let(:training_programme) { param }
 
             it { is_expected.to eq(training_programme) }
           end
-        end
-
-        context "when training_programme is anything else" do
-          let(:training_programme) { :anything_else }
-
-          it { is_expected.to eq(training_programme) }
         end
       end
     end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-4182

### Changes proposed in this pull request

* `Api::V3::ECF::SchoolSerializer` updated to return new programme mapping when `programme_type_changes_2025` feature is enabled.

### Guidance to review

