### PR TITLE
[CPDLP-4158] Update appropriate bodies views for the new programme types

### DIFF
--- a/app/components/appropriate_bodies/participants/table_row.rb
+++ b/app/components/appropriate_bodies/participants/table_row.rb
@@ -16,20 +16,13 @@ module AppropriateBodies
       delegate :participant_profile,
                :school,
                :user,
+               :induction_type,
                to: :induction_record,
                allow_nil: true
 
       def initialize(induction_record:, training_record_states:)
         @induction_record = induction_record
         @training_record_states = training_record_states
-      end
-
-      def induction_type
-        if induction_record.enrolled_in_cip?
-          "CIP"
-        elsif induction_record.enrolled_in_fip?
-          "FIP"
-        end
       end
 
       def induction_tutor

--- a/app/models/induction_record.rb
+++ b/app/models/induction_record.rb
@@ -251,9 +251,9 @@ class InductionRecord < ApplicationRecord
 
   def induction_type
     if enrolled_in_cip?
-      ProgrammeTypeMappings.training_programme_friendly_name("core_induction_programme", length: :short)
+      ProgrammeTypeMappings.training_programme_friendly_name("core_induction_programme")
     elsif enrolled_in_fip?
-      ProgrammeTypeMappings.training_programme_friendly_name("full_induction_programme", length: :short)
+      ProgrammeTypeMappings.training_programme_friendly_name("full_induction_programme")
     end
   end
 

--- a/app/models/induction_record.rb
+++ b/app/models/induction_record.rb
@@ -251,9 +251,9 @@ class InductionRecord < ApplicationRecord
 
   def induction_type
     if enrolled_in_cip?
-      ProgrammeTypeMappings.training_programme_friendly_name("core_induction_programme", short: true)
+      ProgrammeTypeMappings.training_programme_friendly_name("core_induction_programme", length: :short)
     elsif enrolled_in_fip?
-      ProgrammeTypeMappings.training_programme_friendly_name("full_induction_programme", short: true)
+      ProgrammeTypeMappings.training_programme_friendly_name("full_induction_programme", length: :short)
     end
   end
 

--- a/app/models/induction_record.rb
+++ b/app/models/induction_record.rb
@@ -249,6 +249,14 @@ class InductionRecord < ApplicationRecord
     update!(induction_status: :withdrawn, end_date: date_of_change)
   end
 
+  def induction_type
+    if enrolled_in_cip?
+      ProgrammeTypeMappings.training_programme_friendly_name("core_induction_programme", short: true)
+    elsif enrolled_in_fip?
+      ProgrammeTypeMappings.training_programme_friendly_name("full_induction_programme", short: true)
+    end
+  end
+
 private
 
   def end_unknown?

--- a/app/serializers/appropriate_bodies/induction_records_serializer.rb
+++ b/app/serializers/appropriate_bodies/induction_records_serializer.rb
@@ -26,13 +26,7 @@ module AppropriateBodies
       StatusTags::AppropriateBodyParticipantStatusTag.new(params[:training_record_states][participant_profile.id]).label
     end
 
-    attribute :induction_type do |induction_record|
-      if induction_record.enrolled_in_cip?
-        "CIP"
-      elsif induction_record.enrolled_in_fip?
-        "FIP"
-      end
-    end
+    attribute :induction_type
 
     attribute :induction_tutor do |induction_record|
       induction_record.school.contact_email

--- a/app/services/programme_type_mappings.rb
+++ b/app/services/programme_type_mappings.rb
@@ -30,40 +30,9 @@ class ProgrammeTypeMappings
       end
     end
 
