### PR TITLE
Programme type changes for 2025 - Part 2

### DIFF
--- a/app/forms/induction_choice_form.rb
+++ b/app/forms/induction_choice_form.rb
@@ -24,7 +24,7 @@ class InductionChoiceForm
   validates :programme_choice, inclusion: { message: "Select how you want to run your training", in: ->(form) { form.programme_choices.map(&:id) } }
 
   def programme_choices
-    school_training_options(state_funded: !school.cip_only?, include_no_ects_option: true)
+    school_training_options(state_funded: !school.cip_only?, include_no_ects_option: true).reject { |opt| opt.id == school_cohort.induction_programme_choice&.to_sym }
   end
 
   def opt_out_choice_selected?

--- a/app/forms/schools/cohorts/wizard_steps/how_will_you_run_training_step.rb
+++ b/app/forms/schools/cohorts/wizard_steps/how_will_you_run_training_step.rb
@@ -4,76 +4,18 @@ module Schools
   module Cohorts
     module WizardSteps
       class HowWillYouRunTrainingStep < ::WizardStep
-        CIP_ONLY_SCHOOL_PROGRAMME_CHOICES = %i[
-          core_induction_programme
-          school_funded_fip
-          design_our_own
-        ].freeze
-
-        NON_CIP_ONLY_SCHOOL_PROGRAMME_CHOICES = %i[
-          full_induction_programme
-          core_induction_programme
-          design_our_own
-        ].freeze
-
-        PROGRAMME_CHOICES = {
-          full_induction_programme: "Use a training provider, funded by the DfE",
-          core_induction_programme: "Deliver your own programme using DfE-accredited materials",
-          school_funded_fip: "Use a training provider funded by your school",
-          design_our_own: "Design and deliver your own programme based on the early career framework (ECF)",
-        }.freeze
-
-        # NOTE: These are to support 2025 programme type changes
-        CIP_ONLY_SCHOOL_PROGRAMME_CHOICES_2025 = %i[
-          school_funded_fip
-          core_induction_programme
-        ].freeze
-
-        NON_CIP_ONLY_SCHOOL_PROGRAMME_CHOICES_2025 = %i[
-          full_induction_programme
-          core_induction_programme
-        ].freeze
-
-        PROGRAMME_CHOICES_2025 = {
-          full_induction_programme: {
-            name: "Provider-led",
-            description: "Your school will work with providers who will deliver early career framework based training funded by the Department for Education.",
-          },
-          core_induction_programme: {
-            name: "School-led",
-            description: "Your school will deliver training based on the early career framework.",
-          },
-          school_funded_fip: {
-            name: "Provider-led",
-            description: "Your school will fund providers who will deliver early career framework based training.",
-          },
-        }.freeze
+        include TrainingProgrammeOptions
 
         attr_accessor :how_will_you_run_training
 
         validates :how_will_you_run_training, inclusion: { message: "Please select an option", in: ->(form) { form.choices.map(&:id).map(&:to_s) } }
+
         def self.permitted_params
           %i[how_will_you_run_training]
         end
 
         def choices
-          if FeatureFlag.active?(:programme_type_changes_2025)
-            school_choices_2025
-          else
-            school_choices
-          end
-        end
-
-        def school_choices
-          (wizard.school.cip_only? ? CIP_ONLY_SCHOOL_PROGRAMME_CHOICES : NON_CIP_ONLY_SCHOOL_PROGRAMME_CHOICES).map do |id|
-            OpenStruct.new(id:, name: PROGRAMME_CHOICES[id])
-          end
-        end
-
-        def school_choices_2025
-          (wizard.school.cip_only? ? CIP_ONLY_SCHOOL_PROGRAMME_CHOICES_2025 : NON_CIP_ONLY_SCHOOL_PROGRAMME_CHOICES_2025).map do |id|
-            OpenStruct.new(id:, name: PROGRAMME_CHOICES_2025[id][:name], description: PROGRAMME_CHOICES_2025[id][:description])
-          end
+          school_training_options(state_funded: !wizard.school.cip_only?)
         end
 
         def expected?

--- a/app/helpers/schools/cohort_setup_helper.rb
+++ b/app/helpers/schools/cohort_setup_helper.rb
@@ -12,5 +12,16 @@ module Schools
     def training_confirmation_template(training_choice)
       TRAINING_CONFIRMATION_TEMPLATES[training_choice.to_sym].to_s
     end
