### PR TITLE
Programme type changes for 2025 - Part 7

### DIFF
--- a/app/forms/schools/cohorts/wizard_steps/how_will_you_run_training_step.rb
+++ b/app/forms/schools/cohorts/wizard_steps/how_will_you_run_training_step.rb
@@ -15,7 +15,7 @@ module Schools
         end
 
         def choices
-          school_training_options(state_funded: !wizard.school.cip_only?)
+          school_training_options(state_funded: !wizard.school.cip_only?, exclude: [:no_early_career_teachers])
         end
 
         def expected?

--- a/spec/features/scenarios/participants/ect_doing_cip/after_cohort_transfer_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_cip/after_cohort_transfer_spec.rb
@@ -89,95 +89,99 @@ RSpec.feature "ECT doing CIP: after cohort transfer", type: :feature do
   let(:participant_profile) { participant_details.participant_profile }
   let(:preferred_identity) { participant_details.participant_identity }
 
-  scenario "The current school induction tutor can locate a record for the ECT" do
-    given_i_sign_in_as_the_user_with_the_full_name sit_full_name
+  %w[active inactive].each do |flag_state|
+    context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      scenario "The current school induction tutor can locate a record for the ECT" do
+        given_i_sign_in_as_the_user_with_the_full_name sit_full_name
 
-    school_dashboard = Pages::SchoolDashboardPage.load(slug: school.slug)
-    school_dashboard.view_ect_dashboard
+        school_dashboard = Pages::SchoolDashboardPage.load(slug: school.slug)
+        school_dashboard.view_ect_dashboard
 
-    participant_dashboard = Pages::SchoolEarlyCareerTeachersDashboardPage.loaded(slug: school.slug)
-    participant_dashboard.view_participant participant_full_name
+        participant_dashboard = Pages::SchoolEarlyCareerTeachersDashboardPage.loaded(slug: school.slug)
+        participant_dashboard.view_participant participant_full_name
 
-    participant_details = Pages::SchoolEarlyCareerTeacherDetailsPage.loaded(slug: school.slug, participant_id: training_record_id)
-    expect(participant_details).to have_participant_name participant_full_name
-    expect(participant_details).to have_email participant_email
-    expect(participant_details).to have_full_name participant_full_name
-    expect(participant_details).to have_status school_record_state
-  end
+        participant_details = Pages::SchoolEarlyCareerTeacherDetailsPage.loaded(slug: school.slug, participant_id: training_record_id)
+        expect(participant_details).to have_participant_name participant_full_name
+        expect(participant_details).to have_email participant_email
+        expect(participant_details).to have_full_name participant_full_name
+        expect(participant_details).to have_status school_record_state
+      end
 
-  scenario "The current appropriate body can locate a record for the ECT", :skip do
-    given_i_sign_in_as_the_user_with_the_full_name ab_full_name
+      scenario "The current appropriate body can locate a record for the ECT", :skip do
+        given_i_sign_in_as_the_user_with_the_full_name ab_full_name
 
-    appropriate_body_portal = Pages::AppropriateBodyPortal.loaded
-    appropriate_body_portal.get_participant(participant_full_name)
+        appropriate_body_portal = Pages::AppropriateBodyPortal.loaded
+        appropriate_body_portal.get_participant(participant_full_name)
 
-    expect(appropriate_body_portal).to have_full_name participant_full_name
-    expect(appropriate_body_portal).to have_email_address participant_email
-    expect(appropriate_body_portal).to have_teacher_reference_number teacher_reference_number
-    expect(appropriate_body_portal).to have_participant_type long_participant_type
-    expect(appropriate_body_portal).to have_lead_provider_name lead_provider_name
-    expect(appropriate_body_portal).to have_school_name school_name
-    expect(appropriate_body_portal).to have_school_urn school.urn
-    expect(appropriate_body_portal).to have_academic_year start_year
-    expect(appropriate_body_portal).to have_training_status training_status
-    expect(appropriate_body_portal).to have_training_record_status appropriate_body_Record_state
-  end
+        expect(appropriate_body_portal).to have_full_name participant_full_name
+        expect(appropriate_body_portal).to have_email_address participant_email
+        expect(appropriate_body_portal).to have_teacher_reference_number teacher_reference_number
+        expect(appropriate_body_portal).to have_participant_type long_participant_type
+        expect(appropriate_body_portal).to have_lead_provider_name lead_provider_name
+        expect(appropriate_body_portal).to have_school_name school_name
+        expect(appropriate_body_portal).to have_school_urn school.urn
+        expect(appropriate_body_portal).to have_academic_year start_year
+        expect(appropriate_body_portal).to have_training_status training_status
+        expect(appropriate_body_portal).to have_training_record_status appropriate_body_Record_state
+      end
 
-  scenario "The Support for ECTs service can locate a record for the CIP ECT" do
-    user_endpoint = APIs::ECFUsersEndpoint.load
-    user_endpoint.get_user participant_id
+      scenario "The Support for ECTs service can locate a record for the CIP ECT" do
+        user_endpoint = APIs::ECFUsersEndpoint.load
+        user_endpoint.get_user participant_id
 
-    expect(user_endpoint).to have_email participant_email
-    expect(user_endpoint).to have_full_name participant_full_name
-    expect(user_endpoint).to have_cohort previous_start_year
-    expect(user_endpoint).to have_core_induction_programme cip_materials
-    expect(user_endpoint).to have_induction_programme_choice programme_type
-    expect(user_endpoint).to have_registration_completed registration_completed
-    expect(user_endpoint).to have_user_type participant_type
-  end
+        expect(user_endpoint).to have_email participant_email
+        expect(user_endpoint).to have_full_name participant_full_name
+        expect(user_endpoint).to have_cohort previous_start_year
+        expect(user_endpoint).to have_core_induction_programme cip_materials
+        expect(user_endpoint).to have_induction_programme_choice programme_type
+        expect(user_endpoint).to have_registration_completed registration_completed
+        expect(user_endpoint).to have_user_type participant_type
+      end
 
-  scenario "A DfE admin user can locate the record for the ECT" do
-    given_i_sign_in_as_an_admin_user
+      scenario "A DfE admin user can locate the record for the ECT" do
+        given_i_sign_in_as_an_admin_user
 
-    participant_list = Pages::AdminSupportParticipantList.load
-    participant_list.view_participant participant_full_name
+        participant_list = Pages::AdminSupportParticipantList.load
+        participant_list.view_participant participant_full_name
 
-    participant_detail = Pages::AdminSupportParticipantDetail.loaded(participant_id: training_record_id)
-    expect(participant_detail).to have_full_name participant_full_name
-    expect(participant_detail).to have_email_address participant_email
-    expect(participant_detail).to have_trn teacher_reference_number
-    expect(participant_detail).to have_cohort previous_start_year
-    expect(participant_detail).to have_training_record_state training_record_state
-    expect(participant_detail).to have_user_id participant_id
-    expect(participant_detail).to have_associated_email_address participant_email
+        participant_detail = Pages::AdminSupportParticipantDetail.loaded(participant_id: training_record_id)
+        expect(participant_detail).to have_full_name participant_full_name
+        expect(participant_detail).to have_email_address participant_email
+        expect(participant_detail).to have_trn teacher_reference_number
+        expect(participant_detail).to have_cohort previous_start_year
+        expect(participant_detail).to have_training_record_state training_record_state
+        expect(participant_detail).to have_user_id participant_id
+        expect(participant_detail).to have_associated_email_address participant_email
 
-    participant_detail.open_training_tab
+        participant_detail.open_training_tab
 
-    participant_training = Pages::AdminSupportParticipantTraining.loaded(participant_id: training_record_id)
-    expect(participant_training).to have_cohort previous_start_year
-    expect(participant_training).to have_school_name school.name
-    expect(participant_training).to have_schedule_identifier schedule_identifier
-  end
+        participant_training = Pages::AdminSupportParticipantTraining.loaded(participant_id: training_record_id)
+        expect(participant_training).to have_cohort previous_start_year
+        expect(participant_training).to have_school_name school.name
+        expect(participant_training).to have_schedule_identifier schedule_identifier
+      end
 
-  scenario "A DfE finance user can locate the record for the ECT" do
-    given_i_sign_in_as_a_finance_user
+      scenario "A DfE finance user can locate the record for the ECT" do
+        given_i_sign_in_as_a_finance_user
 
-    drilldown_search = Pages::FinanceParticipantDrilldownSearch.load
-    drilldown_search.find participant_id
+        drilldown_search = Pages::FinanceParticipantDrilldownSearch.load
+        drilldown_search.find participant_id
 
-    drilldown = Pages::FinanceParticipantDrilldown.loaded(user_id: participant_id)
-    expect(drilldown).to have_participant_id participant_id
-    expect(drilldown).to have_full_name participant_full_name
-    expect(drilldown).to have_lead_provider lead_provider_name
-    expect(drilldown).to have_school_urn school.urn
-    expect(drilldown).to have_status participant_status
-    expect(drilldown).to have_induction_status participant_status
-    expect(drilldown).to have_training_status training_status
-    expect(drilldown).to be_eligible_for_funding
-    expect(drilldown).to have_schedule schedule_identifier
-    expect(drilldown).to have_schedule_identifier schedule_identifier
-    expect(drilldown).to have_schedule_cohort previous_start_year
-    expect(drilldown).to have_training_programme programme_name
-    expect(drilldown).to have_participant_class participant_class
+        drilldown = Pages::FinanceParticipantDrilldown.loaded(user_id: participant_id)
+        expect(drilldown).to have_participant_id participant_id
+        expect(drilldown).to have_full_name participant_full_name
+        expect(drilldown).to have_lead_provider lead_provider_name
+        expect(drilldown).to have_school_urn school.urn
+        expect(drilldown).to have_status participant_status
+        expect(drilldown).to have_induction_status participant_status
+        expect(drilldown).to have_training_status training_status
+        expect(drilldown).to be_eligible_for_funding
+        expect(drilldown).to have_schedule schedule_identifier
+        expect(drilldown).to have_schedule_identifier schedule_identifier
+        expect(drilldown).to have_schedule_cohort previous_start_year
+        expect(drilldown).to have_training_programme programme_name
+        expect(drilldown).to have_participant_class participant_class
+      end
+    end
   end
 end

--- a/spec/features/scenarios/participants/ect_doing_cip/after_cohort_transfer_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_cip/after_cohort_transfer_spec.rb
@@ -23,7 +23,6 @@ RSpec.feature "ECT doing CIP: after cohort transfer", type: :feature do
   let(:long_participant_type) { "Early career teacher" }
   let(:participant_class) { "ParticipantProfile::ECT" }
   let(:programme_type) { "core_induction_programme" }
-  let(:programme_name) { "Core induction programme" }
   let(:schedule_identifier) { "ecf-standard-september" }
   let(:cip_material_provider) { "Education Development Trust" }
   let(:cip_materials) { "edt" }
@@ -91,6 +90,10 @@ RSpec.feature "ECT doing CIP: after cohort transfer", type: :feature do
 
   %w[active inactive].each do |flag_state|
     context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      let(:programme_name) do
+        flag_state == "inactive" ? "Core induction programme" : "School-led"
+      end
+
       scenario "The current school induction tutor can locate a record for the ECT" do
         given_i_sign_in_as_the_user_with_the_full_name sit_full_name
 

--- a/spec/features/scenarios/participants/ect_doing_cip/in_training_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_cip/in_training_spec.rb
@@ -23,7 +23,6 @@ RSpec.feature "ECT doing CIP: in training", type: :feature do
   let(:long_participant_type) { "Early career teacher" }
   let(:participant_class) { "ParticipantProfile::ECT" }
   let(:programme_type) { "core_induction_programme" }
-  let(:programme_name) { "Core induction programme" }
   let(:schedule_identifier) { "ecf-standard-september" }
   let(:cip_material_provider) { "Education Development Trust" }
   let(:cip_materials) { "edt" }
@@ -75,6 +74,10 @@ RSpec.feature "ECT doing CIP: in training", type: :feature do
 
   %w[active inactive].each do |flag_state|
     context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      let(:programme_name) do
+        flag_state == "inactive" ? "Core induction programme" : "School-led"
+      end
+
       scenario "The current school induction tutor can locate a record for the ECT" do
         inside_registration_window(cohort:) do
           given_i_sign_in_as_the_user_with_the_full_name sit_full_name

--- a/spec/features/scenarios/participants/ect_doing_cip/in_training_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_cip/in_training_spec.rb
@@ -73,97 +73,101 @@ RSpec.feature "ECT doing CIP: in training", type: :feature do
   let(:participant_profile) { participant_details.participant_profile }
   let(:preferred_identity) { participant_details.participant_identity }
 
-  scenario "The current school induction tutor can locate a record for the ECT" do
-    inside_registration_window(cohort:) do
-      given_i_sign_in_as_the_user_with_the_full_name sit_full_name
+  %w[active inactive].each do |flag_state|
+    context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      scenario "The current school induction tutor can locate a record for the ECT" do
+        inside_registration_window(cohort:) do
+          given_i_sign_in_as_the_user_with_the_full_name sit_full_name
 
-      school_dashboard = Pages::SchoolDashboardPage.load(slug: school.slug)
-      school_dashboard.view_ect_dashboard
+          school_dashboard = Pages::SchoolDashboardPage.load(slug: school.slug)
+          school_dashboard.view_ect_dashboard
 
-      participant_dashboard = Pages::SchoolEarlyCareerTeachersDashboardPage.loaded(slug: school.slug)
-      participant_dashboard.view_participant participant_full_name
+          participant_dashboard = Pages::SchoolEarlyCareerTeachersDashboardPage.loaded(slug: school.slug)
+          participant_dashboard.view_participant participant_full_name
 