-    def training_programme_friendly_name(name, short: false)
-      long_names = if mappings_enabled?
-                     {
-                       "full_induction_programme" => "Provider led",
-                       "core_induction_programme" => "School led",
-                       "design_our_own" => "School led",
-                       "school_funded_fip" => "Provider led",
-                     }
-                   else
-                     {
-                       "full_induction_programme" => "Full induction programme",
-                       "core_induction_programme" => "Core induction programme",
-                       "design_our_own" => "Design our own",
-                       "school_funded_fip" => "School funded full induction programme",
-                     }
-                   end
-
-      short_names = if mappings_enabled?
-                      {
-                        "full_induction_programme" => "Provider led",
-                        "core_induction_programme" => "School led",
-                        "design_our_own" => "School led",
-                        "school_funded_fip" => "Provider led",
-                      }
-                    else
-                      {
-                        "full_induction_programme" => "FIP",
-                        "core_induction_programme" => "CIP",
-                        "design_our_own" => "Design our own",
-                        "school_funded_fip" => "School funded FIP",
-                      }
-                    end
-
-      short ? short_names.fetch(name) : long_names.fetch(name)
+    def training_programme_friendly_name(training_programme, length: :long)
+      translation_key = training_programme(training_programme:)
+      I18n.t("training_programme.#{length}.#{translation_key}")
     end
   end
 end

--- a/app/services/programme_type_mappings.rb
+++ b/app/services/programme_type_mappings.rb
@@ -30,9 +30,9 @@ class ProgrammeTypeMappings
       end
     end
 
-    def training_programme_friendly_name(training_programme, length: :long)
+    def training_programme_friendly_name(training_programme)
       translation_key = training_programme(training_programme:)
-      I18n.t("training_programme.#{length}.#{translation_key}")
+      I18n.t("training_programme.#{translation_key}")
     end
   end
 end

--- a/app/services/programme_type_mappings.rb
+++ b/app/services/programme_type_mappings.rb
@@ -29,5 +29,41 @@ class ProgrammeTypeMappings
         training_programme
       end
     end
+
+    def training_programme_friendly_name(name, short: false)
+      long_names = if mappings_enabled?
+                     {
+                       "full_induction_programme" => "Provider led",
+                       "core_induction_programme" => "School led",
+                       "design_our_own" => "School led",
+                       "school_funded_fip" => "Provider led",
+                     }
+                   else
+                     {
+                       "full_induction_programme" => "Full induction programme",
+                       "core_induction_programme" => "Core induction programme",
+                       "design_our_own" => "Design our own",
+                       "school_funded_fip" => "School funded full induction programme",
+                     }
+                   end
+
+      short_names = if mappings_enabled?
+                      {
+                        "full_induction_programme" => "Provider led",
+                        "core_induction_programme" => "School led",
+                        "design_our_own" => "School led",
+                        "school_funded_fip" => "Provider led",
+                      }
+                    else
+                      {
+                        "full_induction_programme" => "FIP",
+                        "core_induction_programme" => "CIP",
+                        "design_our_own" => "Design our own",
+                        "school_funded_fip" => "School funded FIP",
+                      }
+                    end
+
+      short ? short_names.fetch(name) : long_names.fetch(name)
+    end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,20 +25,10 @@ en:
     change_to_design_our_own: the school wants to design and deliver their own programme based on the early career framework (ECF)
     change_to_school_funded_fip: the school wants to design and deliver their own programme
   training_programme:
-    short:
-      full_induction_programme: FIP
-      core_induction_programme: CIP
-      design_our_own: Design our own
-      school_funded_fip: School funded FIP
-      provider_led: Provider led
-      school_led: School led
-    long:
-      full_induction_programme: Full induction programme
-      core_induction_programme: Core induction programme
-      design_our_own: Design our own
-      school_funded_fip: School funded full induction programme
-      provider_led: Provider led
-      school_led: School led
+    full_induction_programme: FIP
+    core_induction_programme: CIP
+    provider_led: Provider-led
+    school_led: School-led
 
   # Errors
   fail: "FAIL"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,21 @@ en:
     change_to_core_induction_programme: the school wants to deliver their own programme using DfE-accredited materials
     change_to_design_our_own: the school wants to design and deliver their own programme based on the early career framework (ECF)
     change_to_school_funded_fip: the school wants to design and deliver their own programme
+  training_programme:
+    short:
+      full_induction_programme: FIP
+      core_induction_programme: CIP
+      design_our_own: Design our own
+      school_funded_fip: School funded FIP
+      provider_led: Provider led
+      school_led: School led
+    long:
+      full_induction_programme: Full induction programme
+      core_induction_programme: Core induction programme
+      design_our_own: Design our own
+      school_funded_fip: School funded full induction programme
+      provider_led: Provider led
+      school_led: School led
 
   # Errors
   fail: "FAIL"

