### PR TITLE
Fix the link to guidance on how a mentor gets a TRN in ECF1.

### DIFF
--- a/app/views/participants/start_registrations/show.html.erb
+++ b/app/views/participants/start_registrations/show.html.erb
@@ -21,7 +21,8 @@
     <p class="govuk-body">You can enter your National Insurance number instead. This will help us find and check your TRN.</p>
 
     <h2 class="govuk-heading-m">If you’re a mentor without a TRN</h2>
-    <p class="govuk-body">You must <%= govuk_link_to "apply for a TRN", get_a_trn_participants_start_registrations_path %> before you can use this service. You need a TRN to be eligible for DfE-funded mentor training and access to training materials</p>
+    <p class="govuk-body">You must <%= govuk_link_to "apply for a TRN", "https://www.gov.uk/guidance/teacher-reference-number-trn#request-a-trn"
+ %> before you can use this service. You need a TRN to be eligible for DfE-funded mentor training and access to training materials</p>
 
     <%= govuk_button_link_to "Continue", new_user_session_path %>
 

--- a/app/views/schools/add_participants/cannot_add_mentor_without_trn.html.erb
+++ b/app/views/schools/add_participants/cannot_add_mentor_without_trn.html.erb
@@ -20,7 +20,7 @@
       </li>
       <li>have never had one, <%= @wizard.sit_mentor? ? "you" : "they" %>’ll need to
         <%= govuk_link_to "get a TRN (opens in new tab)",
-                          get_a_trn_participants_start_registrations_path,
+                          "https://www.gov.uk/guidance/teacher-reference-number-trn#request-a-trn",
                           target: :_blank,
                           no_visited_state: true %>
       </li>


### PR DESCRIPTION
### Context

- Ticket:  https://github.com/DFE-Digital/register-ects-project-board/issues/1577

### Changes proposed in this pull request
Fix the link for how to get a TRN.

### Guidance to review

Make sure the link works to the new guidance.

I don't think cleaning up the pages matters no much given we're hopefully decommissioning ECF1 relatively soon.

