### PR TITLE
Fix Dockerfile warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY docs /docs
 COPY public /public
 COPY swagger /swagger
 
-WORKDIR docs
+WORKDIR /docs
 RUN bundle exec middleman build --build-dir=../public/api-reference
 
 # Stage 1: Download gems and node modules.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+# syntax=docker/dockerfile:1
+# check=skip=SecretsUsedInArgOrEnv
+
 # To use or update to a ruby version, change {BASE_RUBY_IMAGE}
 ARG BASE_RUBY_IMAGE=ruby:3.2.6-alpine3.21
 # BASE_RUBY_IMAGE_WITH_GEMS_AND_NODE_MODULES will default to early-careers-framework-gems-node-modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -121,4 +121,4 @@ WORKDIR /app
 # new code on an old schema (which will be updated a moment later) to running
 # old code on the new schema (which will require another deploy or other manual
 # intervention to correct).
-CMD bundle exec rails db:migrate:ignore_concurrent_migration_exceptions && bundle exec rails server -b 0.0.0.0
+CMD ["/bin/sh", "-c", "bundle exec rails db:migrate:ignore_concurrent_migration_exceptions && bundle exec rails server -b 0.0.0.0"]


### PR DESCRIPTION
### Context

We are getting warnings from the docker file run for:
- Absolute paths
- Secrets in ARG
- JSON arguments in commands


### Changes proposed in this pull request
- Absolute paths: set absolute path for work dir by adding forward slash
- Secrets in ARGs: unfortunately because we are setting the `SECRET_KEY_BASE` it will always fail even if its a placeholder and not really a secret. I had to disable it for the whole file
- JSON arguments: set the arguments in JSON format however due to us using `&&` we had to also set the shell otherwise it will fail see https://docs.docker.com/reference/build-checks/json-args-recommended/#explicitly-specify-the-shell

### Guidance to review

Keen to hear any other ways we can resolve the JSON arguments as tried many variations without the shell but didn't work and kept failing

Build warning can be found here: https://docs.docker.com/reference/build-checks/