--- a/documentation/service-rules/appropriate-body-users.md
+++ b/documentation/service-rules/appropriate-body-users.md
@@ -170,7 +170,7 @@ The induction history table shows the following:
 -   Number of terms (this must be a whole number, and this is given when the
     ECT is released)
 
--   Induction programme type (Provider led or School led)
+-   Induction programme type (Provider-led or School-led)
 
 Below the induction history are 2 more subheadings:
 
@@ -215,7 +215,7 @@ When they are claiming an ECT, the appropriate body user needs to state:
 
 1.  When the induction began for that ECT with that appropriate body
 
-2.  What type of induction programme they are doing (Provider led or School led)
+2.  What type of induction programme they are doing (Provider-led or School-led)
 
 On 1, there is validation that makes sure the date given isn't
 before the date QTS was recorded. This is because induction should only
@@ -437,7 +437,7 @@ with schools, for example when:
 * a school has registered an ECT's details directly with them but has
     not registered the ECT correctly on Manage ECTs
 * an appropriate body has concerns that fidelity checks (needed for
-    School led) may be required for an ECT's induction
+    School-led) may be required for an ECT's induction
 * an appropriate body may need to use this to double-check they have
     successfully registered for induction any ECTs on the TRA AB portal
 
@@ -484,7 +484,7 @@ expand to other academic years.
 
 -   Status (defined below)
 
--   Induction type (Provider led or School led)
+-   Induction type (Provider-led or School-led)
 
 -   Induction tutor (their email)
 

--- a/documentation/service-rules/appropriate-body-users.md
+++ b/documentation/service-rules/appropriate-body-users.md
@@ -35,7 +35,7 @@ They can also view their appropriate body ID. This is referred to later as an em
 ---
 ### Individually claim an ECT for their induction status with the TRA
 
-The process of 'claiming' an ECT refers to an AB telling the TRA which ECTs they are quality assuring the induction of. 
+The process of 'claiming' an ECT refers to an AB telling the TRA which ECTs they are quality assuring the induction of.
 
 The appropriate body needs to enter both the date of birth and the TRN number for the ECT record to show up and be claimed.
 
