### PR TITLE
Remove unused method in withdraw service

### DIFF
--- a/app/services/withdraw_participant.rb
+++ b/app/services/withdraw_participant.rb
@@ -72,15 +72,6 @@ private
     errors.add(:participant_profile, I18n.t(:invalid_withdrawal)) if participant_profile.withdrawn_for?(cpd_lead_provider:)
   end
 
-  def any_participant_declarations_started?
-    participant_profile
-      .participant_declarations
-      .where(
-        course_identifier:,
-        declaration_type: "started",
-      ).exists?
-  end
-
   def relevant_induction_record
     @relevant_induction_record ||= participant_profile.latest_induction_record_for(cpd_lead_provider:)
   end


### PR DESCRIPTION

### Context

This was used when NPQ was also part of the service, no longer needed


- Ticket: n/a

### Changes proposed in this pull request

Remove unused method

### Guidance to review
@leandroalemao thanks for flagging!

