### PR TITLE
Programme type changes for 2025 - Part 6

### DIFF
--- a/spec/features/scenarios/onboarding_a_withdrawn_participant/cip_to_fip_spec.rb
+++ b/spec/features/scenarios/onboarding_a_withdrawn_participant/cip_to_fip_spec.rb
@@ -20,7 +20,7 @@ def when_context(scenario)
 end
 
 RSpec.feature "CIP to FIP - Onboarding a withdrawn participant",
-              with_feature_flags: { eligibility_notifications: "active", programme_type_changes_2025: "inactive" },
+              with_feature_flags: { eligibility_notifications: "active" },
               type: :feature,
               end_to_end_scenario: true do
   include Steps::ChangesOfCircumstanceSteps
@@ -28,92 +28,96 @@ RSpec.feature "CIP to FIP - Onboarding a withdrawn participant",
   includes = ENV.fetch("SCENARIOS", "").split(",").map(&:to_i)
 
   fixture_data_path = File.join(File.dirname(__FILE__), "../changes_of_circumstances_fixtures.csv")
-  CSV.parse(File.read(fixture_data_path), headers: true).each_with_index do |fixture_data, index|
-    next if includes.any? && !includes.include?(index + 2)
 
-    scenario = ChangesOfCircumstanceScenario.new index + 2, fixture_data
+  %w[active inactive].each do |flag_state|
+    context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      CSV.parse(File.read(fixture_data_path), headers: true).each_with_index do |fixture_data, index|
+        next if includes.any? && !includes.include?(index + 2)
 
-    next unless scenario.original_programme == "CIP" && scenario.new_programme == "FIP"
+        scenario = ChangesOfCircumstanceScenario.new index + 2, fixture_data
 
-    let(:tokens) { {} }
+        next unless scenario.original_programme == "CIP" && scenario.new_programme == "FIP"
 
-    let!(:cohort) do
-      cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
-      allow(Cohort).to receive(:current).and_return(cohort)
-      allow(Cohort).to receive(:next).and_return(cohort)
-      allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
-      allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
-      allow(cohort).to receive(:next).and_return(cohort)
-      allow(cohort).to receive(:previous).and_return(cohort)
-      cohort
-    end
-    let!(:schedule) do
-      create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
-    end
-    let!(:milestone_started) do
-      create :milestone,
-             schedule:,
-             name: "Output 1 - Participant Start",
-             start_date: Date.new(2021, 9, 1),
-             milestone_date: Date.new(2021, 11, 30),
-             payment_date: Date.new(2021, 11, 30),
-             declaration_type: "started"
-    end
-    let!(:milestone_retained_1) do
-      create :milestone,
-             schedule:,
-             name: "Output 2 - Retention Point 1",
-             start_date: Date.new(2021, 11, 1),
-             milestone_date: Date.new(2022, 1, 31),
-             payment_date: Date.new(2022, 2, 28),
-             declaration_type: "retained-1"
-    end
-    let!(:privacy_policy) do
-      privacy_policy = create(:privacy_policy)
-      PrivacyPolicy::Publish.call
-      privacy_policy
-    end
+        let(:tokens) { {} }
 
-    context given_context(scenario) do
-      before do
-        given_lead_providers_contracted_to_deliver_ecf "New Lead Provider"
-        given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
-
-        travel_to(milestone_started.milestone_date - 2.months) do
-          Importers::CreateCohort.new(path_to_csv: Rails.root.join("db/data/cohorts/cohorts.csv")).call
-          Importers::CreateCallOffContract.new.call
-          Importers::CreateStatement.new(path_to_csv: Rails.root.join("db/data/statements/statements.csv")).call
+        let!(:cohort) do
+          cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
+          allow(Cohort).to receive(:current).and_return(cohort)
+          allow(Cohort).to receive(:next).and_return(cohort)
+          allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
+          allow(cohort).to receive(:next).and_return(cohort)
+          allow(cohort).to receive(:previous).and_return(cohort)
+          cohort
+        end
+        let!(:schedule) do
+          create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+        end
+        let!(:milestone_started) do
+          create :milestone,
+                 schedule:,
+                 name: "Output 1 - Participant Start",
+                 start_date: Date.new(2021, 9, 1),
+                 milestone_date: Date.new(2021, 11, 30),
+                 payment_date: Date.new(2021, 11, 30),
+                 declaration_type: "started"
+        end
+        let!(:milestone_retained_1) do
+          create :milestone,
+                 schedule:,
+                 name: "Output 2 - Retention Point 1",
+                 start_date: Date.new(2021, 11, 1),
+                 milestone_date: Date.new(2022, 1, 31),
+                 payment_date: Date.new(2022, 2, 28),
+                 declaration_type: "retained-1"
+        end
+        let!(:privacy_policy) do
+          privacy_policy = create(:privacy_policy)
+          PrivacyPolicy::Publish.call
+          privacy_policy
         end
 