@@ -54,7 +54,7 @@ If the ECT has previously failed induction, they cannot do induction again.
 * 📜 This is due to policy restricting those who have failed from reapplying to practice teaching. [AB
 guidance details this here.](https://assets.publishing.service.gov.uk/media/6629237f3b0122a378a7e6ef/Induction_for_early_career_teachers__England__statutory_guidance_.pdf)
 
---- 
+---
 
 If an early career teacher did their initial teacher training (ITT) through an accredited ITT provider who is also an AB, the school cannot appoint that appropriate body for that teacher.
 
@@ -80,9 +80,9 @@ When the portal pulls up the record for the ECT, it would show:
 
 -   The date they achieved QTS
 
--   Induction, which is the current status of their induction. 
+-   Induction, which is the current status of their induction.
 
-This status would be one of the following: in progress, pass, fail, extended, not yet completed (when they have stopped induction with 
+This status would be one of the following: in progress, pass, fail, extended, not yet completed (when they have stopped induction with
 their current appropriate body but not finished their induction)
 
 #### Teacher details
@@ -170,7 +170,7 @@ The induction history table shows the following:
 -   Number of terms (this must be a whole number, and this is given when the
     ECT is released)
 
--   Induction programme type (FIP/CIP/DIY)
+-   Induction programme type (Provider led or School led)
 
 Below the induction history are 2 more subheadings:
 
@@ -215,7 +215,7 @@ When they are claiming an ECT, the appropriate body user needs to state:
 
 1.  When the induction began for that ECT with that appropriate body
 
-2.  What type of induction programme they are doing (FIP, CIP, DIY)
+2.  What type of induction programme they are doing (Provider led or School led)
 
 On 1, there is validation that makes sure the date given isn't
 before the date QTS was recorded. This is because induction should only
@@ -272,7 +272,7 @@ regardless of reasons for leaving allows their record to be picked up
 from where it was last updated.
 
 ---
-### Pass or fail an ECT's induction 
+### Pass or fail an ECT's induction
 
 This would be under where AB users 5ecord an induction outcome.
 
@@ -365,7 +365,7 @@ be a GDPR breach to show this to users that do not require access.
 this data. This is why it is escalated to policy teams, not just support
 teams. Appropriate bodies are often delivery partners too. The Appropriate
 bodies and regulation team gives information to the policy team on who
-is serving as an appropriate body. 
+is serving as an appropriate body.
 
 ---
 Those users will then receive an email notification that they can sign
@@ -427,7 +427,7 @@ their own data and information on ECTs with what schools had submitted
 in Manage ECTs. This could be useful when submitting other data to the
 Teaching Regulation Agency as well.
 
---- 
+---
 
 It also meant that appropriate bodies could follow up when necessary
 with schools, for example when:
@@ -437,10 +437,10 @@ with schools, for example when:
 * a school has registered an ECT's details directly with them but has
     not registered the ECT correctly on Manage ECTs
 * an appropriate body has concerns that fidelity checks (needed for
-    both CIP and DIY) may be required for an ECT's induction
+    School led) may be required for an ECT's induction
 * an appropriate body may need to use this to double-check they have
     successfully registered for induction any ECTs on the TRA AB portal
-    
+
 ---
 
 There was also a hope that showing this information schools had
@@ -484,7 +484,7 @@ expand to other academic years.
 
 -   Status (defined below)
 
--   Induction type (FIP, CIP or DIY)
+-   Induction type (Provider led or School led)
 
 -   Induction tutor (their email)
 

--- a/spec/components/appropriate_bodies/participants/table_row_spec.rb
+++ b/spec/components/appropriate_bodies/participants/table_row_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe AppropriateBodies::Participants::TableRow, type: :component do
     context "when the programme_type_changes_2025 feature flag is enabled" do
       before { FeatureFlag.activate(:programme_type_changes_2025) }
 
-      it { is_expected.to have_text("Provider led") }
+      it { is_expected.to have_text("Provider-led") }
     end
   end
 
@@ -41,7 +41,7 @@ RSpec.describe AppropriateBodies::Participants::TableRow, type: :component do
     context "when the programme_type_changes_2025 feature flag is enabled" do
       before { FeatureFlag.activate(:programme_type_changes_2025) }
 
-      it { is_expected.to have_text("School led") }
+      it { is_expected.to have_text("School-led") }
     end
   end
 end

--- a/spec/components/appropriate_bodies/participants/table_row_spec.rb
+++ b/spec/components/appropriate_bodies/participants/table_row_spec.rb
@@ -20,6 +20,12 @@ RSpec.describe AppropriateBodies::Participants::TableRow, type: :component do
     it { is_expected.to have_text("ECT not currently linked to you") }
     it { is_expected.to have_text("FIP") }
     it { is_expected.to have_text(induction_record.school.contact_email) }
+
+    context "when the programme_type_changes_2025 feature flag is enabled" do
+      before { FeatureFlag.activate(:programme_type_changes_2025) }
+
+      it { is_expected.to have_text("Provider led") }
+    end
   end
 
   context "CIP induction type" do
@@ -31,5 +37,11 @@ RSpec.describe AppropriateBodies::Participants::TableRow, type: :component do
     it { is_expected.to have_text("ECT not currently linked to you") }
     it { is_expected.to have_text("CIP") }
     it { is_expected.to have_text(induction_record.school.contact_email) }
+
+    context "when the programme_type_changes_2025 feature flag is enabled" do
+      before { FeatureFlag.activate(:programme_type_changes_2025) }
+
+      it { is_expected.to have_text("School led") }
+    end
   end
 end

--- a/spec/models/induction_record_spec.rb
+++ b/spec/models/induction_record_spec.rb
@@ -464,4 +464,30 @@ RSpec.describe InductionRecord, type: :model do
       )
     end
   end
