### PR TITLE
Fix failing analytics upsert jobs on review deploy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,9 @@ gem "ar-uuid", "~> 0.2.3"
 # Use Puma as the app server
 gem "puma", "~> 6.0"
 
+# after_commit track changes
+gem "ar_transaction_changes"
+
 # Soft delete
 gem "discard", "~> 1.4"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,8 @@ GEM
     amazing_print (1.7.2)
     ar-uuid (0.2.3)
       activerecord
+    ar_transaction_changes (1.1.9)
+      activerecord (>= 5.2.0)
     ast (2.4.3)
     auto_strip_attributes (2.6.0)
       activerecord (>= 4.0)
@@ -745,6 +747,7 @@ DEPENDENCIES
   activerecord-session_store (~> 2.2)
   amazing_print
   ar-uuid (~> 0.2.3)
+  ar_transaction_changes
   auto_strip_attributes (~> 2.6)
   axe-core-rspec
   bootsnap (~> 1.18)

--- a/app/jobs/analytics/upsert_ecf_appropriate_body_job.rb
+++ b/app/jobs/analytics/upsert_ecf_appropriate_body_job.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class Analytics::UpsertECFAppropriateBodyJob < ApplicationJob
-  def perform(appropriate_body:)
-    Analytics::ECFAppropriateBodyService.upsert_record(appropriate_body)
+  def perform(appropriate_body_id:)
+    appropriate_body = AppropriateBody.find_by(id: appropriate_body_id)
+    Analytics::ECFAppropriateBodyService.upsert_record(appropriate_body) if appropriate_body
   end
 end

--- a/app/jobs/analytics/upsert_ecf_induction_job.rb
+++ b/app/jobs/analytics/upsert_ecf_induction_job.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class Analytics::UpsertECFInductionJob < ApplicationJob
-  def perform(induction_record:)
-    Analytics::ECFInductionService.upsert_record(induction_record)
+  def perform(induction_record_id:)
+    induction_record = InductionRecord.find_by(id: induction_record_id)
+    Analytics::ECFInductionService.upsert_record(induction_record) if induction_record
   end
 end

--- a/app/jobs/analytics/upsert_ecf_participant_profile_job.rb
+++ b/app/jobs/analytics/upsert_ecf_participant_profile_job.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class Analytics::UpsertECFParticipantProfileJob < ApplicationJob
-  def perform(participant_profile:)
-    Analytics::ECFValidationService.upsert_record(participant_profile)
+  def perform(participant_profile_id:)
+    participant_profile = ParticipantProfile::ECF.find_by(id: participant_profile_id)
+    Analytics::ECFValidationService.upsert_record(participant_profile) if participant_profile
   end
 end

--- a/app/jobs/analytics/upsert_ecf_partnership_job.rb
+++ b/app/jobs/analytics/upsert_ecf_partnership_job.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class Analytics::UpsertECFPartnershipJob < ApplicationJob
-  def perform(partnership:)
-    Analytics::ECFPartnershipService.upsert_record(partnership)
+  def perform(partnership_id:)
+    partnership = Partnership.find_by(id: partnership_id)
+    Analytics::ECFPartnershipService.upsert_record(partnership) if partnership
   end
 end

--- a/app/jobs/analytics/upsert_ecf_school_cohort_job.rb
+++ b/app/jobs/analytics/upsert_ecf_school_cohort_job.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class Analytics::UpsertECFSchoolCohortJob < ApplicationJob
-  def perform(school_cohort:)
-    Analytics::ECFSchoolCohortService.upsert_record(school_cohort)
+  def perform(school_cohort_id:)
+    school_cohort = SchoolCohort.find_by(id: school_cohort_id)
+    Analytics::ECFSchoolCohortService.upsert_record(school_cohort) if school_cohort
   end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 class ApplicationRecord < ActiveRecord::Base
+  include ArTransactionChanges
+
   self.abstract_class = true
 end

