### PR TITLE
Programme type changes for 2025 - Part 1

### DIFF
--- a/app/forms/schools/cohorts/wizard_steps/how_will_you_run_training_step.rb
+++ b/app/forms/schools/cohorts/wizard_steps/how_will_you_run_training_step.rb
@@ -23,6 +23,32 @@ module Schools
           design_our_own: "Design and deliver your own programme based on the early career framework (ECF)",
         }.freeze
 
+        # NOTE: These are to support 2025 programme type changes
+        CIP_ONLY_SCHOOL_PROGRAMME_CHOICES_2025 = %i[
+          school_funded_fip
+          core_induction_programme
+        ].freeze
+
+        NON_CIP_ONLY_SCHOOL_PROGRAMME_CHOICES_2025 = %i[
+          full_induction_programme
+          core_induction_programme
+        ].freeze
+
+        PROGRAMME_CHOICES_2025 = {
+          full_induction_programme: {
+            name: "Provider-led",
+            description: "Your school will work with providers who will deliver early career framework based training funded by the Department for Education.",
+          },
+          core_induction_programme: {
+            name: "School-led",
+            description: "Your school will deliver training based on the early career framework.",
+          },
+          school_funded_fip: {
+            name: "Provider-led",
+            description: "Your school will fund providers who will deliver early career framework based training.",
+          },
+        }.freeze
+
         attr_accessor :how_will_you_run_training
 
         validates :how_will_you_run_training, inclusion: { message: "Please select an option", in: ->(form) { form.choices.map(&:id).map(&:to_s) } }
@@ -31,8 +57,22 @@ module Schools
         end
 
         def choices
+          if FeatureFlag.active?(:programme_type_changes_2025)
+            school_choices_2025
+          else
+            school_choices
+          end
+        end
+
+        def school_choices
           (wizard.school.cip_only? ? CIP_ONLY_SCHOOL_PROGRAMME_CHOICES : NON_CIP_ONLY_SCHOOL_PROGRAMME_CHOICES).map do |id|
             OpenStruct.new(id:, name: PROGRAMME_CHOICES[id])
+          end
+        end
+
+        def school_choices_2025
+          (wizard.school.cip_only? ? CIP_ONLY_SCHOOL_PROGRAMME_CHOICES_2025 : NON_CIP_ONLY_SCHOOL_PROGRAMME_CHOICES_2025).map do |id|
+            OpenStruct.new(id:, name: PROGRAMME_CHOICES_2025[id][:name], description: PROGRAMME_CHOICES_2025[id][:description])
           end
         end
 

--- a/app/views/schools/cohort_setup/how_will_you_run_training.html.erb
+++ b/app/views/schools/cohort_setup/how_will_you_run_training.html.erb
@@ -13,12 +13,16 @@
         <%= form_with model: @wizard.form, url: url_for(action: :update), scope: @wizard.to_key, method: :put do |f| %>
             <%= f.govuk_error_summary %>
 
-            <%= f.govuk_collection_radio_buttons(
-                :how_will_you_run_training,
-                @wizard.form.choices,
-                :id,
-                :name,
-                legend: { text: title, tag: 'h1', size: 'l' }) do %>
+            <%
+                radio_args = [
+                  :how_will_you_run_training,
+                  @wizard.form.choices,
+                  :id,
+                  :name,
+                ]
+                radio_args << :description if FeatureFlag.active?(:programme_type_changes_2025)
+            %>
+            <%= f.govuk_collection_radio_buttons(*radio_args, legend: { text: title, tag: 'h1', size: 'l' }) do %>
 
                 <p class="govuk-body govuk-!-margin-top-4">To learn more about your training options, visit
                     <%= govuk_link_to "How to set up training for early career teachers (opens in new tab)",


### PR DESCRIPTION
### Context

- Ticket: [JIRA](https://dfedigital.atlassian.net/browse/CST-2849)

We need to update the UI for schools and Administrators to use the new Provider-led and School-led programme type names.  This involves "smooshing" together the current "Full induction programme" and "School-funded FIP" into "Provider-led" and "Core induction programme" and "Design our own" into "School-led"

We are using the `:programme_type_changes_2025` feature flag to keep the changes hidden until we are ready launch

This is part one, split off from #5647 - refer to that PR for screen shots and more info.

There will be more PRs to follow, some that may refactor the work in this one.

These PRs will make changes to the programme type naming that are visible to School and Admin users in the UI.
