### PR TITLE
Fix bug that might duplicate induction records in the DQT daily checks

### DIFF
--- a/app/jobs/set_participant_completion_date_job.rb
+++ b/app/jobs/set_participant_completion_date_job.rb
@@ -6,7 +6,7 @@
 # It runs in batches of 200 as we have a 300 lookup per minute limit on the API
 # This could get adapted later to be a regular running process with a bit more logic
 class SetParticipantCompletionDateJob < ApplicationJob
-  MAX_CANDIDATES = 200
+  MAX_CANDIDATES = 150
 
   def perform
     candidates.each do |candidate|
@@ -20,6 +20,10 @@ class SetParticipantCompletionDateJob < ApplicationJob
 private
 
   def candidates
-    @candidates ||= CompletionCandidate.includes(participant_profile: :teacher_profile).limit(MAX_CANDIDATES)
+    @candidates ||= CompletionCandidate
+                      .includes(participant_profile: :teacher_profile)
+                      .order(:participant_profile_id)
+                      .limit(MAX_CANDIDATES)
+                      .to_a
   end
 end

--- a/app/services/participants/check_and_set_completion_date.rb
+++ b/app/services/participants/check_and_set_completion_date.rb
@@ -33,10 +33,13 @@ module Participants
     end
 
     def amend_cohort_to_continue_training
-      @amend_cohort_to_continue_training ||= Induction::AmendParticipantCohort.new(participant_profile:,
-                                                                                   source_cohort_start_year:,
-                                                                                   target_cohort_start_year:,
-                                                                                   force_from_frozen_cohort: true)
+      @amend_cohort_to_continue_training ||=
+        Induction::AmendParticipantCohort.new(participant_profile:,
+                                              source_cohort_start_year:,
+                                              target_cohort_start_year:,
+                                              force_from_frozen_cohort: true).tap do
+          participant_profile.reload
+        end
     end
 
     def clear_participant_continue_training_errors
@@ -44,7 +47,7 @@ module Participants
     end
 
     def complete_induction
-      Induction::Complete.call(participant_profile:, completion_date:)
+      Induction::Complete.call(participant_profile:, completion_date:).tap { participant_profile.reload }
     end
 
     def complete_induction?
@@ -114,7 +117,7 @@ module Participants
     end
 
     def sync_with_dqt
-      Participants::SyncDQTInductionStartDate.call(start_date, participant_profile)
+      Participants::SyncDQTInductionStartDate.call(start_date, participant_profile).tap { participant_profile.reload }
     end
 
     def target_cohort


### PR DESCRIPTION
### Context

- [Ticket](https://dfedigital.atlassian.net/browse/CPDLP-4148): 

The daily DQT checks are duplicating the induction records when the participant needs to be moved from their current cohort.

After analysing the code and trying to reproduce the issue the outcome is that the service object that actually checks DQT for a participant and apply the logic to change the cohort of the ECT, is working fine. 

I wasn't able to reproduce the bug using the snapshot database though but I was able to revert and re-submit some of these ECTs in the snapshot database and the service class `Participants::CheckAndSetCompletionDate` is doing the right thing (without duplicating induction records).

So the only thing I can think of causing this issue is the parent process that picks ECTs in batches from the database and submit them for processing one by one.

I suspect this loop actually submits an ECT twice when the SO processing it changes their cohort. It might have to do with the fact that actually it is processing an `ActiveRecord::Relation` list rather than an array.

Another suspicious area could be that each bunch of ECTs (200 currently) takes more than 2 minutes to be processed so that the next worker picking another 200 ECTs actually picks the same records or some common ECT records due to the first bunch not having finished yet (and all/some of them haven't been destroyed yet from the database).


 
### Changes proposed in this pull request

1. In case 200 ECTs are not processed in time during the 2-minute window until the next bunch is retrieved from the database, reduce that number (200) to 150. 

2. Instantiate in memory the 150 participants to be processed on each run by `SetParticipantCompletionDateJob`. This should fix the issue if the problem comes from the list to actually be an `ActiveRecord::Relation` object. Each candidate participant profile entry is destroyed from the database inmediately after it has been processed. The loop might be have unexpected behaviour if the list is not a proper array object.

3. Reload the `participant_profile` instance been processed after their induction record chain has suffered some update during its processing. There are 3 different checks in which this could happen: 
  - complete induction 
  - new/different induction start date received from DQT
  - ECT still in progress accordiing to DQT
  
By re-creating a fresh new instance after each of these updates, we guarantee it fully picks the changes applied in the previous task (specially important to have an up to date chain of induction records loaded ready for the next task)



