### PR TITLE
Add tests to verify clawbacks attach to correct statement cohorts

### DIFF
--- a/spec/services/finance/declaration_statement_attacher_spec.rb
+++ b/spec/services/finance/declaration_statement_attacher_spec.rb
@@ -42,9 +42,12 @@ RSpec.describe Finance::DeclarationStatementAttacher do
       end
 
       context "when the participant has since changed to a later cohort" do
-        before { participant_profile.schedule.update!(cohort: current_cohort) }
+        before do
+          participant_profile.latest_induction_record.induction_programme.school_cohort.update!(cohort: cohort.next)
+          participant_profile.schedule.update!(cohort: cohort.next)
+        end
 
-        it "creates line item against the schedule in the previous cohort" do
+        it "creates line item against the statement in the previous cohort" do
           expect {
             subject.call
           }.to change { statement.reload.statement_line_items.count }.by(1)


### PR DESCRIPTION
[Jira-4232](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-4232)

### Context

When a declaration is clawed back we want to confirm that the statement it is clawed back to is in the same cohort as the original declaration (rather than using the participants cohort, which may have changed).

### Changes proposed in this pull request

Improve existing test in `DeclarationStatementAttacher` spec and add coverage to `ClawbackDeclaration` spec.