--- a/app/models/appropriate_body.rb
+++ b/app/models/appropriate_body.rb
@@ -28,7 +28,7 @@ class AppropriateBody < ApplicationRecord
   scope :nationals, -> { where(body_type: :national) }
   scope :active_in_year, ->(year) { where("disable_from_year IS NULL OR disable_from_year > ?", year) }
 
-  after_save :update_analytics
+  after_commit :update_analytics
 
   def self.ransackable_attributes(_auth_object = nil)
     %w[name]
@@ -45,6 +45,6 @@ class AppropriateBody < ApplicationRecord
 private
 
   def update_analytics
-    Analytics::UpsertECFAppropriateBodyJob.perform_later(appropriate_body: self) if saved_changes?
+    Analytics::UpsertECFAppropriateBodyJob.perform_later(appropriate_body: self) if transaction_changed_attributes.any?
   end
 end

--- a/app/models/appropriate_body.rb
+++ b/app/models/appropriate_body.rb
@@ -45,6 +45,6 @@ class AppropriateBody < ApplicationRecord
 private
 
   def update_analytics
-    Analytics::UpsertECFAppropriateBodyJob.perform_later(appropriate_body: self) if transaction_changed_attributes.any?
+    Analytics::UpsertECFAppropriateBodyJob.perform_later(appropriate_body_id: id) if transaction_changed_attributes.any?
   end
 end

--- a/app/models/induction_record.rb
+++ b/app/models/induction_record.rb
@@ -89,7 +89,7 @@ class InductionRecord < ApplicationRecord
   scope :oldest, -> { oldest_first.first }
 
   # Callbacks
-  after_save :update_analytics
+  after_commit :update_analytics
 
   # Class Methods
   def self.latest
@@ -256,6 +256,6 @@ private
   end
 
   def update_analytics
-    Analytics::UpsertECFInductionJob.perform_later(induction_record: self) if saved_changes?
+    Analytics::UpsertECFInductionJob.perform_later(induction_record: self) if transaction_changed_attributes.any?
   end
 end

--- a/app/models/induction_record.rb
+++ b/app/models/induction_record.rb
@@ -256,6 +256,6 @@ private
   end
 
   def update_analytics
-    Analytics::UpsertECFInductionJob.perform_later(induction_record: self) if transaction_changed_attributes.any?
+    Analytics::UpsertECFInductionJob.perform_later(induction_record_id: id) if transaction_changed_attributes.any?
   end
 end

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -40,7 +40,7 @@ class ParticipantProfile::ECF < ParticipantProfile
   scope :ineligible_status, -> { joins(:ecf_participant_eligibility).where(ecf_participant_eligibility: { status: :ineligible }).where.not(ecf_participant_eligibility: { reason: %i[previous_participation duplicate_profile] }) }
 
   # Callbacks
-  after_save :update_analytics
+  after_commit :update_analytics
   after_update :sync_status_with_induction_record
   after_update :update_declaration_types!, if: :saved_change_to_type?
 
@@ -194,7 +194,7 @@ class ParticipantProfile::ECF < ParticipantProfile
 private
 
   def update_analytics
-    Analytics::UpsertECFParticipantProfileJob.perform_later(participant_profile: self) if saved_changes?
+    Analytics::UpsertECFParticipantProfileJob.perform_later(participant_profile: self) if transaction_changed_attributes.any?
   end
 
   def sync_status_with_induction_record

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -194,7 +194,7 @@ class ParticipantProfile::ECF < ParticipantProfile
 private
 
   def update_analytics
-    Analytics::UpsertECFParticipantProfileJob.perform_later(participant_profile: self) if transaction_changed_attributes.any?
+    Analytics::UpsertECFParticipantProfileJob.perform_later(participant_profile_id: id) if transaction_changed_attributes.any?
   end
 
   def sync_status_with_induction_record

--- a/app/models/partnership.rb
+++ b/app/models/partnership.rb
@@ -28,7 +28,7 @@ class Partnership < ApplicationRecord
     end
   end
 
-  after_save :update_analytics
+  after_commit :update_analytics
 
   scope :in_year, ->(year) { joins(:cohort).where(cohort: { start_year: year }) }
   scope :unchallenged, -> { where(challenged_at: nil, challenge_reason: nil) }
