### PR TITLE
[CPDLP-4112] Add new valid test generator for withdrawn participants

### DIFF
--- a/app/services/valid_test_data_generators/withdrawn_participants_generator.rb
+++ b/app/services/valid_test_data_generators/withdrawn_participants_generator.rb
@@ -11,13 +11,13 @@ module ValidTestDataGenerators
     PROGRAMME_TYPES = %i[fip cip design_our_own school_funded_fip].freeze
 
     class << self
-      def call(name:, cohort: Cohort.current, number: 20)
-        new(name:, cohort:).call(number:)
+      def call(name:, cohort: Cohort.current, count: 20)
+        new(name:, cohort:).call(count:)
       end
     end
 
-    def call(number:)
-      number.times do
+    def call(count:)
+      count.times do
         PROGRAMME_TYPES.each do |programme_type|
           create_ect_partially_trained_withdrawn(programme_type:)
           create_mentor_partially_trained_withdrawn(programme_type:)

--- a/app/services/valid_test_data_generators/withdrawn_participants_generator.rb
+++ b/app/services/valid_test_data_generators/withdrawn_participants_generator.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "active_support/testing/time_helpers"
+require Rails.root.join("db/new_seeds/scenarios/schools/school.rb")
+require Rails.root.join("app/services/withdraw_participant.rb")
+
+module ValidTestDataGenerators
+  class WithdrawnParticipantsGenerator
+    include ActiveSupport::Testing::TimeHelpers
+
+    PROGRAMME_TYPES = %i[fip cip design_our_own school_funded_fip].freeze
+
+    class << self
+      def call(name:, cohort: Cohort.current, number: 20)
+        new(name:, cohort:).call(number:)
+      end
+    end
+
+    def call(number:)
+      number.times do
+        PROGRAMME_TYPES.each do |programme_type|
+          create_ect_partially_trained_withdrawn(programme_type:)
+          create_mentor_partially_trained_withdrawn(programme_type:)
+        end
+      end
+    end
+
+  private
+
+    attr_reader :lead_provider, :cohort
+
+    def initialize(name:, cohort:)
+      @lead_provider = ::LeadProvider.find_by!(name:)
+      @cohort = cohort
+    end
+
+    def create_random_participant_identity
+      name = Faker::Name.name
+      user = User.create!(full_name: name, email: Faker::Internet.email(name:))
+      TeacherProfile.create!(user:, trn: Helpers::TrnGenerator.next)
+      Identity::Create.call(user:, origin: :ecf)
+    end
+
+    def create_ect_partially_trained_withdrawn(programme_type:)
+      participant_profile = create_participant(klass: ParticipantProfile::ECT, programme_type:).participant_profile
+
+      course_identifier = "ecf-induction"
+      create_declaration(participant_profile:, course_identifier:)
+
+      WithdrawParticipant.new(
+        cpd_lead_provider: lead_provider.cpd_lead_provider,
+        participant_id: participant_profile.user_id,
+        reason: "school-left-fip",
+        course_identifier:,
+      ).call
+    end
+
+    def create_mentor_partially_trained_withdrawn(programme_type:)
+      participant_profile = create_participant(klass: ParticipantProfile::Mentor, programme_type:).participant_profile
+
+      course_identifier = "ecf-mentor"
+      create_declaration(participant_profile:, course_identifier:)
+
+      WithdrawParticipant.new(
+        cpd_lead_provider: lead_provider.cpd_lead_provider,
+        participant_id: participant_profile.user_id,
+        reason: "school-left-fip",
+        course_identifier:,
+      ).call
+    end
+
+    def create_declaration(participant_profile:, course_identifier:)
+      declaration_date = participant_profile.schedule.milestones.find_by(declaration_type: "started").start_date.rfc3339
+
+      RecordDeclaration.new(
+        participant_id: participant_profile.user_id,
+        course_identifier:,
+        declaration_date:,
+        cpd_lead_provider: lead_provider.cpd_lead_provider,
+        declaration_type: "started",
+        evidence_held: "other",
+      ).call
+    end
+
+    def create_school(cohort:, programme_type:)
+      ::NewSeeds::Scenarios::Schools::School
+      .new(name: "Programme type changes - #{lead_provider.name} - #{cohort.start_year} - #{programme_type}")
+      .build
+      .with_partnership_in(cohort:, delivery_partner: DeliveryPartner.create!(name: Faker::Company.name), lead_provider:)
+      .with_an_induction_tutor(full_name: "Programme type changes SIT - #{lead_provider.name} - #{cohort.start_year} - #{programme_type}", email: Faker::Internet.email)
+      .with_school_cohort_and_programme(cohort:, programme_type:)
+    end
+
+    def create_participant(klass:, programme_type:)
+      school = create_school(cohort:, programme_type:)
+      school_cohort = school.school.school_cohorts.find_by(cohort:)
+      induction_programme = school.induction_programme
+      induction_programme.update!(partnership_id: school.partnership.id)
+      participant_identity = create_random_participant_identity
+      teacher_profile = participant_identity.user.teacher_profile
+      schedule = Finance::Schedule.find_by(
+        schedule_identifier: "ecf-standard-september",
+        cohort:,
+      )
+      participant_profile = klass.create!(teacher_profile:, school_cohort:, status: :active, schedule:, participant_identity:)
+      ParticipantProfileState.create!(participant_profile:)
+      ECFParticipantEligibility.create!(participant_profile:).eligible_status!
+
+      Induction::Enrol.call(participant_profile:, induction_programme:, start_date: Time.zone.now)
+    end
+  end
+end