-      participant_details = Pages::SchoolEarlyCareerTeacherDetailsPage.loaded(slug: school.slug, participant_id: training_record_id)
-      expect(participant_details).to have_participant_name participant_full_name
-      expect(participant_details).to have_email participant_email
-      expect(participant_details).to have_full_name participant_full_name
-      expect(participant_details).to have_status school_record_state
+          participant_details = Pages::SchoolEarlyCareerTeacherDetailsPage.loaded(slug: school.slug, participant_id: training_record_id)
+          expect(participant_details).to have_participant_name participant_full_name
+          expect(participant_details).to have_email participant_email
+          expect(participant_details).to have_full_name participant_full_name
+          expect(participant_details).to have_status school_record_state
+        end
+      end
+
+      scenario "The current appropriate body can locate a record for the ECT", :skip do
+        given_i_sign_in_as_the_user_with_the_full_name ab_full_name
+
+        appropriate_body_portal = Pages::AppropriateBodyPortal.loaded
+        appropriate_body_portal.get_participant(participant_full_name)
+
+        expect(appropriate_body_portal).to have_full_name participant_full_name
+        expect(appropriate_body_portal).to have_email_address participant_email
+        expect(appropriate_body_portal).to have_teacher_reference_number teacher_reference_number
+        expect(appropriate_body_portal).to have_participant_type long_participant_type
+        expect(appropriate_body_portal).to have_lead_provider_name lead_provider_name
+        expect(appropriate_body_portal).to have_school_name school_name
+        expect(appropriate_body_portal).to have_school_urn school.urn
+        expect(appropriate_body_portal).to have_academic_year start_year
+        expect(appropriate_body_portal).to have_training_status training_status
+        expect(appropriate_body_portal).to have_training_record_status appropriate_body_Record_state
+      end
+
+      scenario "The Support for ECTs service can locate a record for the CIP ECT" do
+        user_endpoint = APIs::ECFUsersEndpoint.load
+        user_endpoint.get_user participant_id
+
+        expect(user_endpoint).to have_email participant_email
+        expect(user_endpoint).to have_full_name participant_full_name
+        expect(user_endpoint).to have_cohort start_year
+        expect(user_endpoint).to have_core_induction_programme cip_materials
+        expect(user_endpoint).to have_induction_programme_choice programme_type
+        expect(user_endpoint).to have_registration_completed registration_completed
+        expect(user_endpoint).to have_user_type participant_type
+      end
+
+      scenario "A DfE admin user can locate the record for the ECT" do
+        given_i_sign_in_as_an_admin_user
+
+        participant_list = Pages::AdminSupportParticipantList.load
+        participant_list.view_participant participant_full_name
+
+        participant_detail = Pages::AdminSupportParticipantDetail.loaded(participant_id: training_record_id)
+        expect(participant_detail).to have_full_name participant_full_name
+        expect(participant_detail).to have_email_address participant_email
+        expect(participant_detail).to have_trn teacher_reference_number
+        expect(participant_detail).to have_cohort start_year
+        expect(participant_detail).to have_training_record_state training_record_state
+        expect(participant_detail).to have_user_id participant_id
+        expect(participant_detail).to have_associated_email_address participant_email
+
+        participant_detail.open_training_tab
+
+        participant_training = Pages::AdminSupportParticipantTraining.loaded(participant_id: training_record_id)
+        expect(participant_training).to have_cohort start_year
+        expect(participant_training).to have_school_name school.name
+        expect(participant_training).to have_schedule_identifier schedule_identifier
+      end
+
+      scenario "A DfE finance user can locate the record for the ECT" do
+        given_i_sign_in_as_a_finance_user
+
+        drilldown_search = Pages::FinanceParticipantDrilldownSearch.load
+        drilldown_search.find participant_id
+
+        drilldown = Pages::FinanceParticipantDrilldown.loaded(user_id: participant_id)
+        expect(drilldown).to have_participant_id participant_id
+        expect(drilldown).to have_full_name participant_full_name
+        expect(drilldown).to have_lead_provider lead_provider_name
+        expect(drilldown).to have_school_urn school.urn
+        expect(drilldown).to have_status participant_status
+        expect(drilldown).to have_induction_status participant_status
+        expect(drilldown).to have_training_status training_status
+        expect(drilldown).to be_eligible_for_funding
+        expect(drilldown).to have_schedule schedule_identifier
+        expect(drilldown).to have_schedule_identifier schedule_identifier
+        expect(drilldown).to have_schedule_cohort start_year
+        expect(drilldown).to have_training_programme programme_name
+        expect(drilldown).to have_participant_class participant_class
+      end
     end
-  end
-
-  scenario "The current appropriate body can locate a record for the ECT", :skip do
-    given_i_sign_in_as_the_user_with_the_full_name ab_full_name
-
-    appropriate_body_portal = Pages::AppropriateBodyPortal.loaded
-    appropriate_body_portal.get_participant(participant_full_name)
-
-    expect(appropriate_body_portal).to have_full_name participant_full_name
-    expect(appropriate_body_portal).to have_email_address participant_email
-    expect(appropriate_body_portal).to have_teacher_reference_number teacher_reference_number
-    expect(appropriate_body_portal).to have_participant_type long_participant_type
-    expect(appropriate_body_portal).to have_lead_provider_name lead_provider_name
-    expect(appropriate_body_portal).to have_school_name school_name
-    expect(appropriate_body_portal).to have_school_urn school.urn
-    expect(appropriate_body_portal).to have_academic_year start_year
-    expect(appropriate_body_portal).to have_training_status training_status
-    expect(appropriate_body_portal).to have_training_record_status appropriate_body_Record_state
-  end
-
-  scenario "The Support for ECTs service can locate a record for the CIP ECT" do
-    user_endpoint = APIs::ECFUsersEndpoint.load
-    user_endpoint.get_user participant_id
-
-    expect(user_endpoint).to have_email participant_email
-    expect(user_endpoint).to have_full_name participant_full_name
-    expect(user_endpoint).to have_cohort start_year
-    expect(user_endpoint).to have_core_induction_programme cip_materials
-    expect(user_endpoint).to have_induction_programme_choice programme_type
-    expect(user_endpoint).to have_registration_completed registration_completed
-    expect(user_endpoint).to have_user_type participant_type
-  end
-
-  scenario "A DfE admin user can locate the record for the ECT" do
-    given_i_sign_in_as_an_admin_user
-
-    participant_list = Pages::AdminSupportParticipantList.load
-    participant_list.view_participant participant_full_name
-
-    participant_detail = Pages::AdminSupportParticipantDetail.loaded(participant_id: training_record_id)
-    expect(participant_detail).to have_full_name participant_full_name
-    expect(participant_detail).to have_email_address participant_email
-    expect(participant_detail).to have_trn teacher_reference_number
-    expect(participant_detail).to have_cohort start_year
-    expect(participant_detail).to have_training_record_state training_record_state
-    expect(participant_detail).to have_user_id participant_id
-    expect(participant_detail).to have_associated_email_address participant_email
-
-    participant_detail.open_training_tab
-
-    participant_training = Pages::AdminSupportParticipantTraining.loaded(participant_id: training_record_id)
-    expect(participant_training).to have_cohort start_year
-    expect(participant_training).to have_school_name school.name
-    expect(participant_training).to have_schedule_identifier schedule_identifier
-  end
-
-  scenario "A DfE finance user can locate the record for the ECT" do
-    given_i_sign_in_as_a_finance_user
-
-    drilldown_search = Pages::FinanceParticipantDrilldownSearch.load
-    drilldown_search.find participant_id
-
-    drilldown = Pages::FinanceParticipantDrilldown.loaded(user_id: participant_id)
-    expect(drilldown).to have_participant_id participant_id
-    expect(drilldown).to have_full_name participant_full_name
-    expect(drilldown).to have_lead_provider lead_provider_name
-    expect(drilldown).to have_school_urn school.urn
-    expect(drilldown).to have_status participant_status
-    expect(drilldown).to have_induction_status participant_status
-    expect(drilldown).to have_training_status training_status
-    expect(drilldown).to be_eligible_for_funding
-    expect(drilldown).to have_schedule schedule_identifier
-    expect(drilldown).to have_schedule_identifier schedule_identifier
-    expect(drilldown).to have_schedule_cohort start_year
-    expect(drilldown).to have_training_programme programme_name
-    expect(drilldown).to have_participant_class participant_class
   end
 end

--- a/spec/features/scenarios/participants/ect_doing_cip/no_validation_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_cip/no_validation_spec.rb
@@ -73,96 +73,100 @@ RSpec.feature "ECT doing CIP: no validation", type: :feature, early_in_cohort: t
   let(:participant_profile) { participant_details.participant_profile }
   let(:preferred_identity) { participant_details.participant_identity }
 
-  scenario "The current school induction tutor can locate a record for the ECT" do
-    given_i_sign_in_as_the_user_with_the_full_name sit_full_name
+  %w[active inactive].each do |flag_state|
+    context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      scenario "The current school induction tutor can locate a record for the ECT" do
+        given_i_sign_in_as_the_user_with_the_full_name sit_full_name
 
-    school_dashboard = Pages::SchoolDashboardPage.load(slug: school.slug)
-    school_dashboard.view_ect_dashboard
+        school_dashboard = Pages::SchoolDashboardPage.load(slug: school.slug)
+        school_dashboard.view_ect_dashboard
 
-    participant_dashboard = Pages::SchoolEarlyCareerTeachersDashboardPage.loaded(slug: school.slug)
-    participant_dashboard.view_participant participant_full_name
+        participant_dashboard = Pages::SchoolEarlyCareerTeachersDashboardPage.loaded(slug: school.slug)
+        participant_dashboard.view_participant participant_full_name
 
-    participant_details = Pages::SchoolEarlyCareerTeacherDetailsPage.loaded(slug: school.slug, participant_id: training_record_id)
-    expect(participant_details).to have_participant_name participant_full_name
-    expect(participant_details).to have_email participant_email
-    expect(participant_details).to have_full_name participant_full_name
-    expect(participant_details).to have_status school_record_state
-    expect(participant_details).to have_materials_supplier cip_material_provider
-  end
+        participant_details = Pages::SchoolEarlyCareerTeacherDetailsPage.loaded(slug: school.slug, participant_id: training_record_id)
+        expect(participant_details).to have_participant_name participant_full_name
+        expect(participant_details).to have_email participant_email
+        expect(participant_details).to have_full_name participant_full_name
+        expect(participant_details).to have_status school_record_state
+        expect(participant_details).to have_materials_supplier cip_material_provider
+      end
 
-  scenario "The current appropriate body can locate a record for the ECT", :skip do
-    given_i_sign_in_as_the_user_with_the_full_name ab_full_name
+      scenario "The current appropriate body can locate a record for the ECT", :skip do
+        given_i_sign_in_as_the_user_with_the_full_name ab_full_name
 
-    appropriate_body_portal = Pages::AppropriateBodyPortal.loaded
-    appropriate_body_portal.get_participant(participant_full_name)
+        appropriate_body_portal = Pages::AppropriateBodyPortal.loaded
+        appropriate_body_portal.get_participant(participant_full_name)
 
-    expect(appropriate_body_portal).to have_full_name participant_full_name
-    expect(appropriate_body_portal).to have_email_address participant_email
-    expect(appropriate_body_portal).to have_teacher_reference_number teacher_reference_number
-    expect(appropriate_body_portal).to have_participant_type long_participant_type
-    expect(appropriate_body_portal).to have_lead_provider_name lead_provider_name
-    expect(appropriate_body_portal).to have_school_name school_name
-    expect(appropriate_body_portal).to have_school_urn school.urn
-    expect(appropriate_body_portal).to have_academic_year start_year
-    expect(appropriate_body_portal).to have_training_status training_status
-    expect(appropriate_body_portal).to have_training_record_status appropriate_body_Record_state
-  end
+        expect(appropriate_body_portal).to have_full_name participant_full_name
+        expect(appropriate_body_portal).to have_email_address participant_email
+        expect(appropriate_body_portal).to have_teacher_reference_number teacher_reference_number
+        expect(appropriate_body_portal).to have_participant_type long_participant_type
+        expect(appropriate_body_portal).to have_lead_provider_name lead_provider_name
+        expect(appropriate_body_portal).to have_school_name school_name
+        expect(appropriate_body_portal).to have_school_urn school.urn
+        expect(appropriate_body_portal).to have_academic_year start_year
+        expect(appropriate_body_portal).to have_training_status training_status
+        expect(appropriate_body_portal).to have_training_record_status appropriate_body_Record_state
+      end
 
-  scenario "The Support for ECTs service can locate a record for the CIP ECT" do
-    user_endpoint = APIs::ECFUsersEndpoint.load
-    user_endpoint.get_user participant_id
+      scenario "The Support for ECTs service can locate a record for the CIP ECT" do
+        user_endpoint = APIs::ECFUsersEndpoint.load
+        user_endpoint.get_user participant_id
 
-    expect(user_endpoint).to have_email participant_email
-    expect(user_endpoint).to have_full_name participant_full_name
-    expect(user_endpoint).to have_cohort start_year
-    expect(user_endpoint).to have_core_induction_programme cip_materials
-    expect(user_endpoint).to have_induction_programme_choice programme_type
-    expect(user_endpoint).to have_registration_completed registration_completed
-    expect(user_endpoint).to have_user_type participant_type
-  end
+        expect(user_endpoint).to have_email participant_email
+        expect(user_endpoint).to have_full_name participant_full_name
+        expect(user_endpoint).to have_cohort start_year
+        expect(user_endpoint).to have_core_induction_programme cip_materials
+        expect(user_endpoint).to have_induction_programme_choice programme_type
+        expect(user_endpoint).to have_registration_completed registration_completed
+        expect(user_endpoint).to have_user_type participant_type
+      end
 
-  scenario "A DfE admin user can locate the record for the ECT" do
-    given_i_sign_in_as_an_admin_user
+      scenario "A DfE admin user can locate the record for the ECT" do
+        given_i_sign_in_as_an_admin_user
 
-    participant_list = Pages::AdminSupportParticipantList.load
-    participant_list.view_participant participant_full_name
+        participant_list = Pages::AdminSupportParticipantList.load
+        participant_list.view_participant participant_full_name
 
-    participant_detail = Pages::AdminSupportParticipantDetail.loaded(participant_id: training_record_id)
-    expect(participant_detail).to have_full_name participant_full_name
-    expect(participant_detail).to have_email_address participant_email
-    expect(participant_detail).to have_trn teacher_reference_number
-    expect(participant_detail).to have_cohort start_year
-    expect(participant_detail).to have_training_record_state training_record_state
-    expect(participant_detail).to have_user_id participant_id
-    expect(participant_detail).to have_associated_email_address participant_email
+        participant_detail = Pages::AdminSupportParticipantDetail.loaded(participant_id: training_record_id)
+        expect(participant_detail).to have_full_name participant_full_name
+        expect(participant_detail).to have_email_address participant_email
+        expect(participant_detail).to have_trn teacher_reference_number
+        expect(participant_detail).to have_cohort start_year
+        expect(participant_detail).to have_training_record_state training_record_state
+        expect(participant_detail).to have_user_id participant_id
+        expect(participant_detail).to have_associated_email_address participant_email
 
-    participant_detail.open_training_tab
+        participant_detail.open_training_tab
 
-    participant_training = Pages::AdminSupportParticipantTraining.loaded(participant_id: training_record_id)
-    expect(participant_training).to have_cohort start_year
-    expect(participant_training).to have_school_name school.name
-    expect(participant_training).to have_schedule_identifier schedule_identifier
-  end
+        participant_training = Pages::AdminSupportParticipantTraining.loaded(participant_id: training_record_id)
+        expect(participant_training).to have_cohort start_year
+        expect(participant_training).to have_school_name school.name
+        expect(participant_training).to have_schedule_identifier schedule_identifier
+      end
 
-  scenario "A DfE finance user can locate the record for the ECT" do
-    given_i_sign_in_as_a_finance_user
+      scenario "A DfE finance user can locate the record for the ECT" do
+        given_i_sign_in_as_a_finance_user
 
-    drilldown_search = Pages::FinanceParticipantDrilldownSearch.load
-    drilldown_search.find participant_id
+        drilldown_search = Pages::FinanceParticipantDrilldownSearch.load
+        drilldown_search.find participant_id
 
-    drilldown = Pages::FinanceParticipantDrilldown.loaded(user_id: participant_id)
-    expect(drilldown).to have_participant_id participant_id
-    expect(drilldown).to have_full_name participant_full_name
-    expect(drilldown).to have_lead_provider lead_provider_name
-    expect(drilldown).to have_school_urn school.urn
-    expect(drilldown).to have_status participant_status
-    expect(drilldown).to have_induction_status participant_status
-    expect(drilldown).to have_training_status training_status
-    expect(drilldown).to be_not_eligible_for_funding
-    expect(drilldown).to have_schedule schedule_identifier
-    expect(drilldown).to have_schedule_identifier schedule_identifier
-    expect(drilldown).to have_schedule_cohort start_year
-    expect(drilldown).to have_training_programme programme_name
-    expect(drilldown).to have_participant_class participant_class
+        drilldown = Pages::FinanceParticipantDrilldown.loaded(user_id: participant_id)
+        expect(drilldown).to have_participant_id participant_id
+        expect(drilldown).to have_full_name participant_full_name
+        expect(drilldown).to have_lead_provider lead_provider_name
+        expect(drilldown).to have_school_urn school.urn
+        expect(drilldown).to have_status participant_status
+        expect(drilldown).to have_induction_status participant_status
+        expect(drilldown).to have_training_status training_status
+        expect(drilldown).to be_not_eligible_for_funding
+        expect(drilldown).to have_schedule schedule_identifier
+        expect(drilldown).to have_schedule_identifier schedule_identifier
+        expect(drilldown).to have_schedule_cohort start_year
+        expect(drilldown).to have_training_programme programme_name
+        expect(drilldown).to have_participant_class participant_class
+      end
+    end
   end
 end