@@ -74,6 +74,6 @@ private
   end
 
   def update_analytics
-    Analytics::UpsertECFPartnershipJob.perform_later(partnership: self) if saved_changes?
+    Analytics::UpsertECFPartnershipJob.perform_later(partnership: self) if transaction_changed_attributes.any?
   end
 end

--- a/app/models/partnership.rb
+++ b/app/models/partnership.rb
@@ -74,6 +74,6 @@ private
   end
 
   def update_analytics
-    Analytics::UpsertECFPartnershipJob.perform_later(partnership: self) if transaction_changed_attributes.any?
+    Analytics::UpsertECFPartnershipJob.perform_later(partnership_id: id) if transaction_changed_attributes.any?
   end
 end

--- a/app/models/school_cohort.rb
+++ b/app/models/school_cohort.rb
@@ -44,7 +44,7 @@ class SchoolCohort < ApplicationRecord
   delegate :description, :academic_year, :start_year, to: :cohort
   delegate :delivery_partner_to_be_confirmed, to: :default_induction_programme
 
-  after_save :update_analytics
+  after_commit :update_analytics
 
   after_save do |school_cohort|
     unless school_cohort.saved_changes.empty?
@@ -119,6 +119,6 @@ class SchoolCohort < ApplicationRecord
 private
 
   def update_analytics
-    Analytics::UpsertECFSchoolCohortJob.perform_later(school_cohort: self) if saved_changes?
+    Analytics::UpsertECFSchoolCohortJob.perform_later(school_cohort: self) if transaction_changed_attributes.any?
   end
 end

--- a/app/models/school_cohort.rb
+++ b/app/models/school_cohort.rb
@@ -119,6 +119,6 @@ class SchoolCohort < ApplicationRecord
 private
 
   def update_analytics
-    Analytics::UpsertECFSchoolCohortJob.perform_later(school_cohort: self) if transaction_changed_attributes.any?
+    Analytics::UpsertECFSchoolCohortJob.perform_later(school_cohort_id: id) if transaction_changed_attributes.any?
   end
 end

--- a/app/services/store_participant_eligibility.rb
+++ b/app/services/store_participant_eligibility.rb
@@ -153,7 +153,7 @@ private
 
     Participants::DetermineEligibilityStatus.call(ecf_participant_eligibility: @participant_eligibility)
 
-    Analytics::UpsertECFParticipantProfileJob.perform_later(participant_profile:)
+    Analytics::UpsertECFParticipantProfileJob.perform_later(participant_profile_id: participant_profile.id)
   end
 
   def default_eligibility_flags

--- a/spec/jobs/analytics/upsert_ecf_appropriate_body_job_spec.rb
+++ b/spec/jobs/analytics/upsert_ecf_appropriate_body_job_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Analytics::UpsertECFAppropriateBodyJob do
+  describe "#perform" do
+    it "calls Analytics::ECFAppropriateBodyService.upsert_record when the appropriate body exists" do
+      appropriate_body = create(:appropriate_body_local_authority)
+      expect(Analytics::ECFAppropriateBodyService).to receive(:upsert_record).with(appropriate_body)
+
+      described_class.new.perform(appropriate_body_id: appropriate_body.id)
+    end
+
+    it "does not call Analytics::ECFAppropriateBodyService.upsert_record when the appropriate body does not exist" do
+      expect(Analytics::ECFAppropriateBodyService).not_to receive(:upsert_record)
+
+      described_class.new.perform(appropriate_body_id: SecureRandom.uuid)
+    end
+  end
+end

