### PR TITLE
Update analytics_hidden_pii.yml

### DIFF
--- a/config/analytics_hidden_pii.yml
+++ b/config/analytics_hidden_pii.yml
@@ -8,3 +8,6 @@
   :emails:
   - to
   - personalisation
+  :users:
+  - id
+  - full_name


### PR DESCRIPTION
Added user info to hidden PII

### Context
I need user name and ID streamed through to ECF big query to allow user names to appear on the ECF Voided Declarations Dashboard

### Changes proposed in this pull request
Added user_id and name to hidden PII yml

### Guidance to review
Please get in touch with Theo Phillips if there are any problems / concerns