+
+    def programme_radio_options(form, attr_name, choices, legend)
+      args = [
+        attr_name,
+        choices,
+        :id,
+        :name,
+      ]
+      args << :description if FeatureFlag.active?(:programme_type_changes_2025)
+      form.govuk_collection_radio_buttons(*args, legend: { text: legend, tag: "h1", size: "l" })
+    end
   end
 end

--- a/app/models/concerns/training_programme_options.rb
+++ b/app/models/concerns/training_programme_options.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module TrainingProgrammeOptions
+  extend ActiveSupport::Concern
+
+  CIP_ONLY_SCHOOL_PROGRAMME_CHOICES = %i[
+    core_induction_programme
+    school_funded_fip
+    design_our_own
+  ].freeze
+
+  NON_CIP_ONLY_SCHOOL_PROGRAMME_CHOICES = %i[
+    full_induction_programme
+    core_induction_programme
+    design_our_own
+  ].freeze
+
+  PROGRAMME_CHOICES = {
+    full_induction_programme: "Use a training provider, funded by the DfE",
+    core_induction_programme: "Deliver your own programme using DfE-accredited materials",
+    school_funded_fip: "Use a training provider funded by your school",
+    design_our_own: "Design and deliver your own programme based on the early career framework (ECF)",
+    no_early_career_teachers: "We do not expect any early career teachers to join",
+  }.freeze
+
+  # NOTE: These are to support 2025 programme type changes
+  CIP_ONLY_SCHOOL_PROGRAMME_CHOICES_2025 = %i[
+    school_funded_fip
+    core_induction_programme
+  ].freeze
+
+  NON_CIP_ONLY_SCHOOL_PROGRAMME_CHOICES_2025 = %i[
+    full_induction_programme
+    core_induction_programme
+  ].freeze
+
+  PROGRAMME_CHOICES_2025 = {
+    full_induction_programme: {
+      name: "Provider-led",
+      description: "Your school will work with providers who will deliver early career framework based training funded by the Department for Education.",
+    },
+    core_induction_programme: {
+      name: "School-led",
+      description: "Your school will deliver training based on the early career framework.",
+    },
+    school_funded_fip: {
+      name: "Provider-led",
+      description: "Your school will fund providers who will deliver early career framework based training.",
+    },
+    no_early_career_teachers: {
+      name: "We do not expect any early career teachers to join",
+      description: "Your school does not expect any early career teachers this year and we will opt you out of notifications.",
+    },
+  }.freeze
+
+  def school_training_options(state_funded: true, include_no_ects_option: false)
+    if FeatureFlag.active?(:programme_type_changes_2025)
+      school_choices_2025(state_funded, include_no_ects_option)
+    else
+      school_choices_pre_2025(state_funded, include_no_ects_option)
+    end
+  end
+
+  def school_choices_pre_2025(state_funded, include_no_ects_option)
+    choices = Array.new(state_funded ? NON_CIP_ONLY_SCHOOL_PROGRAMME_CHOICES : CIP_ONLY_SCHOOL_PROGRAMME_CHOICES)
+    choices << :no_early_career_teachers if include_no_ects_option
+    choices.map { |id| OpenStruct.new(id:, name: PROGRAMME_CHOICES[id]) }
+  end
+
+  def school_choices_2025(state_funded, include_no_ects_option)
+    choices = Array.new(state_funded ? NON_CIP_ONLY_SCHOOL_PROGRAMME_CHOICES_2025 : CIP_ONLY_SCHOOL_PROGRAMME_CHOICES_2025)
+    choices << :no_early_career_teachers if include_no_ects_option
+    choices.map do |id|
+      OpenStruct.new(id:, name: PROGRAMME_CHOICES_2025[id][:name], description: PROGRAMME_CHOICES_2025[id][:description])
+    end
+  end
+end