--- a/spec/services/valid_test_data_generators/withdrawn_participants_generator_spec.rb
+++ b/spec/services/valid_test_data_generators/withdrawn_participants_generator_spec.rb
@@ -11,16 +11,16 @@ RSpec.describe ValidTestDataGenerators::WithdrawnParticipantsGenerator do
   let(:instance) { described_class.new(name: lead_provider.name, cohort:) }
 
   describe "#call" do
-    let(:number) { 1 }
-    subject(:generate) { instance.call(number:) }
+    let(:count) { 1 }
+    subject(:generate) { instance.call(count:) }
 
     before do
       create(:partnership, cohort:, lead_provider:)
       create(:ecf_statement, :next_output_fee, cpd_lead_provider:, cohort:)
     end
 
-    it { expect { generate }.to change(ParticipantProfile::ECT, :count).by(number * programme_types.count) }
-    it { expect { generate }.to change(ParticipantProfile::Mentor, :count).by(number * programme_types.count) }
+    it { expect { generate }.to change(ParticipantProfile::ECT, :count).by(count * programme_types.count) }
+    it { expect { generate }.to change(ParticipantProfile::Mentor, :count).by(count * programme_types.count) }
 
     it "creates a partially trained and withdrawn ECT" do
       generate
@@ -47,10 +47,10 @@ RSpec.describe ValidTestDataGenerators::WithdrawnParticipantsGenerator do
     end
 
     context "when creating multiple participants" do
-      let(:number) { 2 }
+      let(:count) { 2 }
 
-      it { expect { generate }.to change(ParticipantProfile::ECT, :count).by(number * programme_types.count) }
-      it { expect { generate }.to change(ParticipantProfile::Mentor, :count).by(number * programme_types.count) }
+      it { expect { generate }.to change(ParticipantProfile::ECT, :count).by(count * programme_types.count) }
+      it { expect { generate }.to change(ParticipantProfile::Mentor, :count).by(count * programme_types.count) }
     end
   end
 end

--- a/spec/services/valid_test_data_generators/withdrawn_participants_generator_spec.rb
+++ b/spec/services/valid_test_data_generators/withdrawn_participants_generator_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ValidTestDataGenerators::WithdrawnParticipantsGenerator do
+  let(:cohort) { create(:cohort, :current) }
+  let(:cpd_lead_provider) { lead_provider.cpd_lead_provider }
+  let(:lead_provider) { create(:lead_provider) }
+  let(:programme_types) { %i[fip cip design_our_own school_funded_fip] }
+
+  let(:instance) { described_class.new(name: lead_provider.name, cohort:) }
+
+  describe "#call" do
+    let(:number) { 1 }
+    subject(:generate) { instance.call(number:) }
+
+    before do
+      create(:partnership, cohort:, lead_provider:)
+      create(:ecf_statement, :next_output_fee, cpd_lead_provider:, cohort:)
+    end
+
+    it { expect { generate }.to change(ParticipantProfile::ECT, :count).by(number * programme_types.count) }
+    it { expect { generate }.to change(ParticipantProfile::Mentor, :count).by(number * programme_types.count) }
+
+    it "creates a partially trained and withdrawn ECT" do
+      generate
+
+      created_ect = ParticipantProfile::ECT.order(created_at: :asc).first
+
+      expect(created_ect.training_status).to eq("withdrawn")
+      expect(created_ect.latest_induction_record.training_status).to eq("withdrawn")
+      expect(created_ect.latest_induction_record.cohort).to eq(cohort)
+      expect(created_ect.participant_declarations).to be_present
+      expect(created_ect.participant_declarations.map(&:cohort)).to all(eq(cohort))
+    end
+
+    it "creates a partially trained and withdrawn Mentor" do
+      generate
+
+      created_ect = ParticipantProfile::Mentor.order(created_at: :asc).first
+
+      expect(created_ect.training_status).to eq("withdrawn")
+      expect(created_ect.latest_induction_record.training_status).to eq("withdrawn")
+      expect(created_ect.latest_induction_record.cohort).to eq(cohort)
+      expect(created_ect.participant_declarations).to be_present
+      expect(created_ect.participant_declarations.map(&:cohort)).to all(eq(cohort))
+    end
+
+    context "when creating multiple participants" do
+      let(:number) { 2 }
+
+      it { expect { generate }.to change(ParticipantProfile::ECT, :count).by(number * programme_types.count) }
+      it { expect { generate }.to change(ParticipantProfile::Mentor, :count).by(number * programme_types.count) }
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-4112](https://dfedigital.atlassian.net/browse/CPDLP-4112)

### Changes proposed in this pull request

- Add new valid test generator to be run in sandbox;
- Script to add ECT/Mentors participants that are already withdrawn with the value `school-left-fip` in every cohort;

### Guidance to review

```
LeadProvider.name_order.joins(:cohorts).includes(:cohorts).find_each do |lp|
  Cohort.between_years((Date.current - 3.years + 1.day).year, (Date.current + 1.year).year).each do |c|
    next if c.start_year == 2025 && lp.name == "Best Practice Network"

    ValidTestDataGenerators::WithdrawnParticipantsGenerator.call(name: lp.name, cohort: c, count: 30)
  end
end
```

[CPDLP-4112]: https://dfedigital.atlassian.net/browse/CPDLP-4112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