--- a/spec/features/scenarios/participants/ect_doing_cip/no_validation_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_cip/no_validation_spec.rb
@@ -23,7 +23,6 @@ RSpec.feature "ECT doing CIP: no validation", type: :feature, early_in_cohort: t
   let(:long_participant_type) { "Early career teacher" }
   let(:participant_class) { "ParticipantProfile::ECT" }
   let(:programme_type) { "core_induction_programme" }
-  let(:programme_name) { "Core induction programme" }
   let(:schedule_identifier) { "ecf-standard-september" }
   let(:cip_material_provider) { "Education Development Trust" }
   let(:cip_materials) { "edt" }
@@ -75,6 +74,10 @@ RSpec.feature "ECT doing CIP: no validation", type: :feature, early_in_cohort: t
 
   %w[active inactive].each do |flag_state|
     context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      let(:programme_name) do
+        flag_state == "inactive" ? "Core induction programme" : "School-led"
+      end
+
       scenario "The current school induction tutor can locate a record for the ECT" do
         given_i_sign_in_as_the_user_with_the_full_name sit_full_name
 

--- a/spec/features/scenarios/participants/ect_doing_fip/after_cohort_transfer_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_fip/after_cohort_transfer_spec.rb
@@ -23,7 +23,6 @@ RSpec.feature "ECT doing FIP: after cohort transfer", type: :feature do
   let(:short_participant_type) { "ect" }
   let(:participant_class) { "ParticipantProfile::ECT" }
   let(:programme_type) { "full_induction_programme" }
-  let(:programme_name) { "Full induction programme" }
   let(:schedule_identifier) { "ecf-standard-september" }
   let(:cip_materials) { "none" }
   let(:start_year) { Cohort.next.start_year }
@@ -97,6 +96,10 @@ RSpec.feature "ECT doing FIP: after cohort transfer", type: :feature do
 
   %w[active inactive].each do |flag_state|
     context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      let(:programme_name) do
+        flag_state == "inactive" ? "Full induction programme" : "Provider-led"
+      end
+
       scenario "The current school induction tutor can locate a record for the ECT" do
         given_i_sign_in_as_the_user_with_the_full_name sit_full_name
 

--- a/spec/features/scenarios/participants/ect_doing_fip/after_cohort_transfer_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_fip/after_cohort_transfer_spec.rb
@@ -95,152 +95,156 @@ RSpec.feature "ECT doing FIP: after cohort transfer", type: :feature do
   let(:participant_profile) { participant_details.participant_profile }
   let(:preferred_identity) { participant_details.participant_identity }
 
-  scenario "The current school induction tutor can locate a record for the ECT" do
-    given_i_sign_in_as_the_user_with_the_full_name sit_full_name
+  %w[active inactive].each do |flag_state|
+    context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      scenario "The current school induction tutor can locate a record for the ECT" do
+        given_i_sign_in_as_the_user_with_the_full_name sit_full_name
 
-    school_dashboard = Pages::SchoolDashboardPage.load(slug: school.slug)
-    school_dashboard.view_ect_dashboard
+        school_dashboard = Pages::SchoolDashboardPage.load(slug: school.slug)
+        school_dashboard.view_ect_dashboard
 
-    participant_dashboard = Pages::SchoolEarlyCareerTeachersDashboardPage.loaded(slug: school.slug)
-    participant_dashboard.view_participant participant_full_name
+        participant_dashboard = Pages::SchoolEarlyCareerTeachersDashboardPage.loaded(slug: school.slug)
+        participant_dashboard.view_participant participant_full_name
 
-    participant_details = Pages::SchoolEarlyCareerTeacherDetailsPage.loaded(slug: school.slug, participant_id: training_record_id)
-    expect(participant_details).to have_participant_name participant_full_name
-    expect(participant_details).to have_email participant_email
-    expect(participant_details).to have_full_name participant_full_name
-    expect(participant_details).to have_status school_record_state
-  end
+        participant_details = Pages::SchoolEarlyCareerTeacherDetailsPage.loaded(slug: school.slug, participant_id: training_record_id)
+        expect(participant_details).to have_participant_name participant_full_name
+        expect(participant_details).to have_email participant_email
+        expect(participant_details).to have_full_name participant_full_name
+        expect(participant_details).to have_status school_record_state
+      end
 
-  scenario "The current appropriate body can locate a record for the ECT", :skip do
-    given_i_sign_in_as_the_user_with_the_full_name ab_full_name
+      scenario "The current appropriate body can locate a record for the ECT", :skip do
+        given_i_sign_in_as_the_user_with_the_full_name ab_full_name
 
-    appropriate_body_portal = Pages::AppropriateBodyPortal.loaded
-    appropriate_body_portal.get_participant(participant_full_name)
+        appropriate_body_portal = Pages::AppropriateBodyPortal.loaded
+        appropriate_body_portal.get_participant(participant_full_name)
 
-    expect(appropriate_body_portal).to have_full_name participant_full_name
-    expect(appropriate_body_portal).to have_email_address participant_email
-    expect(appropriate_body_portal).to have_teacher_reference_number teacher_reference_number
-    expect(appropriate_body_portal).to have_participant_type long_participant_type
-    expect(appropriate_body_portal).to have_lead_provider_name lead_provider_name
-    expect(appropriate_body_portal).to have_school_name school_name
-    expect(appropriate_body_portal).to have_school_urn school.urn
-    expect(appropriate_body_portal).to have_academic_year start_year
-    expect(appropriate_body_portal).to have_training_status training_status
-    expect(appropriate_body_portal).to have_training_record_status appropriate_body_record_state
-  end
+        expect(appropriate_body_portal).to have_full_name participant_full_name
+        expect(appropriate_body_portal).to have_email_address participant_email
+        expect(appropriate_body_portal).to have_teacher_reference_number teacher_reference_number
+        expect(appropriate_body_portal).to have_participant_type long_participant_type
+        expect(appropriate_body_portal).to have_lead_provider_name lead_provider_name
+        expect(appropriate_body_portal).to have_school_name school_name
+        expect(appropriate_body_portal).to have_school_urn school.urn
+        expect(appropriate_body_portal).to have_academic_year start_year
+        expect(appropriate_body_portal).to have_training_status training_status
+        expect(appropriate_body_portal).to have_training_record_status appropriate_body_record_state
+      end
 
-  scenario "The current lead provider can locate a record for the ECT" do
-    lead_provider_token = LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: lead_provider_details.cpd_lead_provider)
+      scenario "The current lead provider can locate a record for the ECT" do
+        lead_provider_token = LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: lead_provider_details.cpd_lead_provider)
 
-    ecf_participant_endpoint = APIs::ECFParticipantsEndpoint.load(lead_provider_token)
-    ecf_participant_endpoint.get_participant participant_id
+        ecf_participant_endpoint = APIs::ECFParticipantsEndpoint.load(lead_provider_token)
+        ecf_participant_endpoint.get_participant participant_id
 
-    expect(ecf_participant_endpoint).to have_email_address participant_email
-    expect(ecf_participant_endpoint).to have_full_name participant_full_name
-    expect(ecf_participant_endpoint).to have_mentor_id nil
-    expect(ecf_participant_endpoint).to have_school_urn school.urn
-    expect(ecf_participant_endpoint).to have_participant_type short_participant_type
-    expect(ecf_participant_endpoint).to have_cohort previous_start_year
-    expect(ecf_participant_endpoint).to have_trn teacher_reference_number
-    # teacher_reference_number_validated: true,
-    expect(ecf_participant_endpoint).to be_eligible_for_funding
-    expect(ecf_participant_endpoint).to have_pupil_premium_uplift
-    expect(ecf_participant_endpoint).to have_sparsity_uplift
-    expect(ecf_participant_endpoint).to have_status participant_status
-    expect(ecf_participant_endpoint).to have_training_record_id training_record_id
-    expect(ecf_participant_endpoint).to have_schedule_identifier schedule_identifier
+        expect(ecf_participant_endpoint).to have_email_address participant_email
+        expect(ecf_participant_endpoint).to have_full_name participant_full_name
+        expect(ecf_participant_endpoint).to have_mentor_id nil
+        expect(ecf_participant_endpoint).to have_school_urn school.urn
+        expect(ecf_participant_endpoint).to have_participant_type short_participant_type
+        expect(ecf_participant_endpoint).to have_cohort previous_start_year
+        expect(ecf_participant_endpoint).to have_trn teacher_reference_number
+        # teacher_reference_number_validated: true,
+        expect(ecf_participant_endpoint).to be_eligible_for_funding
+        expect(ecf_participant_endpoint).to have_pupil_premium_uplift
+        expect(ecf_participant_endpoint).to have_sparsity_uplift
+        expect(ecf_participant_endpoint).to have_status participant_status
+        expect(ecf_participant_endpoint).to have_training_record_id training_record_id
+        expect(ecf_participant_endpoint).to have_schedule_identifier schedule_identifier
 
-    participant_endpoint = APIs::ParticipantsEndpoint.load(lead_provider_token)
-    participant_endpoint.get_participant participant_id
+        participant_endpoint = APIs::ParticipantsEndpoint.load(lead_provider_token)
+        participant_endpoint.get_participant participant_id
 
-    expect(participant_endpoint).to have_email_address participant_email
-    expect(participant_endpoint).to have_full_name participant_full_name
-    expect(participant_endpoint).to have_mentor_id nil
-    expect(participant_endpoint).to have_school_urn school.urn
-    expect(participant_endpoint).to have_participant_type short_participant_type
-    expect(participant_endpoint).to have_cohort previous_start_year
-    expect(participant_endpoint).to have_trn teacher_reference_number
-    # teacher_reference_number_validated: true,
-    expect(participant_endpoint).to be_eligible_for_funding
-    expect(participant_endpoint).to have_pupil_premium_uplift
-    expect(participant_endpoint).to have_sparsity_uplift
-    expect(participant_endpoint).to have_status participant_status
-    expect(participant_endpoint).to have_training_record_id training_record_id
-    expect(participant_endpoint).to have_schedule_identifier schedule_identifier
-  end
+        expect(participant_endpoint).to have_email_address participant_email
+        expect(participant_endpoint).to have_full_name participant_full_name
+        expect(participant_endpoint).to have_mentor_id nil
+        expect(participant_endpoint).to have_school_urn school.urn
+        expect(participant_endpoint).to have_participant_type short_participant_type
+        expect(participant_endpoint).to have_cohort previous_start_year
+        expect(participant_endpoint).to have_trn teacher_reference_number
+        # teacher_reference_number_validated: true,
+        expect(participant_endpoint).to be_eligible_for_funding
+        expect(participant_endpoint).to have_pupil_premium_uplift
+        expect(participant_endpoint).to have_sparsity_uplift
+        expect(participant_endpoint).to have_status participant_status
+        expect(participant_endpoint).to have_training_record_id training_record_id
+        expect(participant_endpoint).to have_schedule_identifier schedule_identifier
+      end
 
-  scenario "The current delivery partner can locate a record for the ECT" do
-    given_i_sign_in_as_the_user_with_the_full_name delivery_partner_name
+      scenario "The current delivery partner can locate a record for the ECT" do
+        given_i_sign_in_as_the_user_with_the_full_name delivery_partner_name
 
-    delivery_partner_portal = Pages::DeliveryPartnerPortal.loaded
-    delivery_partner_portal.get_participant(participant_full_name)
+        delivery_partner_portal = Pages::DeliveryPartnerPortal.loaded
+        delivery_partner_portal.get_participant(participant_full_name)
 
-    expect(delivery_partner_portal).to have_full_name participant_full_name
-    expect(delivery_partner_portal).to have_email_address participant_email
-    expect(delivery_partner_portal).to have_teacher_reference_number teacher_reference_number
-    expect(delivery_partner_portal).to have_participant_type long_participant_type
-    expect(delivery_partner_portal).to have_lead_provider_name lead_provider_name
-    expect(delivery_partner_portal).to have_school_name school_name
-    expect(delivery_partner_portal).to have_school_urn school.urn
-    expect(delivery_partner_portal).to have_academic_year new_school_cohort.start_year
-    expect(delivery_partner_portal).to have_training_record_status delivery_partner_record_state
-  end
+        expect(delivery_partner_portal).to have_full_name participant_full_name
+        expect(delivery_partner_portal).to have_email_address participant_email
+        expect(delivery_partner_portal).to have_teacher_reference_number teacher_reference_number
+        expect(delivery_partner_portal).to have_participant_type long_participant_type
+        expect(delivery_partner_portal).to have_lead_provider_name lead_provider_name
+        expect(delivery_partner_portal).to have_school_name school_name
+        expect(delivery_partner_portal).to have_school_urn school.urn
+        expect(delivery_partner_portal).to have_academic_year new_school_cohort.start_year
+        expect(delivery_partner_portal).to have_training_record_status delivery_partner_record_state
+      end
 
-  scenario "The Support for ECTs service can locate a record for the CIP ECT" do
-    user_endpoint = APIs::ECFUsersEndpoint.load
-    user_endpoint.get_user participant_id
+      scenario "The Support for ECTs service can locate a record for the CIP ECT" do
+        user_endpoint = APIs::ECFUsersEndpoint.load
+        user_endpoint.get_user participant_id
 
-    expect(user_endpoint).to have_email participant_email
-    expect(user_endpoint).to have_full_name participant_full_name
-    expect(user_endpoint).to have_cohort previous_start_year
-    expect(user_endpoint).to have_core_induction_programme cip_materials
-    expect(user_endpoint).to have_induction_programme_choice programme_type
-    expect(user_endpoint).to have_registration_completed registration_completed
-    expect(user_endpoint).to have_user_type participant_type
-  end
+        expect(user_endpoint).to have_email participant_email
+        expect(user_endpoint).to have_full_name participant_full_name
+        expect(user_endpoint).to have_cohort previous_start_year
+        expect(user_endpoint).to have_core_induction_programme cip_materials
+        expect(user_endpoint).to have_induction_programme_choice programme_type
+        expect(user_endpoint).to have_registration_completed registration_completed
+        expect(user_endpoint).to have_user_type participant_type
+      end
 
-  scenario "A DfE admin user can locate the record for the ECT" do
-    given_i_sign_in_as_an_admin_user
+      scenario "A DfE admin user can locate the record for the ECT" do
+        given_i_sign_in_as_an_admin_user
 
-    participant_list = Pages::AdminSupportParticipantList.load
-    participant_list.view_participant participant_full_name
+        participant_list = Pages::AdminSupportParticipantList.load
+        participant_list.view_participant participant_full_name
 
-    participant_detail = Pages::AdminSupportParticipantDetail.loaded(participant_id: training_record_id)
-    expect(participant_detail).to have_full_name participant_full_name
-    expect(participant_detail).to have_email_address participant_email
-    expect(participant_detail).to have_trn teacher_reference_number
-    expect(participant_detail).to have_cohort previous_start_year
-    expect(participant_detail).to have_training_record_state training_record_state
-    expect(participant_detail).to have_user_id participant_id
-    expect(participant_detail).to have_associated_email_address participant_email
+        participant_detail = Pages::AdminSupportParticipantDetail.loaded(participant_id: training_record_id)
+        expect(participant_detail).to have_full_name participant_full_name
+        expect(participant_detail).to have_email_address participant_email
+        expect(participant_detail).to have_trn teacher_reference_number
+        expect(participant_detail).to have_cohort previous_start_year
+        expect(participant_detail).to have_training_record_state training_record_state
+        expect(participant_detail).to have_user_id participant_id
+        expect(participant_detail).to have_associated_email_address participant_email
 
