### PR TITLE
Add ingress rate limit

### DIFF
--- a/terraform/domains/environment_domains/main.tf
+++ b/terraform/domains/environment_domains/main.tf
@@ -11,6 +11,7 @@ module "domains" {
   multiple_hosted_zones = var.multiple_hosted_zones
   null_host_header      = try(each.value.null_host_header, false)
   cached_paths          = try(each.value.cached_paths, [])
+  rate_limit            = try(var.rate_limit, null)
 }
 
 # Takes values from hosted_zone.domain_name.cnames (or txt_records, a-records). Use for domains which are not associated with front door.

--- a/terraform/domains/environment_domains/variables.tf
+++ b/terraform/domains/environment_domains/variables.tf
@@ -7,3 +7,16 @@ variable "multiple_hosted_zones" {
   type = bool
   default = false
 }
+
+variable "rate_limit" {
+  type = list(object({
+    agent        = optional(string)
+    priority     = optional(number)
+    duration     = optional(number)
+    limit        = optional(number)
+    selector     = optional(string)
+    operator     = optional(string)
+    match_values = optional(string)
+  }))
+  default = null
+}

--- a/terraform/domains/environment_domains/workspace_variables/cpd_ecf_production.tfvars.json
+++ b/terraform/domains/environment_domains/workspace_variables/cpd_ecf_production.tfvars.json
@@ -15,5 +15,16 @@
         }
       }
     }
-  }
+  },
+    "rate_limit": [
+      {
+        "agent": "all",
+        "priority": 100,
+        "duration": 5,
+        "limit": 2000,
+        "selector": "Host",
+        "operator": "GreaterThanOrEqual",
+        "match_values": "0"
+      }
+    ]
 }

--- a/terraform/domains/environment_domains/workspace_variables/cpd_ecf_sandbox.tfvars.json
+++ b/terraform/domains/environment_domains/workspace_variables/cpd_ecf_sandbox.tfvars.json
@@ -9,5 +9,16 @@
       "environment_short": "sb",
       "origin_hostname": "cpd-ecf-sandbox-web.teacherservices.cloud"
     }
-  }
+  },
+    "rate_limit": [
+      {
+        "agent": "all",
+        "priority": 100,
+        "duration": 5,
+        "limit": 2000,
+        "selector": "Host",
+        "operator": "GreaterThanOrEqual",
+        "match_values": "0"
+      }
+    ]
 }


### PR DESCRIPTION
### Context

Configure rate limiting for production & sandbox

### Changes proposed in this pull request

Add global rate limit per IP for 5 minute intervals
Value for global rate set from checking ingress logs for the last 4 weeks 

### Guidance to review

make production|sandbox domains-plan

### Link to Trello card

https://trello.com/c/rmljcE5W/2345-add-rate-limiting-for-services


