### PR TITLE
Disable nightly migration db refresh

### DIFF
--- a/.github/workflows/refresh_migration_database.yml
+++ b/.github/workflows/refresh_migration_database.yml
@@ -9,8 +9,9 @@ on:
         options:
           - production
         required: true
-  schedule:
-    - cron: "0 0 * * *" # Run at midnight.
+  # Disable nightly refresh until end to end testing is complete for 2025
+  # schedule:
+  #   - cron: "0 0 * * *" # Run at midnight.
 
 jobs:
   refresh-migration-db:


### PR DESCRIPTION
### Context

The migration runs nightly to refresh the data. However we are testing with custom setup cohort 2025 e2e on the migration environment and don't want the data wiped for a few days

- Ticket: n/a

### Changes proposed in this pull request

Disable the nightly migration db refresh temporarily until we finish testing. This will be enabled after

### Guidance to review