+
+  describe "#induction_type" do
+    subject { induction_record.induction_type }
+
+    context "when enrolled in cip " do
+      let(:induction_programme) { create(:induction_programme, :cip) }
+      let(:induction_record) { Induction::Enrol.call(participant_profile: create(:ect_participant_profile), induction_programme:) }
+
+      it "calls ProgrammeTypeMappings with correct params" do
+        expect(ProgrammeTypeMappings).to receive(:training_programme_friendly_name).with("core_induction_programme", short: true)
+
+        subject
+      end
+    end
+
+    context "when enrolled in fip " do
+      let(:induction_programme) { create(:induction_programme, :fip) }
+      let(:induction_record) { Induction::Enrol.call(participant_profile: create(:ect_participant_profile), induction_programme:) }
+
+      it "calls ProgrammeTypeMappings with correct params" do
+        expect(ProgrammeTypeMappings).to receive(:training_programme_friendly_name).with("full_induction_programme", short: true)
+
+        subject
+      end
+    end
+  end
 end

--- a/spec/models/induction_record_spec.rb
+++ b/spec/models/induction_record_spec.rb
@@ -473,7 +473,7 @@ RSpec.describe InductionRecord, type: :model do
       let(:induction_record) { Induction::Enrol.call(participant_profile: create(:ect_participant_profile), induction_programme:) }
 
       it "calls ProgrammeTypeMappings with correct params" do
-        expect(ProgrammeTypeMappings).to receive(:training_programme_friendly_name).with("core_induction_programme", short: true)
+        expect(ProgrammeTypeMappings).to receive(:training_programme_friendly_name).with("core_induction_programme", length: :short)
 
         subject
       end
@@ -484,7 +484,7 @@ RSpec.describe InductionRecord, type: :model do
       let(:induction_record) { Induction::Enrol.call(participant_profile: create(:ect_participant_profile), induction_programme:) }
 
       it "calls ProgrammeTypeMappings with correct params" do
-        expect(ProgrammeTypeMappings).to receive(:training_programme_friendly_name).with("full_induction_programme", short: true)
+        expect(ProgrammeTypeMappings).to receive(:training_programme_friendly_name).with("full_induction_programme", length: :short)
 
         subject
       end

--- a/spec/models/induction_record_spec.rb
+++ b/spec/models/induction_record_spec.rb
@@ -472,6 +472,8 @@ RSpec.describe InductionRecord, type: :model do
       let(:induction_programme) { create(:induction_programme, :cip) }
       let(:induction_record) { Induction::Enrol.call(participant_profile: create(:ect_participant_profile), induction_programme:) }
 
+      it { is_expected.to eq("CIP") }
+
       it "calls ProgrammeTypeMappings with correct params" do
         expect(ProgrammeTypeMappings).to receive(:training_programme_friendly_name).with("core_induction_programme", length: :short)
 
@@ -482,6 +484,8 @@ RSpec.describe InductionRecord, type: :model do
     context "when enrolled in fip " do
       let(:induction_programme) { create(:induction_programme, :fip) }
       let(:induction_record) { Induction::Enrol.call(participant_profile: create(:ect_participant_profile), induction_programme:) }
+
+      it { is_expected.to eq("FIP") }
 
       it "calls ProgrammeTypeMappings with correct params" do
         expect(ProgrammeTypeMappings).to receive(:training_programme_friendly_name).with("full_induction_programme", length: :short)

--- a/spec/models/induction_record_spec.rb
+++ b/spec/models/induction_record_spec.rb
@@ -475,7 +475,7 @@ RSpec.describe InductionRecord, type: :model do
       it { is_expected.to eq("CIP") }
 
       it "calls ProgrammeTypeMappings with correct params" do
-        expect(ProgrammeTypeMappings).to receive(:training_programme_friendly_name).with("core_induction_programme", length: :short)
+        expect(ProgrammeTypeMappings).to receive(:training_programme_friendly_name).with("core_induction_programme")
 
         subject
       end
@@ -488,7 +488,7 @@ RSpec.describe InductionRecord, type: :model do
       it { is_expected.to eq("FIP") }
 
       it "calls ProgrammeTypeMappings with correct params" do
