### PR TITLE
[CPDLP-4217] add hyphenated values for programme type

### DIFF
--- a/app/services/programme_type_mappings.rb
+++ b/app/services/programme_type_mappings.rb
@@ -30,9 +30,9 @@ class ProgrammeTypeMappings
       end
     end
 
-    def training_programme_friendly_name(training_programme)
+    def training_programme_friendly_name(training_programme, length: :short)
       translation_key = training_programme(training_programme:)
-      I18n.t("training_programme.#{translation_key}")
+      I18n.t("training_programme.#{length}.#{translation_key}")
     end
   end
 end

--- a/app/views/finance/ecf/duplicates/compare/_induction_record_summary_list.html.erb
+++ b/app/views/finance/ecf/duplicates/compare/_induction_record_summary_list.html.erb
@@ -37,6 +37,6 @@
   end
   summary_list.with_row(classes: "govuk-body-s") do |row|
     row.with_key    { "Induction Programme Type" }
-    row.with_value  { ProgrammeTypeMappings.training_programme(training_programme: induction_record.induction_programme.training_programme).humanize }
+    row.with_value  { ProgrammeTypeMappings.training_programme_friendly_name(induction_record.induction_programme.training_programme, length: :long) }
   end
 end %>

--- a/app/views/finance/participants/_ecf_profile.html.erb
+++ b/app/views/finance/participants/_ecf_profile.html.erb
@@ -68,7 +68,7 @@
   <%= govuk_summary_list do |summary_list| %>
     <% summary_list.with_row do |row| %>
       <% row.with_key { "Training programme" } %>
-      <% row.with_value { ProgrammeTypeMappings.training_programme(training_programme: ir.induction_programme.training_programme).humanize } %>
+      <% row.with_value { ProgrammeTypeMappings.training_programme_friendly_name(ir.induction_programme.training_programme, length: :long) } %>
       <% row.with_action(text: :none) %>
     <% end %>
 

--- a/app/views/lead_providers/content/partnership_guide.html.erb
+++ b/app/views/lead_providers/content/partnership_guide.html.erb
@@ -85,7 +85,7 @@
   component.with_row do |row|
     row.with_key { "School not eligible for funding" }
 
-    programme = ProgrammeTypeMappings.training_programme(training_programme: "core_induction_programme").humanize(capitalize: false)
+    programme = ProgrammeTypeMappings.training_programme_friendly_name("core_induction_programme", length: :long)
     row.with_value { "This school is not eligible to receive funding from the DfE. (Other independent special schools, Welsh establishments, British schools overseas etc.)<br/><br/>They can only use the accredited materials (#{programme}).".html_safe }
   end
   component.with_row do |row|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,10 +25,25 @@ en:
     change_to_design_our_own: the school wants to design and deliver their own programme based on the early career framework (ECF)
     change_to_school_funded_fip: the school wants to design and deliver their own programme
   training_programme:
-    full_induction_programme: FIP
-    core_induction_programme: CIP
-    provider_led: Provider-led
-    school_led: School-led
+    short:
+      full_induction_programme: FIP
+      core_induction_programme: CIP
+      design_our_own: Design our own
+      school_funded_fip: School funded FIP
+      provider_led: Provider-led
+      school_led: School-led
+      no_early_career_teachers: "No early career teachers for this cohort"
+      not_yet_known: "Not yet decided"
+    long:
+      full_induction_programme: Full induction programme
+      core_induction_programme: Core induction programme
+      design_our_own: Design our own
+      school_funded_fip: School funded full induction programme
+      provider_led: Provider-led
+      school_led: School-led
+      no_early_career_teachers: "No early career teachers for this cohort"
+      not_yet_known: "Not yet decided"
+
 
   # Errors
   fail: "FAIL"

--- a/documentation/service-rules/lead-provider-users.md
+++ b/documentation/service-rules/lead-provider-users.md
@@ -294,7 +294,7 @@ Partnership will not be confirmed if:
 -   School not eligible for inductions as per our GIAS list of
     eligible schools
 
--   School not eligible for funding from DfE (they can only do school led)
+-   School not eligible for funding from DfE (they can only do School-led)
 
 -   School programme not yet confirmed -- SIT has not yet logged into
     the service to confirm if they will deliver training using a

--- a/spec/features/lead_providers/partnership_guidance_spec.rb
+++ b/spec/features/lead_providers/partnership_guidance_spec.rb
@@ -49,11 +49,11 @@ private
 
   def then_i_should_see_core_induction_programme
     @guidance_page = Pages::LeadProviderPartnershipGuidancePage.new
-    expect(@guidance_page).to have_content("They can only use the accredited materials (core induction programme).")
+    expect(@guidance_page).to have_content("They can only use the accredited materials (Core induction programme).")
   end
 
   def then_i_should_see_school_led
     @guidance_page = Pages::LeadProviderPartnershipGuidancePage.new