-    participant_detail.open_training_tab
+        participant_detail.open_training_tab
 
-    participant_training = Pages::AdminSupportParticipantTraining.loaded(participant_id: training_record_id)
-    expect(participant_training).to have_cohort previous_start_year
-    expect(participant_training).to have_school_name school.name
-    expect(participant_training).to have_lead_provider lead_provider_name
-    expect(participant_training).to have_schedule_identifier schedule_identifier
-  end
+        participant_training = Pages::AdminSupportParticipantTraining.loaded(participant_id: training_record_id)
+        expect(participant_training).to have_cohort previous_start_year
+        expect(participant_training).to have_school_name school.name
+        expect(participant_training).to have_lead_provider lead_provider_name
+        expect(participant_training).to have_schedule_identifier schedule_identifier
+      end
 
-  scenario "A DfE finance user can locate the record for the ECT" do
-    given_i_sign_in_as_a_finance_user
+      scenario "A DfE finance user can locate the record for the ECT" do
+        given_i_sign_in_as_a_finance_user
 
-    drilldown_search = Pages::FinanceParticipantDrilldownSearch.load
-    drilldown_search.find participant_id
+        drilldown_search = Pages::FinanceParticipantDrilldownSearch.load
+        drilldown_search.find participant_id
 
-    drilldown = Pages::FinanceParticipantDrilldown.loaded(user_id: participant_id)
-    expect(drilldown).to have_participant_id participant_id
-    expect(drilldown).to have_full_name participant_full_name
-    expect(drilldown).to have_lead_provider lead_provider_name
-    expect(drilldown).to have_school_urn school.urn
-    expect(drilldown).to have_status participant_status
-    expect(drilldown).to have_induction_status participant_status
-    expect(drilldown).to be_eligible_for_funding
-    expect(drilldown).to have_schedule schedule_identifier
-    expect(drilldown).to have_schedule_identifier schedule_identifier
-    expect(drilldown).to have_schedule_cohort previous_start_year
-    expect(drilldown).to have_training_programme programme_name
-    expect(drilldown).to have_participant_class participant_class
+        drilldown = Pages::FinanceParticipantDrilldown.loaded(user_id: participant_id)
+        expect(drilldown).to have_participant_id participant_id
+        expect(drilldown).to have_full_name participant_full_name
+        expect(drilldown).to have_lead_provider lead_provider_name
+        expect(drilldown).to have_school_urn school.urn
+        expect(drilldown).to have_status participant_status
+        expect(drilldown).to have_induction_status participant_status
+        expect(drilldown).to be_eligible_for_funding
+        expect(drilldown).to have_schedule schedule_identifier
+        expect(drilldown).to have_schedule_identifier schedule_identifier
+        expect(drilldown).to have_schedule_cohort previous_start_year
+        expect(drilldown).to have_training_programme programme_name
+        expect(drilldown).to have_participant_class participant_class
+      end
+    end
   end
 end

--- a/spec/features/scenarios/participants/ect_doing_fip/in_training_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_fip/in_training_spec.rb
@@ -79,157 +79,161 @@ RSpec.feature "ECT doing FIP: in training", type: :feature do
   let(:participant_profile) { participant_details.participant_profile }
   let(:preferred_identity) { participant_details.participant_identity }
 
-  scenario "The current school induction tutor can locate a record for the ECT" do
-    inside_registration_window(cohort:) do
-      given_i_sign_in_as_the_user_with_the_full_name sit_full_name
+  %w[active inactive].each do |flag_state|
+    context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      scenario "The current school induction tutor can locate a record for the ECT" do
+        inside_registration_window(cohort:) do
+          given_i_sign_in_as_the_user_with_the_full_name sit_full_name
 
-      school_dashboard = Pages::SchoolDashboardPage.load(slug: school.slug)
-      school_dashboard.view_ect_dashboard
+          school_dashboard = Pages::SchoolDashboardPage.load(slug: school.slug)
+          school_dashboard.view_ect_dashboard
 
-      participant_dashboard = Pages::SchoolEarlyCareerTeachersDashboardPage.loaded(slug: school.slug)
-      participant_dashboard.view_participant participant_full_name
+          participant_dashboard = Pages::SchoolEarlyCareerTeachersDashboardPage.loaded(slug: school.slug)
+          participant_dashboard.view_participant participant_full_name
 
-      participant_details = Pages::SchoolEarlyCareerTeacherDetailsPage.loaded(slug: school.slug, participant_id: training_record_id)
-      expect(participant_details).to have_participant_name participant_full_name
-      expect(participant_details).to have_email participant_email
-      expect(participant_details).to have_full_name participant_full_name
-      expect(participant_details).to have_status school_record_state
+          participant_details = Pages::SchoolEarlyCareerTeacherDetailsPage.loaded(slug: school.slug, participant_id: training_record_id)
+          expect(participant_details).to have_participant_name participant_full_name
+          expect(participant_details).to have_email participant_email
+          expect(participant_details).to have_full_name participant_full_name
+          expect(participant_details).to have_status school_record_state
+        end
+      end
+
+      scenario "The current appropriate body can locate a record for the ECT", :skip do
+        given_i_sign_in_as_the_user_with_the_full_name ab_full_name
+
+        appropriate_body_portal = Pages::AppropriateBodyPortal.loaded
+        appropriate_body_portal.get_participant(participant_full_name)
+
+        expect(appropriate_body_portal).to have_full_name participant_full_name
+        expect(appropriate_body_portal).to have_email_address participant_email
+        expect(appropriate_body_portal).to have_teacher_reference_number teacher_reference_number
+        expect(appropriate_body_portal).to have_participant_type long_participant_type
+        expect(appropriate_body_portal).to have_lead_provider_name lead_provider_name
+        expect(appropriate_body_portal).to have_school_name school_name
+        expect(appropriate_body_portal).to have_school_urn school.urn
+        expect(appropriate_body_portal).to have_academic_year start_year
+        expect(appropriate_body_portal).to have_training_record_status appropriate_body_record_state
+      end
+
+      scenario "The current lead provider can locate a record for the ECT" do
+        lead_provider_token = LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: lead_provider_details.cpd_lead_provider)
+
+        ecf_participant_endpoint = APIs::ECFParticipantsEndpoint.load(lead_provider_token)
+        ecf_participant_endpoint.get_participant participant_id
+
+        expect(ecf_participant_endpoint).to have_email_address participant_email
+        expect(ecf_participant_endpoint).to have_full_name participant_full_name
+        expect(ecf_participant_endpoint).to have_mentor_id nil
+        expect(ecf_participant_endpoint).to have_school_urn school.urn
+        expect(ecf_participant_endpoint).to have_participant_type short_participant_type
+        expect(ecf_participant_endpoint).to have_cohort start_year
+        expect(ecf_participant_endpoint).to have_trn teacher_reference_number
+        # teacher_reference_number_validated: true,
+        expect(ecf_participant_endpoint).to be_eligible_for_funding
+        expect(ecf_participant_endpoint).to have_pupil_premium_uplift
+        expect(ecf_participant_endpoint).to have_sparsity_uplift
+        expect(ecf_participant_endpoint).to have_status participant_status
+        expect(ecf_participant_endpoint).to have_training_record_id training_record_id
+        expect(ecf_participant_endpoint).to have_schedule_identifier schedule_identifier
+
+        participant_endpoint = APIs::ParticipantsEndpoint.load(lead_provider_token)
+        participant_endpoint.get_participant participant_id
+
+        expect(participant_endpoint).to have_email_address participant_email
+        expect(participant_endpoint).to have_full_name participant_full_name
+        expect(participant_endpoint).to have_mentor_id nil
+        expect(participant_endpoint).to have_school_urn school.urn
+        expect(participant_endpoint).to have_participant_type short_participant_type
+        expect(participant_endpoint).to have_cohort start_year
+        expect(participant_endpoint).to have_trn teacher_reference_number
+        # teacher_reference_number_validated: true,
+        expect(participant_endpoint).to be_eligible_for_funding
+        expect(participant_endpoint).to have_pupil_premium_uplift
+        expect(participant_endpoint).to have_sparsity_uplift
+        expect(participant_endpoint).to have_status participant_status
+        expect(participant_endpoint).to have_training_record_id training_record_id
+        expect(participant_endpoint).to have_schedule_identifier schedule_identifier
+      end
+
+      context "when the participant cohort is #{DeliveryPartners::ParticipantsFilter::LATEST_COHORT_TO_RETURN} or earlier" do
+        let(:start_year) { DeliveryPartners::ParticipantsFilter::LATEST_COHORT_TO_RETURN }
+
+        scenario "The current delivery partner can locate a record for the ECT" do
+          given_i_sign_in_as_the_user_with_the_full_name delivery_partner_name
+
+          delivery_partner_portal = Pages::DeliveryPartnerPortal.loaded
+          delivery_partner_portal.get_participant(participant_full_name)
+
+          expect(delivery_partner_portal).to have_full_name participant_full_name
+          expect(delivery_partner_portal).to have_email_address participant_email
+          expect(delivery_partner_portal).to have_teacher_reference_number teacher_reference_number
+          expect(delivery_partner_portal).to have_participant_type long_participant_type
+          expect(delivery_partner_portal).to have_lead_provider_name lead_provider_name
+          expect(delivery_partner_portal).to have_school_name school_name
+          expect(delivery_partner_portal).to have_school_urn school.urn
+          expect(delivery_partner_portal).to have_academic_year start_year
+          expect(delivery_partner_portal).to have_training_record_status delivery_partner_record_state
+        end
+      end
+
+      scenario "The Support for ECTs service can locate a record for the ECT" do
+        user_endpoint = APIs::ECFUsersEndpoint.load
+        user_endpoint.get_user participant_id
+
+        expect(user_endpoint).to have_email participant_email
+        expect(user_endpoint).to have_full_name participant_full_name
+        expect(user_endpoint).to have_cohort start_year
+        expect(user_endpoint).to have_core_induction_programme cip_materials
+        expect(user_endpoint).to have_induction_programme_choice programme_type
+        expect(user_endpoint).to have_registration_completed registration_completed
+        expect(user_endpoint).to have_user_type participant_type
+      end
+
+      scenario "A DfE admin user can locate the record for the ECT" do
+        given_i_sign_in_as_an_admin_user
+
+        participant_list = Pages::AdminSupportParticipantList.load
+        participant_list.view_participant participant_full_name
+
+        participant_detail = Pages::AdminSupportParticipantDetail.loaded(participant_id: training_record_id)
+        expect(participant_detail).to have_full_name participant_full_name
+        expect(participant_detail).to have_email_address participant_email
+        expect(participant_detail).to have_trn teacher_reference_number
+        expect(participant_detail).to have_cohort start_year
+        expect(participant_detail).to have_training_record_state training_record_state
+        expect(participant_detail).to have_user_id participant_id
+        expect(participant_detail).to have_associated_email_address participant_email
+
+        participant_detail.open_training_tab
+
+        participant_training = Pages::AdminSupportParticipantTraining.loaded(participant_id: training_record_id)
+        expect(participant_training).to have_cohort start_year
+        expect(participant_training).to have_school_name school.name
+        expect(participant_training).to have_lead_provider lead_provider_name
+        expect(participant_training).to have_schedule_identifier schedule_identifier
+      end
+
+      scenario "A DfE finance user can locate the record for the ECT" do
+        given_i_sign_in_as_a_finance_user
+
+        drilldown_search = Pages::FinanceParticipantDrilldownSearch.load
+        drilldown_search.find participant_id
+
+        drilldown = Pages::FinanceParticipantDrilldown.loaded(user_id: participant_id)
+        expect(drilldown).to have_participant_id participant_id
+        expect(drilldown).to have_full_name participant_full_name
+        expect(drilldown).to have_lead_provider lead_provider_name
+        expect(drilldown).to have_school_urn school.urn
+        expect(drilldown).to have_status participant_status
+        expect(drilldown).to have_induction_status participant_status
+        expect(drilldown).to be_eligible_for_funding
+        expect(drilldown).to have_schedule schedule_identifier
+        expect(drilldown).to have_schedule_identifier schedule_identifier
+        expect(drilldown).to have_schedule_cohort start_year
+        expect(drilldown).to have_training_programme programme_name
+        expect(drilldown).to have_participant_class participant_class
+      end
     end