-        expect(ProgrammeTypeMappings).to receive(:training_programme_friendly_name).with("full_induction_programme", length: :short)
+        expect(ProgrammeTypeMappings).to receive(:training_programme_friendly_name).with("full_induction_programme")
 
         subject
       end

--- a/spec/serializers/appropriate_bodies/induction_records_serializer_spec.rb
+++ b/spec/serializers/appropriate_bodies/induction_records_serializer_spec.rb
@@ -45,7 +45,7 @@ module AppropriateBodies
             trn: participant_profile.teacher_profile.trn,
             school_urn: induction_record.school.urn,
             status: "ECT not currently linked to you",
-            induction_type: "Provider led",
+            induction_type: "Provider-led",
             induction_tutor: induction_record.school.contact_email,
           )
         end

--- a/spec/serializers/appropriate_bodies/induction_records_serializer_spec.rb
+++ b/spec/serializers/appropriate_bodies/induction_records_serializer_spec.rb
@@ -35,6 +35,21 @@ module AppropriateBodies
           induction_tutor: induction_record.school.contact_email,
         )
       end
+
+      context "when the programme_type_changes_2025 feature flag is enabled" do
+        before { FeatureFlag.activate(:programme_type_changes_2025) }
+
+        it "returns valid hash" do
+          expect(subject.serializable_hash[:data][:attributes]).to eq(
+            full_name: participant_profile.user.full_name,
+            trn: participant_profile.teacher_profile.trn,
+            school_urn: induction_record.school.urn,
+            status: "ECT not currently linked to you",
+            induction_type: "Provider led",
+            induction_tutor: induction_record.school.contact_email,
+          )
+        end
+      end
     end
   end
 end

--- a/spec/serializers/appropriate_bodies/induction_records_serializer_spec.rb
+++ b/spec/serializers/appropriate_bodies/induction_records_serializer_spec.rb
@@ -39,7 +39,7 @@ module AppropriateBodies
       context "when the programme_type_changes_2025 feature flag is enabled" do
         before { FeatureFlag.activate(:programme_type_changes_2025) }
 