--- a/spec/jobs/analytics/upsert_ecf_induction_job_spec.rb
+++ b/spec/jobs/analytics/upsert_ecf_induction_job_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Analytics::UpsertECFInductionJob do
+  describe "#perform" do
+    it "calls Analytics::ECFInductionService.upsert_record when the induction record exists" do
+      induction_record = create(:induction_record)
+      expect(Analytics::ECFInductionService).to receive(:upsert_record).with(induction_record)
+
+      described_class.new.perform(induction_record_id: induction_record.id)
+    end
+
+    it "does not call Analytics::ECFInductionService.upsert_record when the induction record does not exist" do
+      expect(Analytics::ECFInductionService).not_to receive(:upsert_record)
+
+      described_class.new.perform(induction_record_id: SecureRandom.uuid)
+    end
+  end
+end

--- a/spec/jobs/analytics/upsert_ecf_participant_profile_job_spec.rb
+++ b/spec/jobs/analytics/upsert_ecf_participant_profile_job_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Analytics::UpsertECFParticipantProfileJob do
+  describe "#perform" do
+    it "calls Analytics::ECFValidationService.upsert_record when the participant profile exists" do
+      participant_profile = create(:ect)
+      expect(Analytics::ECFValidationService).to receive(:upsert_record).with(participant_profile)
+
+      described_class.new.perform(participant_profile_id: participant_profile.id)
+    end
+
+    it "does not call Analytics::ECFValidationService.upsert_record when the participant profile does not exist" do
+      expect(Analytics::ECFValidationService).not_to receive(:upsert_record)
+
+      described_class.new.perform(participant_profile_id: SecureRandom.uuid)
+    end
+  end
+end

--- a/spec/jobs/analytics/upsert_ecf_partnership_job_spec.rb
+++ b/spec/jobs/analytics/upsert_ecf_partnership_job_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Analytics::UpsertECFPartnershipJob do
+  describe "#perform" do
+    it "calls Analytics::ECFPartnershipService.upsert_record when the partnership exists" do
+      partnership = create(:partnership)
+      expect(Analytics::ECFPartnershipService).to receive(:upsert_record).with(partnership)
+
+      described_class.new.perform(partnership_id: partnership.id)
+    end
+
+    it "does not call Analytics::ECFPartnershipService.upsert_record when the partnership does not exist" do
+      expect(Analytics::ECFPartnershipService).not_to receive(:upsert_record)
+
+      described_class.new.perform(partnership_id: SecureRandom.uuid)
+    end
+  end
+end

--- a/spec/jobs/analytics/upsert_ecf_school_cohort_job_spec.rb
+++ b/spec/jobs/analytics/upsert_ecf_school_cohort_job_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Analytics::UpsertECFSchoolCohortJob do
+  describe "#perform" do
+    it "calls Analytics::ECFSchoolCohortService.upsert_record when the school cohort exists" do
+      school_cohort = create(:school_cohort)
+      expect(Analytics::ECFSchoolCohortService).to receive(:upsert_record).with(school_cohort)
+
+      described_class.new.perform(school_cohort_id: school_cohort.id)
+    end
+
+    it "does not call Analytics::ECFSchoolCohortService.upsert_record when the school cohort does not exist" do
+      expect(Analytics::ECFSchoolCohortService).not_to receive(:upsert_record)
+
+      described_class.new.perform(school_cohort_id: SecureRandom.uuid)
+    end
+  end
+end

--- a/spec/models/appropriate_body_spec.rb
+++ b/spec/models/appropriate_body_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe AppropriateBody, type: :model do
 
     expect {
       appropriate_body.update!(name: "Crispy Code")
-    }.to have_enqueued_job(Analytics::UpsertECFAppropriateBodyJob).with(appropriate_body:)
+    }.to have_enqueued_job(Analytics::UpsertECFAppropriateBodyJob).with(appropriate_body_id: appropriate_body.id)
   end
 
   it "filter appropriate bodies disabled in a given year" do

--- a/spec/models/induction_record_spec.rb
+++ b/spec/models/induction_record_spec.rb
@@ -460,7 +460,7 @@ RSpec.describe InductionRecord, type: :model do
       expect {
         induction_record.leaving!(1.week.from_now)
       }.to have_enqueued_job(Analytics::UpsertECFInductionJob).with(
-        induction_record:,
+        induction_record_id: induction_record.id,
       )
     end
   end