-        and_sit_at_pupil_premium_school_reported_programme "Original SIT", "CIP"
+        context given_context(scenario) do
+          before do
+            given_lead_providers_contracted_to_deliver_ecf "New Lead Provider"
+            given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
 
-        and_sit_at_pupil_premium_school_reported_programme "New SIT", "FIP"
-        and_lead_provider_reported_partnership "New Lead Provider", "New SIT"
+            travel_to(milestone_started.milestone_date - 2.months) do
+              Importers::CreateCohort.new(path_to_csv: Rails.root.join("db/data/cohorts/cohorts.csv")).call
+              Importers::CreateCallOffContract.new.call
+              Importers::CreateStatement.new(path_to_csv: Rails.root.join("db/data/statements/statements.csv")).call
+            end
 
-        and_sit_reported_participant "Original SIT",
-                                     "The Participant",
-                                     scenario.participant_trn,
-                                     scenario.participant_dob,
-                                     scenario.participant_email,
-                                     scenario.participant_type
-      end
+            and_sit_at_pupil_premium_school_reported_programme "Original SIT", "CIP"
 
-      context when_context(scenario) do
-        before do
-          when_developers_transfer_the_withdrawn_participant "New SIT",
-                                                             "The Participant"
+            and_sit_at_pupil_premium_school_reported_programme "New SIT", "FIP"
+            and_lead_provider_reported_partnership "New Lead Provider", "New SIT"
 
-          scenario.new_declarations.each do |declaration_type|
-            and_lead_provider_has_made_training_declaration "New Lead Provider",
-                                                            scenario.participant_type,
-                                                            "The Participant",
-                                                            declaration_type
+            and_sit_reported_participant "Original SIT",
+                                         "The Participant",
+                                         scenario.participant_trn,
+                                         scenario.participant_dob,
+                                         scenario.participant_email,
+                                         scenario.participant_type
           end
 
-          and_eligible_training_declarations_are_made_payable
-        end
+          context when_context(scenario) do
+            before do
+              when_developers_transfer_the_withdrawn_participant "New SIT",
+                                                                 "The Participant"
 
-        include_examples "CIP to FIP", scenario
+              scenario.new_declarations.each do |declaration_type|
+                and_lead_provider_has_made_training_declaration "New Lead Provider",
+                                                                scenario.participant_type,
+                                                                "The Participant",
+                                                                declaration_type
+              end
+
+              and_eligible_training_declarations_are_made_payable
+            end
+
+            include_examples "CIP to FIP", scenario
+          end
+        end
       end
     end
   end

--- a/spec/features/scenarios/onboarding_a_withdrawn_participant/fip_to_cip_spec.rb
+++ b/spec/features/scenarios/onboarding_a_withdrawn_participant/fip_to_cip_spec.rb
@@ -20,7 +20,7 @@ def when_context(scenario)
 end
 
 RSpec.feature "FIP to CIP - Onboarding a withdrawn participant",
-              with_feature_flags: { eligibility_notifications: "active", programme_type_changes_2025: "inactive" },
+              with_feature_flags: { eligibility_notifications: "active" },
               type: :feature,
               end_to_end_scenario: true do
   include Steps::ChangesOfCircumstanceSteps