-        it "returns valid hash" do
+        it "returns the correct `induction_type`" do
           expect(subject.serializable_hash[:data][:attributes]).to eq(
             full_name: participant_profile.user.full_name,
             trn: participant_profile.teacher_profile.trn,

--- a/spec/services/programme_type_mappings_spec.rb
+++ b/spec/services/programme_type_mappings_spec.rb
@@ -100,5 +100,113 @@ RSpec.describe ProgrammeTypeMappings do
         end
       end
     end
+
+    describe ".training_programme_friendly_name" do
+      subject { described_class.training_programme_friendly_name(training_programme, short:) }
+
+      context("when short: false") do
+        let(:short) { false }
+
+        context "when mappings are enabled" do
+          let(:mappings_enabled) { true }
+
+          %i[full_induction_programme school_funded_fip].each do |induction_programme_type|
+            context "when training_programme is '#{induction_programme_type}'" do
+              let(:training_programme) { build(:induction_programme, induction_programme_type).training_programme }
+
+              it { is_expected.to eq("Provider led") }
+            end
+          end
+
+          %i[core_induction_programme design_our_own].each do |induction_programme_type|
+            context "when training_programme is '#{induction_programme_type}'" do
+              let(:training_programme) { build(:induction_programme, induction_programme_type).training_programme }
+
+              it { is_expected.to eq("School led") }
+            end
+          end
+        end
+
+        context "when mappings are not enabled" do
+          let(:mappings_enabled) { false }
+
+          context "when training_programme is `full_induction_programme`" do
+            let(:training_programme) { build(:induction_programme, :fip).training_programme }
+
+            it { is_expected.to eq("Full induction programme") }
+          end
+
+          context "when training_programme is `core_induction_programme`" do
+            let(:training_programme) { build(:induction_programme, :cip).training_programme }
+
+            it { is_expected.to eq("Core induction programme") }
+          end
+
+          context "when training_programme is `design_our_own`" do
+            let(:training_programme) { build(:induction_programme, :design_our_own).training_programme }
+
+            it { is_expected.to eq("Design our own") }
+          end
+
+          context "when training_programme is `school_funded_fip`" do
+            let(:training_programme) { build(:induction_programme, :school_funded_fip).training_programme }
+
+            it { is_expected.to eq("School funded full induction programme") }
+          end
+        end
+      end
+
+      context("when short: true") do
+        let(:short) { true }
+
+        context "when mappings are enabled" do
+          let(:mappings_enabled) { true }
+
+          %i[full_induction_programme school_funded_fip].each do |induction_programme_type|
+            context "when training_programme is '#{induction_programme_type}'" do
+              let(:training_programme) { build(:induction_programme, induction_programme_type).training_programme }
+
+              it { is_expected.to eq("Provider led") }
+            end
+          end
+
+          %i[core_induction_programme design_our_own].each do |induction_programme_type|
+            context "when training_programme is '#{induction_programme_type}'" do
+              let(:training_programme) { build(:induction_programme, induction_programme_type).training_programme }
+
+              it { is_expected.to eq("School led") }
+            end
+          end
+        end
+
+        context "when mappings are not enabled" do
+          let(:mappings_enabled) { false }
+
+          context "when training_programme is `full_induction_programme`" do
+            let(:training_programme) { build(:induction_programme, :fip).training_programme }
+
+            it { is_expected.to eq("FIP") }
+          end
+
+          context "when training_programme is `core_induction_programme`" do
+            let(:training_programme) { build(:induction_programme, :cip).training_programme }
+
+            it { is_expected.to eq("CIP") }
+          end
+
+          context "when training_programme is `design_our_own`" do
+            let(:training_programme) { build(:induction_programme, :design_our_own).training_programme }
+
+            it { is_expected.to eq("Design our own") }
+          end
+
+          context "when training_programme is `school_funded_fip`" do
+            let(:training_programme) { build(:induction_programme, :school_funded_fip).training_programme }
+
+            it { is_expected.to eq("School funded FIP") }
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/services/programme_type_mappings_spec.rb
+++ b/spec/services/programme_type_mappings_spec.rb
@@ -102,109 +102,37 @@ RSpec.describe ProgrammeTypeMappings do
     end
 
     describe ".training_programme_friendly_name" do
-      subject { described_class.training_programme_friendly_name(training_programme, length:) }
+      subject { described_class.training_programme_friendly_name(training_programme) }
 
-      context("when length: :long") do
-        let(:length) { :long }
+      context "when mappings are enabled" do
+        let(:mappings_enabled) { true }
 
-        context "when mappings are enabled" do
-          let(:mappings_enabled) { true }
+        context "when training_programme is `full_induction_programme`" do
+          let(:training_programme) { build(:induction_programme, :fip).training_programme }
 
-          %i[full_induction_programme school_funded_fip].each do |induction_programme_type|
-            context "when training_programme is '#{induction_programme_type}'" do
-              let(:training_programme) { build(:induction_programme, induction_programme_type).training_programme }
-
-              it { is_expected.to eq("Provider led") }
-            end
-          end
-
-          %i[core_induction_programme design_our_own].each do |induction_programme_type|
-            context "when training_programme is '#{induction_programme_type}'" do
-              let(:training_programme) { build(:induction_programme, induction_programme_type).training_programme }
-
-              it { is_expected.to eq("School led") }
-            end
-          end
+          it { is_expected.to eq("Provider-led") }
         end
 
-        context "when mappings are not enabled" do
-          let(:mappings_enabled) { false }
+        context "when training_programme is `core_induction_programme`" do
+          let(:training_programme) { build(:induction_programme, :cip).training_programme }
 
-          context "when training_programme is `full_induction_programme`" do
-            let(:training_programme) { build(:induction_programme, :fip).training_programme }
-
-            it { is_expected.to eq("Full induction programme") }
-          end
-
-          context "when training_programme is `core_induction_programme`" do
-            let(:training_programme) { build(:induction_programme, :cip).training_programme }
-
-            it { is_expected.to eq("Core induction programme") }
-          end
-
-          context "when training_programme is `design_our_own`" do
-            let(:training_programme) { build(:induction_programme, :design_our_own).training_programme }
-
-            it { is_expected.to eq("Design our own") }
-          end
-
-          context "when training_programme is `school_funded_fip`" do
-            let(:training_programme) { build(:induction_programme, :school_funded_fip).training_programme }
-
-            it { is_expected.to eq("School funded full induction programme") }
-          end
+          it { is_expected.to eq("School-led") }
         end
       end
 
-      context("when length: :short") do
-        let(:length) { :short }
+      context "when mappings are not enabled" do
+        let(:mappings_enabled) { false }
 
-        context "when mappings are enabled" do
-          let(:mappings_enabled) { true }
+        context "when training_programme is `full_induction_programme`" do
+          let(:training_programme) { build(:induction_programme, :fip).training_programme }
 
-          %i[full_induction_programme school_funded_fip].each do |induction_programme_type|
-            context "when training_programme is '#{induction_programme_type}'" do
-              let(:training_programme) { build(:induction_programme, induction_programme_type).training_programme }
-
-              it { is_expected.to eq("Provider led") }
-            end
-          end
-
-          %i[core_induction_programme design_our_own].each do |induction_programme_type|
-            context "when training_programme is '#{induction_programme_type}'" do
-              let(:training_programme) { build(:induction_programme, induction_programme_type).training_programme }
-
-              it { is_expected.to eq("School led") }
-            end
-          end
+          it { is_expected.to eq("FIP") }
         end
 
-        context "when mappings are not enabled" do
-          let(:mappings_enabled) { false }
+        context "when training_programme is `core_induction_programme`" do
+          let(:training_programme) { build(:induction_programme, :cip).training_programme }
 
-          context "when training_programme is `full_induction_programme`" do
-            let(:training_programme) { build(:induction_programme, :fip).training_programme }
-
-            it { is_expected.to eq("FIP") }
-          end
-
-          context "when training_programme is `core_induction_programme`" do
-            let(:training_programme) { build(:induction_programme, :cip).training_programme }
-
-            it { is_expected.to eq("CIP") }
-          end
-
-          context "when training_programme is `design_our_own`" do
-            let(:training_programme) { build(:induction_programme, :design_our_own).training_programme }
-
-            it { is_expected.to eq("Design our own") }
-          end
-
-          context "when training_programme is `school_funded_fip`" do
-            let(:training_programme) { build(:induction_programme, :school_funded_fip).training_programme }
-
-            it { is_expected.to eq("School funded FIP") }
-          end
+          it { is_expected.to eq("CIP") }
         end
       end
     end

--- a/spec/services/programme_type_mappings_spec.rb
+++ b/spec/services/programme_type_mappings_spec.rb
@@ -102,10 +102,10 @@ RSpec.describe ProgrammeTypeMappings do
     end
 
     describe ".training_programme_friendly_name" do
-      subject { described_class.training_programme_friendly_name(training_programme, short:) }
+      subject { described_class.training_programme_friendly_name(training_programme, length:) }
 
-      context("when short: false") do
-        let(:short) { false }
+      context("when length: :long") do
+        let(:length) { :long }
 
         context "when mappings are enabled" do
           let(:mappings_enabled) { true }
@@ -156,8 +156,8 @@ RSpec.describe ProgrammeTypeMappings do
         end
       end
 
-      context("when short: true") do
-        let(:short) { true }
+      context("when length: :short") do
+        let(:length) { :short }
 
         context "when mappings are enabled" do
           let(:mappings_enabled) { true }


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-4158](https://dfedigital.atlassian.net/browse/CPDLP-4158)

We need to update a few places we mention programme types to the new values.

### Changes proposed in this pull request

- `AppropriateBodies::Participants::TableRow` to show provider/school led if feature flag is on instead of CIP/FIP;
- Update `AppropriateBodies::InductionRecordsSerializer` to show provider/school led if feature flag is on instead of CIP/FIP;
- Update mentions to FIP/CIP in ABs documentation. Please see [PR#433](https://github.com/DFE-Digital/register-early-career-teachers-public/pull/433);
### Guidance to review

Review app

[CPDLP-4158]: https://dfedigital.atlassian.net/browse/CPDLP-4158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