--- a/app/views/admin/schools/cohorts/change_programme/show.html.erb
+++ b/app/views/admin/schools/cohorts/change_programme/show.html.erb
@@ -9,7 +9,7 @@
       <%= f.govuk_error_summary %>
       <%= f.govuk_collection_radio_buttons(
             :programme_choice,
-            @induction_choice_form.programme_choices(i18n_scope: "admin.induction_choice_form.options"),
+            @induction_choice_form.programme_choices,
             :id,
             :name,
             legend: { text: "Change induction programme for #{@school.name} #{@induction_choice_form.cohort.academic_year}", size: "l", tag: "h1" },

--- a/app/views/schools/choose_programme/show.html.erb
+++ b/app/views/schools/choose_programme/show.html.erb
@@ -10,13 +10,12 @@
 
         <%= form_for @induction_choice_form, url: schools_choose_programme_path, method: :post do |f| %>
             <%= f.govuk_error_summary %>
-            <%= f.govuk_collection_radio_buttons(
-              :programme_choice,
-              @induction_choice_form.programme_choices,
-              :id,
-              :name,
-              legend: { text: "How do you want to run your training in #{@induction_choice_form.cohort.start_year} to #{@induction_choice_form.cohort.start_year + 1}?", size: "l", tag: "h1" }
-            ) do %>
+
+            <%= programme_radio_options(f,
+                                        :programme_choice,
+                                        @induction_choice_form.programme_choices,
+                                        "How do you want to run your training in #{@induction_choice_form.cohort.description}?") do %>
+
               <p class="govuk-body">To learn more about your training options, visit
                 <%= govuk_link_to "How to set up training for early career teachers (opens in new tab)",
                                   guidance_for_how_to_setup_training_url,

--- a/app/views/schools/cohort_setup/how_will_you_run_training.html.erb
+++ b/app/views/schools/cohort_setup/how_will_you_run_training.html.erb
@@ -13,16 +13,10 @@
         <%= form_with model: @wizard.form, url: url_for(action: :update), scope: @wizard.to_key, method: :put do |f| %>
             <%= f.govuk_error_summary %>
 
-            <%
-                radio_args = [
-                  :how_will_you_run_training,
-                  @wizard.form.choices,
-                  :id,
-                  :name,
-                ]
-                radio_args << :description if FeatureFlag.active?(:programme_type_changes_2025)
-            %>
-            <%= f.govuk_collection_radio_buttons(*radio_args, legend: { text: title, tag: 'h1', size: 'l' }) do %>
+            <%= programme_radio_options(f,
+                                        :how_will_you_run_training,
+                                        @wizard.form.choices,
+                                        title) do %>
 
                 <p class="govuk-body govuk-!-margin-top-4">To learn more about your training options, visit
                     <%= govuk_link_to "How to set up training for early career teachers (opens in new tab)",

--- a/spec/features/scenarios/onboarding_a_deferred_participant/cip_to_fip_spec.rb
+++ b/spec/features/scenarios/onboarding_a_deferred_participant/cip_to_fip_spec.rb
@@ -20,7 +20,7 @@ def when_context(scenario)
 end
 
 RSpec.feature "CIP to FIP - Onboard a deferred participant",
-              with_feature_flags: { eligibility_notifications: "active" },
+              with_feature_flags: { eligibility_notifications: "active", programme_type_changes_2025: "inactive" },
               type: :feature,
               end_to_end_scenario: true do
   include Steps::ChangesOfCircumstanceSteps

--- a/spec/features/scenarios/onboarding_a_deferred_participant/fip_to_cip_spec.rb
+++ b/spec/features/scenarios/onboarding_a_deferred_participant/fip_to_cip_spec.rb
@@ -20,7 +20,7 @@ def when_context(scenario)
 end
 
 RSpec.feature "FIP to CIP - Onboard a deferred participant",
-              with_feature_flags: { eligibility_notifications: "active" },
+              with_feature_flags: { eligibility_notifications: "active", programme_type_changes_2025: "inactive" },
               type: :feature,
               end_to_end_scenario: true do
   include Steps::ChangesOfCircumstanceSteps

--- a/spec/features/scenarios/onboarding_a_deferred_participant/fip_to_fip_with_different_provider_spec.rb
+++ b/spec/features/scenarios/onboarding_a_deferred_participant/fip_to_fip_with_different_provider_spec.rb
@@ -20,7 +20,7 @@ def when_context(scenario)
 end
 
 RSpec.feature "FIP to FIP with different provider - Onboard a deferred participant",
-              with_feature_flags: { eligibility_notifications: "active" },
+              with_feature_flags: { eligibility_notifications: "active", programme_type_changes_2025: "inactive" },
               type: :feature,
               end_to_end_scenario: true do
   include Steps::ChangesOfCircumstanceSteps

--- a/spec/features/scenarios/onboarding_a_deferred_participant/fip_to_fip_with_same_provider_spec.rb
+++ b/spec/features/scenarios/onboarding_a_deferred_participant/fip_to_fip_with_same_provider_spec.rb
@@ -20,7 +20,7 @@ def when_context(scenario)
 end
 
 RSpec.feature "FIP to FIP with same provider - Onboard a deferred participant",
-              with_feature_flags: { eligibility_notifications: "active" },
+              with_feature_flags: { eligibility_notifications: "active", programme_type_changes_2025: "inactive" },
               type: :feature,
               end_to_end_scenario: true do
   include Steps::ChangesOfCircumstanceSteps

--- a/spec/features/scenarios/onboarding_a_withdrawn_participant/cip_to_fip_spec.rb
+++ b/spec/features/scenarios/onboarding_a_withdrawn_participant/cip_to_fip_spec.rb
@@ -20,7 +20,7 @@ def when_context(scenario)
 end
 
 RSpec.feature "CIP to FIP - Onboarding a withdrawn participant",
-              with_feature_flags: { eligibility_notifications: "active" },
+              with_feature_flags: { eligibility_notifications: "active", programme_type_changes_2025: "inactive" },
               type: :feature,
               end_to_end_scenario: true do
   include Steps::ChangesOfCircumstanceSteps

--- a/spec/features/scenarios/onboarding_a_withdrawn_participant/fip_to_cip_spec.rb
+++ b/spec/features/scenarios/onboarding_a_withdrawn_participant/fip_to_cip_spec.rb
@@ -20,7 +20,7 @@ def when_context(scenario)
 end
 
 RSpec.feature "FIP to CIP - Onboarding a withdrawn participant",
-              with_feature_flags: { eligibility_notifications: "active" },
+              with_feature_flags: { eligibility_notifications: "active", programme_type_changes_2025: "inactive" },
               type: :feature,
               end_to_end_scenario: true do
   include Steps::ChangesOfCircumstanceSteps

--- a/spec/features/scenarios/onboarding_a_withdrawn_participant/fip_to_fip_with_different_provider_spec.rb
+++ b/spec/features/scenarios/onboarding_a_withdrawn_participant/fip_to_fip_with_different_provider_spec.rb
@@ -20,7 +20,7 @@ def when_context(scenario)
 end
 
 RSpec.feature "FIP to FIP with different provider - Onboarding a withdrawn participant",
-              with_feature_flags: { eligibility_notifications: "active" },
+              with_feature_flags: { eligibility_notifications: "active", programme_type_changes_2025: "inactive" },
               type: :feature,
               end_to_end_scenario: true do
   include Steps::ChangesOfCircumstanceSteps

--- a/spec/features/scenarios/onboarding_a_withdrawn_participant/fip_to_fip_with_same_provider_spec.rb
+++ b/spec/features/scenarios/onboarding_a_withdrawn_participant/fip_to_fip_with_same_provider_spec.rb
@@ -20,7 +20,7 @@ def when_context(scenario)
 end
 
 RSpec.feature "FIP to FIP with same provider - Onboarding a withdrawn participant",
-              with_feature_flags: { eligibility_notifications: "active" },
+              with_feature_flags: { eligibility_notifications: "active", programme_type_changes_2025: "inactive" },
               type: :feature,
               end_to_end_scenario: true do
   include Steps::ChangesOfCircumstanceSteps

--- a/spec/features/scenarios/transfering_a_participant/cip_to_cip_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/cip_to_cip_spec.rb
@@ -19,7 +19,7 @@ def when_context(scenario)
 end
 
 RSpec.feature "CIP to CIP - Transfer a participant",
-              with_feature_flags: { eligibility_notifications: "active" },
+              with_feature_flags: { eligibility_notifications: "active", programme_type_changes_2025: "inactive" },
               type: :feature,
               end_to_end_scenario: true do
   include Steps::ChangesOfCircumstanceSteps

--- a/spec/features/scenarios/transfering_a_participant/cip_to_fip_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/cip_to_fip_spec.rb
@@ -19,7 +19,7 @@ def when_context(scenario)
 end
 
 RSpec.feature "CIP to FIP - Transfer a participant",
-              with_feature_flags: { eligibility_notifications: "active" },
+              with_feature_flags: { eligibility_notifications: "active", programme_type_changes_2025: "inactive" },
               type: :feature,
               end_to_end_scenario: true do
   include Steps::ChangesOfCircumstanceSteps

--- a/spec/features/scenarios/transfering_a_participant/fip_to_cip_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/fip_to_cip_spec.rb
@@ -19,7 +19,7 @@ def when_context(scenario)
 end
 
 RSpec.feature "FIP to CIP - Transfer a participant",
-              with_feature_flags: { eligibility_notifications: "active" },
+              with_feature_flags: { eligibility_notifications: "active", programme_type_changes_2025: "inactive" },
               type: :feature,
               end_to_end_scenario: true do
   include Steps::ChangesOfCircumstanceSteps

--- a/spec/features/scenarios/transfering_a_participant/fip_to_fip_with_different_provider_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/fip_to_fip_with_different_provider_spec.rb
@@ -19,7 +19,7 @@ def when_context(scenario)
 end
 
 RSpec.feature "FIP to FIP with different provider - Transfer a participant",
-              with_feature_flags: { eligibility_notifications: "active" },
+              with_feature_flags: { eligibility_notifications: "active", programme_type_changes_2025: "inactive" },
               type: :feature,
               end_to_end_scenario: true do
   include Steps::ChangesOfCircumstanceSteps

--- a/spec/features/scenarios/transfering_a_participant/fip_to_fip_with_same_provider_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/fip_to_fip_with_same_provider_spec.rb
@@ -19,7 +19,7 @@ def when_context(scenario)
 end
 
 RSpec.feature "FIP to FIP with same provider - Transfer a participant",
-              with_feature_flags: { eligibility_notifications: "active" },
+              with_feature_flags: { eligibility_notifications: "active", programme_type_changes_2025: "inactive" },
               type: :feature,
               end_to_end_scenario: true do
   include Steps::ChangesOfCircumstanceSteps

--- a/spec/features/schools/choose_programme/new_schools_steps.rb
+++ b/spec/features/schools/choose_programme/new_schools_steps.rb
@@ -53,7 +53,7 @@ module NewSchoolsSteps
   end
 
   def when_i_choose_deliver_own_programme
-    choose("Deliver your own programme using DfE accredited materials")
+    choose("Deliver your own programme using DfE-accredited materials")
   end
 
   def then_i_see_appropriate_body_appointed_page

--- a/spec/features/schools/training_dashboard/manage_cip_training_spec.rb
+++ b/spec/features/schools/training_dashboard/manage_cip_training_spec.rb
@@ -62,9 +62,9 @@ RSpec.describe "Manage CIP training", js: true do
       and_i_am_signed_in_as_an_induction_coordinator
       then_i_should_see_the_program_and_click_to_change_it(program_label: "Design and deliver your own programme")
       and_see_the_other_programs_before_choosing(labels: ["Use a training provider, funded by the DfE",
-                                                          "Deliver your own programme using DfE accredited materials",
+                                                          "Deliver your own programme using DfE-accredited materials",
                                                           "We do not expect any early career teachers to join"],
-                                                 choice: "Deliver your own programme using DfE accredited materials")
+                                                 choice: "Deliver your own programme using DfE-accredited materials")
 
       expect(page).to have_text "You’ve submitted your training information"
     end