@@ -28,92 +28,96 @@ RSpec.feature "FIP to CIP - Onboarding a withdrawn participant",
   includes = ENV.fetch("SCENARIOS", "").split(",").map(&:to_i)
 
   fixture_data_path = File.join(File.dirname(__FILE__), "../changes_of_circumstances_fixtures.csv")
-  CSV.parse(File.read(fixture_data_path), headers: true).each_with_index do |fixture_data, index|
-    next if includes.any? && !includes.include?(index + 2)
 
-    scenario = ChangesOfCircumstanceScenario.new index + 2, fixture_data
+  %w[active inactive].each do |flag_state|
+    context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      CSV.parse(File.read(fixture_data_path), headers: true).each_with_index do |fixture_data, index|
+        next if includes.any? && !includes.include?(index + 2)
 
-    next unless scenario.original_programme == "FIP" && scenario.new_programme == "CIP"
+        scenario = ChangesOfCircumstanceScenario.new index + 2, fixture_data
 
-    let(:tokens) { {} }
+        next unless scenario.original_programme == "FIP" && scenario.new_programme == "CIP"
 
-    let!(:cohort) do
-      cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
-      allow(Cohort).to receive(:current).and_return(cohort)
-      allow(Cohort).to receive(:next).and_return(cohort)
-      allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
-      allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
-      allow(cohort).to receive(:next).and_return(cohort)
-      allow(cohort).to receive(:previous).and_return(cohort)
-      cohort
-    end
-    let!(:schedule) do
-      create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
-    end
-    let!(:milestone_started) do
-      create :milestone,
-             schedule:,
-             name: "Output 1 - Participant Start",
-             start_date: Date.new(2021, 9, 1),
-             milestone_date: Date.new(2021, 11, 30),
-             payment_date: Date.new(2021, 11, 30),
-             declaration_type: "started"
-    end
-    let!(:milestone_retained_1) do
-      create :milestone,
-             schedule:,
-             name: "Output 2 - Retention Point 1",
-             start_date: Date.new(2021, 11, 1),
-             milestone_date: Date.new(2022, 1, 31),
-             payment_date: Date.new(2022, 2, 28),
-             declaration_type: "retained-1"
-    end
-    let!(:privacy_policy) do
-      privacy_policy = create(:privacy_policy)
-      PrivacyPolicy::Publish.call
-      privacy_policy
-    end
+        let(:tokens) { {} }
 
-    context given_context(scenario) do
-      before do
-        given_lead_providers_contracted_to_deliver_ecf "Original Lead Provider"
-        given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
-
-        travel_to(milestone_started.milestone_date - 2.months) do
-          Importers::CreateCohort.new(path_to_csv: Rails.root.join("db/data/cohorts/cohorts.csv")).call
-          Importers::CreateCallOffContract.new.call
-          Importers::CreateStatement.new(path_to_csv: Rails.root.join("db/data/statements/statements.csv")).call
+        let!(:cohort) do
+          cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
+          allow(Cohort).to receive(:current).and_return(cohort)
+          allow(Cohort).to receive(:next).and_return(cohort)
+          allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
+          allow(cohort).to receive(:next).and_return(cohort)
+          allow(cohort).to receive(:previous).and_return(cohort)
+          cohort
+        end
+        let!(:schedule) do
+          create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+        end
+        let!(:milestone_started) do
+          create :milestone,
+                 schedule:,
+                 name: "Output 1 - Participant Start",
+                 start_date: Date.new(2021, 9, 1),
+                 milestone_date: Date.new(2021, 11, 30),
+                 payment_date: Date.new(2021, 11, 30),
+                 declaration_type: "started"
+        end
+        let!(:milestone_retained_1) do
+          create :milestone,
+                 schedule:,
+                 name: "Output 2 - Retention Point 1",
+                 start_date: Date.new(2021, 11, 1),
+                 milestone_date: Date.new(2022, 1, 31),
+                 payment_date: Date.new(2022, 2, 28),
+                 declaration_type: "retained-1"
+        end
+        let!(:privacy_policy) do
+          privacy_policy = create(:privacy_policy)
+          PrivacyPolicy::Publish.call
+          privacy_policy
         end
 
