### PR TITLE
Programme type changes for 2025 - Part 4

### DIFF
--- a/app/forms/schools/cohorts/wizard_steps/what_changes_step.rb
+++ b/app/forms/schools/cohorts/wizard_steps/what_changes_step.rb
@@ -13,11 +13,18 @@ module Schools
         end
 
         def choices
-          [
-            OpenStruct.new(id: :change_lead_provider,               name: "Form a new partnership"),
-            OpenStruct.new(id: :change_to_core_induction_programme, name: "Deliver your own programme using DfE-accredited materials"),
-            OpenStruct.new(id: :change_to_design_our_own,           name: "Design and deliver your own programme based on the Early Career Framework (ECF)"),
-          ]
+          if FeatureFlag.active?(:programme_type_changes_2025)
+            [
+              OpenStruct.new(id: :change_lead_provider,               name: "Form a new partnership"),
+              OpenStruct.new(id: :change_to_core_induction_programme, name: "Deliver a school-led programme"),
+            ]
+          else
+            [
+              OpenStruct.new(id: :change_lead_provider,               name: "Form a new partnership"),
+              OpenStruct.new(id: :change_to_core_induction_programme, name: "Deliver your own programme using DfE-accredited materials"),
+              OpenStruct.new(id: :change_to_design_our_own,           name: "Design and deliver your own programme based on the early career framework (ECF)"),
+            ]
+          end
         end
 
         def expected?

--- a/app/views/schools/cohort_setup/_change_to_core_induction_programme_confirmation.html.erb
+++ b/app/views/schools/cohort_setup/_change_to_core_induction_programme_confirmation.html.erb
@@ -1,7 +1,7 @@
 <span class="govuk-caption-l"><%= @school.name %></span>
 <h1 class="govuk-heading-l">Confirm your training programme</h1>
 
-<p class="govuk-body">You‘ve chosen to deliver your own programme using DfE accredited materials.</p>
+<p class="govuk-body">You‘ve chosen to deliver your own programme using DfE-accredited materials.</p>
 
 <p class="govuk-body">You’ll need to:</p>
 <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-7">

--- a/app/views/schools/cohort_setup/programme_confirmation.html.erb
+++ b/app/views/schools/cohort_setup/programme_confirmation.html.erb
@@ -15,7 +15,7 @@
                 <li>add your ECTs and mentors</li>
             </ul>
         <% elsif @wizard.how_will_you_run_training == 'core_induction_programme' %>
-            <p class="govuk-body">You‘ve chosen to deliver your own programme using DfE accredited materials.</p>
+            <p class="govuk-body">You‘ve chosen to deliver your own programme using DfE-accredited materials.</p>
             <p class="govuk-body">You’ll need to:</p>
             <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-7">
                 <li>choose your training materials</li>

--- a/app/views/schools/cohorts/change_programme.html.erb
+++ b/app/views/schools/cohorts/change_programme.html.erb
@@ -35,7 +35,7 @@
 
     <% elsif @school_cohort.design_our_own? %>
 
-      <p class="govuk-body">Your school has chosen to design and deliver your own programme based on the Early Career Framework (ECF).</p>
+      <p class="govuk-body">Your school has chosen to design and deliver your own programme based on the early career framework (ECF).</p>
       <p class="govuk-body"><%= govuk_link_to "Check the other options available", schools_choose_programme_path %> for your school if this changes.</p>
 
     <% elsif @school_cohort.no_early_career_teachers? %>

--- a/app/views/schools/early_career_teachers/show.html.erb
+++ b/app/views/schools/early_career_teachers/show.html.erb
@@ -126,7 +126,7 @@
             Programme
           </dt>
           <dd class="govuk-summary-list__value">
-            DfE accredited materials
+            DfE-accredited materials
           </dd>
         </div>
         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">

--- a/app/views/schools/mentors/_mentor_training.html.erb
+++ b/app/views/schools/mentors/_mentor_training.html.erb
@@ -7,7 +7,7 @@
         Programme
       </dt>
       <dd class="govuk-summary-list__value">
-        DfE accredited materials
+        DfE-accredited materials
       </dd>
     </div>
     <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">

--- a/config/locales/admin/induction_choice_form.yml
+++ b/config/locales/admin/induction_choice_form.yml
@@ -4,13 +4,13 @@ en:
       options:
         core_induction_programme: "Deliver their own programme using DfE-accredited materials (core induction programme)"
         full_induction_programme: "Use a training provider, funded by the DfE (full induction programme)"
-        design_our_own: "Design and deliver their own programme based on the Early Career Framework (ECF)"
+        design_our_own: "Design and deliver their own programme based on the early career framework (ECF)"
         school_funded_fip: "Use a training provider funded by their school"
         no_early_career_teachers: "They don’t expect to have any early career teachers starting in %{cohort}"
 
       confirmation_options:
-        core_induction_programme: "deliver their own programme using DfE accredited materials"
+        core_induction_programme: "deliver their own programme using DfE-accredited materials"
         full_induction_programme: "use a training provider, funded by the DfE"
-        design_our_own: "design and deliver their own programme based on the Early Career Framework (ECF)"
+        design_our_own: "design and deliver their own programme based on the early career framework (ECF)"
         school_funded_fip: "use a training provider funded by their school."
         no_early_career_teachers: "opt out of notifications because they don’t expect to have any early career teachers starting in %{cohort}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -609,8 +609,8 @@ en:
   manage_your_training:
     induction_programmes:
       full_induction_programme: "Use a training provider funded by the DfE"