-  end
-
-  scenario "The current appropriate body can locate a record for the ECT", :skip do
-    given_i_sign_in_as_the_user_with_the_full_name ab_full_name
-
-    appropriate_body_portal = Pages::AppropriateBodyPortal.loaded
-    appropriate_body_portal.get_participant(participant_full_name)
-
-    expect(appropriate_body_portal).to have_full_name participant_full_name
-    expect(appropriate_body_portal).to have_email_address participant_email
-    expect(appropriate_body_portal).to have_teacher_reference_number teacher_reference_number
-    expect(appropriate_body_portal).to have_participant_type long_participant_type
-    expect(appropriate_body_portal).to have_lead_provider_name lead_provider_name
-    expect(appropriate_body_portal).to have_school_name school_name
-    expect(appropriate_body_portal).to have_school_urn school.urn
-    expect(appropriate_body_portal).to have_academic_year start_year
-    expect(appropriate_body_portal).to have_training_record_status appropriate_body_record_state
-  end
-
-  scenario "The current lead provider can locate a record for the ECT" do
-    lead_provider_token = LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: lead_provider_details.cpd_lead_provider)
-
-    ecf_participant_endpoint = APIs::ECFParticipantsEndpoint.load(lead_provider_token)
-    ecf_participant_endpoint.get_participant participant_id
-
-    expect(ecf_participant_endpoint).to have_email_address participant_email
-    expect(ecf_participant_endpoint).to have_full_name participant_full_name
-    expect(ecf_participant_endpoint).to have_mentor_id nil
-    expect(ecf_participant_endpoint).to have_school_urn school.urn
-    expect(ecf_participant_endpoint).to have_participant_type short_participant_type
-    expect(ecf_participant_endpoint).to have_cohort start_year
-    expect(ecf_participant_endpoint).to have_trn teacher_reference_number
-    # teacher_reference_number_validated: true,
-    expect(ecf_participant_endpoint).to be_eligible_for_funding
-    expect(ecf_participant_endpoint).to have_pupil_premium_uplift
-    expect(ecf_participant_endpoint).to have_sparsity_uplift
-    expect(ecf_participant_endpoint).to have_status participant_status
-    expect(ecf_participant_endpoint).to have_training_record_id training_record_id
-    expect(ecf_participant_endpoint).to have_schedule_identifier schedule_identifier
-
-    participant_endpoint = APIs::ParticipantsEndpoint.load(lead_provider_token)
-    participant_endpoint.get_participant participant_id
-
-    expect(participant_endpoint).to have_email_address participant_email
-    expect(participant_endpoint).to have_full_name participant_full_name
-    expect(participant_endpoint).to have_mentor_id nil
-    expect(participant_endpoint).to have_school_urn school.urn
-    expect(participant_endpoint).to have_participant_type short_participant_type
-    expect(participant_endpoint).to have_cohort start_year
-    expect(participant_endpoint).to have_trn teacher_reference_number
-    # teacher_reference_number_validated: true,
-    expect(participant_endpoint).to be_eligible_for_funding
-    expect(participant_endpoint).to have_pupil_premium_uplift
-    expect(participant_endpoint).to have_sparsity_uplift
-    expect(participant_endpoint).to have_status participant_status
-    expect(participant_endpoint).to have_training_record_id training_record_id
-    expect(participant_endpoint).to have_schedule_identifier schedule_identifier
-  end
-
-  context "when the participant cohort is #{DeliveryPartners::ParticipantsFilter::LATEST_COHORT_TO_RETURN} or earlier" do
-    let(:start_year) { DeliveryPartners::ParticipantsFilter::LATEST_COHORT_TO_RETURN }
-
-    scenario "The current delivery partner can locate a record for the ECT" do
-      given_i_sign_in_as_the_user_with_the_full_name delivery_partner_name
-
-      delivery_partner_portal = Pages::DeliveryPartnerPortal.loaded
-      delivery_partner_portal.get_participant(participant_full_name)
-
-      expect(delivery_partner_portal).to have_full_name participant_full_name
-      expect(delivery_partner_portal).to have_email_address participant_email
-      expect(delivery_partner_portal).to have_teacher_reference_number teacher_reference_number
-      expect(delivery_partner_portal).to have_participant_type long_participant_type
-      expect(delivery_partner_portal).to have_lead_provider_name lead_provider_name
-      expect(delivery_partner_portal).to have_school_name school_name
-      expect(delivery_partner_portal).to have_school_urn school.urn
-      expect(delivery_partner_portal).to have_academic_year start_year
-      expect(delivery_partner_portal).to have_training_record_status delivery_partner_record_state
-    end
-  end
-
-  scenario "The Support for ECTs service can locate a record for the ECT" do
-    user_endpoint = APIs::ECFUsersEndpoint.load
-    user_endpoint.get_user participant_id
-
-    expect(user_endpoint).to have_email participant_email
-    expect(user_endpoint).to have_full_name participant_full_name
-    expect(user_endpoint).to have_cohort start_year
-    expect(user_endpoint).to have_core_induction_programme cip_materials
-    expect(user_endpoint).to have_induction_programme_choice programme_type
-    expect(user_endpoint).to have_registration_completed registration_completed
-    expect(user_endpoint).to have_user_type participant_type
-  end
-
-  scenario "A DfE admin user can locate the record for the ECT" do
-    given_i_sign_in_as_an_admin_user
-
-    participant_list = Pages::AdminSupportParticipantList.load
-    participant_list.view_participant participant_full_name
-
-    participant_detail = Pages::AdminSupportParticipantDetail.loaded(participant_id: training_record_id)
-    expect(participant_detail).to have_full_name participant_full_name
-    expect(participant_detail).to have_email_address participant_email
-    expect(participant_detail).to have_trn teacher_reference_number
-    expect(participant_detail).to have_cohort start_year
-    expect(participant_detail).to have_training_record_state training_record_state
-    expect(participant_detail).to have_user_id participant_id
-    expect(participant_detail).to have_associated_email_address participant_email
-
-    participant_detail.open_training_tab
-
-    participant_training = Pages::AdminSupportParticipantTraining.loaded(participant_id: training_record_id)
-    expect(participant_training).to have_cohort start_year
-    expect(participant_training).to have_school_name school.name
-    expect(participant_training).to have_lead_provider lead_provider_name
-    expect(participant_training).to have_schedule_identifier schedule_identifier
-  end
-
-  scenario "A DfE finance user can locate the record for the ECT" do
-    given_i_sign_in_as_a_finance_user
-
-    drilldown_search = Pages::FinanceParticipantDrilldownSearch.load
-    drilldown_search.find participant_id
-
-    drilldown = Pages::FinanceParticipantDrilldown.loaded(user_id: participant_id)
-    expect(drilldown).to have_participant_id participant_id
-    expect(drilldown).to have_full_name participant_full_name
-    expect(drilldown).to have_lead_provider lead_provider_name
-    expect(drilldown).to have_school_urn school.urn
-    expect(drilldown).to have_status participant_status
-    expect(drilldown).to have_induction_status participant_status
-    expect(drilldown).to be_eligible_for_funding
-    expect(drilldown).to have_schedule schedule_identifier
-    expect(drilldown).to have_schedule_identifier schedule_identifier
-    expect(drilldown).to have_schedule_cohort start_year
-    expect(drilldown).to have_training_programme programme_name
-    expect(drilldown).to have_participant_class participant_class
   end
 end

--- a/spec/features/scenarios/participants/ect_doing_fip/in_training_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_fip/in_training_spec.rb
@@ -23,7 +23,6 @@ RSpec.feature "ECT doing FIP: in training", type: :feature do
   let(:long_participant_type) { "Early career teacher" }
   let(:participant_class) { "ParticipantProfile::ECT" }
   let(:programme_type) { "full_induction_programme" }
-  let(:programme_name) { "Full induction programme" }
   let(:schedule_identifier) { "ecf-standard-september" }
   let(:cip_materials) { "none" }
   let(:start_year) { Cohort.next.start_year }
@@ -81,6 +80,10 @@ RSpec.feature "ECT doing FIP: in training", type: :feature do
 
   %w[active inactive].each do |flag_state|
     context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      let(:programme_name) do
+        flag_state == "inactive" ? "Full induction programme" : "Provider-led"
+      end
+
       scenario "The current school induction tutor can locate a record for the ECT" do
         inside_registration_window(cohort:) do
           given_i_sign_in_as_the_user_with_the_full_name sit_full_name

--- a/spec/features/scenarios/participants/ect_doing_fip/no_validation_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_fip/no_validation_spec.rb
@@ -80,158 +80,162 @@ RSpec.feature "ECT doing FIP: no validation", type: :feature do
   let(:participant_profile) { participant_details.participant_profile }
   let(:preferred_identity) { participant_details.participant_identity }
 
-  scenario "The current school induction tutor can locate a record for the ECT" do
-    inside_registration_window(cohort:) do
-      given_i_sign_in_as_the_user_with_the_full_name sit_full_name
+  %w[active inactive].each do |flag_state|
+    context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      scenario "The current school induction tutor can locate a record for the ECT" do
+        inside_registration_window(cohort:) do
+          given_i_sign_in_as_the_user_with_the_full_name sit_full_name
 
-      school_dashboard = Pages::SchoolDashboardPage.load(slug: school.slug)
-      school_dashboard.view_ect_dashboard
+          school_dashboard = Pages::SchoolDashboardPage.load(slug: school.slug)
+          school_dashboard.view_ect_dashboard
 
-      participant_dashboard = Pages::SchoolEarlyCareerTeachersDashboardPage.loaded(slug: school.slug)
-      participant_dashboard.view_participant participant_full_name
+          participant_dashboard = Pages::SchoolEarlyCareerTeachersDashboardPage.loaded(slug: school.slug)
+          participant_dashboard.view_participant participant_full_name
 
-      participant_details = Pages::SchoolEarlyCareerTeacherDetailsPage.loaded(slug: school.slug, participant_id: training_record_id)
-      expect(participant_details).to have_participant_name participant_full_name
-      expect(participant_details).to have_email participant_email
-      expect(participant_details).to have_full_name participant_full_name
-      expect(participant_details).to have_status school_record_state
+          participant_details = Pages::SchoolEarlyCareerTeacherDetailsPage.loaded(slug: school.slug, participant_id: training_record_id)
+          expect(participant_details).to have_participant_name participant_full_name
+          expect(participant_details).to have_email participant_email
+          expect(participant_details).to have_full_name participant_full_name
+          expect(participant_details).to have_status school_record_state
+        end
+      end
+
+      scenario "The current appropriate body can locate a record for the ECT", :skip do
+        given_i_sign_in_as_the_user_with_the_full_name ab_full_name
+
+        appropriate_body_portal = Pages::AppropriateBodyPortal.loaded
+        appropriate_body_portal.get_participant(participant_full_name)
+
+        expect(appropriate_body_portal).to have_full_name participant_full_name
+        expect(appropriate_body_portal).to have_email_address participant_email
+        expect(appropriate_body_portal).to have_teacher_reference_number teacher_reference_number
+        expect(appropriate_body_portal).to have_participant_type long_participant_type
+        expect(appropriate_body_portal).to have_lead_provider_name lead_provider_name
+        expect(appropriate_body_portal).to have_school_name school_name
+        expect(appropriate_body_portal).to have_school_urn school.urn
+        expect(appropriate_body_portal).to have_academic_year start_year
+        expect(appropriate_body_portal).to have_training_record_status appropriate_body_record_state
+      end
+
+      scenario "The current lead provider can locate a record for the ECT" do
+        lead_provider_token = LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: lead_provider_details.cpd_lead_provider)
+
+        ecf_participant_endpoint = APIs::ECFParticipantsEndpoint.load(lead_provider_token)
+        ecf_participant_endpoint.get_participant participant_id
+
+        expect(ecf_participant_endpoint).to have_email_address participant_email
+        expect(ecf_participant_endpoint).to have_full_name participant_full_name
+        expect(ecf_participant_endpoint).to have_mentor_id nil
+        expect(ecf_participant_endpoint).to have_school_urn school.urn
+        expect(ecf_participant_endpoint).to have_participant_type short_participant_type
+        expect(ecf_participant_endpoint).to have_cohort start_year
+        expect(ecf_participant_endpoint).to have_trn teacher_reference_number
+        # teacher_reference_number_validated: true,
+        expect(ecf_participant_endpoint).to be_eligible_for_funding
+        expect(ecf_participant_endpoint).to have_pupil_premium_uplift
+        expect(ecf_participant_endpoint).to have_sparsity_uplift
+        expect(ecf_participant_endpoint).to have_status participant_status
+        expect(ecf_participant_endpoint).to have_training_record_id training_record_id
+        expect(ecf_participant_endpoint).to have_schedule_identifier schedule_identifier
+
+        participant_endpoint = APIs::ParticipantsEndpoint.load(lead_provider_token)
+        participant_endpoint.get_participant participant_id
+
+        expect(participant_endpoint).to have_email_address participant_email
+        expect(participant_endpoint).to have_full_name participant_full_name
+        expect(participant_endpoint).to have_mentor_id nil
+        expect(participant_endpoint).to have_school_urn school.urn
+        expect(participant_endpoint).to have_participant_type short_participant_type
+        expect(participant_endpoint).to have_cohort start_year
+        expect(participant_endpoint).to have_trn teacher_reference_number
+        # teacher_reference_number_validated: true,
+        expect(participant_endpoint).to be_eligible_for_funding
+        expect(participant_endpoint).to have_pupil_premium_uplift
+        expect(participant_endpoint).to have_sparsity_uplift
+        expect(participant_endpoint).to have_status participant_status
+        expect(participant_endpoint).to have_training_record_id training_record_id
+        expect(participant_endpoint).to have_schedule_identifier schedule_identifier
+      end
+
+      context "when the participant cohort is #{DeliveryPartners::ParticipantsFilter::LATEST_COHORT_TO_RETURN} or earlier" do
+        let(:start_year) { DeliveryPartners::ParticipantsFilter::LATEST_COHORT_TO_RETURN }
+
+        scenario "The current delivery partner can locate a record for the ECT" do
+          given_i_sign_in_as_the_user_with_the_full_name delivery_partner_name
+
+          delivery_partner_portal = Pages::DeliveryPartnerPortal.loaded
+          delivery_partner_portal.get_participant(participant_full_name)
+
+          expect(delivery_partner_portal).to have_full_name participant_full_name
+          expect(delivery_partner_portal).to have_email_address participant_email
+          expect(delivery_partner_portal).to have_teacher_reference_number teacher_reference_number
+          expect(delivery_partner_portal).to have_participant_type long_participant_type
+          expect(delivery_partner_portal).to have_lead_provider_name lead_provider_name
+          expect(delivery_partner_portal).to have_school_name school_name
+          expect(delivery_partner_portal).to have_school_urn school.urn
+          expect(delivery_partner_portal).to have_academic_year start_year
+          expect(delivery_partner_portal).to have_training_record_status delivery_partner_record_state
+        end
+      end
+
+      scenario "The Support for ECTs service can locate a record for the CIP ECT" do
+        user_endpoint = APIs::ECFUsersEndpoint.load
+        user_endpoint.get_user participant_id
+
+        expect(user_endpoint).to have_email participant_email
+        expect(user_endpoint).to have_full_name participant_full_name
+        expect(user_endpoint).to have_cohort start_year
+        expect(user_endpoint).to have_core_induction_programme cip_materials
+        expect(user_endpoint).to have_induction_programme_choice programme_type
+        expect(user_endpoint).to have_registration_completed registration_completed
+        expect(user_endpoint).to have_user_type participant_type
+      end
+
+      scenario "A DfE admin user can locate the record for the ECT" do
+        given_i_sign_in_as_an_admin_user
+
+        participant_list = Pages::AdminSupportParticipantList.load
+        participant_list.view_participant participant_full_name
+
+        participant_detail = Pages::AdminSupportParticipantDetail.loaded(participant_id: training_record_id)
+        expect(participant_detail).to have_full_name participant_full_name
+        expect(participant_detail).to have_email_address participant_email
+        expect(participant_detail).to have_trn teacher_reference_number
+        expect(participant_detail).to have_cohort start_year
+        expect(participant_detail).to have_training_record_state training_record_state
+        expect(participant_detail).to have_user_id participant_id
+        expect(participant_detail).to have_associated_email_address participant_email
+
+        participant_detail.open_training_tab
+
+        participant_training = Pages::AdminSupportParticipantTraining.loaded(participant_id: training_record_id)
+        expect(participant_training).to have_cohort start_year
+        expect(participant_training).to have_school_name school.name
+        expect(participant_training).to have_lead_provider lead_provider_name
+        expect(participant_training).to have_schedule_identifier schedule_identifier
+      end
+
+      scenario "A DfE finance user can locate the record for the ECT" do
+        given_i_sign_in_as_a_finance_user
+
+        drilldown_search = Pages::FinanceParticipantDrilldownSearch.load
+        drilldown_search.find participant_id
+
+        drilldown = Pages::FinanceParticipantDrilldown.loaded(user_id: participant_id)
+        expect(drilldown).to have_participant_id participant_id
+        expect(drilldown).to have_full_name participant_full_name
+        expect(drilldown).to have_lead_provider lead_provider_name
+        expect(drilldown).to have_school_urn school.urn
+        expect(drilldown).to have_status participant_status
+        expect(drilldown).to have_induction_status participant_status
+        # TODO: is this correct?
+        expect(drilldown).to be_eligible_for_funding
+        expect(drilldown).to have_schedule schedule_identifier
+        expect(drilldown).to have_schedule_identifier schedule_identifier
+        expect(drilldown).to have_schedule_cohort start_year
+        expect(drilldown).to have_training_programme programme_name
+        expect(drilldown).to have_participant_class participant_class
+      end
     end
