### PR TITLE
Update analytics_blocklist.yml

### DIFF
--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -409,8 +409,6 @@
   - created_at
   - updated_at
   :users:
-  - id
-  - full_name
   - email
   - login_token
   - login_token_valid_until
@@ -420,8 +418,6 @@
   - current_sign_in_ip
   - last_sign_in_ip
   - sign_in_count
-  - created_at
-  - updated_at
   - discarded_at
   - get_an_identity_id
   - archived_email


### PR DESCRIPTION
Updated blocklist to allow user ID and name to be streamed through to the ECF Voided Declaration Dashboard

### Context
I need user name and ID streamed through to ECF big query to allow user names to appear on the ECF Voided Declarations Dashboard

### Changes proposed in this pull request
Removed user_id, name, created_at and updated_at from the block list

### Guidance to review
Please get in touch with Theo Phillips if there are any problems / concerns
