### PR TITLE
Remove `plpgsql` db extension as enabled by default in azure

### DIFF
--- a/terraform/application/databases.tf
+++ b/terraform/application/databases.tf
@@ -59,7 +59,7 @@ module "postgres" {
   use_azure                      = var.deploy_azure_backing_services
   azure_enable_monitoring        = var.enable_monitoring
   azure_storage_tier             = var.azure_storage_tier
-  azure_extensions               = ["citext", "fuzzystrmatch", "pg_stat_statements", "pgcrypto", "plpgsql", "uuid-ossp"]
+  azure_extensions               = ["citext", "fuzzystrmatch", "pg_stat_statements", "pgcrypto", "uuid-ossp"]
   azure_maintenance_window       = var.azure_maintenance_window
   server_version                 = "14"
 }
@@ -84,7 +84,7 @@ module "postgres-snapshot" {
   azure_enable_backup_storage    = false
   azure_enable_monitoring        = false
   azure_storage_mb               = "65536"
-  azure_extensions               = ["citext", "fuzzystrmatch", "pg_stat_statements", "pgcrypto", "plpgsql", "uuid-ossp"]
+  azure_extensions               = ["citext", "fuzzystrmatch", "pg_stat_statements", "pgcrypto", "uuid-ossp"]
   server_version                 = "14"
 }
 


### PR DESCRIPTION

### Context

Deployments are failing with the following error:
```
The value: [citext,fuzzystrmatch,pg_stat_statements,pgcrypto,plpgsql,uuid-ossp] of Server Parameter: [azure.extensions] is invalid, the allowed values are: [,address_standardizer,address_standardizer_data_us,age,amcheck,anon,azure_ai,azure_local_ai,azure_storage,bloom,btree_gin,btree_gist,citext,cube,dblink,dict_int,dict_xsyn,earthdistance,fuzzystrmatch,hll,hstore,hypopg,intagg,intarray,isn,lo,login_hook,ltree,oracle_fdw,orafce,pageinspect,pg_buffercache,pg_cron,pg_diskann,pg_freespacemap,pg_hint_plan,pg_partman,pg_prewarm,pg_repack,pg_squeeze,pg_stat_statements,pg_trgm,pg_visibility,pgaudit,pgcrypto,pglogical,pgrouting,pgrowlocks,pgstattuple,plv8,postgis,postgis_raster,postgis_sfcgal,postgis_tiger_geocoder,postgis_topology,postgres_fdw,postgres_protobuf,semver,session_variable,sslinfo,tablefunc,tdigest,tds_fdw,timescaledb,topn,tsm_system_rows,tsm_system_time,unaccent,uuid-ossp,vector]
```

- Ticket: n/a

### Changes proposed in this pull request

Remove `plpgsql` db extension as enabled by default in azure. This has now been removed from the extension list in azure but is enabled by default


### Guidance to review