-  end
-
-  scenario "The current appropriate body can locate a record for the ECT", :skip do
-    given_i_sign_in_as_the_user_with_the_full_name ab_full_name
-
-    appropriate_body_portal = Pages::AppropriateBodyPortal.loaded
-    appropriate_body_portal.get_participant(participant_full_name)
-
-    expect(appropriate_body_portal).to have_full_name participant_full_name
-    expect(appropriate_body_portal).to have_email_address participant_email
-    expect(appropriate_body_portal).to have_teacher_reference_number teacher_reference_number
-    expect(appropriate_body_portal).to have_participant_type long_participant_type
-    expect(appropriate_body_portal).to have_lead_provider_name lead_provider_name
-    expect(appropriate_body_portal).to have_school_name school_name
-    expect(appropriate_body_portal).to have_school_urn school.urn
-    expect(appropriate_body_portal).to have_academic_year start_year
-    expect(appropriate_body_portal).to have_training_record_status appropriate_body_record_state
-  end
-
-  scenario "The current lead provider can locate a record for the ECT" do
-    lead_provider_token = LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: lead_provider_details.cpd_lead_provider)
-
-    ecf_participant_endpoint = APIs::ECFParticipantsEndpoint.load(lead_provider_token)
-    ecf_participant_endpoint.get_participant participant_id
-
-    expect(ecf_participant_endpoint).to have_email_address participant_email
-    expect(ecf_participant_endpoint).to have_full_name participant_full_name
-    expect(ecf_participant_endpoint).to have_mentor_id nil
-    expect(ecf_participant_endpoint).to have_school_urn school.urn
-    expect(ecf_participant_endpoint).to have_participant_type short_participant_type
-    expect(ecf_participant_endpoint).to have_cohort start_year
-    expect(ecf_participant_endpoint).to have_trn teacher_reference_number
-    # teacher_reference_number_validated: true,
-    expect(ecf_participant_endpoint).to be_eligible_for_funding
-    expect(ecf_participant_endpoint).to have_pupil_premium_uplift
-    expect(ecf_participant_endpoint).to have_sparsity_uplift
-    expect(ecf_participant_endpoint).to have_status participant_status
-    expect(ecf_participant_endpoint).to have_training_record_id training_record_id
-    expect(ecf_participant_endpoint).to have_schedule_identifier schedule_identifier
-
-    participant_endpoint = APIs::ParticipantsEndpoint.load(lead_provider_token)
-    participant_endpoint.get_participant participant_id
-
-    expect(participant_endpoint).to have_email_address participant_email
-    expect(participant_endpoint).to have_full_name participant_full_name
-    expect(participant_endpoint).to have_mentor_id nil
-    expect(participant_endpoint).to have_school_urn school.urn
-    expect(participant_endpoint).to have_participant_type short_participant_type
-    expect(participant_endpoint).to have_cohort start_year
-    expect(participant_endpoint).to have_trn teacher_reference_number
-    # teacher_reference_number_validated: true,
-    expect(participant_endpoint).to be_eligible_for_funding
-    expect(participant_endpoint).to have_pupil_premium_uplift
-    expect(participant_endpoint).to have_sparsity_uplift
-    expect(participant_endpoint).to have_status participant_status
-    expect(participant_endpoint).to have_training_record_id training_record_id
-    expect(participant_endpoint).to have_schedule_identifier schedule_identifier
-  end
-
-  context "when the participant cohort is #{DeliveryPartners::ParticipantsFilter::LATEST_COHORT_TO_RETURN} or earlier" do
-    let(:start_year) { DeliveryPartners::ParticipantsFilter::LATEST_COHORT_TO_RETURN }
-
-    scenario "The current delivery partner can locate a record for the ECT" do
-      given_i_sign_in_as_the_user_with_the_full_name delivery_partner_name
-
-      delivery_partner_portal = Pages::DeliveryPartnerPortal.loaded
-      delivery_partner_portal.get_participant(participant_full_name)
-
-      expect(delivery_partner_portal).to have_full_name participant_full_name
-      expect(delivery_partner_portal).to have_email_address participant_email
-      expect(delivery_partner_portal).to have_teacher_reference_number teacher_reference_number
-      expect(delivery_partner_portal).to have_participant_type long_participant_type
-      expect(delivery_partner_portal).to have_lead_provider_name lead_provider_name
-      expect(delivery_partner_portal).to have_school_name school_name
-      expect(delivery_partner_portal).to have_school_urn school.urn
-      expect(delivery_partner_portal).to have_academic_year start_year
-      expect(delivery_partner_portal).to have_training_record_status delivery_partner_record_state
-    end
-  end
-
-  scenario "The Support for ECTs service can locate a record for the CIP ECT" do
-    user_endpoint = APIs::ECFUsersEndpoint.load
-    user_endpoint.get_user participant_id
-
-    expect(user_endpoint).to have_email participant_email
-    expect(user_endpoint).to have_full_name participant_full_name
-    expect(user_endpoint).to have_cohort start_year
-    expect(user_endpoint).to have_core_induction_programme cip_materials
-    expect(user_endpoint).to have_induction_programme_choice programme_type
-    expect(user_endpoint).to have_registration_completed registration_completed
-    expect(user_endpoint).to have_user_type participant_type
-  end
-
-  scenario "A DfE admin user can locate the record for the ECT" do
-    given_i_sign_in_as_an_admin_user
-
-    participant_list = Pages::AdminSupportParticipantList.load
-    participant_list.view_participant participant_full_name
-
-    participant_detail = Pages::AdminSupportParticipantDetail.loaded(participant_id: training_record_id)
-    expect(participant_detail).to have_full_name participant_full_name
-    expect(participant_detail).to have_email_address participant_email
-    expect(participant_detail).to have_trn teacher_reference_number
-    expect(participant_detail).to have_cohort start_year
-    expect(participant_detail).to have_training_record_state training_record_state
-    expect(participant_detail).to have_user_id participant_id
-    expect(participant_detail).to have_associated_email_address participant_email
-
-    participant_detail.open_training_tab
-
-    participant_training = Pages::AdminSupportParticipantTraining.loaded(participant_id: training_record_id)
-    expect(participant_training).to have_cohort start_year
-    expect(participant_training).to have_school_name school.name
-    expect(participant_training).to have_lead_provider lead_provider_name
-    expect(participant_training).to have_schedule_identifier schedule_identifier
-  end
-
-  scenario "A DfE finance user can locate the record for the ECT" do
-    given_i_sign_in_as_a_finance_user
-
-    drilldown_search = Pages::FinanceParticipantDrilldownSearch.load
-    drilldown_search.find participant_id
-
-    drilldown = Pages::FinanceParticipantDrilldown.loaded(user_id: participant_id)
-    expect(drilldown).to have_participant_id participant_id
-    expect(drilldown).to have_full_name participant_full_name
-    expect(drilldown).to have_lead_provider lead_provider_name
-    expect(drilldown).to have_school_urn school.urn
-    expect(drilldown).to have_status participant_status
-    expect(drilldown).to have_induction_status participant_status
-    # TODO: is this correct?
-    expect(drilldown).to be_eligible_for_funding
-    expect(drilldown).to have_schedule schedule_identifier
-    expect(drilldown).to have_schedule_identifier schedule_identifier
-    expect(drilldown).to have_schedule_cohort start_year
-    expect(drilldown).to have_training_programme programme_name
-    expect(drilldown).to have_participant_class participant_class
   end
 end

--- a/spec/features/scenarios/participants/ect_doing_fip/no_validation_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_fip/no_validation_spec.rb
@@ -23,7 +23,6 @@ RSpec.feature "ECT doing FIP: no validation", type: :feature do
   let(:long_participant_type) { "Early career teacher" }
   let(:participant_class) { "ParticipantProfile::ECT" }
   let(:programme_type) { "full_induction_programme" }
-  let(:programme_name) { "Full induction programme" }
   let(:schedule_identifier) { "ecf-standard-september" }
   let(:cip_materials) { "none" }
   let(:start_year) { Cohort.next.start_year }
@@ -82,6 +81,10 @@ RSpec.feature "ECT doing FIP: no validation", type: :feature do
 
   %w[active inactive].each do |flag_state|
     context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      let(:programme_name) do
+        flag_state == "inactive" ? "Full induction programme" : "Provider-led"
+      end
+
       scenario "The current school induction tutor can locate a record for the ECT" do
         inside_registration_window(cohort:) do
           given_i_sign_in_as_the_user_with_the_full_name sit_full_name

--- a/spec/features/scenarios/transfering_a_participant/cip_to_cip_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/cip_to_cip_spec.rb
@@ -19,7 +19,7 @@ def when_context(scenario)
 end
 
 RSpec.feature "CIP to CIP - Transfer a participant",
-              with_feature_flags: { eligibility_notifications: "active", programme_type_changes_2025: "inactive" },
+              with_feature_flags: { eligibility_notifications: "active" },
               type: :feature,
               end_to_end_scenario: true do
   include Steps::ChangesOfCircumstanceSteps
@@ -27,83 +27,87 @@ RSpec.feature "CIP to CIP - Transfer a participant",
   includes = ENV.fetch("SCENARIOS", "").split(",").map(&:to_i)
 
   fixture_data_path = File.join(File.dirname(__FILE__), "../changes_of_circumstances_fixtures.csv")
-  CSV.parse(File.read(fixture_data_path), headers: true).each_with_index do |fixture_data, index|
-    next if includes.any? && !includes.include?(index + 2)
 
-    scenario = ChangesOfCircumstanceScenario.new index + 2, fixture_data
+  %w[active inactive].each do |flag_state|
+    context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      CSV.parse(File.read(fixture_data_path), headers: true).each_with_index do |fixture_data, index|
+        next if includes.any? && !includes.include?(index + 2)
 
-    next unless scenario.original_programme == "CIP" && scenario.new_programme == "CIP"
+        scenario = ChangesOfCircumstanceScenario.new index + 2, fixture_data
 
-    let(:tokens) { {} }
+        next unless scenario.original_programme == "CIP" && scenario.new_programme == "CIP"
 
-    let!(:cohort) do
-      cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
-      allow(Cohort).to receive(:current).and_return(cohort)
-      allow(Cohort).to receive(:next).and_return(cohort)
-      allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
-      allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
-      allow(cohort).to receive(:next).and_return(cohort)
-      allow(cohort).to receive(:previous).and_return(cohort)
-      cohort
-    end
-    let!(:schedule) do
-      create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
-    end
-    let!(:milestone_started) do
-      create :milestone,
-             schedule:,
-             name: "Output 1 - Participant Start",
-             start_date: Date.new(2021, 9, 1),
-             milestone_date: Date.new(2021, 11, 30),
-             payment_date: Date.new(2021, 11, 30),
-             declaration_type: "started"
-    end
-    let!(:milestone_retained_1) do
-      create :milestone,
-             schedule:,
-             name: "Output 2 - Retention Point 1",
-             start_date: Date.new(2021, 11, 1),
-             milestone_date: Date.new(2022, 1, 31),
-             payment_date: Date.new(2022, 2, 28),
-             declaration_type: "retained-1"
-    end
-    let!(:privacy_policy) do
-      privacy_policy = create(:privacy_policy)
-      PrivacyPolicy::Publish.call
-      privacy_policy
-    end
+        let(:tokens) { {} }
 
-    context given_context(scenario) do
-      before do
-        given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
-
-        travel_to(milestone_started.milestone_date - 2.months) do
-          Importers::CreateCohort.new(path_to_csv: Rails.root.join("db/data/cohorts/cohorts.csv")).call
-          Importers::CreateCallOffContract.new.call
-          Importers::CreateStatement.new(path_to_csv: Rails.root.join("db/data/statements/statements.csv")).call
+        let!(:cohort) do
+          cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
+          allow(Cohort).to receive(:current).and_return(cohort)
+          allow(Cohort).to receive(:next).and_return(cohort)
+          allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
+          allow(cohort).to receive(:next).and_return(cohort)
+          allow(cohort).to receive(:previous).and_return(cohort)
+          cohort
+        end
+        let!(:schedule) do
+          create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+        end
+        let!(:milestone_started) do
+          create :milestone,
+                 schedule:,
+                 name: "Output 1 - Participant Start",
+                 start_date: Date.new(2021, 9, 1),
+                 milestone_date: Date.new(2021, 11, 30),
+                 payment_date: Date.new(2021, 11, 30),
+                 declaration_type: "started"
+        end
+        let!(:milestone_retained_1) do
+          create :milestone,
+                 schedule:,
+                 name: "Output 2 - Retention Point 1",
+                 start_date: Date.new(2021, 11, 1),
+                 milestone_date: Date.new(2022, 1, 31),
+                 payment_date: Date.new(2022, 2, 28),
+                 declaration_type: "retained-1"
+        end
+        let!(:privacy_policy) do
+          privacy_policy = create(:privacy_policy)
+          PrivacyPolicy::Publish.call
+          privacy_policy
         end
 
-        and_sit_at_pupil_premium_school_reported_programme "Original SIT", "CIP"
+        context given_context(scenario) do
+          before do
+            given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
 
-        and_sit_at_pupil_premium_school_reported_programme "New SIT", "CIP"
+            travel_to(milestone_started.milestone_date - 2.months) do
+              Importers::CreateCohort.new(path_to_csv: Rails.root.join("db/data/cohorts/cohorts.csv")).call
+              Importers::CreateCallOffContract.new.call
+              Importers::CreateStatement.new(path_to_csv: Rails.root.join("db/data/statements/statements.csv")).call
+            end
 
-        and_sit_reported_participant "Original SIT",
-                                     "The Participant",
-                                     scenario.participant_trn,
-                                     scenario.participant_dob,
-                                     scenario.participant_email,
-                                     scenario.participant_type
-      end
+            and_sit_at_pupil_premium_school_reported_programme "Original SIT", "CIP"
 
-      context when_context(scenario) do
-        before do
-          when_developers_transfer_the_active_participant "New SIT",
-                                                          "The Participant"
+            and_sit_at_pupil_premium_school_reported_programme "New SIT", "CIP"
 
-          and_eligible_training_declarations_are_made_payable
+            and_sit_reported_participant "Original SIT",
+                                         "The Participant",
+                                         scenario.participant_trn,
+                                         scenario.participant_dob,
+                                         scenario.participant_email,
+                                         scenario.participant_type
+          end
+
+          context when_context(scenario) do
+            before do
+              when_developers_transfer_the_active_participant "New SIT",
+                                                              "The Participant"
+
+              and_eligible_training_declarations_are_made_payable
+            end
+
+            include_examples "CIP to CIP", scenario
+          end
         end
-
-        include_examples "CIP to CIP", scenario
       end
     end
   end

--- a/spec/features/scenarios/transfering_a_participant/cip_to_cip_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/cip_to_cip_spec.rb
@@ -44,6 +44,7 @@ RSpec.feature "CIP to CIP - Transfer a participant",
           allow(Cohort).to receive(:current).and_return(cohort)
           allow(Cohort).to receive(:next).and_return(cohort)
           allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
+          allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
           allow(cohort).to receive(:next).and_return(cohort)
           allow(cohort).to receive(:previous).and_return(cohort)
           cohort

--- a/spec/features/scenarios/transfering_a_participant/cip_to_fip_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/cip_to_fip_spec.rb
@@ -44,6 +44,7 @@ RSpec.feature "CIP to FIP - Transfer a participant",
           allow(Cohort).to receive(:current).and_return(cohort)
           allow(Cohort).to receive(:next).and_return(cohort)
           allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
+          allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
           allow(cohort).to receive(:next).and_return(cohort)
           allow(cohort).to receive(:previous).and_return(cohort)
           cohort

--- a/spec/features/scenarios/transfering_a_participant/cip_to_fip_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/cip_to_fip_spec.rb
@@ -19,7 +19,7 @@ def when_context(scenario)
 end
 
 RSpec.feature "CIP to FIP - Transfer a participant",
-              with_feature_flags: { eligibility_notifications: "active", programme_type_changes_2025: "inactive" },
+              with_feature_flags: { eligibility_notifications: "active" },
               type: :feature,
               end_to_end_scenario: true do
   include Steps::ChangesOfCircumstanceSteps
@@ -27,92 +27,96 @@ RSpec.feature "CIP to FIP - Transfer a participant",
   includes = ENV.fetch("SCENARIOS", "").split(",").map(&:to_i)
 
   fixture_data_path = File.join(File.dirname(__FILE__), "../changes_of_circumstances_fixtures.csv")
-  CSV.parse(File.read(fixture_data_path), headers: true).each_with_index do |fixture_data, index|
-    next if includes.any? && !includes.include?(index + 2)
 
-    scenario = ChangesOfCircumstanceScenario.new index + 2, fixture_data
+  %w[active inactive].each do |flag_state|
+    context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      CSV.parse(File.read(fixture_data_path), headers: true).each_with_index do |fixture_data, index|
+        next if includes.any? && !includes.include?(index + 2)
 
-    next unless scenario.original_programme == "CIP" && scenario.new_programme == "FIP"
+        scenario = ChangesOfCircumstanceScenario.new index + 2, fixture_data
 