-        and_sit_at_pupil_premium_school_reported_programme "Original SIT", "FIP"
-        and_lead_provider_reported_partnership "Original Lead Provider", "Original SIT"
+        context given_context(scenario) do
+          before do
+            given_lead_providers_contracted_to_deliver_ecf "Original Lead Provider"
+            given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
 
-        and_sit_at_pupil_premium_school_reported_programme "New SIT", "CIP"
+            travel_to(milestone_started.milestone_date - 2.months) do
+              Importers::CreateCohort.new(path_to_csv: Rails.root.join("db/data/cohorts/cohorts.csv")).call
+              Importers::CreateCallOffContract.new.call
+              Importers::CreateStatement.new(path_to_csv: Rails.root.join("db/data/statements/statements.csv")).call
+            end
 
-        and_sit_reported_participant "Original SIT",
-                                     "The Participant",
-                                     scenario.participant_trn,
-                                     scenario.participant_dob,
-                                     scenario.participant_email,
-                                     scenario.participant_type
-      end
+            and_sit_at_pupil_premium_school_reported_programme "Original SIT", "FIP"
+            and_lead_provider_reported_partnership "Original Lead Provider", "Original SIT"
 
-      context when_context(scenario) do
-        before do
-          scenario.prior_declarations.each do |declaration_type|
-            and_lead_provider_has_made_training_declaration "Original Lead Provider",
-                                                            scenario.participant_type,
-                                                            "The Participant",
-                                                            declaration_type
+            and_sit_at_pupil_premium_school_reported_programme "New SIT", "CIP"
+
+            and_sit_reported_participant "Original SIT",
+                                         "The Participant",
+                                         scenario.participant_trn,
+                                         scenario.participant_dob,
+                                         scenario.participant_email,
+                                         scenario.participant_type
           end
 
-          when_developers_transfer_the_withdrawn_participant "New SIT",
-                                                             "The Participant"
+          context when_context(scenario) do
+            before do
+              scenario.prior_declarations.each do |declaration_type|
+                and_lead_provider_has_made_training_declaration "Original Lead Provider",
+                                                                scenario.participant_type,
+                                                                "The Participant",
+                                                                declaration_type
+              end
 
-          and_eligible_training_declarations_are_made_payable
+              when_developers_transfer_the_withdrawn_participant "New SIT",
+                                                                 "The Participant"
+
+              and_eligible_training_declarations_are_made_payable
+            end
+
+            include_examples "FIP to CIP", scenario, "withdrawn"
+          end
         end
-
-        include_examples "FIP to CIP", scenario, "withdrawn"
       end
     end
   end

--- a/spec/features/scenarios/onboarding_a_withdrawn_participant/fip_to_fip_with_different_provider_spec.rb
+++ b/spec/features/scenarios/onboarding_a_withdrawn_participant/fip_to_fip_with_different_provider_spec.rb
@@ -20,7 +20,7 @@ def when_context(scenario)
 end
 
 RSpec.feature "FIP to FIP with different provider - Onboarding a withdrawn participant",
-              with_feature_flags: { eligibility_notifications: "active", programme_type_changes_2025: "inactive" },
+              with_feature_flags: { eligibility_notifications: "active" },
               type: :feature,
               end_to_end_scenario: true do
   include Steps::ChangesOfCircumstanceSteps
@@ -28,101 +28,105 @@ RSpec.feature "FIP to FIP with different provider - Onboarding a withdrawn parti
   includes = ENV.fetch("SCENARIOS", "").split(",").map(&:to_i)
 
   fixture_data_path = File.join(File.dirname(__FILE__), "../changes_of_circumstances_fixtures.csv")
-  CSV.parse(File.read(fixture_data_path), headers: true).each_with_index do |fixture_data, index|
-    next if includes.any? && !includes.include?(index + 2)
 