--- a/spec/models/participant_profile_spec.rb
+++ b/spec/models/participant_profile_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe ParticipantProfile, type: :model do
     expect {
       profile.save!
     }.to have_enqueued_job(Analytics::UpsertECFParticipantProfileJob).with(
-      participant_profile: profile,
+      participant_profile_id: profile.id,
     )
   end
 

--- a/spec/models/partnership_spec.rb
+++ b/spec/models/partnership_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Partnership, type: :model do
     expect {
       partnership.save!
     }.to have_enqueued_job(Analytics::UpsertECFPartnershipJob).with(
-      partnership:,
+      partnership_id: partnership.id,
     )
   end
 

--- a/spec/models/school_cohort_spec.rb
+++ b/spec/models/school_cohort_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe SchoolCohort, type: :model do
     expect {
       school_cohort.save!
     }.to have_enqueued_job(Analytics::UpsertECFSchoolCohortJob).with(
-      school_cohort:,
+      school_cohort_id: school_cohort.id,
     )
   end
 

--- a/spec/requests/admin/participants_spec.rb
+++ b/spec/requests/admin/participants_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe "Admin::Participants", type: :request do
     it "updates analytics" do
       expect {
         delete "/admin/participants/#{ect_profile.id}"
-      }.to have_enqueued_job(Analytics::UpsertECFParticipantProfileJob).with(participant_profile: ect_profile)
+      }.to have_enqueued_job(Analytics::UpsertECFParticipantProfileJob).with(participant_profile_id: ect_profile.id)
     end
   end
 end

--- a/spec/requests/schools/participants_request_spec.rb
+++ b/spec/requests/schools/participants_request_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "Schools::Participants", type: :request, js: true, with_feature_f
 
       expect {
         put "/schools/#{school.slug}/participants/#{mentor_profile.id}/add-ect", params:
-      }.to have_enqueued_job(Analytics::UpsertECFParticipantProfileJob).with(participant_profile: new_ect)
+      }.to have_enqueued_job(Analytics::UpsertECFParticipantProfileJob).with(participant_profile_id: new_ect.id)
     end
   end
 
@@ -111,7 +111,7 @@ RSpec.describe "Schools::Participants", type: :request, js: true, with_feature_f
       params = { participant_mentor_form: { mentor_id: mentor_user_2.id } }
       expect {
         put "/schools/#{school.slug}/participants/#{ect_profile.id}/update-mentor", params:
-      }.to have_enqueued_job(Analytics::UpsertECFParticipantProfileJob).with(participant_profile: ect_profile)
+      }.to have_enqueued_job(Analytics::UpsertECFParticipantProfileJob).with(participant_profile_id: ect_profile.id)
     end
   end
 

--- a/spec/services/early_career_teachers/create_spec.rb
+++ b/spec/services/early_career_teachers/create_spec.rb
@@ -169,14 +169,14 @@ RSpec.describe ::EarlyCareerTeachers::Create do
   end
 
   it "records the profile for analytics" do
-    expect {
-      described_class.call(
-        email: user.email,
-        full_name: user.full_name,
-        school_cohort:,
-        mentor_profile_id: mentor_profile.id,
-      )
-    }.to have_enqueued_job(Analytics::UpsertECFParticipantProfileJob)
-           .with(participant_profile: instance_of(ParticipantProfile::ECT))
+    described_class.call(
+      email: user.email,
+      full_name: user.full_name,
+      school_cohort:,
+      mentor_profile_id: mentor_profile.id,
+    )
+
+    created_participant = ParticipantProfile.order(:created_at).last
+    expect(Analytics::UpsertECFParticipantProfileJob).to have_been_enqueued.with(participant_profile_id: created_participant.id)
   end
 end

--- a/spec/services/early_career_teachers/reactivate_spec.rb
+++ b/spec/services/early_career_teachers/reactivate_spec.rb
@@ -151,15 +151,15 @@ RSpec.describe ::EarlyCareerTeachers::Reactivate do
   end
 
   it "records the profile for analytics" do