-    let(:tokens) { {} }
+        next unless scenario.original_programme == "CIP" && scenario.new_programme == "FIP"
 
-    let!(:cohort) do
-      cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
-      allow(Cohort).to receive(:current).and_return(cohort)
-      allow(Cohort).to receive(:next).and_return(cohort)
-      allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
-      allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
-      allow(cohort).to receive(:next).and_return(cohort)
-      allow(cohort).to receive(:previous).and_return(cohort)
-      cohort
-    end
-    let!(:schedule) do
-      create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
-    end
-    let!(:milestone_started) do
-      create :milestone,
-             schedule:,
-             name: "Output 1 - Participant Start",
-             start_date: Date.new(2021, 9, 1),
-             milestone_date: Date.new(2021, 11, 30),
-             payment_date: Date.new(2021, 11, 30),
-             declaration_type: "started"
-    end
-    let!(:milestone_retained_1) do
-      create :milestone,
-             schedule:,
-             name: "Output 2 - Retention Point 1",
-             start_date: Date.new(2021, 11, 1),
-             milestone_date: Date.new(2022, 1, 31),
-             payment_date: Date.new(2022, 2, 28),
-             declaration_type: "retained-1"
-    end
-    let!(:privacy_policy) do
-      privacy_policy = create(:privacy_policy)
-      PrivacyPolicy::Publish.call
-      privacy_policy
-    end
+        let(:tokens) { {} }
 
-    context given_context(scenario) do
-      before do
-        given_lead_providers_contracted_to_deliver_ecf "New Lead Provider"
-        given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
-
-        travel_to(milestone_started.milestone_date - 2.months) do
-          Importers::CreateCohort.new(path_to_csv: Rails.root.join("db/data/cohorts/cohorts.csv")).call
-          Importers::CreateCallOffContract.new.call
-          Importers::CreateStatement.new(path_to_csv: Rails.root.join("db/data/statements/statements.csv")).call
+        let!(:cohort) do
+          cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
+          allow(Cohort).to receive(:current).and_return(cohort)
+          allow(Cohort).to receive(:next).and_return(cohort)
+          allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
+          allow(cohort).to receive(:next).and_return(cohort)
+          allow(cohort).to receive(:previous).and_return(cohort)
+          cohort
+        end
+        let!(:schedule) do
+          create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+        end
+        let!(:milestone_started) do
+          create :milestone,
+                 schedule:,
+                 name: "Output 1 - Participant Start",
+                 start_date: Date.new(2021, 9, 1),
+                 milestone_date: Date.new(2021, 11, 30),
+                 payment_date: Date.new(2021, 11, 30),
+                 declaration_type: "started"
+        end
+        let!(:milestone_retained_1) do
+          create :milestone,
+                 schedule:,
+                 name: "Output 2 - Retention Point 1",
+                 start_date: Date.new(2021, 11, 1),
+                 milestone_date: Date.new(2022, 1, 31),
+                 payment_date: Date.new(2022, 2, 28),
+                 declaration_type: "retained-1"
+        end
+        let!(:privacy_policy) do
+          privacy_policy = create(:privacy_policy)
+          PrivacyPolicy::Publish.call
+          privacy_policy
         end
 
-        and_sit_at_pupil_premium_school_reported_programme "Original SIT", "CIP"
+        context given_context(scenario) do
+          before do
+            given_lead_providers_contracted_to_deliver_ecf "New Lead Provider"
+            given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
 
-        and_sit_at_pupil_premium_school_reported_programme "New SIT", "FIP"
-        and_lead_provider_reported_partnership "New Lead Provider", "New SIT"
+            travel_to(milestone_started.milestone_date - 2.months) do
+              Importers::CreateCohort.new(path_to_csv: Rails.root.join("db/data/cohorts/cohorts.csv")).call
+              Importers::CreateCallOffContract.new.call
+              Importers::CreateStatement.new(path_to_csv: Rails.root.join("db/data/statements/statements.csv")).call
+            end
 
-        and_sit_reported_participant "Original SIT",
-                                     "The Participant",
-                                     scenario.participant_trn,
-                                     scenario.participant_dob,
-                                     scenario.participant_email,
-                                     scenario.participant_type
-      end
+            and_sit_at_pupil_premium_school_reported_programme "Original SIT", "CIP"
 
-      context when_context(scenario) do
-        before do
-          when_developers_transfer_the_active_participant "New SIT",
-                                                          "The Participant"
+            and_sit_at_pupil_premium_school_reported_programme "New SIT", "FIP"
+            and_lead_provider_reported_partnership "New Lead Provider", "New SIT"
 
-          scenario.new_declarations.each do |declaration_type|
-            and_lead_provider_has_made_training_declaration "New Lead Provider",
-                                                            scenario.participant_type,
-                                                            "The Participant",
-                                                            declaration_type
+            and_sit_reported_participant "Original SIT",
+                                         "The Participant",
+                                         scenario.participant_trn,
+                                         scenario.participant_dob,
+                                         scenario.participant_email,
+                                         scenario.participant_type
           end
 
-          and_eligible_training_declarations_are_made_payable
-        end
+          context when_context(scenario) do
+            before do
+              when_developers_transfer_the_active_participant "New SIT",
+                                                              "The Participant"
 
-        include_examples "CIP to FIP", scenario
+              scenario.new_declarations.each do |declaration_type|
+                and_lead_provider_has_made_training_declaration "New Lead Provider",
+                                                                scenario.participant_type,
+                                                                "The Participant",
+                                                                declaration_type
+              end
+
+              and_eligible_training_declarations_are_made_payable
+            end
+
+            include_examples "CIP to FIP", scenario
+          end
+        end
       end
     end
   end

--- a/spec/features/scenarios/transfering_a_participant/fip_to_cip_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/fip_to_cip_spec.rb
@@ -19,7 +19,7 @@ def when_context(scenario)
 end
 
 RSpec.feature "FIP to CIP - Transfer a participant",
-              with_feature_flags: { eligibility_notifications: "active", programme_type_changes_2025: "inactive" },
+              with_feature_flags: { eligibility_notifications: "active" },
               type: :feature,
               end_to_end_scenario: true do
   include Steps::ChangesOfCircumstanceSteps
@@ -27,92 +27,96 @@ RSpec.feature "FIP to CIP - Transfer a participant",
   includes = ENV.fetch("SCENARIOS", "").split(",").map(&:to_i)
 
   fixture_data_path = File.join(File.dirname(__FILE__), "../changes_of_circumstances_fixtures.csv")
-  CSV.parse(File.read(fixture_data_path), headers: true).each_with_index do |fixture_data, index|
-    next if includes.any? && !includes.include?(index + 2)
 
-    scenario = ChangesOfCircumstanceScenario.new index + 2, fixture_data
+  %w[active inactive].each do |flag_state|
+    context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      CSV.parse(File.read(fixture_data_path), headers: true).each_with_index do |fixture_data, index|
+        next if includes.any? && !includes.include?(index + 2)
 
-    next unless scenario.original_programme == "FIP" && scenario.new_programme == "CIP"
+        scenario = ChangesOfCircumstanceScenario.new index + 2, fixture_data
 
-    let(:tokens) { {} }
+        next unless scenario.original_programme == "FIP" && scenario.new_programme == "CIP"
 
-    let!(:cohort) do
-      cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
-      allow(Cohort).to receive(:current).and_return(cohort)
-      allow(Cohort).to receive(:next).and_return(cohort)
-      allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
-      allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
-      allow(cohort).to receive(:next).and_return(cohort)
-      allow(cohort).to receive(:previous).and_return(cohort)
-      cohort
-    end
-    let!(:schedule) do
-      create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
-    end
-    let!(:milestone_started) do
-      create :milestone,
-             schedule:,
-             name: "Output 1 - Participant Start",
-             start_date: Date.new(2021, 9, 1),
-             milestone_date: Date.new(2021, 11, 30),
-             payment_date: Date.new(2021, 11, 30),
-             declaration_type: "started"
-    end
-    let!(:milestone_retained_1) do
-      create :milestone,
-             schedule:,
-             name: "Output 2 - Retention Point 1",
-             start_date: Date.new(2021, 11, 1),
-             milestone_date: Date.new(2022, 1, 31),
-             payment_date: Date.new(2022, 2, 28),
-             declaration_type: "retained-1"
-    end
-    let!(:privacy_policy) do
-      privacy_policy = create(:privacy_policy)
-      PrivacyPolicy::Publish.call
-      privacy_policy
-    end
+        let(:tokens) { {} }
 
-    context given_context(scenario) do
-      before do
-        given_lead_providers_contracted_to_deliver_ecf "Original Lead Provider"
-        given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
-
-        travel_to(milestone_started.milestone_date - 2.months) do
-          Importers::CreateCohort.new(path_to_csv: Rails.root.join("db/data/cohorts/cohorts.csv")).call
-          Importers::CreateCallOffContract.new.call
-          Importers::CreateStatement.new(path_to_csv: Rails.root.join("db/data/statements/statements.csv")).call
+        let!(:cohort) do
+          cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
+          allow(Cohort).to receive(:current).and_return(cohort)
+          allow(Cohort).to receive(:next).and_return(cohort)
+          allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
+          allow(cohort).to receive(:next).and_return(cohort)
+          allow(cohort).to receive(:previous).and_return(cohort)
+          cohort
+        end
+        let!(:schedule) do
+          create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+        end
+        let!(:milestone_started) do
+          create :milestone,
+                 schedule:,
+                 name: "Output 1 - Participant Start",
+                 start_date: Date.new(2021, 9, 1),
+                 milestone_date: Date.new(2021, 11, 30),
+                 payment_date: Date.new(2021, 11, 30),
+                 declaration_type: "started"
+        end
+        let!(:milestone_retained_1) do
+          create :milestone,
+                 schedule:,
+                 name: "Output 2 - Retention Point 1",
+                 start_date: Date.new(2021, 11, 1),
+                 milestone_date: Date.new(2022, 1, 31),
+                 payment_date: Date.new(2022, 2, 28),
+                 declaration_type: "retained-1"
+        end
+        let!(:privacy_policy) do
+          privacy_policy = create(:privacy_policy)
+          PrivacyPolicy::Publish.call
+          privacy_policy
         end
 
-        and_sit_at_pupil_premium_school_reported_programme "Original SIT", "FIP"
-        and_lead_provider_reported_partnership "Original Lead Provider", "Original SIT"
+        context given_context(scenario) do
+          before do
+            given_lead_providers_contracted_to_deliver_ecf "Original Lead Provider"
+            given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
 
-        and_sit_at_pupil_premium_school_reported_programme "New SIT", "CIP"
+            travel_to(milestone_started.milestone_date - 2.months) do
+              Importers::CreateCohort.new(path_to_csv: Rails.root.join("db/data/cohorts/cohorts.csv")).call
+              Importers::CreateCallOffContract.new.call
+              Importers::CreateStatement.new(path_to_csv: Rails.root.join("db/data/statements/statements.csv")).call
+            end
 
-        and_sit_reported_participant "Original SIT",
-                                     "The Participant",
-                                     scenario.participant_trn,
-                                     scenario.participant_dob,
-                                     scenario.participant_email,
-                                     scenario.participant_type
-      end
+            and_sit_at_pupil_premium_school_reported_programme "Original SIT", "FIP"
+            and_lead_provider_reported_partnership "Original Lead Provider", "Original SIT"
 
-      context when_context(scenario) do
-        before do
-          scenario.prior_declarations.each do |declaration_type|
-            and_lead_provider_has_made_training_declaration "Original Lead Provider",
-                                                            scenario.participant_type,
-                                                            "The Participant",
-                                                            declaration_type
+            and_sit_at_pupil_premium_school_reported_programme "New SIT", "CIP"
+
+            and_sit_reported_participant "Original SIT",
+                                         "The Participant",
+                                         scenario.participant_trn,
+                                         scenario.participant_dob,
+                                         scenario.participant_email,
+                                         scenario.participant_type
           end
 
-          when_developers_transfer_the_active_participant "New SIT",
-                                                          "The Participant"
+          context when_context(scenario) do
+            before do
+              scenario.prior_declarations.each do |declaration_type|
+                and_lead_provider_has_made_training_declaration "Original Lead Provider",
+                                                                scenario.participant_type,
+                                                                "The Participant",
+                                                                declaration_type
+              end
 
-          and_eligible_training_declarations_are_made_payable
+              when_developers_transfer_the_active_participant "New SIT",
+                                                              "The Participant"
+
+              and_eligible_training_declarations_are_made_payable
+            end
+
+            include_examples "FIP to CIP", scenario, "withdrawn"
+          end
         end
-
-        include_examples "FIP to CIP", scenario, "withdrawn"
       end
     end
   end

--- a/spec/features/scenarios/transfering_a_participant/fip_to_cip_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/fip_to_cip_spec.rb
@@ -44,6 +44,7 @@ RSpec.feature "FIP to CIP - Transfer a participant",
           allow(Cohort).to receive(:current).and_return(cohort)
           allow(Cohort).to receive(:next).and_return(cohort)
           allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
+          allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
           allow(cohort).to receive(:next).and_return(cohort)
           allow(cohort).to receive(:previous).and_return(cohort)
           cohort

--- a/spec/features/scenarios/transfering_a_participant/fip_to_fip_with_different_provider_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/fip_to_fip_with_different_provider_spec.rb
@@ -19,7 +19,7 @@ def when_context(scenario)
 end
 
 RSpec.feature "FIP to FIP with different provider - Transfer a participant",
-              with_feature_flags: { eligibility_notifications: "active", programme_type_changes_2025: "inactive" },
+              with_feature_flags: { eligibility_notifications: "active" },
               type: :feature,
               end_to_end_scenario: true do
   include Steps::ChangesOfCircumstanceSteps
@@ -27,105 +27,109 @@ RSpec.feature "FIP to FIP with different provider - Transfer a participant",
   includes = ENV.fetch("SCENARIOS", "").split(",").map(&:to_i)
 
   fixture_data_path = File.join(File.dirname(__FILE__), "../changes_of_circumstances_fixtures.csv")
-  CSV.parse(File.read(fixture_data_path), headers: true).each_with_index do |fixture_data, index|
-    next if includes.any? && !includes.include?(index + 2)
 
-    scenario = ChangesOfCircumstanceScenario.new index + 2, fixture_data
+  %w[active inactive].each do |flag_state|
+    context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      CSV.parse(File.read(fixture_data_path), headers: true).each_with_index do |fixture_data, index|
+        next if includes.any? && !includes.include?(index + 2)
 
-    next unless scenario.original_programme == "FIP" && scenario.new_programme == "FIP" && scenario.transfer == :different_provider
+        scenario = ChangesOfCircumstanceScenario.new index + 2, fixture_data
 
-    let(:tokens) { {} }
+        next unless scenario.original_programme == "FIP" && scenario.new_programme == "FIP" && scenario.transfer == :different_provider
 
-    let!(:cohort) do
-      cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
-      allow(Cohort).to receive(:current).and_return(cohort)
-      allow(Cohort).to receive(:next).and_return(cohort)
-      allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
-      allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
-      allow(cohort).to receive(:next).and_return(cohort)
-      allow(cohort).to receive(:previous).and_return(cohort)
-      cohort
-    end
-    let!(:schedule) do
-      create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
-    end
-    let!(:milestone_started) do
-      create :milestone,
-             schedule:,
-             name: "Output 1 - Participant Start",
-             start_date: Date.new(2021, 9, 1),
-             milestone_date: Date.new(2021, 11, 30),
-             payment_date: Date.new(2021, 11, 30),
-             declaration_type: "started"
-    end
-    let!(:milestone_retained_1) do
-      create :milestone,
-             schedule:,
-             name: "Output 2 - Retention Point 1",
-             start_date: Date.new(2021, 11, 1),
-             milestone_date: Date.new(2022, 1, 31),
-             payment_date: Date.new(2022, 2, 28),
-             declaration_type: "retained-1"
-    end
-    let!(:privacy_policy) do
-      privacy_policy = create(:privacy_policy)
-      PrivacyPolicy::Publish.call
-      privacy_policy
-    end
+        let(:tokens) { {} }
 