-      core_induction_programme: "DfE accredited materials"
-      design_our_own: "Design and deliver your own programme based on the Early Career Framework (ECF)"
+      core_induction_programme: "DfE-accredited materials"
+      design_our_own: "Design and deliver your own programme based on the early career framework (ECF)"
       school_funded_fip: "Use a training provider funded by your school"
       no_early_career_teachers: "No early career teachers for this cohort"
       not_yet_known: "Not yet decided"

--- a/config/locales/schools/induction_choice_form.yml
+++ b/config/locales/schools/induction_choice_form.yml
@@ -2,15 +2,15 @@ en:
   schools:
     induction_choice_form:
       options:
-        core_induction_programme: "Deliver your own programme using DfE accredited materials"
+        core_induction_programme: "Deliver your own programme using DfE-accredited materials"
         full_induction_programme: "Use a training provider, funded by the DfE (full induction programme)"
-        design_our_own: "Design and deliver your own programme based on the Early Career Framework (ECF)"
+        design_our_own: "Design and deliver your own programme based on the early career framework (ECF)"
         school_funded_fip: "Use a training provider funded by your school"
         no_early_career_teachers: "We do not expect any early career teachers to join"
 
       confirmation_options:
         core_induction_programme: "deliver your own programme using DfE-accredited materials"
         full_induction_programme: "use a training provider, funded by the DfE"
-        design_our_own: "design and deliver your own programme based on the Early Career Framework (ECF)"
+        design_our_own: "design and deliver your own programme based on the early career framework (ECF)"
         school_funded_fip: "use a training provider funded by your school"
         no_early_career_teachers: "opt out of notifications, because you do not expect any early career teachers to join this academic year"

--- a/spec/features/schools/choose_programme/choose_programme_steps.rb
+++ b/spec/features/schools/choose_programme/choose_programme_steps.rb
@@ -95,7 +95,7 @@ module ChooseProgrammeSteps
 
   def then_i_am_taken_to_the_change_to_design_own_programme_confirmation_page
     expect(page).to have_content("Confirm your training programme")
-    expect(page).to have_content("You‘ve chosen to deliver your own programme using DfE accredited materials.")
+    expect(page).to have_content("You‘ve chosen to deliver your own programme using DfE-accredited materials.")
   end
 
   def then_i_am_taken_to_the_change_to_design_and_deliver_own_programme_confirmation_page
@@ -219,7 +219,7 @@ module ChooseProgrammeSteps
   end
 
   def and_i_see_programme_to_dfe_accredited_materials
-    expect(page).to have_summary_row("Programme", "DfE accredited materials")
+    expect(page).to have_summary_row("Programme", "DfE-accredited materials")
   end
 
   def and_i_see_programme_to_design_and_deliver_own_programme
@@ -323,7 +323,7 @@ module ChooseProgrammeSteps
   end
 
   def when_i_choose_to_design_and_deliver_own_programme
-    choose("Design and deliver your own programme based on the Early Career Framework (ECF)")
+    choose("Design and deliver your own programme based on the early career framework (ECF)")
   end
 
   def when_i_challenge_the_new_cohort_partnership

--- a/spec/features/schools/choose_programme/choose_programme_steps.rb
+++ b/spec/features/schools/choose_programme/choose_programme_steps.rb
@@ -223,7 +223,7 @@ module ChooseProgrammeSteps
   end
 
   def and_i_see_programme_to_design_and_deliver_own_programme
-    expect(page).to have_summary_row("Programme", "Design and deliver your own programme based on the Early Career Framework (ECF)")
+    expect(page).to have_summary_row("Programme", "Design and deliver your own programme based on the early career framework (ECF)")
   end
 
   def and_i_see_the_school_name

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -558,7 +558,7 @@ module ManageTrainingSteps
     click_on "Continue"
     click_on("Return to manage your training")
     expect(page).to have_content("Manage your training")
-    expect(page).to have_summary_row("Programme", "Design and deliver your own programme based on the Early Career Framework (ECF)")
+    expect(page).to have_summary_row("Programme", "Design and deliver your own programme based on the early career framework (ECF)")
   end
 
   def and_i_click_on(string)

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -1502,7 +1502,7 @@ module ManageTrainingSteps
   end
 
   def and_i_see_the_cip_programme
-    expect(page).to have_summary_row("Programme", "DfE accredited materials")
+    expect(page).to have_summary_row("Programme", "DfE-accredited materials")
   end
 
   def and_i_dont_see_the_lead_provider


### PR DESCRIPTION
### Context

- Ticket: [JIRA](https://dfedigital.atlassian.net/browse/CST-2849)

We need to update the UI for schools and Administrators to use the new Provider-led and School-led programme type names.  This involves "smooshing" together the current "Full induction programme" and "School-funded FIP" into "Provider-led" and "Core induction programme" and "Design our own" into "School-led"

We are using the `:programme_type_changes_2025` feature flag to keep the changes hidden until we are ready launch

This is part four, split off from #5647 - refer to that PR for screen shots and more info.

There will be more PRs to follow, some that may refactor the work in this one.

These PRs will make changes to the programme type naming that are visible to School and Admin users in the UI.

### Changes proposed in this pull request

* Make content more consistent across the views