-    scenario = ChangesOfCircumstanceScenario.new index + 2, fixture_data
+  %w[active inactive].each do |flag_state|
+    context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      CSV.parse(File.read(fixture_data_path), headers: true).each_with_index do |fixture_data, index|
+        next if includes.any? && !includes.include?(index + 2)
 
-    next unless scenario.original_programme == "FIP" && scenario.new_programme == "FIP" && scenario.transfer == :different_provider
+        scenario = ChangesOfCircumstanceScenario.new index + 2, fixture_data
 
-    let(:tokens) { {} }
+        next unless scenario.original_programme == "FIP" && scenario.new_programme == "FIP" && scenario.transfer == :different_provider
 
-    let!(:cohort) do
-      cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
-      allow(Cohort).to receive(:current).and_return(cohort)
-      allow(Cohort).to receive(:next).and_return(cohort)
-      allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
-      allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
-      allow(cohort).to receive(:next).and_return(cohort)
-      allow(cohort).to receive(:previous).and_return(cohort)
-      cohort
-    end
-    let!(:schedule) do
-      create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
-    end
-    let!(:milestone_started) do
-      create :milestone,
-             schedule:,
-             name: "Output 1 - Participant Start",
-             start_date: Date.new(2021, 9, 1),
-             milestone_date: Date.new(2021, 11, 30),
-             payment_date: Date.new(2021, 11, 30),
-             declaration_type: "started"
-    end
-    let!(:milestone_retained_1) do
-      create :milestone,
-             schedule:,
-             name: "Output 2 - Retention Point 1",
-             start_date: Date.new(2021, 11, 1),
-             milestone_date: Date.new(2022, 1, 31),
-             payment_date: Date.new(2022, 2, 28),
-             declaration_type: "retained-1"
-    end
-    let!(:privacy_policy) do
-      privacy_policy = create(:privacy_policy)
-      PrivacyPolicy::Publish.call
-      privacy_policy
-    end
+        let(:tokens) { {} }
 
-    context given_context(scenario) do
-      before do
-        given_lead_providers_contracted_to_deliver_ecf "Original Lead Provider"
-        given_lead_providers_contracted_to_deliver_ecf "New Lead Provider"
-        given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
-
-        travel_to(milestone_started.milestone_date - 2.months) do
-          Importers::CreateCohort.new(path_to_csv: Rails.root.join("db/data/cohorts/cohorts.csv")).call
-          Importers::CreateCallOffContract.new.call
-          Importers::CreateStatement.new(path_to_csv: Rails.root.join("db/data/statements/statements.csv")).call
+        let!(:cohort) do
+          cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
+          allow(Cohort).to receive(:current).and_return(cohort)
+          allow(Cohort).to receive(:next).and_return(cohort)
+          allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
+          allow(cohort).to receive(:next).and_return(cohort)
+          allow(cohort).to receive(:previous).and_return(cohort)
+          cohort
+        end
+        let!(:schedule) do
+          create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+        end
+        let!(:milestone_started) do
+          create :milestone,
+                 schedule:,
+                 name: "Output 1 - Participant Start",
+                 start_date: Date.new(2021, 9, 1),
+                 milestone_date: Date.new(2021, 11, 30),
+                 payment_date: Date.new(2021, 11, 30),
+                 declaration_type: "started"
+        end
+        let!(:milestone_retained_1) do
+          create :milestone,
+                 schedule:,
+                 name: "Output 2 - Retention Point 1",
+                 start_date: Date.new(2021, 11, 1),
+                 milestone_date: Date.new(2022, 1, 31),
+                 payment_date: Date.new(2022, 2, 28),
+                 declaration_type: "retained-1"
+        end
+        let!(:privacy_policy) do
+          privacy_policy = create(:privacy_policy)
+          PrivacyPolicy::Publish.call
+          privacy_policy
         end
 
-        and_sit_at_pupil_premium_school_reported_programme "Original SIT", "FIP"
-        and_lead_provider_reported_partnership "Original Lead Provider", "Original SIT"
+        context given_context(scenario) do
+          before do
+            given_lead_providers_contracted_to_deliver_ecf "Original Lead Provider"
+            given_lead_providers_contracted_to_deliver_ecf "New Lead Provider"
+            given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
 
