### PR TITLE
Update analytics.yml

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -377,3 +377,6 @@
   - status
   - delivered_at
   - tags
+  :users:
+  - created_at
+  - updated_at


### PR DESCRIPTION
Added created_at and updated_at dates to users table

### Context
I need user name and ID streamed through to ECF big query to allow user names to appear on the ECF Voided Declarations Dashboard

### Changes proposed in this pull request
Added created_at and updated_at dates to analytics.yml

### Guidance to review
Please get in touch with Theo Phillips if there are any problems / concerns
