### PR TITLE
Update delete workflow to use standardized action

### DIFF
--- a/.github/workflows/destroy_review.yml
+++ b/.github/workflows/destroy_review.yml
@@ -1,39 +1,27 @@
-name: Delete review
+name: Delete Review App
 
 on:
   pull_request:
     types: [closed]
-    branches: [main]
 
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: PR number for the review app to destroy
+        required: true
 permissions:
   id-token: write
+  pull-requests: write
+  contents: write
 
 jobs:
   delete-review-app:
     name: Delete Review App ${{ github.event.pull_request.number }}
-    concurrency: deploy_review_${{ github.event.pull_request.number }}
+    concurrency: deploy_review_${{ github.event.pull_request.number || github.event.inputs.pr_number }}
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') }}
     runs-on: ubuntu-latest
     environment: review
     steps:
-      - uses: actions/checkout@v3
-
-      - uses: Azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ecf-bq
-          workload_identity_provider: projects/808138694727/locations/global/workloadIdentityPools/early-careers-framework/providers/early-careers-framework
-
-      - uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: 1.5.4
-          terraform_wrapper: false
-
       - name: Set environment variables
         run: |
           state_file_name=terraform-${{ github.event.pull_request.number }}.tfstate
@@ -55,18 +43,17 @@ jobs:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Destroy Terraform
-        if: env.TF_STATE_EXISTS == 'true'
-        id: destroy-terraform
-        shell: bash
-        run: make ci review terraform-destroy
+      - name: Delete review app
+        uses: DFE-Digital/github-actions/delete-review-app@master
+        with:
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          pr-number: ${{ github.event.pull_request.number || github.event.inputs.pr-number }}
+          resource-group-name: "s189t01-cpdecf-rv-rg"
+          storage-account-name: "s189t01cpdecftfstatervsa"
+          tf-state-file: "${{ github.event.pull_request.number || github.event.inputs.pr-number }}.tfstate"
+          gcp-project-id: ecf-bq
+          gcp-wip: projects/808138694727/locations/global/workloadIdentityPools/early-careers-framework/providers/early-careers-framework
         env:
-          TF_VAR_statuscake_api_token: ${{ secrets.STATUSCAKE_API_TOKEN }}
-          DOCKER_IMAGE: "ghcr.io/dfe-digital/early-careers-framework:no-tag"
-          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
-
-      - name: Delete Terraform state file
-        if: env.TF_STATE_EXISTS == 'true'
-        run: |
-          az storage blob delete -c cpdecf-tfstate --name ${{ env.TF_STATE_FILE }} \
-            --account-name "s189t01cpdecftfstatervsa"
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr-number }}


### PR DESCRIPTION
This PR updates the review app cleanup process by adopting the shared delete-review-app action:

- Replace existing implementation with the standardized approach from teacher-services-cloud template
- Configure the workflow to properly handle Terraform state cleanup
- Update parameters to work with the new DFE-Digital/github-actions/delete-review-app action
- Maintain service-specific configuration for resource groups and storage accounts
- Ensure proper authentication with both Azure and Google Cloud Platform

This standardization improves maintainability across services and ensures consistent cleanup of review environments when PRs are closed.

### Context

- Ticket: https://trello.com/c/7M3ZvinR/2323-use-delete-review-app-github-action

### Guidance to review

https://github.com/DFE-Digital/early-careers-framework/actions/runs/15188406380