-    expect {
-      described_class.call(
-        email: user.email,
-        participant_profile:,
-        school_cohort:,
-        mentor_profile_id: mentor_profile.id,
-      )
-    }.to have_enqueued_job(Analytics::UpsertECFParticipantProfileJob)
-     .with(participant_profile: instance_of(ParticipantProfile::ECT))
+    described_class.call(
+      email: user.email,
+      participant_profile:,
+      school_cohort:,
+      mentor_profile_id: mentor_profile.id,
+    )
+
+    created_participant = ParticipantProfile.order(:created_at).last
+    expect(Analytics::UpsertECFParticipantProfileJob).to have_been_enqueued.with(participant_profile_id: created_participant.id)
   end
 
   def add_and_remove_participant_from_school_cohort(school_cohort)


### PR DESCRIPTION
[Jira-4196](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-4196)

### Context

We see a lot of errors in logit when review apps are deployed. These are to do with jobs that are running where the data the job was serialized with no longer exists in the database. We want to fix this to prevent review deploys from spamming the logs/eating into our quota.

### Changes proposed in this pull request

- Run analytics job after_commit instead of after_save

There is a race condition when the various models that have an `update_analytics` callback are persisted in a transaction (as is the case with some of the seed data).

The `after_save` will enqueue the job before the transaction is commited; if a worker picks up the job it attempts to deserialize and verify the model argument and raises an error as it hasn't been commited to the database yet.

Using `after_commit` instead of `after_save` ensures the model will be in the database. As all changes aren't readily available to `after_commit` (`previous_changes` only retains changes from the last save, which is often empty) we are leveraging `ar_transaction_changes`, which retains all changes from a commit across multiple saves.

- Avoid serializing entire objects for job arguments

We currently pass in (and therefore serialize) whole objects for the various analytic job parameters. This is inefficient and also causes an issue if the object that was serialized is deleted before the job is picked up by a worker (as it can't then deserialize it).

To avoid this issue we can just pass the `id` of the object, which will take up much less space in Redis, and load it into memory when the worker picks up the job. We can guard against the object no longer existing to avoid potential race
conditions/errors.

### Guidance to review

We get these errors when deploying both a fresh review app and when we do a redeploy.

The first commit fixed 90% of the errors we see; when I checked the errors I was able to find the objects in the database it complained were not there, so I expect it's down to the job being queued on save rather than after commit and is the result of a race condition.

The remaining 10% were all for the participant profile analytics jobs. I haven't been able to verify this as there's a lot going on in the seeds, but for these when I checked the database they objects didn't exist and I expect some are being deleted somewhere during seeding causing the error when the worker gets around to the job. To prevent this I changed to serialize only the id of the object and return if it no longer exists. This probably makes the first commit unnecessary, but doing it `after_commit` feels like the better approach regardless so I left the change in.

You can verify this change by re-running the review deploy and checking the logs [here](https://kibana-uk1.logit.io/s/b2876053-0173-44fc-983d-99567292ba31/app/data-explorer/discover#?_a=(discover:(columns:!(app.message,kubernetes.deployment.name,app.payload.job_class,app.exception.cause.message),isDirty:!t,sort:!(!('@timestamp',desc),!(app.payload.job_class,desc))),metadata:(indexPattern:'filebeat-*',view:discover))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2025-04-09T13:47:00.000Z',to:now))&_q=(filters:!(('$state':(store:appState),exists:(field:app.exception.stack_trace),meta:(alias:!n,disabled:!f,index:'filebeat-*',key:app.exception.stack_trace,negate:!f,type:exists,value:exists)),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'filebeat-*',key:kubernetes.namespace,negate:!f,params:(query:cpd-development),type:phrase),query:(match_phrase:(kubernetes.namespace:cpd-development))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'filebeat-*',key:kubernetes.container.name,negate:!f,params:(query:cpd-ecf-review-5705-worker),type:phrase),query:(match_phrase:(kubernetes.container.name:cpd-ecf-review-5705-worker)))),query:(language:kuery,query:''))).