-        and_sit_at_pupil_premium_school_reported_programme "New SIT", "FIP"
-        and_lead_provider_reported_partnership "New Lead Provider", "New SIT"
+            travel_to(milestone_started.milestone_date - 2.months) do
+              Importers::CreateCohort.new(path_to_csv: Rails.root.join("db/data/cohorts/cohorts.csv")).call
+              Importers::CreateCallOffContract.new.call
+              Importers::CreateStatement.new(path_to_csv: Rails.root.join("db/data/statements/statements.csv")).call
+            end
 
-        and_sit_reported_participant "Original SIT",
-                                     "The Participant",
-                                     scenario.participant_trn,
-                                     scenario.participant_dob,
-                                     scenario.participant_email,
-                                     scenario.participant_type
-      end
+            and_sit_at_pupil_premium_school_reported_programme "Original SIT", "FIP"
+            and_lead_provider_reported_partnership "Original Lead Provider", "Original SIT"
 
-      context when_context(scenario) do
-        before do
-          scenario.prior_declarations.each do |declaration_type|
-            and_lead_provider_has_made_training_declaration "Original Lead Provider",
-                                                            scenario.participant_type,
-                                                            "The Participant",
-                                                            declaration_type
+            and_sit_at_pupil_premium_school_reported_programme "New SIT", "FIP"
+            and_lead_provider_reported_partnership "New Lead Provider", "New SIT"
+
+            and_sit_reported_participant "Original SIT",
+                                         "The Participant",
+                                         scenario.participant_trn,
+                                         scenario.participant_dob,
+                                         scenario.participant_email,
+                                         scenario.participant_type
           end
 
-          when_developers_transfer_the_withdrawn_participant "New SIT",
-                                                             "The Participant"
+          context when_context(scenario) do
+            before do
+              scenario.prior_declarations.each do |declaration_type|
+                and_lead_provider_has_made_training_declaration "Original Lead Provider",
+                                                                scenario.participant_type,
+                                                                "The Participant",
+                                                                declaration_type
+              end
 
-          scenario.new_declarations.each do |declaration_type|
-            and_lead_provider_has_made_training_declaration "New Lead Provider",
-                                                            scenario.participant_type,
-                                                            "The Participant",
-                                                            declaration_type
+              when_developers_transfer_the_withdrawn_participant "New SIT",
+                                                                 "The Participant"
+
+              scenario.new_declarations.each do |declaration_type|
+                and_lead_provider_has_made_training_declaration "New Lead Provider",
+                                                                scenario.participant_type,
+                                                                "The Participant",
+                                                                declaration_type
+              end
+
+              and_eligible_training_declarations_are_made_payable
+            end
+
+            include_examples "FIP to FIP with different provider", scenario, "withdrawn", is_hidden: true
           end
-
-          and_eligible_training_declarations_are_made_payable
         end
-
-        include_examples "FIP to FIP with different provider", scenario, "withdrawn", is_hidden: true
       end
     end
   end

--- a/spec/features/scenarios/onboarding_a_withdrawn_participant/fip_to_fip_with_same_provider_spec.rb
+++ b/spec/features/scenarios/onboarding_a_withdrawn_participant/fip_to_fip_with_same_provider_spec.rb
@@ -20,7 +20,7 @@ def when_context(scenario)
 end
 
 RSpec.feature "FIP to FIP with same provider - Onboarding a withdrawn participant",
-              with_feature_flags: { eligibility_notifications: "active", programme_type_changes_2025: "inactive" },
+              with_feature_flags: { eligibility_notifications: "active" },
               type: :feature,
               end_to_end_scenario: true do
   include Steps::ChangesOfCircumstanceSteps
@@ -28,101 +28,105 @@ RSpec.feature "FIP to FIP with same provider - Onboarding a withdrawn participan
   includes = ENV.fetch("SCENARIOS", "").split(",").map(&:to_i)
 
   fixture_data_path = File.join(File.dirname(__FILE__), "../changes_of_circumstances_fixtures.csv")
