### PR TITLE
Do not wrap text when column value is wrapped in code

### DIFF
--- a/docs/source/api-reference/stylesheets/screen.css.scss
+++ b/docs/source/api-reference/stylesheets/screen.css.scss
@@ -10,6 +10,10 @@ $govuk-assets-path: "/api-reference/assets/govuk/assets/";
   font-size: 14px;
 }
 
+.technical-documentation td code {
+  white-space: nowrap;
+}
+
 .technical-documentation table ul li {
   padding: 3px 0;
 }


### PR DESCRIPTION
### Context

Columns width not extending when value is wrapped in `<code>` example [here](https://manage-training-for-early-career-teachers.education.gov.uk/api-reference/ecf/definitions-and-states.html#definitions-and-states-key-concepts)

- Ticket: n/a

### Changes proposed in this pull request
Add `nowrap` to code while embedded in tables

### Guidance to review

Can view the difference in review app [here](https://cpd-ecf-review-5724-web.test.teacherservices.cloud/api-reference/ecf/definitions-and-states.html#definitions-and-states)
