### PR TITLE
Add 'Change to withdrawal reason value to reflect new programme types…

### DIFF
--- a/docs/source/changes-for-the-2025-2026-academic-year.html.md
+++ b/docs/source/changes-for-the-2025-2026-academic-year.html.md
@@ -74,12 +74,22 @@ We recommend providers check their integrations can:
 
 ## Changes to induction programme types 
 
-We’ll be making the following changes to the `induction_programme_choice` field options in the `GET schools` endpoint:
+We’ll be making the following changes to the `induction_programme_choice` field options in the `GET schools/ecf` and `GET schools/ecf/{id}` endpoints:
 
-* `core-induction-programme` and `diy` will all be known as `school-led`
+* `core-induction-programme` and `diy` will change to `school-led`
 * `full-induction-programme` and `school-funded-full-induction-programme` will change to `provider-led`
 
 <div class="govuk-inset-text">These changes will apply across all cohorts. We’ll contact providers directly to ensure their integrations can support the new values.</div>
+
+### Change to withdrawal reason value to reflect new programme types terminology 
+
+To align with the new programme types terminology, we’ll be changing one of the options in the `reason` field for the `PUT participants/ecf/{id}/withdraw` endpoint: 
+ 
+* `school-left-fip` will change to `switched-to-school-led`   
+
+As a result, we’ll update records across all cohorts that have previously used the `school-left-fip` value. This is not expected to affect how the endpoint functions. However, lead providers will need to update the options when submitting withdrawal requests to pass through the new value.  
+
+Records that have already been withdrawn using the old value will surface the new value and have a modified `updated_at` timestamp.  
 
 ## Seed data for testing 
 


### PR DESCRIPTION
- Ticket: [CPDLP-4193](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-4193)

### Changes proposed in this pull request

Add a new sub-section within the 'Changes to induction programme types' section with information about changes to the withdrawal reasons field in the `PUT participants/ecf/{id}/withdraw` endpoint.



[CPDLP-4193]: https://dfedigital.atlassian.net/browse/CPDLP-4193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