-  CSV.parse(File.read(fixture_data_path), headers: true).each_with_index do |fixture_data, index|
-    next if includes.any? && !includes.include?(index + 2)
 
-    scenario = ChangesOfCircumstanceScenario.new index + 2, fixture_data
+  %w[active inactive].each do |flag_state|
+    context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      CSV.parse(File.read(fixture_data_path), headers: true).each_with_index do |fixture_data, index|
+        next if includes.any? && !includes.include?(index + 2)
 
-    next unless scenario.original_programme == "FIP" && scenario.new_programme == "FIP" && scenario.transfer == :same_provider
+        scenario = ChangesOfCircumstanceScenario.new index + 2, fixture_data
 
-    let(:tokens) { {} }
+        next unless scenario.original_programme == "FIP" && scenario.new_programme == "FIP" && scenario.transfer == :same_provider
 
-    let!(:cohort) do
-      cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
-      allow(Cohort).to receive(:current).and_return(cohort)
-      allow(Cohort).to receive(:next).and_return(cohort)
-      allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
-      allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
-      allow(cohort).to receive(:next).and_return(cohort)
-      allow(cohort).to receive(:previous).and_return(cohort)
-      cohort
-    end
-    let!(:schedule) do
-      create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
-    end
-    let!(:milestone_started) do
-      create :milestone,
-             schedule:,
-             name: "Output 1 - Participant Start",
-             start_date: Date.new(2021, 9, 1),
-             milestone_date: Date.new(2021, 11, 30),
-             payment_date: Date.new(2021, 11, 30),
-             declaration_type: "started"
-    end
-    let!(:milestone_retained_1) do
-      create :milestone,
-             schedule:,
-             name: "Output 2 - Retention Point 1",
-             start_date: Date.new(2021, 11, 1),
-             milestone_date: Date.new(2022, 1, 31),
-             payment_date: Date.new(2022, 2, 28),
-             declaration_type: "retained-1"
-    end
-    let!(:privacy_policy) do
-      privacy_policy = create(:privacy_policy)
-      PrivacyPolicy::Publish.call
-      privacy_policy
-    end
+        let(:tokens) { {} }
 
-    context given_context(scenario) do
-      before do
-        given_lead_providers_contracted_to_deliver_ecf "Original Lead Provider"
-        given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
-
-        travel_to(milestone_started.milestone_date - 2.months) do
-          Importers::CreateCohort.new(path_to_csv: Rails.root.join("db/data/cohorts/cohorts.csv")).call
-          Importers::CreateCallOffContract.new.call
-          Importers::CreateStatement.new(path_to_csv: Rails.root.join("db/data/statements/statements.csv")).call
+        let!(:cohort) do
+          cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
+          allow(Cohort).to receive(:current).and_return(cohort)
+          allow(Cohort).to receive(:next).and_return(cohort)
+          allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
+          allow(cohort).to receive(:next).and_return(cohort)
+          allow(cohort).to receive(:previous).and_return(cohort)
+          cohort
+        end
+        let!(:schedule) do
+          create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+        end
+        let!(:milestone_started) do
+          create :milestone,
+                 schedule:,
+                 name: "Output 1 - Participant Start",
+                 start_date: Date.new(2021, 9, 1),
+                 milestone_date: Date.new(2021, 11, 30),
+                 payment_date: Date.new(2021, 11, 30),
+                 declaration_type: "started"
+        end
+        let!(:milestone_retained_1) do
+          create :milestone,
+                 schedule:,
+                 name: "Output 2 - Retention Point 1",
+                 start_date: Date.new(2021, 11, 1),
+                 milestone_date: Date.new(2022, 1, 31),
+                 payment_date: Date.new(2022, 2, 28),
+                 declaration_type: "retained-1"
+        end
+        let!(:privacy_policy) do
+          privacy_policy = create(:privacy_policy)
+          PrivacyPolicy::Publish.call
+          privacy_policy
         end
 