-    expect(@guidance_page).to have_content("They can only use the accredited materials (school led).")
+    expect(@guidance_page).to have_content("They can only use the accredited materials (School-led).")
   end
 end

--- a/spec/services/programme_type_mappings_spec.rb
+++ b/spec/services/programme_type_mappings_spec.rb
@@ -102,37 +102,113 @@ RSpec.describe ProgrammeTypeMappings do
     end
 
     describe ".training_programme_friendly_name" do
-      subject { described_class.training_programme_friendly_name(training_programme) }
+      subject { described_class.training_programme_friendly_name(training_programme, length:) }
+
+      it "should default to short length" do
+        allow(described_class).to receive(:training_programme) { "full_induction_programme" }
+        val = described_class.training_programme_friendly_name("full_induction_programme")
+        expect(val).to eq(I18n.t("training_programme.short.full_induction_programme"))
+      end
 
       context "when mappings are enabled" do
         let(:mappings_enabled) { true }
 
-        context "when training_programme is `full_induction_programme`" do
-          let(:training_programme) { build(:induction_programme, :fip).training_programme }
+        context "when length is short" do
+          let(:length) { :short }
 
-          it { is_expected.to eq("Provider-led") }
+          %w[full_induction_programme school_funded_fip].each do |param|
+            context "when training_programme is '#{param}'" do
+              let(:training_programme) { param }
+
+              it { is_expected.to eq("Provider-led") }
+            end
+          end
+
+          %w[core_induction_programme design_our_own].each do |param|
+            context "when training_programme is '#{param}'" do
+              let(:training_programme) { param }
+
+              it { is_expected.to eq("School-led") }
+            end
+          end
+
+          %w[no_early_career_teachers not_yet_known].each do |param|
+            context "when training_programme is '#{param}'" do
+              let(:training_programme) { param }
+
+              it { is_expected.to eq(I18n.t("training_programme.short.#{training_programme}")) }
+            end
+          end
         end
 
-        context "when training_programme is `core_induction_programme`" do
-          let(:training_programme) { build(:induction_programme, :cip).training_programme }
+        context "when length is long" do
+          let(:length) { :long }
 
-          it { is_expected.to eq("School-led") }
+          %w[full_induction_programme school_funded_fip].each do |param|
+            context "when training_programme is '#{param}'" do
+              let(:training_programme) { param }
+
+              it { is_expected.to eq("Provider-led") }
+            end
+          end
+
+          %w[core_induction_programme design_our_own].each do |param|
+            context "when training_programme is '#{param}'" do
+              let(:training_programme) { param }
+
+              it { is_expected.to eq("School-led") }
+            end
+          end
+
+          %w[no_early_career_teachers not_yet_known].each do |param|
+            context "when training_programme is '#{param}'" do
+              let(:training_programme) { param }
+
+              it { is_expected.to eq(I18n.t("training_programme.long.#{training_programme}")) }
+            end
+          end
         end
       end
 
       context "when mappings are not enabled" do
         let(:mappings_enabled) { false }
 
-        context "when training_programme is `full_induction_programme`" do
-          let(:training_programme) { build(:induction_programme, :fip).training_programme }
+        context "when length is short" do
+          let(:length) { :short }
 
-          it { is_expected.to eq("FIP") }
+          %w[
+            full_induction_programme
+            school_funded_fip
+            core_induction_programme
+            design_our_own
+            no_early_career_teachers
+            not_yet_known
+          ].each do |param|
+            context "when training_programme is '#{param}'" do
+              let(:training_programme) { param }
+
+              it { is_expected.to eq(I18n.t("training_programme.short.#{training_programme}")) }
+            end
+          end
         end
 
-        context "when training_programme is `core_induction_programme`" do
-          let(:training_programme) { build(:induction_programme, :cip).training_programme }
+        context "when length is long" do
+          let(:length) { :long }
 
-          it { is_expected.to eq("CIP") }
+          %w[
+            full_induction_programme
+            school_funded_fip
+            core_induction_programme
+            design_our_own
+            no_early_career_teachers
+            not_yet_known
+          ].each do |param|
+            context "when training_programme is '#{param}'" do
+              let(:training_programme) { param }
+
+              it { is_expected.to eq(I18n.t("training_programme.long.#{training_programme}")) }
+            end
+          end
         end
       end
     end

--- a/spec/views/finance/participants/show.html.erb_spec.rb
+++ b/spec/views/finance/participants/show.html.erb_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "finance/participants/show.html.erb" do
 
         render
 
-        expect(rendered).to have_content("Training programmeProvider led")
+        expect(rendered).to have_content("Training programmeProvider-led")
       end
     end
 


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-4217

### Changes proposed in this pull request

* Updated `ProgrammeTypeMappings.training_programme_friendly_name` to allow short/long values
* Extended locale for all possible values
* Updated views and docs to the hyphenated values.

### Guidance to review

