### PR TITLE
Add test to cover when profile is not active

### DIFF
--- a/spec/validators/course_validator_spec.rb
+++ b/spec/validators/course_validator_spec.rb
@@ -34,8 +34,12 @@ RSpec.describe CourseValidator do
       subject { klass.new(participant_identity:, course_identifier:) }
 
       context "with one identity" do
-        it "is valid" do
-          expect(subject).to be_valid
+        it { is_expected.to be_valid }
+
+        context "when the profile status is not active" do
+          before { profile.withdrawn_record! }
+
+          it { is_expected.to be_invalid }
         end
       end
 
@@ -52,17 +56,13 @@ RSpec.describe CourseValidator do
           )
         end
 
-        it "is valid" do
-          expect(subject).to be_valid
-        end
+        it { is_expected.to be_valid }
       end
 
       context "with different course_identifier" do
         let(:course_identifier) { "incorrect-course-identifier" }
 
-        it "is invalid" do
-          expect(subject).to be_invalid
-        end
+        it { is_expected.to be_invalid }
       end
     end
   end


### PR DESCRIPTION
[Jira-4204](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-4204)

### Context

We only check active participant profiles when cross-referencing the course identifier. The `active_record` method is confusing as it is an inferred method on `ParticipantProfile` that is suffixed.

### Changes proposed in this pull request

Add test coverage to protect against accidental removal of `active_record` check and also to explain what its doing.