-        and_sit_at_pupil_premium_school_reported_programme "Original SIT", "FIP"
-        and_lead_provider_reported_partnership "Original Lead Provider", "Original SIT"
+        context given_context(scenario) do
+          before do
+            given_lead_providers_contracted_to_deliver_ecf "Original Lead Provider"
+            given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
 
-        and_sit_at_pupil_premium_school_reported_programme "New SIT", "FIP"
-        and_lead_provider_reported_partnership "Original Lead Provider", "New SIT"
+            travel_to(milestone_started.milestone_date - 2.months) do
+              Importers::CreateCohort.new(path_to_csv: Rails.root.join("db/data/cohorts/cohorts.csv")).call
+              Importers::CreateCallOffContract.new.call
+              Importers::CreateStatement.new(path_to_csv: Rails.root.join("db/data/statements/statements.csv")).call
+            end
 
-        and_sit_reported_participant "Original SIT",
-                                     "The Participant",
-                                     scenario.participant_trn,
-                                     scenario.participant_dob,
-                                     scenario.participant_email,
-                                     scenario.participant_type
-      end
+            and_sit_at_pupil_premium_school_reported_programme "Original SIT", "FIP"
+            and_lead_provider_reported_partnership "Original Lead Provider", "Original SIT"
 
-      context when_context(scenario) do
-        before do
-          scenario.prior_declarations.each do |declaration_type|
-            and_lead_provider_has_made_training_declaration "Original Lead Provider",
-                                                            scenario.participant_type,
-                                                            "The Participant",
-                                                            declaration_type
+            and_sit_at_pupil_premium_school_reported_programme "New SIT", "FIP"
+            and_lead_provider_reported_partnership "Original Lead Provider", "New SIT"
+
+            and_sit_reported_participant "Original SIT",
+                                         "The Participant",
+                                         scenario.participant_trn,
+                                         scenario.participant_dob,
+                                         scenario.participant_email,
+                                         scenario.participant_type
           end
 
-          when_developers_transfer_the_withdrawn_participant "New SIT",
-                                                             "The Participant"
+          context when_context(scenario) do
+            before do
+              scenario.prior_declarations.each do |declaration_type|
+                and_lead_provider_has_made_training_declaration "Original Lead Provider",
+                                                                scenario.participant_type,
+                                                                "The Participant",
+                                                                declaration_type
+              end
 
-          scenario.new_declarations.each do |declaration_type|
-            and_lead_provider_has_made_training_declaration "Original Lead Provider",
-                                                            scenario.participant_type,
-                                                            "The Participant",
-                                                            declaration_type
+              when_developers_transfer_the_withdrawn_participant "New SIT",
+                                                                 "The Participant"
+
+              scenario.new_declarations.each do |declaration_type|
+                and_lead_provider_has_made_training_declaration "Original Lead Provider",
+                                                                scenario.participant_type,
+                                                                "The Participant",
+                                                                declaration_type
+              end
+
+              and_eligible_training_declarations_are_made_payable
+            end
+
+            include_examples "FIP to FIP with same provider",
+                             scenario, "active", is_hidden: true, see_prior_school: false
           end
-
-          and_eligible_training_declarations_are_made_payable
         end
-
-        include_examples "FIP to FIP with same provider",
-                         scenario, "active", is_hidden: true, see_prior_school: false
       end
     end
   end


### PR DESCRIPTION
### Context

- Ticket: [JIRA](https://dfedigital.atlassian.net/browse/CST-2849)

We need to update the UI for schools and Administrators to use the new Provider-led and School-led programme type names.  This involves "smooshing" together the current "Full induction programme" and "School-funded FIP" into "Provider-led" and "Core induction programme" and "Design our own" into "School-led"

We are using the `:programme_type_changes_2025` feature flag to keep the changes hidden until we are ready launch

This is part six, split off from #5647 - refer to that PR for screen shots and more info.

There will be more PRs to follow, some that may refactor the work in this one.

These PRs will make changes to the programme type naming that are visible to School and Admin users in the UI.

### Changes proposed in this pull request

* Adding loops to specs to ensure coverage with and without the feature flag active - 2nd batch