--- a/spec/features/schools/training_dashboard/manage_fip_training_spec.rb
+++ b/spec/features/schools/training_dashboard/manage_fip_training_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Manage FIP training", js: true do
       and_i_am_signed_in_as_an_induction_coordinator
       then_i_should_see_the_program_and_click_to_change_it(program_label: "Design and deliver your own programme")
       and_see_the_other_programs_before_choosing(labels: ["Use a training provider, funded by the DfE",
-                                                          "Deliver your own programme using DfE accredited materials"],
+                                                          "Deliver your own programme using DfE-accredited materials"],
                                                  choice: "Use a training provider, funded by the DfE")
 
       expect(page).to have_text "You’ve submitted your training information"

--- a/spec/features/schools/training_dashboard/manage_no_ect_training_spec.rb
+++ b/spec/features/schools/training_dashboard/manage_no_ect_training_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Manage No ECT training", js: true, early_in_cohort: true do
     and_i_am_signed_in_as_an_induction_coordinator
     then_i_should_see_the_program_and_click_to_change_it(program_label: "Design and deliver your own programme")
     and_see_the_other_programs_before_choosing(labels: ["Use a training provider, funded by the DfE",
-                                                        "Deliver your own programme using DfE accredited materials"],
+                                                        "Deliver your own programme using DfE-accredited materials"],
                                                choice: "We do not expect any early career teachers to join")
 
     expect(page).to have_text "You’ve submitted your training information"

