### PR TITLE
[CPDLP-4219] Remove service name from govuk_header

### DIFF
--- a/app/assets/stylesheets/primary-nav.scss
+++ b/app/assets/stylesheets/primary-nav.scss
@@ -66,3 +66,13 @@ $primaryNavHeight: 2.5rem;
     @extend .govuk-width-container__wide;
   }
 }
+
+.govuk-service-navigation {
+  &__container {
+    justify-content: space-between;
+  }
+
+  &__link {
+    font-weight: bold;
+  }
+}

--- a/app/assets/stylesheets/primary-nav.scss
+++ b/app/assets/stylesheets/primary-nav.scss
@@ -60,3 +60,9 @@ $primaryNavHeight: 2.5rem;
     line-height: $primaryNavHeight;
   }
 }
+
+.app-service-navigation {
+  .govuk-width-container {
+    @extend .govuk-width-container__wide;
+  }
+}

--- a/app/views/layouts/_application.html.erb
+++ b/app/views/layouts/_application.html.erb
@@ -73,17 +73,9 @@
       end
     end %>
 
-    <section aria-label="Service information" class="govuk-service-navigation" data-module="govuk-service-navigation">
-      <div class="govuk-width-container <%= "govuk-width-container__wide" if wide_container_view? %>">
-        <div class="govuk-service-navigation__container">
-          <span class="govuk-service-navigation__service-name">
-            <a href=<%= root_path%> class="govuk-service-navigation__link">
-              <%= service_name %>
-            </a>
-          </span>
-        </div>
-      </div>
-    </section>
+    <%= govuk_service_navigation(classes: ("app-service-navigation" if wide_container_view?)) do |sn|
+      sn.with_service_name(service_name:, service_url: root_path)
+    end %>
 
     <%= render "layouts/phase_banner" unless params[:controller].starts_with?("admin") %>
 

--- a/app/views/layouts/_application.html.erb
+++ b/app/views/layouts/_application.html.erb
@@ -67,11 +67,23 @@
 
     <a href="#main-content" class="govuk-skip-link" tabindex="0">Skip to main content</a>
 
-    <%= govuk_header(service_name:, container_classes: ("govuk-width-container__wide" if wide_container_view?)) do |header|
+    <%= govuk_header(full_width_border: true, container_classes: ("govuk-width-container__wide" if wide_container_view?)) do |header|
       if user_signed_in?
         header.with_navigation_item(text: "Sign out", href: destroy_user_session_path)
       end
     end %>
+
+    <section aria-label="Service information" class="govuk-service-navigation" data-module="govuk-service-navigation">
+      <div class="govuk-width-container <%= "govuk-width-container__wide" if wide_container_view? %>">
+        <div class="govuk-service-navigation__container">
+          <span class="govuk-service-navigation__service-name">
+            <a href=<%= root_path%> class="govuk-service-navigation__link">
+              <%= service_name %>
+            </a>
+          </span>
+        </div>
+      </div>
+    </section>
 
     <%= render "layouts/phase_banner" unless params[:controller].starts_with?("admin") %>
 

--- a/app/views/layouts/_application.html.erb
+++ b/app/views/layouts/_application.html.erb
@@ -67,14 +67,13 @@
 
     <a href="#main-content" class="govuk-skip-link" tabindex="0">Skip to main content</a>
 
-    <%= govuk_header(full_width_border: true, container_classes: ("govuk-width-container__wide" if wide_container_view?)) do |header|
-      if user_signed_in?
-        header.with_navigation_item(text: "Sign out", href: destroy_user_session_path)
-      end
-    end %>
+    <%= govuk_header(full_width_border: true, container_classes: ("govuk-width-container__wide" if wide_container_view?)) %>
 
     <%= govuk_service_navigation(classes: ("app-service-navigation" if wide_container_view?)) do |sn|
       sn.with_service_name(service_name:, service_url: root_path)
+      if user_signed_in?
+        sn.with_navigation_item(text: "Sign out", href: destroy_user_session_path)
+      end
     end %>
 
     <%= render "layouts/phase_banner" unless params[:controller].starts_with?("admin") %>


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-4219](https://dfedigital.atlassian.net/browse/CPDLP-4219)

When tailing the logs for reviews we are getting the following warning: 

`Service name and navigation links are deprecated and will be removed in the next breaking release of GOV.UK Frontend. See https://github.com/alphagov/govuk-frontend/releases/tag/v5.9.0`

### Changes proposed in this pull request

- Remove deprecation message
- Remove service name from `govuk_header`
- Move it to `govuk_service_navigation` component (please see https://govuk-components.netlify.app/components/service-navigation/)

### Guidance to review

Review app frontend & logs

Before:

![Screenshot 2025-04-25 at 16 59 13](https://github.com/user-attachments/assets/36e26023-52e4-4fb1-b225-a735b71dc5fd)

After:

![Screenshot 2025-04-28 at 14 53 19](https://github.com/user-attachments/assets/a25a1a75-ac42-4dd6-929a-4f58861145da)

[CPDLP-4219]: https://dfedigital.atlassian.net/browse/CPDLP-4219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