-    context given_context(scenario) do
-      before do
-        given_lead_providers_contracted_to_deliver_ecf "Original Lead Provider"
-        given_lead_providers_contracted_to_deliver_ecf "New Lead Provider"
-        given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
-
-        travel_to(milestone_started.milestone_date - 2.months) do
-          Importers::CreateCohort.new(path_to_csv: Rails.root.join("db/data/cohorts/cohorts.csv")).call
-          Importers::CreateCallOffContract.new.call
-          Importers::CreateStatement.new(path_to_csv: Rails.root.join("db/data/statements/statements.csv")).call
+        let!(:cohort) do
+          cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
+          allow(Cohort).to receive(:current).and_return(cohort)
+          allow(Cohort).to receive(:next).and_return(cohort)
+          allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
+          allow(cohort).to receive(:next).and_return(cohort)
+          allow(cohort).to receive(:previous).and_return(cohort)
+          cohort
+        end
+        let!(:schedule) do
+          create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+        end
+        let!(:milestone_started) do
+          create :milestone,
+                 schedule:,
+                 name: "Output 1 - Participant Start",
+                 start_date: Date.new(2021, 9, 1),
+                 milestone_date: Date.new(2021, 11, 30),
+                 payment_date: Date.new(2021, 11, 30),
+                 declaration_type: "started"
+        end
+        let!(:milestone_retained_1) do
+          create :milestone,
+                 schedule:,
+                 name: "Output 2 - Retention Point 1",
+                 start_date: Date.new(2021, 11, 1),
+                 milestone_date: Date.new(2022, 1, 31),
+                 payment_date: Date.new(2022, 2, 28),
+                 declaration_type: "retained-1"
+        end
+        let!(:privacy_policy) do
+          privacy_policy = create(:privacy_policy)
+          PrivacyPolicy::Publish.call
+          privacy_policy
         end
 
-        and_sit_at_pupil_premium_school_reported_programme "Original SIT", "FIP"
-        and_lead_provider_reported_partnership "Original Lead Provider", "Original SIT"
+        context given_context(scenario) do
+          before do
+            given_lead_providers_contracted_to_deliver_ecf "Original Lead Provider"
+            given_lead_providers_contracted_to_deliver_ecf "New Lead Provider"
+            given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
 
-        and_sit_at_pupil_premium_school_reported_programme "New SIT", "FIP"
-        and_lead_provider_reported_partnership "New Lead Provider", "New SIT"
+            travel_to(milestone_started.milestone_date - 2.months) do
+              Importers::CreateCohort.new(path_to_csv: Rails.root.join("db/data/cohorts/cohorts.csv")).call
+              Importers::CreateCallOffContract.new.call
+              Importers::CreateStatement.new(path_to_csv: Rails.root.join("db/data/statements/statements.csv")).call
+            end
 
-        and_sit_reported_participant "Original SIT",
-                                     "The Participant",
-                                     scenario.participant_trn,
-                                     scenario.participant_dob,
-                                     scenario.participant_email,
-                                     scenario.participant_type
-      end
+            and_sit_at_pupil_premium_school_reported_programme "Original SIT", "FIP"
+            and_lead_provider_reported_partnership "Original Lead Provider", "Original SIT"
 
-      context when_context(scenario) do
-        before do
-          scenario.prior_declarations.each do |declaration_type|
-            and_lead_provider_has_made_training_declaration "Original Lead Provider",
-                                                            scenario.participant_type,
-                                                            "The Participant",
-                                                            declaration_type
+            and_sit_at_pupil_premium_school_reported_programme "New SIT", "FIP"
+            and_lead_provider_reported_partnership "New Lead Provider", "New SIT"
+
+            and_sit_reported_participant "Original SIT",
+                                         "The Participant",
+                                         scenario.participant_trn,
+                                         scenario.participant_dob,
+                                         scenario.participant_email,
+                                         scenario.participant_type
           end
 
-          when_school_uses_the_transfer_participant_wizard "New SIT",
-                                                           "The Participant",
-                                                           scenario.participant_email,
-                                                           scenario.participant_trn,
-                                                           scenario.participant_dob,
-                                                           same_provider: false
+          context when_context(scenario) do
+            before do
+              scenario.prior_declarations.each do |declaration_type|
+                and_lead_provider_has_made_training_declaration "Original Lead Provider",
+                                                                scenario.participant_type,
+                                                                "The Participant",
+                                                                declaration_type
+              end
 
-          scenario.new_declarations.each do |declaration_type|
-            and_lead_provider_has_made_training_declaration "New Lead Provider",
-                                                            scenario.participant_type,
-                                                            "The Participant",
-                                                            declaration_type
+              when_school_uses_the_transfer_participant_wizard "New SIT",
+                                                               "The Participant",
+                                                               scenario.participant_email,
+                                                               scenario.participant_trn,
+                                                               scenario.participant_dob,
+                                                               same_provider: false
+
+              scenario.new_declarations.each do |declaration_type|
+                and_lead_provider_has_made_training_declaration "New Lead Provider",
+                                                                scenario.participant_type,
+                                                                "The Participant",
+                                                                declaration_type
+              end
+
+              and_eligible_training_declarations_are_made_payable
+            end
+
+            include_examples "FIP to FIP with different provider", scenario, "active"
           end
-
-          and_eligible_training_declarations_are_made_payable
         end
-
-        include_examples "FIP to FIP with different provider", scenario, "active"
       end
     end
   end

--- a/spec/features/scenarios/transfering_a_participant/fip_to_fip_with_different_provider_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/fip_to_fip_with_different_provider_spec.rb
@@ -44,6 +44,7 @@ RSpec.feature "FIP to FIP with different provider - Transfer a participant",
           allow(Cohort).to receive(:current).and_return(cohort)
           allow(Cohort).to receive(:next).and_return(cohort)
           allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
+          allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
           allow(cohort).to receive(:next).and_return(cohort)
           allow(cohort).to receive(:previous).and_return(cohort)
           cohort

--- a/spec/features/scenarios/transfering_a_participant/fip_to_fip_with_same_provider_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/fip_to_fip_with_same_provider_spec.rb
@@ -19,7 +19,7 @@ def when_context(scenario)
 end
 
 RSpec.feature "FIP to FIP with same provider - Transfer a participant",
-              with_feature_flags: { eligibility_notifications: "active", programme_type_changes_2025: "inactive" },
+              with_feature_flags: { eligibility_notifications: "active" },
               type: :feature,
               end_to_end_scenario: true do
   include Steps::ChangesOfCircumstanceSteps
@@ -27,104 +27,108 @@ RSpec.feature "FIP to FIP with same provider - Transfer a participant",
   includes = ENV.fetch("SCENARIOS", "").split(",").map(&:to_i)
 
   fixture_data_path = File.join(File.dirname(__FILE__), "../changes_of_circumstances_fixtures.csv")
-  CSV.parse(File.read(fixture_data_path), headers: true).each_with_index do |fixture_data, index|
-    next if includes.any? && !includes.include?(index + 2)
 
-    scenario = ChangesOfCircumstanceScenario.new index + 2, fixture_data
+  %w[active inactive].each do |flag_state|
+    context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      CSV.parse(File.read(fixture_data_path), headers: true).each_with_index do |fixture_data, index|
+        next if includes.any? && !includes.include?(index + 2)
 
-    next unless scenario.original_programme == "FIP" && scenario.new_programme == "FIP" && scenario.transfer == :same_provider
+        scenario = ChangesOfCircumstanceScenario.new index + 2, fixture_data
 
-    let(:tokens) { {} }
+        next unless scenario.original_programme == "FIP" && scenario.new_programme == "FIP" && scenario.transfer == :same_provider
 
-    let!(:cohort) do
-      cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
-      allow(Cohort).to receive(:current).and_return(cohort)
-      allow(Cohort).to receive(:next).and_return(cohort)
-      allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
-      allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
-      allow(cohort).to receive(:next).and_return(cohort)
-      allow(cohort).to receive(:previous).and_return(cohort)
-      cohort
-    end
-    let!(:schedule) do
-      create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
-    end
-    let!(:milestone_started) do
-      create :milestone,
-             schedule:,
-             name: "Output 1 - Participant Start",
-             start_date: Date.new(2021, 9, 1),
-             milestone_date: Date.new(2021, 11, 30),
-             payment_date: Date.new(2021, 11, 30),
-             declaration_type: "started"
-    end
-    let!(:milestone_retained_1) do
-      create :milestone,
-             schedule:,
-             name: "Output 2 - Retention Point 1",
-             start_date: Date.new(2021, 11, 1),
-             milestone_date: Date.new(2022, 1, 31),
-             payment_date: Date.new(2022, 2, 28),
-             declaration_type: "retained-1"
-    end
-    let!(:privacy_policy) do
-      privacy_policy = create(:privacy_policy)
-      PrivacyPolicy::Publish.call
-      privacy_policy
-    end
+        let(:tokens) { {} }
 
-    context given_context(scenario) do
-      before do
-        given_lead_providers_contracted_to_deliver_ecf "Original Lead Provider"
-        given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
-
-        travel_to(milestone_started.milestone_date - 2.months) do
-          Importers::CreateCohort.new(path_to_csv: Rails.root.join("db/data/cohorts/cohorts.csv")).call
-          Importers::CreateCallOffContract.new.call
-          Importers::CreateStatement.new(path_to_csv: Rails.root.join("db/data/statements/statements.csv")).call
+        let!(:cohort) do
+          cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
+          allow(Cohort).to receive(:current).and_return(cohort)
+          allow(Cohort).to receive(:next).and_return(cohort)
+          allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
+          allow(cohort).to receive(:next).and_return(cohort)
+          allow(cohort).to receive(:previous).and_return(cohort)
+          cohort
+        end
+        let!(:schedule) do
+          create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+        end
+        let!(:milestone_started) do
+          create :milestone,
+                 schedule:,
+                 name: "Output 1 - Participant Start",
+                 start_date: Date.new(2021, 9, 1),
+                 milestone_date: Date.new(2021, 11, 30),
+                 payment_date: Date.new(2021, 11, 30),
+                 declaration_type: "started"
+        end
+        let!(:milestone_retained_1) do
+          create :milestone,
+                 schedule:,
+                 name: "Output 2 - Retention Point 1",
+                 start_date: Date.new(2021, 11, 1),
+                 milestone_date: Date.new(2022, 1, 31),
+                 payment_date: Date.new(2022, 2, 28),
+                 declaration_type: "retained-1"
+        end
+        let!(:privacy_policy) do
+          privacy_policy = create(:privacy_policy)
+          PrivacyPolicy::Publish.call
+          privacy_policy
         end
 
-        and_sit_at_pupil_premium_school_reported_programme "Original SIT", "FIP"
-        and_lead_provider_reported_partnership "Original Lead Provider", "Original SIT"
+        context given_context(scenario) do
+          before do
+            given_lead_providers_contracted_to_deliver_ecf "Original Lead Provider"
+            given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
 
-        and_sit_at_pupil_premium_school_reported_programme "New SIT", "FIP"
-        and_lead_provider_reported_partnership "Original Lead Provider", "New SIT"
+            travel_to(milestone_started.milestone_date - 2.months) do
+              Importers::CreateCohort.new(path_to_csv: Rails.root.join("db/data/cohorts/cohorts.csv")).call
+              Importers::CreateCallOffContract.new.call
+              Importers::CreateStatement.new(path_to_csv: Rails.root.join("db/data/statements/statements.csv")).call
+            end
 
-        and_sit_reported_participant "Original SIT",
-                                     "The Participant",
-                                     scenario.participant_trn,
-                                     scenario.participant_dob,
-                                     scenario.participant_email,
-                                     scenario.participant_type
-      end
+            and_sit_at_pupil_premium_school_reported_programme "Original SIT", "FIP"
+            and_lead_provider_reported_partnership "Original Lead Provider", "Original SIT"
 
-      context when_context(scenario) do
-        before do
-          scenario.prior_declarations.each do |declaration_type|
-            and_lead_provider_has_made_training_declaration "Original Lead Provider",
-                                                            scenario.participant_type,
-                                                            "The Participant",
-                                                            declaration_type
+            and_sit_at_pupil_premium_school_reported_programme "New SIT", "FIP"
+            and_lead_provider_reported_partnership "Original Lead Provider", "New SIT"
+
+            and_sit_reported_participant "Original SIT",
+                                         "The Participant",
+                                         scenario.participant_trn,
+                                         scenario.participant_dob,
+                                         scenario.participant_email,
+                                         scenario.participant_type
           end
 
-          when_school_uses_the_transfer_participant_wizard "New SIT",
-                                                           "The Participant",
-                                                           scenario.participant_email,
-                                                           scenario.participant_trn,
-                                                           scenario.participant_dob,
-                                                           same_provider: true
+          context when_context(scenario) do
+            before do
+              scenario.prior_declarations.each do |declaration_type|
+                and_lead_provider_has_made_training_declaration "Original Lead Provider",
+                                                                scenario.participant_type,
+                                                                "The Participant",
+                                                                declaration_type
+              end
 
-          scenario.new_declarations.each do |declaration_type|
-            and_lead_provider_has_made_training_declaration "Original Lead Provider",
-                                                            scenario.participant_type,
-                                                            "The Participant",
-                                                            declaration_type
+              when_school_uses_the_transfer_participant_wizard "New SIT",
+                                                               "The Participant",
+                                                               scenario.participant_email,
+                                                               scenario.participant_trn,
+                                                               scenario.participant_dob,
+                                                               same_provider: true
+
+              scenario.new_declarations.each do |declaration_type|
+                and_lead_provider_has_made_training_declaration "Original Lead Provider",
+                                                                scenario.participant_type,
+                                                                "The Participant",
+                                                                declaration_type
+              end
+
+              and_eligible_training_declarations_are_made_payable
+            end
+
+            include_examples "FIP to FIP with same provider", scenario, "active", see_prior_school: false
           end
-
-          and_eligible_training_declarations_are_made_payable
         end
-
-        include_examples "FIP to FIP with same provider", scenario, "active", see_prior_school: false
       end
     end
   end

--- a/spec/features/scenarios/transfering_a_participant/fip_to_fip_with_same_provider_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/fip_to_fip_with_same_provider_spec.rb
@@ -44,6 +44,7 @@ RSpec.feature "FIP to FIP with same provider - Transfer a participant",
           allow(Cohort).to receive(:current).and_return(cohort)
           allow(Cohort).to receive(:next).and_return(cohort)
           allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
+          allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
           allow(cohort).to receive(:next).and_return(cohort)
           allow(cohort).to receive(:previous).and_return(cohort)
           cohort


### PR DESCRIPTION
### Context

- Ticket: [JIRA](https://dfedigital.atlassian.net/browse/CST-2849)

We need to update the UI for schools and Administrators to use the new Provider-led and School-led programme type names.  This involves "smooshing" together the current "Full induction programme" and "School-funded FIP" into "Provider-led" and "Core induction programme" and "Design our own" into "School-led"

We are using the `:programme_type_changes_2025` feature flag to keep the changes hidden until we are ready launch

This is part seven, split off from #5647 - refer to that PR for screen shots and more info.

There will be more PRs to follow, some that may refactor the work in this one.

These PRs will make changes to the programme type naming that are visible to School and Admin users in the UI.

### Changes proposed in this pull request

* Adding loops to specs to ensure coverage with and without the feature flag active - 3rd batch