--- a/spec/requests/admin/schools/cohorts/change_programme_spec.rb
+++ b/spec/requests/admin/schools/cohorts/change_programme_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "Admin::Schools::Cohorts::ChangeProgramme", type: :request do
-  let(:school_cohort) { create(:school_cohort) }
+  let(:school_cohort) { create(:school_cohort, :cip) }
   let(:school) { school_cohort.school }
   let(:cohort) { school_cohort.cohort }
 
@@ -31,6 +31,7 @@ RSpec.describe "Admin::Schools::Cohorts::ChangeProgramme", type: :request do
       post "/admin/schools/#{school.slug}/cohorts/#{cohort.start_year}/change-programme/confirm", params: {
         induction_choice_form: { programme_choice: "full_induction_programme" },
       }
+
       expect(response).to render_template "admin/schools/cohorts/change_programme/confirm"
     end
   end

--- a/spec/support/features/pages/schools/school_report_programme_wizard.rb
+++ b/spec/support/features/pages/schools/school_report_programme_wizard.rb
@@ -15,14 +15,26 @@ module Pages
     end
 
     def choose_programme_type(programme_type)
-      case programme_type.downcase.to_sym
-      when :fip
-        choose "Use a training provider, funded by the DfE (full induction programme)"
-      when :cip
-        choose "Deliver your own programme using DfE accredited materials"
-      when :diy
-        choose "Design and deliver your own programme based on the Early Career Framework (ECF)"
+      if FeatureFlag.active?(:programme_type_changes_2025)
+        case programme_type.downcase.to_sym
+        when :fip
+          choose "Provider-led"
+        when :cip
+          choose "School-led"
+        when :diy
+          choose "School-led"
+        end
+      else
+        case programme_type.downcase.to_sym
+        when :fip
+          choose "Use a training provider, funded by the DfE (full induction programme)"
+        when :cip
+          choose "Deliver your own programme using DfE accredited materials"
+        when :diy
+          choose "Design and deliver your own programme based on the Early Career Framework (ECF)"
+        end
       end
