### PR TITLE
Update user analytics fields

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -380,3 +380,5 @@
   :users:
   - created_at
   - updated_at
+  - id
+  - full_name

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -377,3 +377,6 @@
   - status
   - delivered_at
   - tags
+  :users:
+  - created_at
+  - updated_at

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -409,8 +409,6 @@
   - created_at
   - updated_at
   :users:
-  - id
-  - full_name
   - email
   - login_token
   - login_token_valid_until
@@ -420,8 +418,6 @@
   - current_sign_in_ip
   - last_sign_in_ip
   - sign_in_count
-  - created_at
-  - updated_at
   - discarded_at
   - get_an_identity_id
   - archived_email

--- a/config/analytics_hidden_pii.yml
+++ b/config/analytics_hidden_pii.yml
@@ -8,3 +8,6 @@
   :emails:
   - to
   - personalisation
+  :users:
+  - id
+  - full_name


### PR DESCRIPTION
### Context

Allow user ID and name to be streamed through to the ECF Voided Declaration Dashboard and added created_at and updated_at dates to users table

Fixes #5770, #5771, #5772