+
       click_button "Continue"
     end
   end

--- a/spec/support/features/pages/schools/school_report_programme_wizard.rb
+++ b/spec/support/features/pages/schools/school_report_programme_wizard.rb
@@ -27,9 +27,9 @@ module Pages
       else
         case programme_type.downcase.to_sym
         when :fip
-          choose "Use a training provider, funded by the DfE (full induction programme)"
+          choose "Use a training provider, funded by the DfE"
         when :cip
-          choose "Deliver your own programme using DfE accredited materials"
+          choose "Deliver your own programme using DfE-accredited materials"
         when :diy
           choose "Design and deliver your own programme based on the Early Career Framework (ECF)"
         end


### PR DESCRIPTION
### Context

- Ticket: [JIRA](https://dfedigital.atlassian.net/browse/CST-2849)

We need to update the UI for schools and Administrators to use the new Provider-led and School-led programme type names.  This involves "smooshing" together the current "Full induction programme" and "School-funded FIP" into "Provider-led" and "Core induction programme" and "Design our own" into "School-led"

We are using the `:programme_type_changes_2025` feature flag to keep the changes hidden until we are ready launch

This is part two, split off from #5647 - refer to that PR for screen shots and more info.

There will be more PRs to follow, some that may refactor the work in this one.

These PRs will make changes to the programme type naming that are visible to School and Admin users in the UI.

Majority of changes are spec fixes in this one.

### Changes proposed in this pull request

* Refactoring and adding 2025 changes to alternative cohort setup
* Replace missing word in legend and make hyphenation consistent

