### PR TITLE
Programme type changes for 2025 - Part 8

### DIFF
--- a/app/forms/schools/cohorts/wizard_steps/how_will_you_run_training_step.rb
+++ b/app/forms/schools/cohorts/wizard_steps/how_will_you_run_training_step.rb
@@ -15,7 +15,7 @@ module Schools
         end
 
         def choices
-          school_training_options(state_funded: !wizard.school.cip_only?)
+          school_training_options(state_funded: !wizard.school.cip_only?, exclude: [:no_early_career_teachers])
         end
 
         def expected?

--- a/spec/features/scenarios/participants/ect_doing_cip/after_cohort_transfer_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_cip/after_cohort_transfer_spec.rb
@@ -89,95 +89,99 @@ RSpec.feature "ECT doing CIP: after cohort transfer", type: :feature do
   let(:participant_profile) { participant_details.participant_profile }
   let(:preferred_identity) { participant_details.participant_identity }
 
-  scenario "The current school induction tutor can locate a record for the ECT" do
-    given_i_sign_in_as_the_user_with_the_full_name sit_full_name
+  %w[active inactive].each do |flag_state|
+    context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      scenario "The current school induction tutor can locate a record for the ECT" do
+        given_i_sign_in_as_the_user_with_the_full_name sit_full_name
 
-    school_dashboard = Pages::SchoolDashboardPage.load(slug: school.slug)
-    school_dashboard.view_ect_dashboard
+        school_dashboard = Pages::SchoolDashboardPage.load(slug: school.slug)
+        school_dashboard.view_ect_dashboard
 
-    participant_dashboard = Pages::SchoolEarlyCareerTeachersDashboardPage.loaded(slug: school.slug)
-    participant_dashboard.view_participant participant_full_name
+        participant_dashboard = Pages::SchoolEarlyCareerTeachersDashboardPage.loaded(slug: school.slug)
+        participant_dashboard.view_participant participant_full_name
 
-    participant_details = Pages::SchoolEarlyCareerTeacherDetailsPage.loaded(slug: school.slug, participant_id: training_record_id)
-    expect(participant_details).to have_participant_name participant_full_name
-    expect(participant_details).to have_email participant_email
-    expect(participant_details).to have_full_name participant_full_name
-    expect(participant_details).to have_status school_record_state
-  end
+        participant_details = Pages::SchoolEarlyCareerTeacherDetailsPage.loaded(slug: school.slug, participant_id: training_record_id)
+        expect(participant_details).to have_participant_name participant_full_name
+        expect(participant_details).to have_email participant_email
+        expect(participant_details).to have_full_name participant_full_name
+        expect(participant_details).to have_status school_record_state
+      end
 
-  scenario "The current appropriate body can locate a record for the ECT", :skip do
-    given_i_sign_in_as_the_user_with_the_full_name ab_full_name
+      scenario "The current appropriate body can locate a record for the ECT", :skip do
+        given_i_sign_in_as_the_user_with_the_full_name ab_full_name
 
-    appropriate_body_portal = Pages::AppropriateBodyPortal.loaded
-    appropriate_body_portal.get_participant(participant_full_name)
+        appropriate_body_portal = Pages::AppropriateBodyPortal.loaded
+        appropriate_body_portal.get_participant(participant_full_name)
 
-    expect(appropriate_body_portal).to have_full_name participant_full_name
-    expect(appropriate_body_portal).to have_email_address participant_email
-    expect(appropriate_body_portal).to have_teacher_reference_number teacher_reference_number
-    expect(appropriate_body_portal).to have_participant_type long_participant_type
-    expect(appropriate_body_portal).to have_lead_provider_name lead_provider_name
-    expect(appropriate_body_portal).to have_school_name school_name
-    expect(appropriate_body_portal).to have_school_urn school.urn
-    expect(appropriate_body_portal).to have_academic_year start_year
-    expect(appropriate_body_portal).to have_training_status training_status
-    expect(appropriate_body_portal).to have_training_record_status appropriate_body_Record_state
-  end
+        expect(appropriate_body_portal).to have_full_name participant_full_name
+        expect(appropriate_body_portal).to have_email_address participant_email
+        expect(appropriate_body_portal).to have_teacher_reference_number teacher_reference_number
+        expect(appropriate_body_portal).to have_participant_type long_participant_type
+        expect(appropriate_body_portal).to have_lead_provider_name lead_provider_name
+        expect(appropriate_body_portal).to have_school_name school_name
+        expect(appropriate_body_portal).to have_school_urn school.urn
+        expect(appropriate_body_portal).to have_academic_year start_year
+        expect(appropriate_body_portal).to have_training_status training_status
+        expect(appropriate_body_portal).to have_training_record_status appropriate_body_Record_state
+      end
 
-  scenario "The Support for ECTs service can locate a record for the CIP ECT" do
-    user_endpoint = APIs::ECFUsersEndpoint.load
-    user_endpoint.get_user participant_id
+      scenario "The Support for ECTs service can locate a record for the CIP ECT" do
+        user_endpoint = APIs::ECFUsersEndpoint.load
+        user_endpoint.get_user participant_id
 
-    expect(user_endpoint).to have_email participant_email
-    expect(user_endpoint).to have_full_name participant_full_name
-    expect(user_endpoint).to have_cohort previous_start_year
-    expect(user_endpoint).to have_core_induction_programme cip_materials
-    expect(user_endpoint).to have_induction_programme_choice programme_type
-    expect(user_endpoint).to have_registration_completed registration_completed
-    expect(user_endpoint).to have_user_type participant_type
-  end
+        expect(user_endpoint).to have_email participant_email
+        expect(user_endpoint).to have_full_name participant_full_name
+        expect(user_endpoint).to have_cohort previous_start_year
+        expect(user_endpoint).to have_core_induction_programme cip_materials
+        expect(user_endpoint).to have_induction_programme_choice programme_type
+        expect(user_endpoint).to have_registration_completed registration_completed
+        expect(user_endpoint).to have_user_type participant_type
+      end
 
-  scenario "A DfE admin user can locate the record for the ECT" do
-    given_i_sign_in_as_an_admin_user
+      scenario "A DfE admin user can locate the record for the ECT" do
+        given_i_sign_in_as_an_admin_user
 
-    participant_list = Pages::AdminSupportParticipantList.load
-    participant_list.view_participant participant_full_name
+        participant_list = Pages::AdminSupportParticipantList.load
+        participant_list.view_participant participant_full_name
 
-    participant_detail = Pages::AdminSupportParticipantDetail.loaded(participant_id: training_record_id)
-    expect(participant_detail).to have_full_name participant_full_name
-    expect(participant_detail).to have_email_address participant_email
-    expect(participant_detail).to have_trn teacher_reference_number
-    expect(participant_detail).to have_cohort previous_start_year
-    expect(participant_detail).to have_training_record_state training_record_state
-    expect(participant_detail).to have_user_id participant_id
-    expect(participant_detail).to have_associated_email_address participant_email
+        participant_detail = Pages::AdminSupportParticipantDetail.loaded(participant_id: training_record_id)
+        expect(participant_detail).to have_full_name participant_full_name
+        expect(participant_detail).to have_email_address participant_email
+        expect(participant_detail).to have_trn teacher_reference_number
+        expect(participant_detail).to have_cohort previous_start_year
+        expect(participant_detail).to have_training_record_state training_record_state
+        expect(participant_detail).to have_user_id participant_id
+        expect(participant_detail).to have_associated_email_address participant_email
 
-    participant_detail.open_training_tab
+        participant_detail.open_training_tab
 
-    participant_training = Pages::AdminSupportParticipantTraining.loaded(participant_id: training_record_id)
-    expect(participant_training).to have_cohort previous_start_year
-    expect(participant_training).to have_school_name school.name
-    expect(participant_training).to have_schedule_identifier schedule_identifier
-  end
+        participant_training = Pages::AdminSupportParticipantTraining.loaded(participant_id: training_record_id)
+        expect(participant_training).to have_cohort previous_start_year
+        expect(participant_training).to have_school_name school.name
+        expect(participant_training).to have_schedule_identifier schedule_identifier
+      end
 
-  scenario "A DfE finance user can locate the record for the ECT" do
-    given_i_sign_in_as_a_finance_user
+      scenario "A DfE finance user can locate the record for the ECT" do
+        given_i_sign_in_as_a_finance_user
 
-    drilldown_search = Pages::FinanceParticipantDrilldownSearch.load
-    drilldown_search.find participant_id
+        drilldown_search = Pages::FinanceParticipantDrilldownSearch.load
+        drilldown_search.find participant_id
 
-    drilldown = Pages::FinanceParticipantDrilldown.loaded(user_id: participant_id)
-    expect(drilldown).to have_participant_id participant_id
-    expect(drilldown).to have_full_name participant_full_name
-    expect(drilldown).to have_lead_provider lead_provider_name
-    expect(drilldown).to have_school_urn school.urn
-    expect(drilldown).to have_status participant_status
-    expect(drilldown).to have_induction_status participant_status
-    expect(drilldown).to have_training_status training_status
-    expect(drilldown).to be_eligible_for_funding
-    expect(drilldown).to have_schedule schedule_identifier
-    expect(drilldown).to have_schedule_identifier schedule_identifier
-    expect(drilldown).to have_schedule_cohort previous_start_year
-    expect(drilldown).to have_training_programme programme_name
-    expect(drilldown).to have_participant_class participant_class
+        drilldown = Pages::FinanceParticipantDrilldown.loaded(user_id: participant_id)
+        expect(drilldown).to have_participant_id participant_id
+        expect(drilldown).to have_full_name participant_full_name
+        expect(drilldown).to have_lead_provider lead_provider_name
+        expect(drilldown).to have_school_urn school.urn
+        expect(drilldown).to have_status participant_status
+        expect(drilldown).to have_induction_status participant_status
+        expect(drilldown).to have_training_status training_status
+        expect(drilldown).to be_eligible_for_funding
+        expect(drilldown).to have_schedule schedule_identifier
+        expect(drilldown).to have_schedule_identifier schedule_identifier
+        expect(drilldown).to have_schedule_cohort previous_start_year
+        expect(drilldown).to have_training_programme programme_name
+        expect(drilldown).to have_participant_class participant_class
+      end
+    end
   end
 end

--- a/spec/features/scenarios/participants/ect_doing_cip/after_cohort_transfer_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_cip/after_cohort_transfer_spec.rb
@@ -23,7 +23,6 @@ RSpec.feature "ECT doing CIP: after cohort transfer", type: :feature do
   let(:long_participant_type) { "Early career teacher" }
   let(:participant_class) { "ParticipantProfile::ECT" }
   let(:programme_type) { "core_induction_programme" }
-  let(:programme_name) { "Core induction programme" }
   let(:schedule_identifier) { "ecf-standard-september" }
   let(:cip_material_provider) { "Education Development Trust" }
   let(:cip_materials) { "edt" }
@@ -91,6 +90,10 @@ RSpec.feature "ECT doing CIP: after cohort transfer", type: :feature do
 
   %w[active inactive].each do |flag_state|
     context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      let(:programme_name) do
+        flag_state == "inactive" ? "Core induction programme" : "School-led"
+      end
+
       scenario "The current school induction tutor can locate a record for the ECT" do
         given_i_sign_in_as_the_user_with_the_full_name sit_full_name
 

--- a/spec/features/scenarios/participants/ect_doing_cip/in_training_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_cip/in_training_spec.rb
@@ -23,7 +23,6 @@ RSpec.feature "ECT doing CIP: in training", type: :feature do
   let(:long_participant_type) { "Early career teacher" }
   let(:participant_class) { "ParticipantProfile::ECT" }
   let(:programme_type) { "core_induction_programme" }
-  let(:programme_name) { "Core induction programme" }
   let(:schedule_identifier) { "ecf-standard-september" }
   let(:cip_material_provider) { "Education Development Trust" }
   let(:cip_materials) { "edt" }
@@ -75,6 +74,10 @@ RSpec.feature "ECT doing CIP: in training", type: :feature do
 
   %w[active inactive].each do |flag_state|
     context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      let(:programme_name) do
+        flag_state == "inactive" ? "Core induction programme" : "School-led"
+      end
+
       scenario "The current school induction tutor can locate a record for the ECT" do
         inside_registration_window(cohort:) do
           given_i_sign_in_as_the_user_with_the_full_name sit_full_name

--- a/spec/features/scenarios/participants/ect_doing_cip/in_training_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_cip/in_training_spec.rb
@@ -73,97 +73,101 @@ RSpec.feature "ECT doing CIP: in training", type: :feature do
   let(:participant_profile) { participant_details.participant_profile }
   let(:preferred_identity) { participant_details.participant_identity }
 
-  scenario "The current school induction tutor can locate a record for the ECT" do
-    inside_registration_window(cohort:) do
-      given_i_sign_in_as_the_user_with_the_full_name sit_full_name
+  %w[active inactive].each do |flag_state|
+    context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      scenario "The current school induction tutor can locate a record for the ECT" do
+        inside_registration_window(cohort:) do
+          given_i_sign_in_as_the_user_with_the_full_name sit_full_name
 
-      school_dashboard = Pages::SchoolDashboardPage.load(slug: school.slug)
-      school_dashboard.view_ect_dashboard
+          school_dashboard = Pages::SchoolDashboardPage.load(slug: school.slug)
+          school_dashboard.view_ect_dashboard
 
-      participant_dashboard = Pages::SchoolEarlyCareerTeachersDashboardPage.loaded(slug: school.slug)
-      participant_dashboard.view_participant participant_full_name
+          participant_dashboard = Pages::SchoolEarlyCareerTeachersDashboardPage.loaded(slug: school.slug)
+          participant_dashboard.view_participant participant_full_name
 
-      participant_details = Pages::SchoolEarlyCareerTeacherDetailsPage.loaded(slug: school.slug, participant_id: training_record_id)
-      expect(participant_details).to have_participant_name participant_full_name
-      expect(participant_details).to have_email participant_email
-      expect(participant_details).to have_full_name participant_full_name
-      expect(participant_details).to have_status school_record_state
+          participant_details = Pages::SchoolEarlyCareerTeacherDetailsPage.loaded(slug: school.slug, participant_id: training_record_id)
+          expect(participant_details).to have_participant_name participant_full_name
+          expect(participant_details).to have_email participant_email
+          expect(participant_details).to have_full_name participant_full_name
+          expect(participant_details).to have_status school_record_state
+        end
+      end
+
+      scenario "The current appropriate body can locate a record for the ECT", :skip do
+        given_i_sign_in_as_the_user_with_the_full_name ab_full_name
+
+        appropriate_body_portal = Pages::AppropriateBodyPortal.loaded
+        appropriate_body_portal.get_participant(participant_full_name)
+
+        expect(appropriate_body_portal).to have_full_name participant_full_name
+        expect(appropriate_body_portal).to have_email_address participant_email
+        expect(appropriate_body_portal).to have_teacher_reference_number teacher_reference_number
+        expect(appropriate_body_portal).to have_participant_type long_participant_type
+        expect(appropriate_body_portal).to have_lead_provider_name lead_provider_name
+        expect(appropriate_body_portal).to have_school_name school_name
+        expect(appropriate_body_portal).to have_school_urn school.urn
+        expect(appropriate_body_portal).to have_academic_year start_year
+        expect(appropriate_body_portal).to have_training_status training_status
+        expect(appropriate_body_portal).to have_training_record_status appropriate_body_Record_state
+      end
+
+      scenario "The Support for ECTs service can locate a record for the CIP ECT" do
+        user_endpoint = APIs::ECFUsersEndpoint.load
+        user_endpoint.get_user participant_id
+
+        expect(user_endpoint).to have_email participant_email
+        expect(user_endpoint).to have_full_name participant_full_name
+        expect(user_endpoint).to have_cohort start_year
+        expect(user_endpoint).to have_core_induction_programme cip_materials
+        expect(user_endpoint).to have_induction_programme_choice programme_type
+        expect(user_endpoint).to have_registration_completed registration_completed
+        expect(user_endpoint).to have_user_type participant_type
+      end
+
+      scenario "A DfE admin user can locate the record for the ECT" do
+        given_i_sign_in_as_an_admin_user
+
+        participant_list = Pages::AdminSupportParticipantList.load
+        participant_list.view_participant participant_full_name
+
+        participant_detail = Pages::AdminSupportParticipantDetail.loaded(participant_id: training_record_id)
+        expect(participant_detail).to have_full_name participant_full_name
+        expect(participant_detail).to have_email_address participant_email
+        expect(participant_detail).to have_trn teacher_reference_number
+        expect(participant_detail).to have_cohort start_year
+        expect(participant_detail).to have_training_record_state training_record_state
+        expect(participant_detail).to have_user_id participant_id
+        expect(participant_detail).to have_associated_email_address participant_email
+
+        participant_detail.open_training_tab
+
+        participant_training = Pages::AdminSupportParticipantTraining.loaded(participant_id: training_record_id)
+        expect(participant_training).to have_cohort start_year
+        expect(participant_training).to have_school_name school.name
+        expect(participant_training).to have_schedule_identifier schedule_identifier
+      end
+
+      scenario "A DfE finance user can locate the record for the ECT" do
+        given_i_sign_in_as_a_finance_user
+
+        drilldown_search = Pages::FinanceParticipantDrilldownSearch.load
+        drilldown_search.find participant_id
+
+        drilldown = Pages::FinanceParticipantDrilldown.loaded(user_id: participant_id)
+        expect(drilldown).to have_participant_id participant_id
+        expect(drilldown).to have_full_name participant_full_name
+        expect(drilldown).to have_lead_provider lead_provider_name
+        expect(drilldown).to have_school_urn school.urn
+        expect(drilldown).to have_status participant_status
+        expect(drilldown).to have_induction_status participant_status
+        expect(drilldown).to have_training_status training_status
+        expect(drilldown).to be_eligible_for_funding
+        expect(drilldown).to have_schedule schedule_identifier
+        expect(drilldown).to have_schedule_identifier schedule_identifier
+        expect(drilldown).to have_schedule_cohort start_year
+        expect(drilldown).to have_training_programme programme_name
+        expect(drilldown).to have_participant_class participant_class
+      end
     end
-  end
-
-  scenario "The current appropriate body can locate a record for the ECT", :skip do
-    given_i_sign_in_as_the_user_with_the_full_name ab_full_name
-
-    appropriate_body_portal = Pages::AppropriateBodyPortal.loaded
-    appropriate_body_portal.get_participant(participant_full_name)
-
-    expect(appropriate_body_portal).to have_full_name participant_full_name
-    expect(appropriate_body_portal).to have_email_address participant_email
-    expect(appropriate_body_portal).to have_teacher_reference_number teacher_reference_number
-    expect(appropriate_body_portal).to have_participant_type long_participant_type
-    expect(appropriate_body_portal).to have_lead_provider_name lead_provider_name
-    expect(appropriate_body_portal).to have_school_name school_name
-    expect(appropriate_body_portal).to have_school_urn school.urn
-    expect(appropriate_body_portal).to have_academic_year start_year
-    expect(appropriate_body_portal).to have_training_status training_status
-    expect(appropriate_body_portal).to have_training_record_status appropriate_body_Record_state
-  end
-
-  scenario "The Support for ECTs service can locate a record for the CIP ECT" do
-    user_endpoint = APIs::ECFUsersEndpoint.load
-    user_endpoint.get_user participant_id
-
-    expect(user_endpoint).to have_email participant_email
-    expect(user_endpoint).to have_full_name participant_full_name
-    expect(user_endpoint).to have_cohort start_year
-    expect(user_endpoint).to have_core_induction_programme cip_materials
-    expect(user_endpoint).to have_induction_programme_choice programme_type
-    expect(user_endpoint).to have_registration_completed registration_completed
-    expect(user_endpoint).to have_user_type participant_type
-  end
-
-  scenario "A DfE admin user can locate the record for the ECT" do
-    given_i_sign_in_as_an_admin_user
-
-    participant_list = Pages::AdminSupportParticipantList.load
-    participant_list.view_participant participant_full_name
-
-    participant_detail = Pages::AdminSupportParticipantDetail.loaded(participant_id: training_record_id)
-    expect(participant_detail).to have_full_name participant_full_name
-    expect(participant_detail).to have_email_address participant_email
-    expect(participant_detail).to have_trn teacher_reference_number
-    expect(participant_detail).to have_cohort start_year
-    expect(participant_detail).to have_training_record_state training_record_state
-    expect(participant_detail).to have_user_id participant_id
-    expect(participant_detail).to have_associated_email_address participant_email
-
-    participant_detail.open_training_tab
-
-    participant_training = Pages::AdminSupportParticipantTraining.loaded(participant_id: training_record_id)
-    expect(participant_training).to have_cohort start_year
-    expect(participant_training).to have_school_name school.name
-    expect(participant_training).to have_schedule_identifier schedule_identifier
-  end
-
-  scenario "A DfE finance user can locate the record for the ECT" do
-    given_i_sign_in_as_a_finance_user
-
-    drilldown_search = Pages::FinanceParticipantDrilldownSearch.load
-    drilldown_search.find participant_id
-
-    drilldown = Pages::FinanceParticipantDrilldown.loaded(user_id: participant_id)
-    expect(drilldown).to have_participant_id participant_id
-    expect(drilldown).to have_full_name participant_full_name
-    expect(drilldown).to have_lead_provider lead_provider_name
-    expect(drilldown).to have_school_urn school.urn
-    expect(drilldown).to have_status participant_status
-    expect(drilldown).to have_induction_status participant_status
-    expect(drilldown).to have_training_status training_status
-    expect(drilldown).to be_eligible_for_funding
-    expect(drilldown).to have_schedule schedule_identifier
-    expect(drilldown).to have_schedule_identifier schedule_identifier
-    expect(drilldown).to have_schedule_cohort start_year
-    expect(drilldown).to have_training_programme programme_name
-    expect(drilldown).to have_participant_class participant_class
   end
 end

--- a/spec/features/scenarios/participants/ect_doing_cip/no_validation_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_cip/no_validation_spec.rb
@@ -73,96 +73,100 @@ RSpec.feature "ECT doing CIP: no validation", type: :feature, early_in_cohort: t
   let(:participant_profile) { participant_details.participant_profile }
   let(:preferred_identity) { participant_details.participant_identity }
 
-  scenario "The current school induction tutor can locate a record for the ECT" do
-    given_i_sign_in_as_the_user_with_the_full_name sit_full_name
+  %w[active inactive].each do |flag_state|
+    context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      scenario "The current school induction tutor can locate a record for the ECT" do
+        given_i_sign_in_as_the_user_with_the_full_name sit_full_name
 
-    school_dashboard = Pages::SchoolDashboardPage.load(slug: school.slug)
-    school_dashboard.view_ect_dashboard
+        school_dashboard = Pages::SchoolDashboardPage.load(slug: school.slug)
+        school_dashboard.view_ect_dashboard
 
-    participant_dashboard = Pages::SchoolEarlyCareerTeachersDashboardPage.loaded(slug: school.slug)
-    participant_dashboard.view_participant participant_full_name
+        participant_dashboard = Pages::SchoolEarlyCareerTeachersDashboardPage.loaded(slug: school.slug)
+        participant_dashboard.view_participant participant_full_name
 
-    participant_details = Pages::SchoolEarlyCareerTeacherDetailsPage.loaded(slug: school.slug, participant_id: training_record_id)
-    expect(participant_details).to have_participant_name participant_full_name
-    expect(participant_details).to have_email participant_email
-    expect(participant_details).to have_full_name participant_full_name
-    expect(participant_details).to have_status school_record_state
-    expect(participant_details).to have_materials_supplier cip_material_provider
-  end
+        participant_details = Pages::SchoolEarlyCareerTeacherDetailsPage.loaded(slug: school.slug, participant_id: training_record_id)
+        expect(participant_details).to have_participant_name participant_full_name
+        expect(participant_details).to have_email participant_email
+        expect(participant_details).to have_full_name participant_full_name
+        expect(participant_details).to have_status school_record_state
+        expect(participant_details).to have_materials_supplier cip_material_provider
+      end
 
-  scenario "The current appropriate body can locate a record for the ECT", :skip do
-    given_i_sign_in_as_the_user_with_the_full_name ab_full_name
+      scenario "The current appropriate body can locate a record for the ECT", :skip do
+        given_i_sign_in_as_the_user_with_the_full_name ab_full_name
 
-    appropriate_body_portal = Pages::AppropriateBodyPortal.loaded
-    appropriate_body_portal.get_participant(participant_full_name)
+        appropriate_body_portal = Pages::AppropriateBodyPortal.loaded
+        appropriate_body_portal.get_participant(participant_full_name)
 
-    expect(appropriate_body_portal).to have_full_name participant_full_name
-    expect(appropriate_body_portal).to have_email_address participant_email
-    expect(appropriate_body_portal).to have_teacher_reference_number teacher_reference_number
-    expect(appropriate_body_portal).to have_participant_type long_participant_type
-    expect(appropriate_body_portal).to have_lead_provider_name lead_provider_name
-    expect(appropriate_body_portal).to have_school_name school_name
-    expect(appropriate_body_portal).to have_school_urn school.urn
-    expect(appropriate_body_portal).to have_academic_year start_year
-    expect(appropriate_body_portal).to have_training_status training_status
-    expect(appropriate_body_portal).to have_training_record_status appropriate_body_Record_state
-  end
+        expect(appropriate_body_portal).to have_full_name participant_full_name
+        expect(appropriate_body_portal).to have_email_address participant_email
+        expect(appropriate_body_portal).to have_teacher_reference_number teacher_reference_number
+        expect(appropriate_body_portal).to have_participant_type long_participant_type
+        expect(appropriate_body_portal).to have_lead_provider_name lead_provider_name
+        expect(appropriate_body_portal).to have_school_name school_name
+        expect(appropriate_body_portal).to have_school_urn school.urn
+        expect(appropriate_body_portal).to have_academic_year start_year
+        expect(appropriate_body_portal).to have_training_status training_status
+        expect(appropriate_body_portal).to have_training_record_status appropriate_body_Record_state
+      end
 
-  scenario "The Support for ECTs service can locate a record for the CIP ECT" do
-    user_endpoint = APIs::ECFUsersEndpoint.load
-    user_endpoint.get_user participant_id
+      scenario "The Support for ECTs service can locate a record for the CIP ECT" do
+        user_endpoint = APIs::ECFUsersEndpoint.load
+        user_endpoint.get_user participant_id
 
-    expect(user_endpoint).to have_email participant_email
-    expect(user_endpoint).to have_full_name participant_full_name
-    expect(user_endpoint).to have_cohort start_year
-    expect(user_endpoint).to have_core_induction_programme cip_materials
-    expect(user_endpoint).to have_induction_programme_choice programme_type
-    expect(user_endpoint).to have_registration_completed registration_completed
-    expect(user_endpoint).to have_user_type participant_type
-  end
+        expect(user_endpoint).to have_email participant_email
+        expect(user_endpoint).to have_full_name participant_full_name
+        expect(user_endpoint).to have_cohort start_year
+        expect(user_endpoint).to have_core_induction_programme cip_materials
+        expect(user_endpoint).to have_induction_programme_choice programme_type
+        expect(user_endpoint).to have_registration_completed registration_completed
+        expect(user_endpoint).to have_user_type participant_type
+      end
 
-  scenario "A DfE admin user can locate the record for the ECT" do
-    given_i_sign_in_as_an_admin_user
+      scenario "A DfE admin user can locate the record for the ECT" do
+        given_i_sign_in_as_an_admin_user
 
-    participant_list = Pages::AdminSupportParticipantList.load
-    participant_list.view_participant participant_full_name
+        participant_list = Pages::AdminSupportParticipantList.load
+        participant_list.view_participant participant_full_name
 
-    participant_detail = Pages::AdminSupportParticipantDetail.loaded(participant_id: training_record_id)
-    expect(participant_detail).to have_full_name participant_full_name
-    expect(participant_detail).to have_email_address participant_email
-    expect(participant_detail).to have_trn teacher_reference_number
-    expect(participant_detail).to have_cohort start_year
-    expect(participant_detail).to have_training_record_state training_record_state
-    expect(participant_detail).to have_user_id participant_id
-    expect(participant_detail).to have_associated_email_address participant_email
+        participant_detail = Pages::AdminSupportParticipantDetail.loaded(participant_id: training_record_id)
+        expect(participant_detail).to have_full_name participant_full_name
+        expect(participant_detail).to have_email_address participant_email
+        expect(participant_detail).to have_trn teacher_reference_number
+        expect(participant_detail).to have_cohort start_year
+        expect(participant_detail).to have_training_record_state training_record_state
+        expect(participant_detail).to have_user_id participant_id
+        expect(participant_detail).to have_associated_email_address participant_email
 
-    participant_detail.open_training_tab
+        participant_detail.open_training_tab
 
-    participant_training = Pages::AdminSupportParticipantTraining.loaded(participant_id: training_record_id)
-    expect(participant_training).to have_cohort start_year
-    expect(participant_training).to have_school_name school.name
-    expect(participant_training).to have_schedule_identifier schedule_identifier
-  end
+        participant_training = Pages::AdminSupportParticipantTraining.loaded(participant_id: training_record_id)
+        expect(participant_training).to have_cohort start_year
+        expect(participant_training).to have_school_name school.name
+        expect(participant_training).to have_schedule_identifier schedule_identifier
+      end
 
-  scenario "A DfE finance user can locate the record for the ECT" do
-    given_i_sign_in_as_a_finance_user
+      scenario "A DfE finance user can locate the record for the ECT" do
+        given_i_sign_in_as_a_finance_user
 
-    drilldown_search = Pages::FinanceParticipantDrilldownSearch.load
-    drilldown_search.find participant_id
+        drilldown_search = Pages::FinanceParticipantDrilldownSearch.load
+        drilldown_search.find participant_id
 
-    drilldown = Pages::FinanceParticipantDrilldown.loaded(user_id: participant_id)
-    expect(drilldown).to have_participant_id participant_id
-    expect(drilldown).to have_full_name participant_full_name
-    expect(drilldown).to have_lead_provider lead_provider_name
-    expect(drilldown).to have_school_urn school.urn
-    expect(drilldown).to have_status participant_status
-    expect(drilldown).to have_induction_status participant_status
-    expect(drilldown).to have_training_status training_status
-    expect(drilldown).to be_not_eligible_for_funding
-    expect(drilldown).to have_schedule schedule_identifier
-    expect(drilldown).to have_schedule_identifier schedule_identifier
-    expect(drilldown).to have_schedule_cohort start_year
-    expect(drilldown).to have_training_programme programme_name
-    expect(drilldown).to have_participant_class participant_class
+        drilldown = Pages::FinanceParticipantDrilldown.loaded(user_id: participant_id)
+        expect(drilldown).to have_participant_id participant_id
+        expect(drilldown).to have_full_name participant_full_name
+        expect(drilldown).to have_lead_provider lead_provider_name
+        expect(drilldown).to have_school_urn school.urn
+        expect(drilldown).to have_status participant_status
+        expect(drilldown).to have_induction_status participant_status
+        expect(drilldown).to have_training_status training_status
+        expect(drilldown).to be_not_eligible_for_funding
+        expect(drilldown).to have_schedule schedule_identifier
+        expect(drilldown).to have_schedule_identifier schedule_identifier
+        expect(drilldown).to have_schedule_cohort start_year
+        expect(drilldown).to have_training_programme programme_name
+        expect(drilldown).to have_participant_class participant_class
+      end
+    end
   end
 end

--- a/spec/features/scenarios/participants/ect_doing_cip/no_validation_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_cip/no_validation_spec.rb
@@ -23,7 +23,6 @@ RSpec.feature "ECT doing CIP: no validation", type: :feature, early_in_cohort: t
   let(:long_participant_type) { "Early career teacher" }
   let(:participant_class) { "ParticipantProfile::ECT" }
   let(:programme_type) { "core_induction_programme" }
-  let(:programme_name) { "Core induction programme" }
   let(:schedule_identifier) { "ecf-standard-september" }
   let(:cip_material_provider) { "Education Development Trust" }
   let(:cip_materials) { "edt" }
@@ -75,6 +74,10 @@ RSpec.feature "ECT doing CIP: no validation", type: :feature, early_in_cohort: t
 
   %w[active inactive].each do |flag_state|
     context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      let(:programme_name) do
+        flag_state == "inactive" ? "Core induction programme" : "School-led"
+      end
+
       scenario "The current school induction tutor can locate a record for the ECT" do
         given_i_sign_in_as_the_user_with_the_full_name sit_full_name
 

--- a/spec/features/scenarios/participants/ect_doing_fip/after_cohort_transfer_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_fip/after_cohort_transfer_spec.rb
@@ -23,7 +23,6 @@ RSpec.feature "ECT doing FIP: after cohort transfer", type: :feature do
   let(:short_participant_type) { "ect" }
   let(:participant_class) { "ParticipantProfile::ECT" }
   let(:programme_type) { "full_induction_programme" }
-  let(:programme_name) { "Full induction programme" }
   let(:schedule_identifier) { "ecf-standard-september" }
   let(:cip_materials) { "none" }
   let(:start_year) { Cohort.next.start_year }
@@ -97,6 +96,10 @@ RSpec.feature "ECT doing FIP: after cohort transfer", type: :feature do
 
   %w[active inactive].each do |flag_state|
     context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      let(:programme_name) do
+        flag_state == "inactive" ? "Full induction programme" : "Provider-led"
+      end
+
       scenario "The current school induction tutor can locate a record for the ECT" do
         given_i_sign_in_as_the_user_with_the_full_name sit_full_name
 

--- a/spec/features/scenarios/participants/ect_doing_fip/after_cohort_transfer_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_fip/after_cohort_transfer_spec.rb
@@ -95,152 +95,156 @@ RSpec.feature "ECT doing FIP: after cohort transfer", type: :feature do
   let(:participant_profile) { participant_details.participant_profile }
   let(:preferred_identity) { participant_details.participant_identity }
 
-  scenario "The current school induction tutor can locate a record for the ECT" do
-    given_i_sign_in_as_the_user_with_the_full_name sit_full_name
+  %w[active inactive].each do |flag_state|
+    context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      scenario "The current school induction tutor can locate a record for the ECT" do
+        given_i_sign_in_as_the_user_with_the_full_name sit_full_name
 
-    school_dashboard = Pages::SchoolDashboardPage.load(slug: school.slug)
-    school_dashboard.view_ect_dashboard
+        school_dashboard = Pages::SchoolDashboardPage.load(slug: school.slug)
+        school_dashboard.view_ect_dashboard
 
-    participant_dashboard = Pages::SchoolEarlyCareerTeachersDashboardPage.loaded(slug: school.slug)
-    participant_dashboard.view_participant participant_full_name
+        participant_dashboard = Pages::SchoolEarlyCareerTeachersDashboardPage.loaded(slug: school.slug)
+        participant_dashboard.view_participant participant_full_name
 
-    participant_details = Pages::SchoolEarlyCareerTeacherDetailsPage.loaded(slug: school.slug, participant_id: training_record_id)
-    expect(participant_details).to have_participant_name participant_full_name
-    expect(participant_details).to have_email participant_email
-    expect(participant_details).to have_full_name participant_full_name
-    expect(participant_details).to have_status school_record_state
-  end
+        participant_details = Pages::SchoolEarlyCareerTeacherDetailsPage.loaded(slug: school.slug, participant_id: training_record_id)
+        expect(participant_details).to have_participant_name participant_full_name
+        expect(participant_details).to have_email participant_email
+        expect(participant_details).to have_full_name participant_full_name
+        expect(participant_details).to have_status school_record_state
+      end
 
-  scenario "The current appropriate body can locate a record for the ECT", :skip do
-    given_i_sign_in_as_the_user_with_the_full_name ab_full_name
+      scenario "The current appropriate body can locate a record for the ECT", :skip do
+        given_i_sign_in_as_the_user_with_the_full_name ab_full_name
 
-    appropriate_body_portal = Pages::AppropriateBodyPortal.loaded
-    appropriate_body_portal.get_participant(participant_full_name)
+        appropriate_body_portal = Pages::AppropriateBodyPortal.loaded
+        appropriate_body_portal.get_participant(participant_full_name)
 
-    expect(appropriate_body_portal).to have_full_name participant_full_name
-    expect(appropriate_body_portal).to have_email_address participant_email
-    expect(appropriate_body_portal).to have_teacher_reference_number teacher_reference_number
-    expect(appropriate_body_portal).to have_participant_type long_participant_type
-    expect(appropriate_body_portal).to have_lead_provider_name lead_provider_name
-    expect(appropriate_body_portal).to have_school_name school_name
-    expect(appropriate_body_portal).to have_school_urn school.urn
-    expect(appropriate_body_portal).to have_academic_year start_year
-    expect(appropriate_body_portal).to have_training_status training_status
-    expect(appropriate_body_portal).to have_training_record_status appropriate_body_record_state
-  end
+        expect(appropriate_body_portal).to have_full_name participant_full_name
+        expect(appropriate_body_portal).to have_email_address participant_email
+        expect(appropriate_body_portal).to have_teacher_reference_number teacher_reference_number
+        expect(appropriate_body_portal).to have_participant_type long_participant_type
+        expect(appropriate_body_portal).to have_lead_provider_name lead_provider_name
+        expect(appropriate_body_portal).to have_school_name school_name
+        expect(appropriate_body_portal).to have_school_urn school.urn
+        expect(appropriate_body_portal).to have_academic_year start_year
+        expect(appropriate_body_portal).to have_training_status training_status
+        expect(appropriate_body_portal).to have_training_record_status appropriate_body_record_state
+      end
 
-  scenario "The current lead provider can locate a record for the ECT" do
-    lead_provider_token = LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: lead_provider_details.cpd_lead_provider)
+      scenario "The current lead provider can locate a record for the ECT" do
+        lead_provider_token = LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: lead_provider_details.cpd_lead_provider)
 
-    ecf_participant_endpoint = APIs::ECFParticipantsEndpoint.load(lead_provider_token)
-    ecf_participant_endpoint.get_participant participant_id
+        ecf_participant_endpoint = APIs::ECFParticipantsEndpoint.load(lead_provider_token)
+        ecf_participant_endpoint.get_participant participant_id
 
-    expect(ecf_participant_endpoint).to have_email_address participant_email
-    expect(ecf_participant_endpoint).to have_full_name participant_full_name
-    expect(ecf_participant_endpoint).to have_mentor_id nil
-    expect(ecf_participant_endpoint).to have_school_urn school.urn
-    expect(ecf_participant_endpoint).to have_participant_type short_participant_type
-    expect(ecf_participant_endpoint).to have_cohort previous_start_year
-    expect(ecf_participant_endpoint).to have_trn teacher_reference_number
-    # teacher_reference_number_validated: true,
-    expect(ecf_participant_endpoint).to be_eligible_for_funding
-    expect(ecf_participant_endpoint).to have_pupil_premium_uplift
-    expect(ecf_participant_endpoint).to have_sparsity_uplift
-    expect(ecf_participant_endpoint).to have_status participant_status
-    expect(ecf_participant_endpoint).to have_training_record_id training_record_id
-    expect(ecf_participant_endpoint).to have_schedule_identifier schedule_identifier
+        expect(ecf_participant_endpoint).to have_email_address participant_email
+        expect(ecf_participant_endpoint).to have_full_name participant_full_name
+        expect(ecf_participant_endpoint).to have_mentor_id nil
+        expect(ecf_participant_endpoint).to have_school_urn school.urn
+        expect(ecf_participant_endpoint).to have_participant_type short_participant_type
+        expect(ecf_participant_endpoint).to have_cohort previous_start_year
+        expect(ecf_participant_endpoint).to have_trn teacher_reference_number
+        # teacher_reference_number_validated: true,
+        expect(ecf_participant_endpoint).to be_eligible_for_funding
+        expect(ecf_participant_endpoint).to have_pupil_premium_uplift
+        expect(ecf_participant_endpoint).to have_sparsity_uplift
+        expect(ecf_participant_endpoint).to have_status participant_status
+        expect(ecf_participant_endpoint).to have_training_record_id training_record_id
+        expect(ecf_participant_endpoint).to have_schedule_identifier schedule_identifier
 
-    participant_endpoint = APIs::ParticipantsEndpoint.load(lead_provider_token)
-    participant_endpoint.get_participant participant_id
+        participant_endpoint = APIs::ParticipantsEndpoint.load(lead_provider_token)
+        participant_endpoint.get_participant participant_id
 
-    expect(participant_endpoint).to have_email_address participant_email
-    expect(participant_endpoint).to have_full_name participant_full_name
-    expect(participant_endpoint).to have_mentor_id nil
-    expect(participant_endpoint).to have_school_urn school.urn
-    expect(participant_endpoint).to have_participant_type short_participant_type
-    expect(participant_endpoint).to have_cohort previous_start_year
-    expect(participant_endpoint).to have_trn teacher_reference_number
-    # teacher_reference_number_validated: true,
-    expect(participant_endpoint).to be_eligible_for_funding
-    expect(participant_endpoint).to have_pupil_premium_uplift
-    expect(participant_endpoint).to have_sparsity_uplift
-    expect(participant_endpoint).to have_status participant_status
-    expect(participant_endpoint).to have_training_record_id training_record_id
-    expect(participant_endpoint).to have_schedule_identifier schedule_identifier
-  end
+        expect(participant_endpoint).to have_email_address participant_email
+        expect(participant_endpoint).to have_full_name participant_full_name
+        expect(participant_endpoint).to have_mentor_id nil
+        expect(participant_endpoint).to have_school_urn school.urn
+        expect(participant_endpoint).to have_participant_type short_participant_type
+        expect(participant_endpoint).to have_cohort previous_start_year
+        expect(participant_endpoint).to have_trn teacher_reference_number
+        # teacher_reference_number_validated: true,
+        expect(participant_endpoint).to be_eligible_for_funding
+        expect(participant_endpoint).to have_pupil_premium_uplift
+        expect(participant_endpoint).to have_sparsity_uplift
+        expect(participant_endpoint).to have_status participant_status
+        expect(participant_endpoint).to have_training_record_id training_record_id
+        expect(participant_endpoint).to have_schedule_identifier schedule_identifier
+      end
 
-  scenario "The current delivery partner can locate a record for the ECT" do
-    given_i_sign_in_as_the_user_with_the_full_name delivery_partner_name
+      scenario "The current delivery partner can locate a record for the ECT" do
+        given_i_sign_in_as_the_user_with_the_full_name delivery_partner_name
 
-    delivery_partner_portal = Pages::DeliveryPartnerPortal.loaded
-    delivery_partner_portal.get_participant(participant_full_name)
+        delivery_partner_portal = Pages::DeliveryPartnerPortal.loaded
+        delivery_partner_portal.get_participant(participant_full_name)
 
-    expect(delivery_partner_portal).to have_full_name participant_full_name
-    expect(delivery_partner_portal).to have_email_address participant_email
-    expect(delivery_partner_portal).to have_teacher_reference_number teacher_reference_number
-    expect(delivery_partner_portal).to have_participant_type long_participant_type
-    expect(delivery_partner_portal).to have_lead_provider_name lead_provider_name
-    expect(delivery_partner_portal).to have_school_name school_name
-    expect(delivery_partner_portal).to have_school_urn school.urn
-    expect(delivery_partner_portal).to have_academic_year new_school_cohort.start_year
-    expect(delivery_partner_portal).to have_training_record_status delivery_partner_record_state
-  end
+        expect(delivery_partner_portal).to have_full_name participant_full_name
+        expect(delivery_partner_portal).to have_email_address participant_email
+        expect(delivery_partner_portal).to have_teacher_reference_number teacher_reference_number
+        expect(delivery_partner_portal).to have_participant_type long_participant_type
+        expect(delivery_partner_portal).to have_lead_provider_name lead_provider_name
+        expect(delivery_partner_portal).to have_school_name school_name
+        expect(delivery_partner_portal).to have_school_urn school.urn
+        expect(delivery_partner_portal).to have_academic_year new_school_cohort.start_year
+        expect(delivery_partner_portal).to have_training_record_status delivery_partner_record_state
+      end
 
-  scenario "The Support for ECTs service can locate a record for the CIP ECT" do
-    user_endpoint = APIs::ECFUsersEndpoint.load
-    user_endpoint.get_user participant_id
+      scenario "The Support for ECTs service can locate a record for the CIP ECT" do
+        user_endpoint = APIs::ECFUsersEndpoint.load
+        user_endpoint.get_user participant_id
 
-    expect(user_endpoint).to have_email participant_email
-    expect(user_endpoint).to have_full_name participant_full_name
-    expect(user_endpoint).to have_cohort previous_start_year
-    expect(user_endpoint).to have_core_induction_programme cip_materials
-    expect(user_endpoint).to have_induction_programme_choice programme_type
-    expect(user_endpoint).to have_registration_completed registration_completed
-    expect(user_endpoint).to have_user_type participant_type
-  end
+        expect(user_endpoint).to have_email participant_email
+        expect(user_endpoint).to have_full_name participant_full_name
+        expect(user_endpoint).to have_cohort previous_start_year
+        expect(user_endpoint).to have_core_induction_programme cip_materials
+        expect(user_endpoint).to have_induction_programme_choice programme_type
+        expect(user_endpoint).to have_registration_completed registration_completed
+        expect(user_endpoint).to have_user_type participant_type
+      end
 
-  scenario "A DfE admin user can locate the record for the ECT" do
-    given_i_sign_in_as_an_admin_user
+      scenario "A DfE admin user can locate the record for the ECT" do
+        given_i_sign_in_as_an_admin_user
 
-    participant_list = Pages::AdminSupportParticipantList.load
-    participant_list.view_participant participant_full_name
+        participant_list = Pages::AdminSupportParticipantList.load
+        participant_list.view_participant participant_full_name
 
-    participant_detail = Pages::AdminSupportParticipantDetail.loaded(participant_id: training_record_id)
-    expect(participant_detail).to have_full_name participant_full_name
-    expect(participant_detail).to have_email_address participant_email
-    expect(participant_detail).to have_trn teacher_reference_number
-    expect(participant_detail).to have_cohort previous_start_year
-    expect(participant_detail).to have_training_record_state training_record_state
-    expect(participant_detail).to have_user_id participant_id
-    expect(participant_detail).to have_associated_email_address participant_email
+        participant_detail = Pages::AdminSupportParticipantDetail.loaded(participant_id: training_record_id)
+        expect(participant_detail).to have_full_name participant_full_name
+        expect(participant_detail).to have_email_address participant_email
+        expect(participant_detail).to have_trn teacher_reference_number
+        expect(participant_detail).to have_cohort previous_start_year
+        expect(participant_detail).to have_training_record_state training_record_state
+        expect(participant_detail).to have_user_id participant_id
+        expect(participant_detail).to have_associated_email_address participant_email
 
-    participant_detail.open_training_tab
+        participant_detail.open_training_tab
 
-    participant_training = Pages::AdminSupportParticipantTraining.loaded(participant_id: training_record_id)
-    expect(participant_training).to have_cohort previous_start_year
-    expect(participant_training).to have_school_name school.name
-    expect(participant_training).to have_lead_provider lead_provider_name
-    expect(participant_training).to have_schedule_identifier schedule_identifier
-  end
+        participant_training = Pages::AdminSupportParticipantTraining.loaded(participant_id: training_record_id)
+        expect(participant_training).to have_cohort previous_start_year
+        expect(participant_training).to have_school_name school.name
+        expect(participant_training).to have_lead_provider lead_provider_name
+        expect(participant_training).to have_schedule_identifier schedule_identifier
+      end
 
-  scenario "A DfE finance user can locate the record for the ECT" do
-    given_i_sign_in_as_a_finance_user
+      scenario "A DfE finance user can locate the record for the ECT" do
+        given_i_sign_in_as_a_finance_user
 
-    drilldown_search = Pages::FinanceParticipantDrilldownSearch.load
-    drilldown_search.find participant_id
+        drilldown_search = Pages::FinanceParticipantDrilldownSearch.load
+        drilldown_search.find participant_id
 
-    drilldown = Pages::FinanceParticipantDrilldown.loaded(user_id: participant_id)
-    expect(drilldown).to have_participant_id participant_id
-    expect(drilldown).to have_full_name participant_full_name
-    expect(drilldown).to have_lead_provider lead_provider_name
-    expect(drilldown).to have_school_urn school.urn
-    expect(drilldown).to have_status participant_status
-    expect(drilldown).to have_induction_status participant_status
-    expect(drilldown).to be_eligible_for_funding
-    expect(drilldown).to have_schedule schedule_identifier
-    expect(drilldown).to have_schedule_identifier schedule_identifier
-    expect(drilldown).to have_schedule_cohort previous_start_year
-    expect(drilldown).to have_training_programme programme_name
-    expect(drilldown).to have_participant_class participant_class
+        drilldown = Pages::FinanceParticipantDrilldown.loaded(user_id: participant_id)
+        expect(drilldown).to have_participant_id participant_id
+        expect(drilldown).to have_full_name participant_full_name
+        expect(drilldown).to have_lead_provider lead_provider_name
+        expect(drilldown).to have_school_urn school.urn
+        expect(drilldown).to have_status participant_status
+        expect(drilldown).to have_induction_status participant_status
+        expect(drilldown).to be_eligible_for_funding
+        expect(drilldown).to have_schedule schedule_identifier
+        expect(drilldown).to have_schedule_identifier schedule_identifier
+        expect(drilldown).to have_schedule_cohort previous_start_year
+        expect(drilldown).to have_training_programme programme_name
+        expect(drilldown).to have_participant_class participant_class
+      end
+    end
   end
 end

--- a/spec/features/scenarios/participants/ect_doing_fip/in_training_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_fip/in_training_spec.rb
@@ -79,157 +79,161 @@ RSpec.feature "ECT doing FIP: in training", type: :feature do
   let(:participant_profile) { participant_details.participant_profile }
   let(:preferred_identity) { participant_details.participant_identity }
 
-  scenario "The current school induction tutor can locate a record for the ECT" do
-    inside_registration_window(cohort:) do
-      given_i_sign_in_as_the_user_with_the_full_name sit_full_name
+  %w[active inactive].each do |flag_state|
+    context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      scenario "The current school induction tutor can locate a record for the ECT" do
+        inside_registration_window(cohort:) do
+          given_i_sign_in_as_the_user_with_the_full_name sit_full_name
 
-      school_dashboard = Pages::SchoolDashboardPage.load(slug: school.slug)
-      school_dashboard.view_ect_dashboard
+          school_dashboard = Pages::SchoolDashboardPage.load(slug: school.slug)
+          school_dashboard.view_ect_dashboard
 
-      participant_dashboard = Pages::SchoolEarlyCareerTeachersDashboardPage.loaded(slug: school.slug)
-      participant_dashboard.view_participant participant_full_name
+          participant_dashboard = Pages::SchoolEarlyCareerTeachersDashboardPage.loaded(slug: school.slug)
+          participant_dashboard.view_participant participant_full_name
 
-      participant_details = Pages::SchoolEarlyCareerTeacherDetailsPage.loaded(slug: school.slug, participant_id: training_record_id)
-      expect(participant_details).to have_participant_name participant_full_name
-      expect(participant_details).to have_email participant_email
-      expect(participant_details).to have_full_name participant_full_name
-      expect(participant_details).to have_status school_record_state
+          participant_details = Pages::SchoolEarlyCareerTeacherDetailsPage.loaded(slug: school.slug, participant_id: training_record_id)
+          expect(participant_details).to have_participant_name participant_full_name
+          expect(participant_details).to have_email participant_email
+          expect(participant_details).to have_full_name participant_full_name
+          expect(participant_details).to have_status school_record_state
+        end
+      end
+
+      scenario "The current appropriate body can locate a record for the ECT", :skip do
+        given_i_sign_in_as_the_user_with_the_full_name ab_full_name
+
+        appropriate_body_portal = Pages::AppropriateBodyPortal.loaded
+        appropriate_body_portal.get_participant(participant_full_name)
+
+        expect(appropriate_body_portal).to have_full_name participant_full_name
+        expect(appropriate_body_portal).to have_email_address participant_email
+        expect(appropriate_body_portal).to have_teacher_reference_number teacher_reference_number
+        expect(appropriate_body_portal).to have_participant_type long_participant_type
+        expect(appropriate_body_portal).to have_lead_provider_name lead_provider_name
+        expect(appropriate_body_portal).to have_school_name school_name
+        expect(appropriate_body_portal).to have_school_urn school.urn
+        expect(appropriate_body_portal).to have_academic_year start_year
+        expect(appropriate_body_portal).to have_training_record_status appropriate_body_record_state
+      end
+
+      scenario "The current lead provider can locate a record for the ECT" do
+        lead_provider_token = LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: lead_provider_details.cpd_lead_provider)
+
+        ecf_participant_endpoint = APIs::ECFParticipantsEndpoint.load(lead_provider_token)
+        ecf_participant_endpoint.get_participant participant_id
+
+        expect(ecf_participant_endpoint).to have_email_address participant_email
+        expect(ecf_participant_endpoint).to have_full_name participant_full_name
+        expect(ecf_participant_endpoint).to have_mentor_id nil
+        expect(ecf_participant_endpoint).to have_school_urn school.urn
+        expect(ecf_participant_endpoint).to have_participant_type short_participant_type
+        expect(ecf_participant_endpoint).to have_cohort start_year
+        expect(ecf_participant_endpoint).to have_trn teacher_reference_number
+        # teacher_reference_number_validated: true,
+        expect(ecf_participant_endpoint).to be_eligible_for_funding
+        expect(ecf_participant_endpoint).to have_pupil_premium_uplift
+        expect(ecf_participant_endpoint).to have_sparsity_uplift
+        expect(ecf_participant_endpoint).to have_status participant_status
+        expect(ecf_participant_endpoint).to have_training_record_id training_record_id
+        expect(ecf_participant_endpoint).to have_schedule_identifier schedule_identifier
+
+        participant_endpoint = APIs::ParticipantsEndpoint.load(lead_provider_token)
+        participant_endpoint.get_participant participant_id
+
+        expect(participant_endpoint).to have_email_address participant_email
+        expect(participant_endpoint).to have_full_name participant_full_name
+        expect(participant_endpoint).to have_mentor_id nil
+        expect(participant_endpoint).to have_school_urn school.urn
+        expect(participant_endpoint).to have_participant_type short_participant_type
+        expect(participant_endpoint).to have_cohort start_year
+        expect(participant_endpoint).to have_trn teacher_reference_number
+        # teacher_reference_number_validated: true,
+        expect(participant_endpoint).to be_eligible_for_funding
+        expect(participant_endpoint).to have_pupil_premium_uplift
+        expect(participant_endpoint).to have_sparsity_uplift
+        expect(participant_endpoint).to have_status participant_status
+        expect(participant_endpoint).to have_training_record_id training_record_id
+        expect(participant_endpoint).to have_schedule_identifier schedule_identifier
+      end
+
+      context "when the participant cohort is #{DeliveryPartners::ParticipantsFilter::LATEST_COHORT_TO_RETURN} or earlier" do
+        let(:start_year) { DeliveryPartners::ParticipantsFilter::LATEST_COHORT_TO_RETURN }
+
+        scenario "The current delivery partner can locate a record for the ECT" do
+          given_i_sign_in_as_the_user_with_the_full_name delivery_partner_name
+
+          delivery_partner_portal = Pages::DeliveryPartnerPortal.loaded
+          delivery_partner_portal.get_participant(participant_full_name)
+
+          expect(delivery_partner_portal).to have_full_name participant_full_name
+          expect(delivery_partner_portal).to have_email_address participant_email
+          expect(delivery_partner_portal).to have_teacher_reference_number teacher_reference_number
+          expect(delivery_partner_portal).to have_participant_type long_participant_type
+          expect(delivery_partner_portal).to have_lead_provider_name lead_provider_name
+          expect(delivery_partner_portal).to have_school_name school_name
+          expect(delivery_partner_portal).to have_school_urn school.urn
+          expect(delivery_partner_portal).to have_academic_year start_year
+          expect(delivery_partner_portal).to have_training_record_status delivery_partner_record_state
+        end
+      end
+
+      scenario "The Support for ECTs service can locate a record for the ECT" do
+        user_endpoint = APIs::ECFUsersEndpoint.load
+        user_endpoint.get_user participant_id
+
+        expect(user_endpoint).to have_email participant_email
+        expect(user_endpoint).to have_full_name participant_full_name
+        expect(user_endpoint).to have_cohort start_year
+        expect(user_endpoint).to have_core_induction_programme cip_materials
+        expect(user_endpoint).to have_induction_programme_choice programme_type
+        expect(user_endpoint).to have_registration_completed registration_completed
+        expect(user_endpoint).to have_user_type participant_type
+      end
+
+      scenario "A DfE admin user can locate the record for the ECT" do
+        given_i_sign_in_as_an_admin_user
+
+        participant_list = Pages::AdminSupportParticipantList.load
+        participant_list.view_participant participant_full_name
+
+        participant_detail = Pages::AdminSupportParticipantDetail.loaded(participant_id: training_record_id)
+        expect(participant_detail).to have_full_name participant_full_name
+        expect(participant_detail).to have_email_address participant_email
+        expect(participant_detail).to have_trn teacher_reference_number
+        expect(participant_detail).to have_cohort start_year
+        expect(participant_detail).to have_training_record_state training_record_state
+        expect(participant_detail).to have_user_id participant_id
+        expect(participant_detail).to have_associated_email_address participant_email
+
+        participant_detail.open_training_tab
+
+        participant_training = Pages::AdminSupportParticipantTraining.loaded(participant_id: training_record_id)
+        expect(participant_training).to have_cohort start_year
+        expect(participant_training).to have_school_name school.name
+        expect(participant_training).to have_lead_provider lead_provider_name
+        expect(participant_training).to have_schedule_identifier schedule_identifier
+      end
+
+      scenario "A DfE finance user can locate the record for the ECT" do
+        given_i_sign_in_as_a_finance_user
+
+        drilldown_search = Pages::FinanceParticipantDrilldownSearch.load
+        drilldown_search.find participant_id
+
+        drilldown = Pages::FinanceParticipantDrilldown.loaded(user_id: participant_id)
+        expect(drilldown).to have_participant_id participant_id
+        expect(drilldown).to have_full_name participant_full_name
+        expect(drilldown).to have_lead_provider lead_provider_name
+        expect(drilldown).to have_school_urn school.urn
+        expect(drilldown).to have_status participant_status
+        expect(drilldown).to have_induction_status participant_status
+        expect(drilldown).to be_eligible_for_funding
+        expect(drilldown).to have_schedule schedule_identifier
+        expect(drilldown).to have_schedule_identifier schedule_identifier
+        expect(drilldown).to have_schedule_cohort start_year
+        expect(drilldown).to have_training_programme programme_name
+        expect(drilldown).to have_participant_class participant_class
+      end
     end
-  end
-
-  scenario "The current appropriate body can locate a record for the ECT", :skip do
-    given_i_sign_in_as_the_user_with_the_full_name ab_full_name
-
-    appropriate_body_portal = Pages::AppropriateBodyPortal.loaded
-    appropriate_body_portal.get_participant(participant_full_name)
-
-    expect(appropriate_body_portal).to have_full_name participant_full_name
-    expect(appropriate_body_portal).to have_email_address participant_email
-    expect(appropriate_body_portal).to have_teacher_reference_number teacher_reference_number
-    expect(appropriate_body_portal).to have_participant_type long_participant_type
-    expect(appropriate_body_portal).to have_lead_provider_name lead_provider_name
-    expect(appropriate_body_portal).to have_school_name school_name
-    expect(appropriate_body_portal).to have_school_urn school.urn
-    expect(appropriate_body_portal).to have_academic_year start_year
-    expect(appropriate_body_portal).to have_training_record_status appropriate_body_record_state
-  end
-
-  scenario "The current lead provider can locate a record for the ECT" do
-    lead_provider_token = LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: lead_provider_details.cpd_lead_provider)
-
-    ecf_participant_endpoint = APIs::ECFParticipantsEndpoint.load(lead_provider_token)
-    ecf_participant_endpoint.get_participant participant_id
-
-    expect(ecf_participant_endpoint).to have_email_address participant_email
-    expect(ecf_participant_endpoint).to have_full_name participant_full_name
-    expect(ecf_participant_endpoint).to have_mentor_id nil
-    expect(ecf_participant_endpoint).to have_school_urn school.urn
-    expect(ecf_participant_endpoint).to have_participant_type short_participant_type
-    expect(ecf_participant_endpoint).to have_cohort start_year
-    expect(ecf_participant_endpoint).to have_trn teacher_reference_number
-    # teacher_reference_number_validated: true,
-    expect(ecf_participant_endpoint).to be_eligible_for_funding
-    expect(ecf_participant_endpoint).to have_pupil_premium_uplift
-    expect(ecf_participant_endpoint).to have_sparsity_uplift
-    expect(ecf_participant_endpoint).to have_status participant_status
-    expect(ecf_participant_endpoint).to have_training_record_id training_record_id
-    expect(ecf_participant_endpoint).to have_schedule_identifier schedule_identifier
-
-    participant_endpoint = APIs::ParticipantsEndpoint.load(lead_provider_token)
-    participant_endpoint.get_participant participant_id
-
-    expect(participant_endpoint).to have_email_address participant_email
-    expect(participant_endpoint).to have_full_name participant_full_name
-    expect(participant_endpoint).to have_mentor_id nil
-    expect(participant_endpoint).to have_school_urn school.urn
-    expect(participant_endpoint).to have_participant_type short_participant_type
-    expect(participant_endpoint).to have_cohort start_year
-    expect(participant_endpoint).to have_trn teacher_reference_number
-    # teacher_reference_number_validated: true,
-    expect(participant_endpoint).to be_eligible_for_funding
-    expect(participant_endpoint).to have_pupil_premium_uplift
-    expect(participant_endpoint).to have_sparsity_uplift
-    expect(participant_endpoint).to have_status participant_status
-    expect(participant_endpoint).to have_training_record_id training_record_id
-    expect(participant_endpoint).to have_schedule_identifier schedule_identifier
-  end
-
-  context "when the participant cohort is #{DeliveryPartners::ParticipantsFilter::LATEST_COHORT_TO_RETURN} or earlier" do
-    let(:start_year) { DeliveryPartners::ParticipantsFilter::LATEST_COHORT_TO_RETURN }
-
-    scenario "The current delivery partner can locate a record for the ECT" do
-      given_i_sign_in_as_the_user_with_the_full_name delivery_partner_name
-
-      delivery_partner_portal = Pages::DeliveryPartnerPortal.loaded
-      delivery_partner_portal.get_participant(participant_full_name)
-
-      expect(delivery_partner_portal).to have_full_name participant_full_name
-      expect(delivery_partner_portal).to have_email_address participant_email
-      expect(delivery_partner_portal).to have_teacher_reference_number teacher_reference_number
-      expect(delivery_partner_portal).to have_participant_type long_participant_type
-      expect(delivery_partner_portal).to have_lead_provider_name lead_provider_name
-      expect(delivery_partner_portal).to have_school_name school_name
-      expect(delivery_partner_portal).to have_school_urn school.urn
-      expect(delivery_partner_portal).to have_academic_year start_year
-      expect(delivery_partner_portal).to have_training_record_status delivery_partner_record_state
-    end
-  end
-
-  scenario "The Support for ECTs service can locate a record for the ECT" do
-    user_endpoint = APIs::ECFUsersEndpoint.load
-    user_endpoint.get_user participant_id
-
-    expect(user_endpoint).to have_email participant_email
-    expect(user_endpoint).to have_full_name participant_full_name
-    expect(user_endpoint).to have_cohort start_year
-    expect(user_endpoint).to have_core_induction_programme cip_materials
-    expect(user_endpoint).to have_induction_programme_choice programme_type
-    expect(user_endpoint).to have_registration_completed registration_completed
-    expect(user_endpoint).to have_user_type participant_type
-  end
-
-  scenario "A DfE admin user can locate the record for the ECT" do
-    given_i_sign_in_as_an_admin_user
-
-    participant_list = Pages::AdminSupportParticipantList.load
-    participant_list.view_participant participant_full_name
-
-    participant_detail = Pages::AdminSupportParticipantDetail.loaded(participant_id: training_record_id)
-    expect(participant_detail).to have_full_name participant_full_name
-    expect(participant_detail).to have_email_address participant_email
-    expect(participant_detail).to have_trn teacher_reference_number
-    expect(participant_detail).to have_cohort start_year
-    expect(participant_detail).to have_training_record_state training_record_state
-    expect(participant_detail).to have_user_id participant_id
-    expect(participant_detail).to have_associated_email_address participant_email
-
-    participant_detail.open_training_tab
-
-    participant_training = Pages::AdminSupportParticipantTraining.loaded(participant_id: training_record_id)
-    expect(participant_training).to have_cohort start_year
-    expect(participant_training).to have_school_name school.name
-    expect(participant_training).to have_lead_provider lead_provider_name
-    expect(participant_training).to have_schedule_identifier schedule_identifier
-  end
-
-  scenario "A DfE finance user can locate the record for the ECT" do
-    given_i_sign_in_as_a_finance_user
-
-    drilldown_search = Pages::FinanceParticipantDrilldownSearch.load
-    drilldown_search.find participant_id
-
-    drilldown = Pages::FinanceParticipantDrilldown.loaded(user_id: participant_id)
-    expect(drilldown).to have_participant_id participant_id
-    expect(drilldown).to have_full_name participant_full_name
-    expect(drilldown).to have_lead_provider lead_provider_name
-    expect(drilldown).to have_school_urn school.urn
-    expect(drilldown).to have_status participant_status
-    expect(drilldown).to have_induction_status participant_status
-    expect(drilldown).to be_eligible_for_funding
-    expect(drilldown).to have_schedule schedule_identifier
-    expect(drilldown).to have_schedule_identifier schedule_identifier
-    expect(drilldown).to have_schedule_cohort start_year
-    expect(drilldown).to have_training_programme programme_name
-    expect(drilldown).to have_participant_class participant_class
   end
 end

--- a/spec/features/scenarios/participants/ect_doing_fip/in_training_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_fip/in_training_spec.rb
@@ -23,7 +23,6 @@ RSpec.feature "ECT doing FIP: in training", type: :feature do
   let(:long_participant_type) { "Early career teacher" }
   let(:participant_class) { "ParticipantProfile::ECT" }
   let(:programme_type) { "full_induction_programme" }
-  let(:programme_name) { "Full induction programme" }
   let(:schedule_identifier) { "ecf-standard-september" }
   let(:cip_materials) { "none" }
   let(:start_year) { Cohort.next.start_year }
@@ -81,6 +80,10 @@ RSpec.feature "ECT doing FIP: in training", type: :feature do
 
   %w[active inactive].each do |flag_state|
     context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      let(:programme_name) do
+        flag_state == "inactive" ? "Full induction programme" : "Provider-led"
+      end
+
       scenario "The current school induction tutor can locate a record for the ECT" do
         inside_registration_window(cohort:) do
           given_i_sign_in_as_the_user_with_the_full_name sit_full_name

--- a/spec/features/scenarios/participants/ect_doing_fip/no_validation_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_fip/no_validation_spec.rb
@@ -80,158 +80,162 @@ RSpec.feature "ECT doing FIP: no validation", type: :feature do
   let(:participant_profile) { participant_details.participant_profile }
   let(:preferred_identity) { participant_details.participant_identity }
 
-  scenario "The current school induction tutor can locate a record for the ECT" do
-    inside_registration_window(cohort:) do
-      given_i_sign_in_as_the_user_with_the_full_name sit_full_name
+  %w[active inactive].each do |flag_state|
+    context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      scenario "The current school induction tutor can locate a record for the ECT" do
+        inside_registration_window(cohort:) do
+          given_i_sign_in_as_the_user_with_the_full_name sit_full_name
 
-      school_dashboard = Pages::SchoolDashboardPage.load(slug: school.slug)
-      school_dashboard.view_ect_dashboard
+          school_dashboard = Pages::SchoolDashboardPage.load(slug: school.slug)
+          school_dashboard.view_ect_dashboard
 
-      participant_dashboard = Pages::SchoolEarlyCareerTeachersDashboardPage.loaded(slug: school.slug)
-      participant_dashboard.view_participant participant_full_name
+          participant_dashboard = Pages::SchoolEarlyCareerTeachersDashboardPage.loaded(slug: school.slug)
+          participant_dashboard.view_participant participant_full_name
 
-      participant_details = Pages::SchoolEarlyCareerTeacherDetailsPage.loaded(slug: school.slug, participant_id: training_record_id)
-      expect(participant_details).to have_participant_name participant_full_name
-      expect(participant_details).to have_email participant_email
-      expect(participant_details).to have_full_name participant_full_name
-      expect(participant_details).to have_status school_record_state
+          participant_details = Pages::SchoolEarlyCareerTeacherDetailsPage.loaded(slug: school.slug, participant_id: training_record_id)
+          expect(participant_details).to have_participant_name participant_full_name
+          expect(participant_details).to have_email participant_email
+          expect(participant_details).to have_full_name participant_full_name
+          expect(participant_details).to have_status school_record_state
+        end
+      end
+
+      scenario "The current appropriate body can locate a record for the ECT", :skip do
+        given_i_sign_in_as_the_user_with_the_full_name ab_full_name
+
+        appropriate_body_portal = Pages::AppropriateBodyPortal.loaded
+        appropriate_body_portal.get_participant(participant_full_name)
+
+        expect(appropriate_body_portal).to have_full_name participant_full_name
+        expect(appropriate_body_portal).to have_email_address participant_email
+        expect(appropriate_body_portal).to have_teacher_reference_number teacher_reference_number
+        expect(appropriate_body_portal).to have_participant_type long_participant_type
+        expect(appropriate_body_portal).to have_lead_provider_name lead_provider_name
+        expect(appropriate_body_portal).to have_school_name school_name
+        expect(appropriate_body_portal).to have_school_urn school.urn
+        expect(appropriate_body_portal).to have_academic_year start_year
+        expect(appropriate_body_portal).to have_training_record_status appropriate_body_record_state
+      end
+
+      scenario "The current lead provider can locate a record for the ECT" do
+        lead_provider_token = LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: lead_provider_details.cpd_lead_provider)
+
+        ecf_participant_endpoint = APIs::ECFParticipantsEndpoint.load(lead_provider_token)
+        ecf_participant_endpoint.get_participant participant_id
+
+        expect(ecf_participant_endpoint).to have_email_address participant_email
+        expect(ecf_participant_endpoint).to have_full_name participant_full_name
+        expect(ecf_participant_endpoint).to have_mentor_id nil
+        expect(ecf_participant_endpoint).to have_school_urn school.urn
+        expect(ecf_participant_endpoint).to have_participant_type short_participant_type
+        expect(ecf_participant_endpoint).to have_cohort start_year
+        expect(ecf_participant_endpoint).to have_trn teacher_reference_number
+        # teacher_reference_number_validated: true,
+        expect(ecf_participant_endpoint).to be_eligible_for_funding
+        expect(ecf_participant_endpoint).to have_pupil_premium_uplift
+        expect(ecf_participant_endpoint).to have_sparsity_uplift
+        expect(ecf_participant_endpoint).to have_status participant_status
+        expect(ecf_participant_endpoint).to have_training_record_id training_record_id
+        expect(ecf_participant_endpoint).to have_schedule_identifier schedule_identifier
+
+        participant_endpoint = APIs::ParticipantsEndpoint.load(lead_provider_token)
+        participant_endpoint.get_participant participant_id
+
+        expect(participant_endpoint).to have_email_address participant_email
+        expect(participant_endpoint).to have_full_name participant_full_name
+        expect(participant_endpoint).to have_mentor_id nil
+        expect(participant_endpoint).to have_school_urn school.urn
+        expect(participant_endpoint).to have_participant_type short_participant_type
+        expect(participant_endpoint).to have_cohort start_year
+        expect(participant_endpoint).to have_trn teacher_reference_number
+        # teacher_reference_number_validated: true,
+        expect(participant_endpoint).to be_eligible_for_funding
+        expect(participant_endpoint).to have_pupil_premium_uplift
+        expect(participant_endpoint).to have_sparsity_uplift
+        expect(participant_endpoint).to have_status participant_status
+        expect(participant_endpoint).to have_training_record_id training_record_id
+        expect(participant_endpoint).to have_schedule_identifier schedule_identifier
+      end
+
+      context "when the participant cohort is #{DeliveryPartners::ParticipantsFilter::LATEST_COHORT_TO_RETURN} or earlier" do
+        let(:start_year) { DeliveryPartners::ParticipantsFilter::LATEST_COHORT_TO_RETURN }
+
+        scenario "The current delivery partner can locate a record for the ECT" do
+          given_i_sign_in_as_the_user_with_the_full_name delivery_partner_name
+
+          delivery_partner_portal = Pages::DeliveryPartnerPortal.loaded
+          delivery_partner_portal.get_participant(participant_full_name)
+
+          expect(delivery_partner_portal).to have_full_name participant_full_name
+          expect(delivery_partner_portal).to have_email_address participant_email
+          expect(delivery_partner_portal).to have_teacher_reference_number teacher_reference_number
+          expect(delivery_partner_portal).to have_participant_type long_participant_type
+          expect(delivery_partner_portal).to have_lead_provider_name lead_provider_name
+          expect(delivery_partner_portal).to have_school_name school_name
+          expect(delivery_partner_portal).to have_school_urn school.urn
+          expect(delivery_partner_portal).to have_academic_year start_year
+          expect(delivery_partner_portal).to have_training_record_status delivery_partner_record_state
+        end
+      end
+
+      scenario "The Support for ECTs service can locate a record for the CIP ECT" do
+        user_endpoint = APIs::ECFUsersEndpoint.load
+        user_endpoint.get_user participant_id
+
+        expect(user_endpoint).to have_email participant_email
+        expect(user_endpoint).to have_full_name participant_full_name
+        expect(user_endpoint).to have_cohort start_year
+        expect(user_endpoint).to have_core_induction_programme cip_materials
+        expect(user_endpoint).to have_induction_programme_choice programme_type
+        expect(user_endpoint).to have_registration_completed registration_completed
+        expect(user_endpoint).to have_user_type participant_type
+      end
+
+      scenario "A DfE admin user can locate the record for the ECT" do
+        given_i_sign_in_as_an_admin_user
+
+        participant_list = Pages::AdminSupportParticipantList.load
+        participant_list.view_participant participant_full_name
+
+        participant_detail = Pages::AdminSupportParticipantDetail.loaded(participant_id: training_record_id)
+        expect(participant_detail).to have_full_name participant_full_name
+        expect(participant_detail).to have_email_address participant_email
+        expect(participant_detail).to have_trn teacher_reference_number
+        expect(participant_detail).to have_cohort start_year
+        expect(participant_detail).to have_training_record_state training_record_state
+        expect(participant_detail).to have_user_id participant_id
+        expect(participant_detail).to have_associated_email_address participant_email
+
+        participant_detail.open_training_tab
+
+        participant_training = Pages::AdminSupportParticipantTraining.loaded(participant_id: training_record_id)
+        expect(participant_training).to have_cohort start_year
+        expect(participant_training).to have_school_name school.name
+        expect(participant_training).to have_lead_provider lead_provider_name
+        expect(participant_training).to have_schedule_identifier schedule_identifier
+      end
+
+      scenario "A DfE finance user can locate the record for the ECT" do
+        given_i_sign_in_as_a_finance_user
+
+        drilldown_search = Pages::FinanceParticipantDrilldownSearch.load
+        drilldown_search.find participant_id
+
+        drilldown = Pages::FinanceParticipantDrilldown.loaded(user_id: participant_id)
+        expect(drilldown).to have_participant_id participant_id
+        expect(drilldown).to have_full_name participant_full_name
+        expect(drilldown).to have_lead_provider lead_provider_name
+        expect(drilldown).to have_school_urn school.urn
+        expect(drilldown).to have_status participant_status
+        expect(drilldown).to have_induction_status participant_status
+        # TODO: is this correct?
+        expect(drilldown).to be_eligible_for_funding
+        expect(drilldown).to have_schedule schedule_identifier
+        expect(drilldown).to have_schedule_identifier schedule_identifier
+        expect(drilldown).to have_schedule_cohort start_year
+        expect(drilldown).to have_training_programme programme_name
+        expect(drilldown).to have_participant_class participant_class
+      end
     end
-  end
-
-  scenario "The current appropriate body can locate a record for the ECT", :skip do
-    given_i_sign_in_as_the_user_with_the_full_name ab_full_name
-
-    appropriate_body_portal = Pages::AppropriateBodyPortal.loaded
-    appropriate_body_portal.get_participant(participant_full_name)
-
-    expect(appropriate_body_portal).to have_full_name participant_full_name
-    expect(appropriate_body_portal).to have_email_address participant_email
-    expect(appropriate_body_portal).to have_teacher_reference_number teacher_reference_number
-    expect(appropriate_body_portal).to have_participant_type long_participant_type
-    expect(appropriate_body_portal).to have_lead_provider_name lead_provider_name
-    expect(appropriate_body_portal).to have_school_name school_name
-    expect(appropriate_body_portal).to have_school_urn school.urn
-    expect(appropriate_body_portal).to have_academic_year start_year
-    expect(appropriate_body_portal).to have_training_record_status appropriate_body_record_state
-  end
-
-  scenario "The current lead provider can locate a record for the ECT" do
-    lead_provider_token = LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: lead_provider_details.cpd_lead_provider)
-
-    ecf_participant_endpoint = APIs::ECFParticipantsEndpoint.load(lead_provider_token)
-    ecf_participant_endpoint.get_participant participant_id
-
-    expect(ecf_participant_endpoint).to have_email_address participant_email
-    expect(ecf_participant_endpoint).to have_full_name participant_full_name
-    expect(ecf_participant_endpoint).to have_mentor_id nil
-    expect(ecf_participant_endpoint).to have_school_urn school.urn
-    expect(ecf_participant_endpoint).to have_participant_type short_participant_type
-    expect(ecf_participant_endpoint).to have_cohort start_year
-    expect(ecf_participant_endpoint).to have_trn teacher_reference_number
-    # teacher_reference_number_validated: true,
-    expect(ecf_participant_endpoint).to be_eligible_for_funding
-    expect(ecf_participant_endpoint).to have_pupil_premium_uplift
-    expect(ecf_participant_endpoint).to have_sparsity_uplift
-    expect(ecf_participant_endpoint).to have_status participant_status
-    expect(ecf_participant_endpoint).to have_training_record_id training_record_id
-    expect(ecf_participant_endpoint).to have_schedule_identifier schedule_identifier
-
-    participant_endpoint = APIs::ParticipantsEndpoint.load(lead_provider_token)
-    participant_endpoint.get_participant participant_id
-
-    expect(participant_endpoint).to have_email_address participant_email
-    expect(participant_endpoint).to have_full_name participant_full_name
-    expect(participant_endpoint).to have_mentor_id nil
-    expect(participant_endpoint).to have_school_urn school.urn
-    expect(participant_endpoint).to have_participant_type short_participant_type
-    expect(participant_endpoint).to have_cohort start_year
-    expect(participant_endpoint).to have_trn teacher_reference_number
-    # teacher_reference_number_validated: true,
-    expect(participant_endpoint).to be_eligible_for_funding
-    expect(participant_endpoint).to have_pupil_premium_uplift
-    expect(participant_endpoint).to have_sparsity_uplift
-    expect(participant_endpoint).to have_status participant_status
-    expect(participant_endpoint).to have_training_record_id training_record_id
-    expect(participant_endpoint).to have_schedule_identifier schedule_identifier
-  end
-
-  context "when the participant cohort is #{DeliveryPartners::ParticipantsFilter::LATEST_COHORT_TO_RETURN} or earlier" do
-    let(:start_year) { DeliveryPartners::ParticipantsFilter::LATEST_COHORT_TO_RETURN }
-
-    scenario "The current delivery partner can locate a record for the ECT" do
-      given_i_sign_in_as_the_user_with_the_full_name delivery_partner_name
-
-      delivery_partner_portal = Pages::DeliveryPartnerPortal.loaded
-      delivery_partner_portal.get_participant(participant_full_name)
-
-      expect(delivery_partner_portal).to have_full_name participant_full_name
-      expect(delivery_partner_portal).to have_email_address participant_email
-      expect(delivery_partner_portal).to have_teacher_reference_number teacher_reference_number
-      expect(delivery_partner_portal).to have_participant_type long_participant_type
-      expect(delivery_partner_portal).to have_lead_provider_name lead_provider_name
-      expect(delivery_partner_portal).to have_school_name school_name
-      expect(delivery_partner_portal).to have_school_urn school.urn
-      expect(delivery_partner_portal).to have_academic_year start_year
-      expect(delivery_partner_portal).to have_training_record_status delivery_partner_record_state
-    end
-  end
-
-  scenario "The Support for ECTs service can locate a record for the CIP ECT" do
-    user_endpoint = APIs::ECFUsersEndpoint.load
-    user_endpoint.get_user participant_id
-
-    expect(user_endpoint).to have_email participant_email
-    expect(user_endpoint).to have_full_name participant_full_name
-    expect(user_endpoint).to have_cohort start_year
-    expect(user_endpoint).to have_core_induction_programme cip_materials
-    expect(user_endpoint).to have_induction_programme_choice programme_type
-    expect(user_endpoint).to have_registration_completed registration_completed
-    expect(user_endpoint).to have_user_type participant_type
-  end
-
-  scenario "A DfE admin user can locate the record for the ECT" do
-    given_i_sign_in_as_an_admin_user
-
-    participant_list = Pages::AdminSupportParticipantList.load
-    participant_list.view_participant participant_full_name
-
-    participant_detail = Pages::AdminSupportParticipantDetail.loaded(participant_id: training_record_id)
-    expect(participant_detail).to have_full_name participant_full_name
-    expect(participant_detail).to have_email_address participant_email
-    expect(participant_detail).to have_trn teacher_reference_number
-    expect(participant_detail).to have_cohort start_year
-    expect(participant_detail).to have_training_record_state training_record_state
-    expect(participant_detail).to have_user_id participant_id
-    expect(participant_detail).to have_associated_email_address participant_email
-
-    participant_detail.open_training_tab
-
-    participant_training = Pages::AdminSupportParticipantTraining.loaded(participant_id: training_record_id)
-    expect(participant_training).to have_cohort start_year
-    expect(participant_training).to have_school_name school.name
-    expect(participant_training).to have_lead_provider lead_provider_name
-    expect(participant_training).to have_schedule_identifier schedule_identifier
-  end
-
-  scenario "A DfE finance user can locate the record for the ECT" do
-    given_i_sign_in_as_a_finance_user
-
-    drilldown_search = Pages::FinanceParticipantDrilldownSearch.load
-    drilldown_search.find participant_id
-
-    drilldown = Pages::FinanceParticipantDrilldown.loaded(user_id: participant_id)
-    expect(drilldown).to have_participant_id participant_id
-    expect(drilldown).to have_full_name participant_full_name
-    expect(drilldown).to have_lead_provider lead_provider_name
-    expect(drilldown).to have_school_urn school.urn
-    expect(drilldown).to have_status participant_status
-    expect(drilldown).to have_induction_status participant_status
-    # TODO: is this correct?
-    expect(drilldown).to be_eligible_for_funding
-    expect(drilldown).to have_schedule schedule_identifier
-    expect(drilldown).to have_schedule_identifier schedule_identifier
-    expect(drilldown).to have_schedule_cohort start_year
-    expect(drilldown).to have_training_programme programme_name
-    expect(drilldown).to have_participant_class participant_class
   end
 end

--- a/spec/features/scenarios/participants/ect_doing_fip/no_validation_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_fip/no_validation_spec.rb
@@ -23,7 +23,6 @@ RSpec.feature "ECT doing FIP: no validation", type: :feature do
   let(:long_participant_type) { "Early career teacher" }
   let(:participant_class) { "ParticipantProfile::ECT" }
   let(:programme_type) { "full_induction_programme" }
-  let(:programme_name) { "Full induction programme" }
   let(:schedule_identifier) { "ecf-standard-september" }
   let(:cip_materials) { "none" }
   let(:start_year) { Cohort.next.start_year }
@@ -82,6 +81,10 @@ RSpec.feature "ECT doing FIP: no validation", type: :feature do
 
   %w[active inactive].each do |flag_state|
     context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      let(:programme_name) do
+        flag_state == "inactive" ? "Full induction programme" : "Provider-led"
+      end
+
       scenario "The current school induction tutor can locate a record for the ECT" do
         inside_registration_window(cohort:) do
           given_i_sign_in_as_the_user_with_the_full_name sit_full_name

--- a/spec/features/scenarios/transfering_a_participant/cip_to_cip_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/cip_to_cip_spec.rb
@@ -19,7 +19,7 @@ def when_context(scenario)
 end
 
 RSpec.feature "CIP to CIP - Transfer a participant",
-              with_feature_flags: { eligibility_notifications: "active", programme_type_changes_2025: "inactive" },
+              with_feature_flags: { eligibility_notifications: "active" },
               type: :feature,
               end_to_end_scenario: true do
   include Steps::ChangesOfCircumstanceSteps
@@ -27,83 +27,87 @@ RSpec.feature "CIP to CIP - Transfer a participant",
   includes = ENV.fetch("SCENARIOS", "").split(",").map(&:to_i)
 
   fixture_data_path = File.join(File.dirname(__FILE__), "../changes_of_circumstances_fixtures.csv")
-  CSV.parse(File.read(fixture_data_path), headers: true).each_with_index do |fixture_data, index|
-    next if includes.any? && !includes.include?(index + 2)
 
-    scenario = ChangesOfCircumstanceScenario.new index + 2, fixture_data
+  %w[active inactive].each do |flag_state|
+    context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      CSV.parse(File.read(fixture_data_path), headers: true).each_with_index do |fixture_data, index|
+        next if includes.any? && !includes.include?(index + 2)
 
-    next unless scenario.original_programme == "CIP" && scenario.new_programme == "CIP"
+        scenario = ChangesOfCircumstanceScenario.new index + 2, fixture_data
 
-    let(:tokens) { {} }
+        next unless scenario.original_programme == "CIP" && scenario.new_programme == "CIP"
 
-    let!(:cohort) do
-      cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
-      allow(Cohort).to receive(:current).and_return(cohort)
-      allow(Cohort).to receive(:next).and_return(cohort)
-      allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
-      allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
-      allow(cohort).to receive(:next).and_return(cohort)
-      allow(cohort).to receive(:previous).and_return(cohort)
-      cohort
-    end
-    let!(:schedule) do
-      create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
-    end
-    let!(:milestone_started) do
-      create :milestone,
-             schedule:,
-             name: "Output 1 - Participant Start",
-             start_date: Date.new(2021, 9, 1),
-             milestone_date: Date.new(2021, 11, 30),
-             payment_date: Date.new(2021, 11, 30),
-             declaration_type: "started"
-    end
-    let!(:milestone_retained_1) do
-      create :milestone,
-             schedule:,
-             name: "Output 2 - Retention Point 1",
-             start_date: Date.new(2021, 11, 1),
-             milestone_date: Date.new(2022, 1, 31),
-             payment_date: Date.new(2022, 2, 28),
-             declaration_type: "retained-1"
-    end
-    let!(:privacy_policy) do
-      privacy_policy = create(:privacy_policy)
-      PrivacyPolicy::Publish.call
-      privacy_policy
-    end
+        let(:tokens) { {} }
 
-    context given_context(scenario) do
-      before do
-        given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
-
-        travel_to(milestone_started.milestone_date - 2.months) do
-          Importers::CreateCohort.new(path_to_csv: Rails.root.join("db/data/cohorts/cohorts.csv")).call
-          Importers::CreateCallOffContract.new.call
-          Importers::CreateStatement.new(path_to_csv: Rails.root.join("db/data/statements/statements.csv")).call
+        let!(:cohort) do
+          cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
+          allow(Cohort).to receive(:current).and_return(cohort)
+          allow(Cohort).to receive(:next).and_return(cohort)
+          allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
+          allow(cohort).to receive(:next).and_return(cohort)
+          allow(cohort).to receive(:previous).and_return(cohort)
+          cohort
+        end
+        let!(:schedule) do
+          create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+        end
+        let!(:milestone_started) do
+          create :milestone,
+                 schedule:,
+                 name: "Output 1 - Participant Start",
+                 start_date: Date.new(2021, 9, 1),
+                 milestone_date: Date.new(2021, 11, 30),
+                 payment_date: Date.new(2021, 11, 30),
+                 declaration_type: "started"
+        end
+        let!(:milestone_retained_1) do
+          create :milestone,
+                 schedule:,
+                 name: "Output 2 - Retention Point 1",
+                 start_date: Date.new(2021, 11, 1),
+                 milestone_date: Date.new(2022, 1, 31),
+                 payment_date: Date.new(2022, 2, 28),
+                 declaration_type: "retained-1"
+        end
+        let!(:privacy_policy) do
+          privacy_policy = create(:privacy_policy)
+          PrivacyPolicy::Publish.call
+          privacy_policy
         end
 
-        and_sit_at_pupil_premium_school_reported_programme "Original SIT", "CIP"
+        context given_context(scenario) do
+          before do
+            given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
 
-        and_sit_at_pupil_premium_school_reported_programme "New SIT", "CIP"
+            travel_to(milestone_started.milestone_date - 2.months) do
+              Importers::CreateCohort.new(path_to_csv: Rails.root.join("db/data/cohorts/cohorts.csv")).call
+              Importers::CreateCallOffContract.new.call
+              Importers::CreateStatement.new(path_to_csv: Rails.root.join("db/data/statements/statements.csv")).call
+            end
 
-        and_sit_reported_participant "Original SIT",
-                                     "The Participant",
-                                     scenario.participant_trn,
-                                     scenario.participant_dob,
-                                     scenario.participant_email,
-                                     scenario.participant_type
-      end
+            and_sit_at_pupil_premium_school_reported_programme "Original SIT", "CIP"
 
-      context when_context(scenario) do
-        before do
-          when_developers_transfer_the_active_participant "New SIT",
-                                                          "The Participant"
+            and_sit_at_pupil_premium_school_reported_programme "New SIT", "CIP"
 
-          and_eligible_training_declarations_are_made_payable
+            and_sit_reported_participant "Original SIT",
+                                         "The Participant",
+                                         scenario.participant_trn,
+                                         scenario.participant_dob,
+                                         scenario.participant_email,
+                                         scenario.participant_type
+          end
+
+          context when_context(scenario) do
+            before do
+              when_developers_transfer_the_active_participant "New SIT",
+                                                              "The Participant"
+
+              and_eligible_training_declarations_are_made_payable
+            end
+
+            include_examples "CIP to CIP", scenario
+          end
         end
-
-        include_examples "CIP to CIP", scenario
       end
     end
   end

--- a/spec/features/scenarios/transfering_a_participant/cip_to_cip_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/cip_to_cip_spec.rb
@@ -44,6 +44,7 @@ RSpec.feature "CIP to CIP - Transfer a participant",
           allow(Cohort).to receive(:current).and_return(cohort)
           allow(Cohort).to receive(:next).and_return(cohort)
           allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
+          allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
           allow(cohort).to receive(:next).and_return(cohort)
           allow(cohort).to receive(:previous).and_return(cohort)
           cohort

--- a/spec/features/scenarios/transfering_a_participant/cip_to_fip_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/cip_to_fip_spec.rb
@@ -44,6 +44,7 @@ RSpec.feature "CIP to FIP - Transfer a participant",
           allow(Cohort).to receive(:current).and_return(cohort)
           allow(Cohort).to receive(:next).and_return(cohort)
           allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
+          allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
           allow(cohort).to receive(:next).and_return(cohort)
           allow(cohort).to receive(:previous).and_return(cohort)
           cohort

--- a/spec/features/scenarios/transfering_a_participant/cip_to_fip_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/cip_to_fip_spec.rb
@@ -19,7 +19,7 @@ def when_context(scenario)
 end
 
 RSpec.feature "CIP to FIP - Transfer a participant",
-              with_feature_flags: { eligibility_notifications: "active", programme_type_changes_2025: "inactive" },
+              with_feature_flags: { eligibility_notifications: "active" },
               type: :feature,
               end_to_end_scenario: true do
   include Steps::ChangesOfCircumstanceSteps
@@ -27,92 +27,96 @@ RSpec.feature "CIP to FIP - Transfer a participant",
   includes = ENV.fetch("SCENARIOS", "").split(",").map(&:to_i)
 
   fixture_data_path = File.join(File.dirname(__FILE__), "../changes_of_circumstances_fixtures.csv")
-  CSV.parse(File.read(fixture_data_path), headers: true).each_with_index do |fixture_data, index|
-    next if includes.any? && !includes.include?(index + 2)
 
-    scenario = ChangesOfCircumstanceScenario.new index + 2, fixture_data
+  %w[active inactive].each do |flag_state|
+    context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      CSV.parse(File.read(fixture_data_path), headers: true).each_with_index do |fixture_data, index|
+        next if includes.any? && !includes.include?(index + 2)
 
-    next unless scenario.original_programme == "CIP" && scenario.new_programme == "FIP"
+        scenario = ChangesOfCircumstanceScenario.new index + 2, fixture_data
 
-    let(:tokens) { {} }
+        next unless scenario.original_programme == "CIP" && scenario.new_programme == "FIP"
 
-    let!(:cohort) do
-      cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
-      allow(Cohort).to receive(:current).and_return(cohort)
-      allow(Cohort).to receive(:next).and_return(cohort)
-      allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
-      allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
-      allow(cohort).to receive(:next).and_return(cohort)
-      allow(cohort).to receive(:previous).and_return(cohort)
-      cohort
-    end
-    let!(:schedule) do
-      create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
-    end
-    let!(:milestone_started) do
-      create :milestone,
-             schedule:,
-             name: "Output 1 - Participant Start",
-             start_date: Date.new(2021, 9, 1),
-             milestone_date: Date.new(2021, 11, 30),
-             payment_date: Date.new(2021, 11, 30),
-             declaration_type: "started"
-    end
-    let!(:milestone_retained_1) do
-      create :milestone,
-             schedule:,
-             name: "Output 2 - Retention Point 1",
-             start_date: Date.new(2021, 11, 1),
-             milestone_date: Date.new(2022, 1, 31),
-             payment_date: Date.new(2022, 2, 28),
-             declaration_type: "retained-1"
-    end
-    let!(:privacy_policy) do
-      privacy_policy = create(:privacy_policy)
-      PrivacyPolicy::Publish.call
-      privacy_policy
-    end
+        let(:tokens) { {} }
 
-    context given_context(scenario) do
-      before do
-        given_lead_providers_contracted_to_deliver_ecf "New Lead Provider"
-        given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
-
-        travel_to(milestone_started.milestone_date - 2.months) do
-          Importers::CreateCohort.new(path_to_csv: Rails.root.join("db/data/cohorts/cohorts.csv")).call
-          Importers::CreateCallOffContract.new.call
-          Importers::CreateStatement.new(path_to_csv: Rails.root.join("db/data/statements/statements.csv")).call
+        let!(:cohort) do
+          cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
+          allow(Cohort).to receive(:current).and_return(cohort)
+          allow(Cohort).to receive(:next).and_return(cohort)
+          allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
+          allow(cohort).to receive(:next).and_return(cohort)
+          allow(cohort).to receive(:previous).and_return(cohort)
+          cohort
+        end
+        let!(:schedule) do
+          create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+        end
+        let!(:milestone_started) do
+          create :milestone,
+                 schedule:,
+                 name: "Output 1 - Participant Start",
+                 start_date: Date.new(2021, 9, 1),
+                 milestone_date: Date.new(2021, 11, 30),
+                 payment_date: Date.new(2021, 11, 30),
+                 declaration_type: "started"
+        end
+        let!(:milestone_retained_1) do
+          create :milestone,
+                 schedule:,
+                 name: "Output 2 - Retention Point 1",
+                 start_date: Date.new(2021, 11, 1),
+                 milestone_date: Date.new(2022, 1, 31),
+                 payment_date: Date.new(2022, 2, 28),
+                 declaration_type: "retained-1"
+        end
+        let!(:privacy_policy) do
+          privacy_policy = create(:privacy_policy)
+          PrivacyPolicy::Publish.call
+          privacy_policy
         end
 
-        and_sit_at_pupil_premium_school_reported_programme "Original SIT", "CIP"
+        context given_context(scenario) do
+          before do
+            given_lead_providers_contracted_to_deliver_ecf "New Lead Provider"
+            given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
 
-        and_sit_at_pupil_premium_school_reported_programme "New SIT", "FIP"
-        and_lead_provider_reported_partnership "New Lead Provider", "New SIT"
+            travel_to(milestone_started.milestone_date - 2.months) do
+              Importers::CreateCohort.new(path_to_csv: Rails.root.join("db/data/cohorts/cohorts.csv")).call
+              Importers::CreateCallOffContract.new.call
+              Importers::CreateStatement.new(path_to_csv: Rails.root.join("db/data/statements/statements.csv")).call
+            end
 
-        and_sit_reported_participant "Original SIT",
-                                     "The Participant",
-                                     scenario.participant_trn,
-                                     scenario.participant_dob,
-                                     scenario.participant_email,
-                                     scenario.participant_type
-      end
+            and_sit_at_pupil_premium_school_reported_programme "Original SIT", "CIP"
 
-      context when_context(scenario) do
-        before do
-          when_developers_transfer_the_active_participant "New SIT",
-                                                          "The Participant"
+            and_sit_at_pupil_premium_school_reported_programme "New SIT", "FIP"
+            and_lead_provider_reported_partnership "New Lead Provider", "New SIT"
 
-          scenario.new_declarations.each do |declaration_type|
-            and_lead_provider_has_made_training_declaration "New Lead Provider",
-                                                            scenario.participant_type,
-                                                            "The Participant",
-                                                            declaration_type
+            and_sit_reported_participant "Original SIT",
+                                         "The Participant",
+                                         scenario.participant_trn,
+                                         scenario.participant_dob,
+                                         scenario.participant_email,
+                                         scenario.participant_type
           end
 
-          and_eligible_training_declarations_are_made_payable
-        end
+          context when_context(scenario) do
+            before do
+              when_developers_transfer_the_active_participant "New SIT",
+                                                              "The Participant"
 
-        include_examples "CIP to FIP", scenario
+              scenario.new_declarations.each do |declaration_type|
+                and_lead_provider_has_made_training_declaration "New Lead Provider",
+                                                                scenario.participant_type,
+                                                                "The Participant",
+                                                                declaration_type
+              end
+
+              and_eligible_training_declarations_are_made_payable
+            end
+
+            include_examples "CIP to FIP", scenario
+          end
+        end
       end
     end
   end

--- a/spec/features/scenarios/transfering_a_participant/fip_to_cip_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/fip_to_cip_spec.rb
@@ -19,7 +19,7 @@ def when_context(scenario)
 end
 
 RSpec.feature "FIP to CIP - Transfer a participant",
-              with_feature_flags: { eligibility_notifications: "active", programme_type_changes_2025: "inactive" },
+              with_feature_flags: { eligibility_notifications: "active" },
               type: :feature,
               end_to_end_scenario: true do
   include Steps::ChangesOfCircumstanceSteps
@@ -27,92 +27,96 @@ RSpec.feature "FIP to CIP - Transfer a participant",
   includes = ENV.fetch("SCENARIOS", "").split(",").map(&:to_i)
 
   fixture_data_path = File.join(File.dirname(__FILE__), "../changes_of_circumstances_fixtures.csv")
-  CSV.parse(File.read(fixture_data_path), headers: true).each_with_index do |fixture_data, index|
-    next if includes.any? && !includes.include?(index + 2)
 
-    scenario = ChangesOfCircumstanceScenario.new index + 2, fixture_data
+  %w[active inactive].each do |flag_state|
+    context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      CSV.parse(File.read(fixture_data_path), headers: true).each_with_index do |fixture_data, index|
+        next if includes.any? && !includes.include?(index + 2)
 
-    next unless scenario.original_programme == "FIP" && scenario.new_programme == "CIP"
+        scenario = ChangesOfCircumstanceScenario.new index + 2, fixture_data
 
-    let(:tokens) { {} }
+        next unless scenario.original_programme == "FIP" && scenario.new_programme == "CIP"
 
-    let!(:cohort) do
-      cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
-      allow(Cohort).to receive(:current).and_return(cohort)
-      allow(Cohort).to receive(:next).and_return(cohort)
-      allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
-      allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
-      allow(cohort).to receive(:next).and_return(cohort)
-      allow(cohort).to receive(:previous).and_return(cohort)
-      cohort
-    end
-    let!(:schedule) do
-      create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
-    end
-    let!(:milestone_started) do
-      create :milestone,
-             schedule:,
-             name: "Output 1 - Participant Start",
-             start_date: Date.new(2021, 9, 1),
-             milestone_date: Date.new(2021, 11, 30),
-             payment_date: Date.new(2021, 11, 30),
-             declaration_type: "started"
-    end
-    let!(:milestone_retained_1) do
-      create :milestone,
-             schedule:,
-             name: "Output 2 - Retention Point 1",
-             start_date: Date.new(2021, 11, 1),
-             milestone_date: Date.new(2022, 1, 31),
-             payment_date: Date.new(2022, 2, 28),
-             declaration_type: "retained-1"
-    end
-    let!(:privacy_policy) do
-      privacy_policy = create(:privacy_policy)
-      PrivacyPolicy::Publish.call
-      privacy_policy
-    end
+        let(:tokens) { {} }
 
-    context given_context(scenario) do
-      before do
-        given_lead_providers_contracted_to_deliver_ecf "Original Lead Provider"
-        given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
-
-        travel_to(milestone_started.milestone_date - 2.months) do
-          Importers::CreateCohort.new(path_to_csv: Rails.root.join("db/data/cohorts/cohorts.csv")).call
-          Importers::CreateCallOffContract.new.call
-          Importers::CreateStatement.new(path_to_csv: Rails.root.join("db/data/statements/statements.csv")).call
+        let!(:cohort) do
+          cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
+          allow(Cohort).to receive(:current).and_return(cohort)
+          allow(Cohort).to receive(:next).and_return(cohort)
+          allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
+          allow(cohort).to receive(:next).and_return(cohort)
+          allow(cohort).to receive(:previous).and_return(cohort)
+          cohort
+        end
+        let!(:schedule) do
+          create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+        end
+        let!(:milestone_started) do
+          create :milestone,
+                 schedule:,
+                 name: "Output 1 - Participant Start",
+                 start_date: Date.new(2021, 9, 1),
+                 milestone_date: Date.new(2021, 11, 30),
+                 payment_date: Date.new(2021, 11, 30),
+                 declaration_type: "started"
+        end
+        let!(:milestone_retained_1) do
+          create :milestone,
+                 schedule:,
+                 name: "Output 2 - Retention Point 1",
+                 start_date: Date.new(2021, 11, 1),
+                 milestone_date: Date.new(2022, 1, 31),
+                 payment_date: Date.new(2022, 2, 28),
+                 declaration_type: "retained-1"
+        end
+        let!(:privacy_policy) do
+          privacy_policy = create(:privacy_policy)
+          PrivacyPolicy::Publish.call
+          privacy_policy
         end
 
-        and_sit_at_pupil_premium_school_reported_programme "Original SIT", "FIP"
-        and_lead_provider_reported_partnership "Original Lead Provider", "Original SIT"
+        context given_context(scenario) do
+          before do
+            given_lead_providers_contracted_to_deliver_ecf "Original Lead Provider"
+            given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
 
-        and_sit_at_pupil_premium_school_reported_programme "New SIT", "CIP"
+            travel_to(milestone_started.milestone_date - 2.months) do
+              Importers::CreateCohort.new(path_to_csv: Rails.root.join("db/data/cohorts/cohorts.csv")).call
+              Importers::CreateCallOffContract.new.call
+              Importers::CreateStatement.new(path_to_csv: Rails.root.join("db/data/statements/statements.csv")).call
+            end
 
-        and_sit_reported_participant "Original SIT",
-                                     "The Participant",
-                                     scenario.participant_trn,
-                                     scenario.participant_dob,
-                                     scenario.participant_email,
-                                     scenario.participant_type
-      end
+            and_sit_at_pupil_premium_school_reported_programme "Original SIT", "FIP"
+            and_lead_provider_reported_partnership "Original Lead Provider", "Original SIT"
 
-      context when_context(scenario) do
-        before do
-          scenario.prior_declarations.each do |declaration_type|
-            and_lead_provider_has_made_training_declaration "Original Lead Provider",
-                                                            scenario.participant_type,
-                                                            "The Participant",
-                                                            declaration_type
+            and_sit_at_pupil_premium_school_reported_programme "New SIT", "CIP"
+
+            and_sit_reported_participant "Original SIT",
+                                         "The Participant",
+                                         scenario.participant_trn,
+                                         scenario.participant_dob,
+                                         scenario.participant_email,
+                                         scenario.participant_type
           end
 
-          when_developers_transfer_the_active_participant "New SIT",
-                                                          "The Participant"
+          context when_context(scenario) do
+            before do
+              scenario.prior_declarations.each do |declaration_type|
+                and_lead_provider_has_made_training_declaration "Original Lead Provider",
+                                                                scenario.participant_type,
+                                                                "The Participant",
+                                                                declaration_type
+              end
 
-          and_eligible_training_declarations_are_made_payable
+              when_developers_transfer_the_active_participant "New SIT",
+                                                              "The Participant"
+
+              and_eligible_training_declarations_are_made_payable
+            end
+
+            include_examples "FIP to CIP", scenario, "withdrawn"
+          end
         end
-
-        include_examples "FIP to CIP", scenario, "withdrawn"
       end
     end
   end

--- a/spec/features/scenarios/transfering_a_participant/fip_to_cip_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/fip_to_cip_spec.rb
@@ -44,6 +44,7 @@ RSpec.feature "FIP to CIP - Transfer a participant",
           allow(Cohort).to receive(:current).and_return(cohort)
           allow(Cohort).to receive(:next).and_return(cohort)
           allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
+          allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
           allow(cohort).to receive(:next).and_return(cohort)
           allow(cohort).to receive(:previous).and_return(cohort)
           cohort

--- a/spec/features/scenarios/transfering_a_participant/fip_to_fip_with_different_provider_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/fip_to_fip_with_different_provider_spec.rb
@@ -19,7 +19,7 @@ def when_context(scenario)
 end
 
 RSpec.feature "FIP to FIP with different provider - Transfer a participant",
-              with_feature_flags: { eligibility_notifications: "active", programme_type_changes_2025: "inactive" },
+              with_feature_flags: { eligibility_notifications: "active" },
               type: :feature,
               end_to_end_scenario: true do
   include Steps::ChangesOfCircumstanceSteps
@@ -27,105 +27,109 @@ RSpec.feature "FIP to FIP with different provider - Transfer a participant",
   includes = ENV.fetch("SCENARIOS", "").split(",").map(&:to_i)
 
   fixture_data_path = File.join(File.dirname(__FILE__), "../changes_of_circumstances_fixtures.csv")
-  CSV.parse(File.read(fixture_data_path), headers: true).each_with_index do |fixture_data, index|
-    next if includes.any? && !includes.include?(index + 2)
 
-    scenario = ChangesOfCircumstanceScenario.new index + 2, fixture_data
+  %w[active inactive].each do |flag_state|
+    context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      CSV.parse(File.read(fixture_data_path), headers: true).each_with_index do |fixture_data, index|
+        next if includes.any? && !includes.include?(index + 2)
 
-    next unless scenario.original_programme == "FIP" && scenario.new_programme == "FIP" && scenario.transfer == :different_provider
+        scenario = ChangesOfCircumstanceScenario.new index + 2, fixture_data
 
-    let(:tokens) { {} }
+        next unless scenario.original_programme == "FIP" && scenario.new_programme == "FIP" && scenario.transfer == :different_provider
 
-    let!(:cohort) do
-      cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
-      allow(Cohort).to receive(:current).and_return(cohort)
-      allow(Cohort).to receive(:next).and_return(cohort)
-      allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
-      allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
-      allow(cohort).to receive(:next).and_return(cohort)
-      allow(cohort).to receive(:previous).and_return(cohort)
-      cohort
-    end
-    let!(:schedule) do
-      create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
-    end
-    let!(:milestone_started) do
-      create :milestone,
-             schedule:,
-             name: "Output 1 - Participant Start",
-             start_date: Date.new(2021, 9, 1),
-             milestone_date: Date.new(2021, 11, 30),
-             payment_date: Date.new(2021, 11, 30),
-             declaration_type: "started"
-    end
-    let!(:milestone_retained_1) do
-      create :milestone,
-             schedule:,
-             name: "Output 2 - Retention Point 1",
-             start_date: Date.new(2021, 11, 1),
-             milestone_date: Date.new(2022, 1, 31),
-             payment_date: Date.new(2022, 2, 28),
-             declaration_type: "retained-1"
-    end
-    let!(:privacy_policy) do
-      privacy_policy = create(:privacy_policy)
-      PrivacyPolicy::Publish.call
-      privacy_policy
-    end
+        let(:tokens) { {} }
 
-    context given_context(scenario) do
-      before do
-        given_lead_providers_contracted_to_deliver_ecf "Original Lead Provider"
-        given_lead_providers_contracted_to_deliver_ecf "New Lead Provider"
-        given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
-
-        travel_to(milestone_started.milestone_date - 2.months) do
-          Importers::CreateCohort.new(path_to_csv: Rails.root.join("db/data/cohorts/cohorts.csv")).call
-          Importers::CreateCallOffContract.new.call
-          Importers::CreateStatement.new(path_to_csv: Rails.root.join("db/data/statements/statements.csv")).call
+        let!(:cohort) do
+          cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
+          allow(Cohort).to receive(:current).and_return(cohort)
+          allow(Cohort).to receive(:next).and_return(cohort)
+          allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
+          allow(cohort).to receive(:next).and_return(cohort)
+          allow(cohort).to receive(:previous).and_return(cohort)
+          cohort
+        end
+        let!(:schedule) do
+          create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+        end
+        let!(:milestone_started) do
+          create :milestone,
+                 schedule:,
+                 name: "Output 1 - Participant Start",
+                 start_date: Date.new(2021, 9, 1),
+                 milestone_date: Date.new(2021, 11, 30),
+                 payment_date: Date.new(2021, 11, 30),
+                 declaration_type: "started"
+        end
+        let!(:milestone_retained_1) do
+          create :milestone,
+                 schedule:,
+                 name: "Output 2 - Retention Point 1",
+                 start_date: Date.new(2021, 11, 1),
+                 milestone_date: Date.new(2022, 1, 31),
+                 payment_date: Date.new(2022, 2, 28),
+                 declaration_type: "retained-1"
+        end
+        let!(:privacy_policy) do
+          privacy_policy = create(:privacy_policy)
+          PrivacyPolicy::Publish.call
+          privacy_policy
         end
 
-        and_sit_at_pupil_premium_school_reported_programme "Original SIT", "FIP"
-        and_lead_provider_reported_partnership "Original Lead Provider", "Original SIT"
+        context given_context(scenario) do
+          before do
+            given_lead_providers_contracted_to_deliver_ecf "Original Lead Provider"
+            given_lead_providers_contracted_to_deliver_ecf "New Lead Provider"
+            given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
 
-        and_sit_at_pupil_premium_school_reported_programme "New SIT", "FIP"
-        and_lead_provider_reported_partnership "New Lead Provider", "New SIT"
+            travel_to(milestone_started.milestone_date - 2.months) do
+              Importers::CreateCohort.new(path_to_csv: Rails.root.join("db/data/cohorts/cohorts.csv")).call
+              Importers::CreateCallOffContract.new.call
+              Importers::CreateStatement.new(path_to_csv: Rails.root.join("db/data/statements/statements.csv")).call
+            end
 
-        and_sit_reported_participant "Original SIT",
-                                     "The Participant",
-                                     scenario.participant_trn,
-                                     scenario.participant_dob,
-                                     scenario.participant_email,
-                                     scenario.participant_type
-      end
+            and_sit_at_pupil_premium_school_reported_programme "Original SIT", "FIP"
+            and_lead_provider_reported_partnership "Original Lead Provider", "Original SIT"
 
-      context when_context(scenario) do
-        before do
-          scenario.prior_declarations.each do |declaration_type|
-            and_lead_provider_has_made_training_declaration "Original Lead Provider",
-                                                            scenario.participant_type,
-                                                            "The Participant",
-                                                            declaration_type
+            and_sit_at_pupil_premium_school_reported_programme "New SIT", "FIP"
+            and_lead_provider_reported_partnership "New Lead Provider", "New SIT"
+
+            and_sit_reported_participant "Original SIT",
+                                         "The Participant",
+                                         scenario.participant_trn,
+                                         scenario.participant_dob,
+                                         scenario.participant_email,
+                                         scenario.participant_type
           end
 
-          when_school_uses_the_transfer_participant_wizard "New SIT",
-                                                           "The Participant",
-                                                           scenario.participant_email,
-                                                           scenario.participant_trn,
-                                                           scenario.participant_dob,
-                                                           same_provider: false
+          context when_context(scenario) do
+            before do
+              scenario.prior_declarations.each do |declaration_type|
+                and_lead_provider_has_made_training_declaration "Original Lead Provider",
+                                                                scenario.participant_type,
+                                                                "The Participant",
+                                                                declaration_type
+              end
 
-          scenario.new_declarations.each do |declaration_type|
-            and_lead_provider_has_made_training_declaration "New Lead Provider",
-                                                            scenario.participant_type,
-                                                            "The Participant",
-                                                            declaration_type
+              when_school_uses_the_transfer_participant_wizard "New SIT",
+                                                               "The Participant",
+                                                               scenario.participant_email,
+                                                               scenario.participant_trn,
+                                                               scenario.participant_dob,
+                                                               same_provider: false
+
+              scenario.new_declarations.each do |declaration_type|
+                and_lead_provider_has_made_training_declaration "New Lead Provider",
+                                                                scenario.participant_type,
+                                                                "The Participant",
+                                                                declaration_type
+              end
+
+              and_eligible_training_declarations_are_made_payable
+            end
+
+            include_examples "FIP to FIP with different provider", scenario, "active"
           end
-
-          and_eligible_training_declarations_are_made_payable
         end
-
-        include_examples "FIP to FIP with different provider", scenario, "active"
       end
     end
   end

--- a/spec/features/scenarios/transfering_a_participant/fip_to_fip_with_different_provider_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/fip_to_fip_with_different_provider_spec.rb
@@ -44,6 +44,7 @@ RSpec.feature "FIP to FIP with different provider - Transfer a participant",
           allow(Cohort).to receive(:current).and_return(cohort)
           allow(Cohort).to receive(:next).and_return(cohort)
           allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
+          allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
           allow(cohort).to receive(:next).and_return(cohort)
           allow(cohort).to receive(:previous).and_return(cohort)
           cohort

--- a/spec/features/scenarios/transfering_a_participant/fip_to_fip_with_same_provider_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/fip_to_fip_with_same_provider_spec.rb
@@ -19,7 +19,7 @@ def when_context(scenario)
 end
 
 RSpec.feature "FIP to FIP with same provider - Transfer a participant",
-              with_feature_flags: { eligibility_notifications: "active", programme_type_changes_2025: "inactive" },
+              with_feature_flags: { eligibility_notifications: "active" },
               type: :feature,
               end_to_end_scenario: true do
   include Steps::ChangesOfCircumstanceSteps
@@ -27,104 +27,108 @@ RSpec.feature "FIP to FIP with same provider - Transfer a participant",
   includes = ENV.fetch("SCENARIOS", "").split(",").map(&:to_i)
 
   fixture_data_path = File.join(File.dirname(__FILE__), "../changes_of_circumstances_fixtures.csv")
-  CSV.parse(File.read(fixture_data_path), headers: true).each_with_index do |fixture_data, index|
-    next if includes.any? && !includes.include?(index + 2)
 
-    scenario = ChangesOfCircumstanceScenario.new index + 2, fixture_data
+  %w[active inactive].each do |flag_state|
+    context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      CSV.parse(File.read(fixture_data_path), headers: true).each_with_index do |fixture_data, index|
+        next if includes.any? && !includes.include?(index + 2)
 
-    next unless scenario.original_programme == "FIP" && scenario.new_programme == "FIP" && scenario.transfer == :same_provider
+        scenario = ChangesOfCircumstanceScenario.new index + 2, fixture_data
 
-    let(:tokens) { {} }
+        next unless scenario.original_programme == "FIP" && scenario.new_programme == "FIP" && scenario.transfer == :same_provider
 
-    let!(:cohort) do
-      cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
-      allow(Cohort).to receive(:current).and_return(cohort)
-      allow(Cohort).to receive(:next).and_return(cohort)
-      allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
-      allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
-      allow(cohort).to receive(:next).and_return(cohort)
-      allow(cohort).to receive(:previous).and_return(cohort)
-      cohort
-    end
-    let!(:schedule) do
-      create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
-    end
-    let!(:milestone_started) do
-      create :milestone,
-             schedule:,
-             name: "Output 1 - Participant Start",
-             start_date: Date.new(2021, 9, 1),
-             milestone_date: Date.new(2021, 11, 30),
-             payment_date: Date.new(2021, 11, 30),
-             declaration_type: "started"
-    end
-    let!(:milestone_retained_1) do
-      create :milestone,
-             schedule:,
-             name: "Output 2 - Retention Point 1",
-             start_date: Date.new(2021, 11, 1),
-             milestone_date: Date.new(2022, 1, 31),
-             payment_date: Date.new(2022, 2, 28),
-             declaration_type: "retained-1"
-    end
-    let!(:privacy_policy) do
-      privacy_policy = create(:privacy_policy)
-      PrivacyPolicy::Publish.call
-      privacy_policy
-    end
+        let(:tokens) { {} }
 
-    context given_context(scenario) do
-      before do
-        given_lead_providers_contracted_to_deliver_ecf "Original Lead Provider"
-        given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
-
-        travel_to(milestone_started.milestone_date - 2.months) do
-          Importers::CreateCohort.new(path_to_csv: Rails.root.join("db/data/cohorts/cohorts.csv")).call
-          Importers::CreateCallOffContract.new.call
-          Importers::CreateStatement.new(path_to_csv: Rails.root.join("db/data/statements/statements.csv")).call
+        let!(:cohort) do
+          cohort = Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021)
+          allow(Cohort).to receive(:current).and_return(cohort)
+          allow(Cohort).to receive(:next).and_return(cohort)
+          allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
+          allow(cohort).to receive(:next).and_return(cohort)
+          allow(cohort).to receive(:previous).and_return(cohort)
+          cohort
+        end
+        let!(:schedule) do
+          create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+        end
+        let!(:milestone_started) do
+          create :milestone,
+                 schedule:,
+                 name: "Output 1 - Participant Start",
+                 start_date: Date.new(2021, 9, 1),
+                 milestone_date: Date.new(2021, 11, 30),
+                 payment_date: Date.new(2021, 11, 30),
+                 declaration_type: "started"
+        end
+        let!(:milestone_retained_1) do
+          create :milestone,
+                 schedule:,
+                 name: "Output 2 - Retention Point 1",
+                 start_date: Date.new(2021, 11, 1),
+                 milestone_date: Date.new(2022, 1, 31),
+                 payment_date: Date.new(2022, 2, 28),
+                 declaration_type: "retained-1"
+        end
+        let!(:privacy_policy) do
+          privacy_policy = create(:privacy_policy)
+          PrivacyPolicy::Publish.call
+          privacy_policy
         end
 
-        and_sit_at_pupil_premium_school_reported_programme "Original SIT", "FIP"
-        and_lead_provider_reported_partnership "Original Lead Provider", "Original SIT"
+        context given_context(scenario) do
+          before do
+            given_lead_providers_contracted_to_deliver_ecf "Original Lead Provider"
+            given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
 
-        and_sit_at_pupil_premium_school_reported_programme "New SIT", "FIP"
-        and_lead_provider_reported_partnership "Original Lead Provider", "New SIT"
+            travel_to(milestone_started.milestone_date - 2.months) do
+              Importers::CreateCohort.new(path_to_csv: Rails.root.join("db/data/cohorts/cohorts.csv")).call
+              Importers::CreateCallOffContract.new.call
+              Importers::CreateStatement.new(path_to_csv: Rails.root.join("db/data/statements/statements.csv")).call
+            end
 
-        and_sit_reported_participant "Original SIT",
-                                     "The Participant",
-                                     scenario.participant_trn,
-                                     scenario.participant_dob,
-                                     scenario.participant_email,
-                                     scenario.participant_type
-      end
+            and_sit_at_pupil_premium_school_reported_programme "Original SIT", "FIP"
+            and_lead_provider_reported_partnership "Original Lead Provider", "Original SIT"
 
-      context when_context(scenario) do
-        before do
-          scenario.prior_declarations.each do |declaration_type|
-            and_lead_provider_has_made_training_declaration "Original Lead Provider",
-                                                            scenario.participant_type,
-                                                            "The Participant",
-                                                            declaration_type
+            and_sit_at_pupil_premium_school_reported_programme "New SIT", "FIP"
+            and_lead_provider_reported_partnership "Original Lead Provider", "New SIT"
+
+            and_sit_reported_participant "Original SIT",
+                                         "The Participant",
+                                         scenario.participant_trn,
+                                         scenario.participant_dob,
+                                         scenario.participant_email,
+                                         scenario.participant_type
           end
 
-          when_school_uses_the_transfer_participant_wizard "New SIT",
-                                                           "The Participant",
-                                                           scenario.participant_email,
-                                                           scenario.participant_trn,
-                                                           scenario.participant_dob,
-                                                           same_provider: true
+          context when_context(scenario) do
+            before do
+              scenario.prior_declarations.each do |declaration_type|
+                and_lead_provider_has_made_training_declaration "Original Lead Provider",
+                                                                scenario.participant_type,
+                                                                "The Participant",
+                                                                declaration_type
+              end
 
-          scenario.new_declarations.each do |declaration_type|
-            and_lead_provider_has_made_training_declaration "Original Lead Provider",
-                                                            scenario.participant_type,
-                                                            "The Participant",
-                                                            declaration_type
+              when_school_uses_the_transfer_participant_wizard "New SIT",
+                                                               "The Participant",
+                                                               scenario.participant_email,
+                                                               scenario.participant_trn,
+                                                               scenario.participant_dob,
+                                                               same_provider: true
+
+              scenario.new_declarations.each do |declaration_type|
+                and_lead_provider_has_made_training_declaration "Original Lead Provider",
+                                                                scenario.participant_type,
+                                                                "The Participant",
+                                                                declaration_type
+              end
+
+              and_eligible_training_declarations_are_made_payable
+            end
+
+            include_examples "FIP to FIP with same provider", scenario, "active", see_prior_school: false
           end
-
-          and_eligible_training_declarations_are_made_payable
         end
-
-        include_examples "FIP to FIP with same provider", scenario, "active", see_prior_school: false
       end
     end
   end

--- a/spec/features/scenarios/transfering_a_participant/fip_to_fip_with_same_provider_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/fip_to_fip_with_same_provider_spec.rb
@@ -44,6 +44,7 @@ RSpec.feature "FIP to FIP with same provider - Transfer a participant",
           allow(Cohort).to receive(:current).and_return(cohort)
           allow(Cohort).to receive(:next).and_return(cohort)
           allow(Cohort).to receive(:active_registration_cohort).and_return(cohort)
+          allow(Cohort).to receive(:destination_from_frozen_cohort).and_return(cohort)
           allow(cohort).to receive(:next).and_return(cohort)
           allow(cohort).to receive(:previous).and_return(cohort)
           cohort

--- a/spec/features/schools/choose_programme/choose_programme_invalid_provider_relationship_spec.rb
+++ b/spec/features/schools/choose_programme/choose_programme_invalid_provider_relationship_spec.rb
@@ -6,38 +6,42 @@ require_relative "./choose_programme_steps"
 RSpec.feature "Schools should be able to choose their programme", type: :feature, js: true, rutabaga: false, travel_to: Time.zone.local(2022, 6, 5, 16, 15, 0) do
   include ChooseProgrammeSteps
 
-  before do
-    given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
-    and_cohort_for_next_academic_year_is_created
-    and_i_am_signed_in_as_an_induction_coordinator
-    then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
-    when_i_click_continue
-    then_i_am_taken_to_ects_expected_in_next_academic_year_page
-  end
+  %w[active inactive].each do |flag_state|
+    context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      before do
+        given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
+        and_cohort_for_next_academic_year_is_created
+        and_i_am_signed_in_as_an_induction_coordinator
+        then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
+        when_i_click_continue
+        then_i_am_taken_to_ects_expected_in_next_academic_year_page
+      end
 
-  context "school cohort provider relationship for 2022 is invalid" do
-    scenario "school continues with different lead provider" do
-      when_i_choose_ects_expected
-      and_i_click_continue
-      then_i_am_taken_to_the_lp_dp_relationship_has_changed_page
+      context "school cohort provider relationship for 2022 is invalid" do
+        scenario "school continues with different lead provider" do
+          when_i_choose_ects_expected
+          and_i_click_continue
+          then_i_am_taken_to_the_lp_dp_relationship_has_changed_page
 
-      when_i_click_the_confirm_button
-      then_i_am_taken_to_what_changes_page
+          when_i_click_the_confirm_button
+          then_i_am_taken_to_what_changes_page
 
-      when_i_choose_to_form_a_new_partnership
-      and_i_click_continue
-      then_i_am_taken_to_the_form_a_new_partnership_confirmation_page
-      when_i_click_the_confirm_button
-      then_i_am_taken_to_the_appropriate_body_appointed_page
+          when_i_choose_to_form_a_new_partnership
+          and_i_click_continue
+          then_i_am_taken_to_the_form_a_new_partnership_confirmation_page
+          when_i_click_the_confirm_button
+          then_i_am_taken_to_the_appropriate_body_appointed_page
 
-      when_i_choose_no
-      and_i_click_continue
-      then_i_am_taken_to_the_complete_page
+          when_i_choose_no
+          and_i_click_continue
+          then_i_am_taken_to_the_complete_page
 
-      when_i_click_on_the_return_to_your_training_link
-      click_on(Cohort.next.description)
-      and_i_see_training_provider_to_be_confirmed
-      and_i_see_delivery_partner_to_be_confirmed
+          when_i_click_on_the_return_to_your_training_link
+          click_on(Cohort.next.description)
+          and_i_see_training_provider_to_be_confirmed
+          and_i_see_delivery_partner_to_be_confirmed
+        end
+      end
     end
   end
 end

--- a/spec/features/schools/choose_programme/choose_programme_spec.rb
+++ b/spec/features/schools/choose_programme/choose_programme_spec.rb
@@ -6,268 +6,32 @@ require_relative "./choose_programme_steps"
 RSpec.feature "Schools should be able to choose their programme", type: :feature, js: true, rutabaga: false, travel_to: Time.zone.local(2022, 6, 5, 16, 15, 0) do
   include ChooseProgrammeSteps
 
-  scenario "A school chooses no ECTs expected in next academic year" do
-    given_a_school_with_no_chosen_programme_for_next_academic_year
-    and_i_am_signed_in_as_an_induction_coordinator
-
-    then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
-    and_the_page_should_be_accessible
-
-    when_i_click_continue
-    then_i_am_taken_to_ects_expected_in_next_academic_year_page
-
-    when_i_choose_no_ects
-    and_i_click_continue
-    then_i_am_taken_to_the_submitted_page
-    and_i_see_the_school_name
-
-    when_i_click_on_the_return_to_your_training_link
-    then_i_am_taken_to_the_manage_your_training_page
-    and_the_dashboard_page_shows_the_no_ects_message
-  end
-
-  scenario "A school chooses ECTs expected in next academic year and training DfE funded" do
-    given_a_school_with_no_chosen_programme_for_next_academic_year
-    and_i_am_signed_in_as_an_induction_coordinator
-
-    then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
-    and_the_page_should_be_accessible
-
-    when_i_click_continue
-    then_i_am_taken_to_ects_expected_in_next_academic_year_page
-
-    when_i_choose_ects_expected
-    and_i_click_continue
-    then_i_am_taken_to_the_how_will_you_run_training_page
-
-    when_i_choose_dfe_funded_training
-    and_i_click_continue
-    then_i_am_taken_to_the_training_confirmation_page
-
-    when_i_click_the_confirm_button
-    then_i_am_taken_to_the_appropriate_body_appointed_page
-
-    when_i_choose_no
-    and_i_click_continue
-    then_i_am_taken_to_the_training_submitted_page
-
-    when_i_click_on_the_return_to_your_training_link
-    then_i_am_taken_to_the_manage_your_training_page
-    and_i_see_training_provider_to_be_confirmed
-    and_i_see_delivery_partner_to_be_confirmed
-  end
-
-  scenario "A CIP-only non-previously_fip school chooses ECTs expected in next academic year and training school funded" do
-    given_a_school_with_no_chosen_programme_for_next_academic_year(cip_only: true)
-    and_i_am_signed_in_as_an_induction_coordinator
-
-    then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
-    and_the_page_should_be_accessible
-
-    when_i_click_continue
-    then_i_am_taken_to_ects_expected_in_next_academic_year_page
-
-    when_i_choose_ects_expected
-    and_i_click_continue
-    then_i_am_taken_to_the_how_will_you_run_training_page
-
-    when_i_choose_use_a_training_provider_funded_by_your_school
-    and_i_click_continue
-    then_i_am_taken_to_the_training_confirmation_page
-
-    when_i_click_the_confirm_button
-    then_i_am_taken_to_the_appropriate_body_appointed_page
-
-    when_i_choose_no
-    and_i_click_continue
-    then_i_am_on_the_school_funded_fip_training_submitted_page
-    and_the_page_should_be_accessible
-    and_i_can_get_guidance_about_an_arrangement_with_a_training_provider_on_the_school_funded_fip_training_submitted_page
-    and_i_can_email_cpd_for_help_on_the_school_funded_fip_training_submitted_page
-
-    when_i_click_on_the_return_to_your_training_link
-    then_i_am_taken_to_the_manage_your_training_page
-  end
-
-  scenario "A CIP-Only previously_fip school chooses ECTs expected in next academic year and training school funded" do
-    given_a_school_with_no_chosen_programme_for_next_academic_year(cip_only: true, previously_fip: true)
-    and_i_am_signed_in_as_an_induction_coordinator
-
-    then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
-    and_the_page_should_be_accessible
-
-    when_i_click_continue
-    then_i_am_taken_to_ects_expected_in_next_academic_year_page
-
-    when_i_choose_ects_expected
-    and_i_click_continue
-    then_i_am_taken_to_the_how_will_you_run_training_page
-
-    when_i_choose_use_a_training_provider_funded_by_your_school
-    and_i_click_continue
-    then_i_am_taken_to_the_training_confirmation_page
-
-    when_i_click_the_confirm_button
-    then_i_am_taken_to_the_appropriate_body_appointed_page
-
-    when_i_choose_no
-    and_i_click_continue
-    then_i_am_on_the_school_funded_fip_training_submitted_page
-    and_the_page_should_be_accessible
-    and_i_can_get_guidance_about_an_arrangement_with_a_training_provider_on_the_school_funded_fip_training_submitted_page
-    and_i_can_email_cpd_for_help_on_the_school_funded_fip_training_submitted_page
-
-    when_i_click_on_the_return_to_your_training_link
-    then_i_am_taken_to_the_manage_your_training_page
-  end
-
-  scenario "A school chooses ECTs expected in next academic year and deliver own programme" do
-    given_a_school_with_no_chosen_programme_for_next_academic_year
-    and_i_am_signed_in_as_an_induction_coordinator
-    then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
-    and_the_page_should_be_accessible
-
-    when_i_click_continue
-    then_i_am_taken_to_ects_expected_in_next_academic_year_page
-
-    when_i_choose_ects_expected
-    and_i_click_continue
-    then_i_am_taken_to_the_how_will_you_run_training_page
-
-    when_i_choose_deliver_your_own_programme
-    and_i_click_continue
-    then_i_am_taken_to_the_training_confirmation_page
-
-    when_i_click_the_confirm_button
-    then_i_am_taken_to_the_appropriate_body_appointed_page
-
-    when_i_choose_no
-    and_i_click_continue
-    then_i_am_taken_to_the_training_submitted_page
-
-    when_i_click_on_the_return_to_your_training_link
-    then_i_am_taken_to_the_manage_your_training_page
-    and_i_see_the_choose_training_material_content
-  end
-
-  scenario "A school chooses ECTs expected in next academic year and design and deliver own programme" do
-    given_a_school_with_no_chosen_programme_for_next_academic_year
-    and_i_am_signed_in_as_an_induction_coordinator
-
-    then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
-    and_the_page_should_be_accessible
-
-    when_i_click_continue
-    then_i_am_taken_to_ects_expected_in_next_academic_year_page
-
-    when_i_choose_ects_expected
-    and_i_click_continue
-    then_i_am_taken_to_the_how_will_you_run_training_page
-
-    when_i_choose_design_and_deliver_your_own_material
-    and_i_click_continue
-    then_i_am_taken_to_the_training_confirmation_page
-
-    when_i_click_the_confirm_button
-    then_i_am_taken_to_the_appropriate_body_appointed_page
-
-    when_i_choose_no
-    and_i_click_continue
-    then_i_am_taken_to_the_training_submitted_page
-
-    when_i_click_on_the_return_to_your_training_link
-    then_i_am_taken_to_the_manage_your_training_page
-  end
-
-  context "FIP" do
-    scenario "A school with challenged partnership chooses expects ects" do
-      given_there_is_a_school_that_has_chosen_fip_for_2021_but_partnership_was_challenged
-      and_cohort_for_next_academic_year_is_created
-      and_a_provider_relationship_exists_for_the_lp_and_dp
-      and_i_am_signed_in_as_an_induction_coordinator
-      then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
-      and_the_page_should_be_accessible
-
-      when_i_click_continue
-      then_i_am_taken_to_ects_expected_in_next_academic_year_page
-
-      when_i_choose_ects_expected
-      and_i_click_continue
-      then_i_am_taken_to_what_changes_page
-    end
-
-    scenario "A school chooses to keep the same FIP programme in the new cohort" do
-      given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
-      and_cohort_for_next_academic_year_is_created
-      and_a_provider_relationship_exists_for_the_lp_and_dp
-      and_i_am_signed_in_as_an_induction_coordinator
-      then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
-      and_the_page_should_be_accessible
-
-      when_i_click_continue
-      then_i_am_taken_to_ects_expected_in_next_academic_year_page
-
-      when_i_choose_ects_expected
-      and_i_click_continue
-      then_i_am_taken_to_the_keep_providers_page
-      and_i_see_the_lead_provider
-      and_i_see_the_delivery_partner
-
-      and_i_choose_yes
-      and_i_click_continue
-      then_i_am_taken_to_the_appropriate_body_appointed_page
-
-      when_i_choose_no
-      and_i_click_continue
-      then_i_am_taken_to_the_complete_page
-
-      when_i_click_on_the_return_to_your_training_link
-      then_i_am_taken_to_the_manage_your_training_page
-      and_i_see_the_lead_provider
-      and_i_see_the_delivery_partner
-      and_i_see_the_challenge_link
-    end
-
-    scenario "Empty LP and DP names for challenged partnerships" do
-      given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
-      and_cohort_for_next_academic_year_is_created
-      and_a_provider_relationship_exists_for_the_lp_and_dp
-      and_i_am_signed_in_as_an_induction_coordinator
-      then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
-      and_the_page_should_be_accessible
-
-      when_i_click_continue
-      then_i_am_taken_to_ects_expected_in_next_academic_year_page
-
-      when_i_choose_ects_expected
-      and_i_click_continue
-      then_i_am_taken_to_the_keep_providers_page
-      and_i_see_the_lead_provider
-      and_i_see_the_delivery_partner
-
-      when_i_choose_yes
-      and_i_click_continue
-      then_i_am_taken_to_the_appropriate_body_appointed_page
-
-      when_i_choose_no
-      and_i_click_continue
-      then_i_am_taken_to_the_complete_page
-
-      when_i_click_on_the_return_to_your_training_link
-      then_i_am_taken_to_the_manage_your_training_page
-
-      when_i_challenge_the_new_cohort_partnership
-      and_i_visit_the_school_manage_training
-      then_i_see_black_lp_and_dp_names
-      and_i_do_not_see_the_challenge_link
-    end
-
-    context "Changing training" do
-      scenario "A school chooses to use a different lead provider" do
-        given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
-        and_cohort_for_next_academic_year_is_created
-        and_a_provider_relationship_exists_for_the_lp_and_dp
+  %w[active inactive].each do |flag_state|
+    context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      scenario "A school chooses no ECTs expected in next academic year" do
+        given_a_school_with_no_chosen_programme_for_next_academic_year
         and_i_am_signed_in_as_an_induction_coordinator
+
+        then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
+        and_the_page_should_be_accessible
+
+        when_i_click_continue
+        then_i_am_taken_to_ects_expected_in_next_academic_year_page
+
+        when_i_choose_no_ects
+        and_i_click_continue
+        then_i_am_taken_to_the_submitted_page
+        and_i_see_the_school_name
+
+        when_i_click_on_the_return_to_your_training_link
+        then_i_am_taken_to_the_manage_your_training_page
+        and_the_dashboard_page_shows_the_no_ects_message
+      end
+
+      scenario "A school chooses ECTs expected in next academic year and training DfE funded" do
+        given_a_school_with_no_chosen_programme_for_next_academic_year
+        and_i_am_signed_in_as_an_induction_coordinator
+
         then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
         and_the_page_should_be_accessible
 
@@ -276,27 +40,18 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
 
         when_i_choose_ects_expected
         and_i_click_continue
-        then_i_am_taken_to_the_keep_providers_page
-        and_i_see_the_lead_provider
-        and_i_see_the_delivery_partner
+        then_i_am_taken_to_the_how_will_you_run_training_page
 
-        when_i_choose_no
+        when_i_choose_dfe_funded_training
         and_i_click_continue
-        then_i_am_taken_to_what_changes_page
-
-        when_i_choose_to_form_a_new_partnership
-        and_i_click_continue
-        then_i_am_taken_to_the_form_a_new_partnership_confirmation_page
+        then_i_am_taken_to_the_training_confirmation_page
 
         when_i_click_the_confirm_button
         then_i_am_taken_to_the_appropriate_body_appointed_page
 
         when_i_choose_no
         and_i_click_continue
-        then_i_am_taken_to_the_training_change_submitted_page
-        and_i_see_the_lead_provider
-        and_i_see_the_delivery_partner
-        and_a_notification_email_is_sent_to_the_lead_provider
+        then_i_am_taken_to_the_training_submitted_page
 
         when_i_click_on_the_return_to_your_training_link
         then_i_am_taken_to_the_manage_your_training_page
@@ -304,11 +59,10 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
         and_i_see_delivery_partner_to_be_confirmed
       end
 
-      scenario "A school chooses to deliver own programme" do
-        given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
-        and_cohort_for_next_academic_year_is_created
-        and_a_provider_relationship_exists_for_the_lp_and_dp
+      scenario "A CIP-only non-previously_fip school chooses ECTs expected in next academic year and training school funded" do
+        given_a_school_with_no_chosen_programme_for_next_academic_year(cip_only: true)
         and_i_am_signed_in_as_an_induction_coordinator
+
         then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
         and_the_page_should_be_accessible
 
@@ -317,36 +71,30 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
 
         when_i_choose_ects_expected
         and_i_click_continue
-        then_i_am_taken_to_the_keep_providers_page
-        and_i_see_the_lead_provider
-        and_i_see_the_delivery_partner
+        then_i_am_taken_to_the_how_will_you_run_training_page
 
-        when_i_choose_no
+        when_i_choose_use_a_training_provider_funded_by_your_school
         and_i_click_continue
-        then_i_am_taken_to_what_changes_page
-
-        when_i_choose_to_deliver_own_programme
-        and_i_click_continue
-        then_i_am_taken_to_the_change_to_design_own_programme_confirmation_page
+        then_i_am_taken_to_the_training_confirmation_page
 
         when_i_click_the_confirm_button
         then_i_am_taken_to_the_appropriate_body_appointed_page
 
         when_i_choose_no
         and_i_click_continue
-        then_i_am_taken_to_the_training_change_submitted_page
-        and_a_notification_email_is_sent_to_the_lead_provider
+        then_i_am_on_the_school_funded_fip_training_submitted_page
+        and_the_page_should_be_accessible
+        and_i_can_get_guidance_about_an_arrangement_with_a_training_provider_on_the_school_funded_fip_training_submitted_page
+        and_i_can_email_cpd_for_help_on_the_school_funded_fip_training_submitted_page
 
         when_i_click_on_the_return_to_your_training_link
         then_i_am_taken_to_the_manage_your_training_page
-        and_i_see_programme_to_dfe_accredited_materials
       end
 
-      scenario "A school chooses to design and deliver own programme" do
-        given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
-        and_cohort_for_next_academic_year_is_created
-        and_a_provider_relationship_exists_for_the_lp_and_dp
+      scenario "A CIP-Only previously_fip school chooses ECTs expected in next academic year and training school funded" do
+        given_a_school_with_no_chosen_programme_for_next_academic_year(cip_only: true, previously_fip: true)
         and_i_am_signed_in_as_an_induction_coordinator
+
         then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
         and_the_page_should_be_accessible
 
@@ -355,79 +103,28 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
 
         when_i_choose_ects_expected
         and_i_click_continue
-        then_i_am_taken_to_the_keep_providers_page
-        and_i_see_the_lead_provider
-        and_i_see_the_delivery_partner
+        then_i_am_taken_to_the_how_will_you_run_training_page
 
-        when_i_choose_no
+        when_i_choose_use_a_training_provider_funded_by_your_school
         and_i_click_continue
-        then_i_am_taken_to_what_changes_page
-
-        when_i_choose_to_design_and_deliver_own_programme
-        and_i_click_continue
-        then_i_am_taken_to_the_change_to_design_and_deliver_own_programme_confirmation_page
+        then_i_am_taken_to_the_training_confirmation_page
 
         when_i_click_the_confirm_button
         then_i_am_taken_to_the_appropriate_body_appointed_page
 
         when_i_choose_no
         and_i_click_continue
-        then_i_am_taken_to_the_training_change_submitted_page
-        and_a_notification_email_is_sent_to_the_lead_provider
+        then_i_am_on_the_school_funded_fip_training_submitted_page
+        and_the_page_should_be_accessible
+        and_i_can_get_guidance_about_an_arrangement_with_a_training_provider_on_the_school_funded_fip_training_submitted_page
+        and_i_can_email_cpd_for_help_on_the_school_funded_fip_training_submitted_page
 
         when_i_click_on_the_return_to_your_training_link
         then_i_am_taken_to_the_manage_your_training_page
-        and_i_see_programme_to_design_and_deliver_own_programme
-      end
-    end
-  end
-
-  context "Appropriate body" do
-    before do
-      @local_authorities = create_list(:appropriate_body_local_authority, 5)
-      @teaching_school_hubs = create_list(:appropriate_body_teaching_school_hub, 5)
-      @national_organisations = create_list(:appropriate_body_national_organisation, 2)
-    end
-
-    scenario "A school does not appoint an appropriate body" do
-      given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
-      and_cohort_for_next_academic_year_is_created
-      and_a_provider_relationship_exists_for_the_lp_and_dp
-      and_i_am_signed_in_as_an_induction_coordinator
-      then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
-      and_the_page_should_be_accessible
-
-      when_i_click_continue
-      then_i_am_taken_to_ects_expected_in_next_academic_year_page
-
-      when_i_choose_ects_expected
-      and_i_click_continue
-      then_i_am_taken_to_the_keep_providers_page
-
-      when_i_choose_yes
-      and_i_click_continue
-      then_i_am_taken_to_the_appropriate_body_appointed_page
-
-      when_i_choose_no
-      and_i_click_continue
-      then_i_am_taken_to_the_complete_page
-      and_i_see_the_tell_us_appropriate_body_copy
-
-      when_i_click_on_the_return_to_your_training_link
-      then_i_am_taken_to_the_manage_your_training_page
-      and_i_see_no_appropriate_body
-    end
-
-    context "When is a British school overseas (GIAS 37)" do
-      before do
-        create(:appropriate_body_national_organisation, name: "Educational Success Partners (ESP)")
       end
 
-      scenario "A school chooses to appoint an appropriate body" do
-        given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
-        and_school_type_is(37)
-        and_cohort_for_next_academic_year_is_created
-        and_a_provider_relationship_exists_for_the_lp_and_dp
+      scenario "A school chooses ECTs expected in next academic year and deliver own programme" do
+        given_a_school_with_no_chosen_programme_for_next_academic_year
         and_i_am_signed_in_as_an_induction_coordinator
         then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
         and_the_page_should_be_accessible
@@ -446,27 +143,19 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
         when_i_click_the_confirm_button
         then_i_am_taken_to_the_appropriate_body_appointed_page
 
-        when_i_choose_yes
+        when_i_choose_no
         and_i_click_continue
-        then_i_am_taken_to_the_appropriate_body_type_page
-
-        choose "Teaching school hub"
-        when_i_fill_appropriate_body_with @teaching_school_hubs.first.name
-        and_i_click_continue
-        then_i_am_taken_to_the_complete_page
-        and_i_dont_see_the_tell_us_appropriate_body_copy
+        then_i_am_taken_to_the_training_submitted_page
 
         when_i_click_on_the_return_to_your_training_link
         then_i_am_taken_to_the_manage_your_training_page
-        and_i_see_appropriate_body @teaching_school_hubs.first.name
+        and_i_see_the_choose_training_material_content
       end
 
-      scenario "A school chooses the default appropriate body" do
-        given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
-        and_school_type_is(37)
-        and_cohort_for_next_academic_year_is_created
-        and_a_provider_relationship_exists_for_the_lp_and_dp
+      scenario "A school chooses ECTs expected in next academic year and design and deliver own programme" do
+        given_a_school_with_no_chosen_programme_for_next_academic_year
         and_i_am_signed_in_as_an_induction_coordinator
+
         then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
         and_the_page_should_be_accessible
 
@@ -477,257 +166,572 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
         and_i_click_continue
         then_i_am_taken_to_the_how_will_you_run_training_page
 
-        when_i_choose_deliver_your_own_programme
+        when_i_choose_design_and_deliver_your_own_material
         and_i_click_continue
         then_i_am_taken_to_the_training_confirmation_page
 
         when_i_click_the_confirm_button
         then_i_am_taken_to_the_appropriate_body_appointed_page
 
-        when_i_choose_yes
+        when_i_choose_no
         and_i_click_continue
-        then_i_am_taken_to_the_appropriate_body_type_page
-
-        choose "Educational Success Partners (ESP)"
-        and_i_click_continue
-        then_i_am_taken_to_the_complete_page
-        and_i_dont_see_the_tell_us_appropriate_body_copy
+        then_i_am_taken_to_the_training_submitted_page
 
         when_i_click_on_the_return_to_your_training_link
         then_i_am_taken_to_the_manage_your_training_page
-        and_i_see_appropriate_body "Educational Success Partners (ESP)"
       end
 
-      scenario "The appropriate body is not listed" do
-        given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
-        and_school_type_is(37)
-        and_cohort_for_next_academic_year_is_created
-        and_a_provider_relationship_exists_for_the_lp_and_dp
-        and_i_am_signed_in_as_an_induction_coordinator
-        then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
-        and_the_page_should_be_accessible
+      context "FIP" do
+        scenario "A school with challenged partnership chooses expects ects" do
+          given_there_is_a_school_that_has_chosen_fip_for_2021_but_partnership_was_challenged
+          and_cohort_for_next_academic_year_is_created
+          and_a_provider_relationship_exists_for_the_lp_and_dp
+          and_i_am_signed_in_as_an_induction_coordinator
+          then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
+          and_the_page_should_be_accessible
 
-        when_i_click_continue
-        then_i_am_taken_to_ects_expected_in_next_academic_year_page
+          when_i_click_continue
+          then_i_am_taken_to_ects_expected_in_next_academic_year_page
 
-        when_i_choose_ects_expected
-        and_i_click_continue
-        then_i_am_taken_to_the_how_will_you_run_training_page
+          when_i_choose_ects_expected
+          and_i_click_continue
+          then_i_am_taken_to_what_changes_page
+        end
 
-        when_i_choose_deliver_your_own_programme
-        and_i_click_continue
-        then_i_am_taken_to_the_training_confirmation_page
+        scenario "A school chooses to keep the same FIP programme in the new cohort" do
+          given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
+          and_cohort_for_next_academic_year_is_created
+          and_a_provider_relationship_exists_for_the_lp_and_dp
+          and_i_am_signed_in_as_an_induction_coordinator
+          then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
+          and_the_page_should_be_accessible
 
-        when_i_click_the_confirm_button
-        then_i_am_taken_to_the_appropriate_body_appointed_page
+          when_i_click_continue
+          then_i_am_taken_to_ects_expected_in_next_academic_year_page
 
-        when_i_choose_yes
-        and_i_click_continue
-        then_i_am_taken_to_the_appropriate_body_type_page
+          when_i_choose_ects_expected
+          and_i_click_continue
+          then_i_am_taken_to_the_keep_providers_page
+          and_i_see_the_lead_provider
+          and_i_see_the_delivery_partner
 
-        when_i_click_on_appropriate_body_not_listed
-        then_i_am_taken_to_the_complete_page
-        and_i_see_the_tell_us_appropriate_body_copy
+          and_i_choose_yes
+          and_i_click_continue
+          then_i_am_taken_to_the_appropriate_body_appointed_page
 
-        when_i_click_on_the_return_to_your_training_link
-        then_i_am_taken_to_the_manage_your_training_page
-        and_i_see_no_appropriate_body
+          when_i_choose_no
+          and_i_click_continue
+          then_i_am_taken_to_the_complete_page
+
+          when_i_click_on_the_return_to_your_training_link
+          then_i_am_taken_to_the_manage_your_training_page
+          and_i_see_the_lead_provider
+          and_i_see_the_delivery_partner
+          and_i_see_the_challenge_link
+        end
+
+        scenario "Empty LP and DP names for challenged partnerships" do
+          given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
+          and_cohort_for_next_academic_year_is_created
+          and_a_provider_relationship_exists_for_the_lp_and_dp
+          and_i_am_signed_in_as_an_induction_coordinator
+          then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
+          and_the_page_should_be_accessible
+
+          when_i_click_continue
+          then_i_am_taken_to_ects_expected_in_next_academic_year_page
+
+          when_i_choose_ects_expected
+          and_i_click_continue
+          then_i_am_taken_to_the_keep_providers_page
+          and_i_see_the_lead_provider
+          and_i_see_the_delivery_partner
+
+          when_i_choose_yes
+          and_i_click_continue
+          then_i_am_taken_to_the_appropriate_body_appointed_page
+
+          when_i_choose_no
+          and_i_click_continue
+          then_i_am_taken_to_the_complete_page
+
+          when_i_click_on_the_return_to_your_training_link
+          then_i_am_taken_to_the_manage_your_training_page
+
+          when_i_challenge_the_new_cohort_partnership
+          and_i_visit_the_school_manage_training
+          then_i_see_black_lp_and_dp_names
+          and_i_do_not_see_the_challenge_link
+        end
+
+        context "Changing training" do
+          scenario "A school chooses to use a different lead provider" do
+            given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
+            and_cohort_for_next_academic_year_is_created
+            and_a_provider_relationship_exists_for_the_lp_and_dp
+            and_i_am_signed_in_as_an_induction_coordinator
+            then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
+            and_the_page_should_be_accessible
+
+            when_i_click_continue
+            then_i_am_taken_to_ects_expected_in_next_academic_year_page
+
+            when_i_choose_ects_expected
+            and_i_click_continue
+            then_i_am_taken_to_the_keep_providers_page
+            and_i_see_the_lead_provider
+            and_i_see_the_delivery_partner
+
+            when_i_choose_no
+            and_i_click_continue
+            then_i_am_taken_to_what_changes_page
+
+            when_i_choose_to_form_a_new_partnership
+            and_i_click_continue
+            then_i_am_taken_to_the_form_a_new_partnership_confirmation_page
+
+            when_i_click_the_confirm_button
+            then_i_am_taken_to_the_appropriate_body_appointed_page
+
+            when_i_choose_no
+            and_i_click_continue
+            then_i_am_taken_to_the_training_change_submitted_page
+            and_i_see_the_lead_provider
+            and_i_see_the_delivery_partner
+            and_a_notification_email_is_sent_to_the_lead_provider
+
+            when_i_click_on_the_return_to_your_training_link
+            then_i_am_taken_to_the_manage_your_training_page
+            and_i_see_training_provider_to_be_confirmed
+            and_i_see_delivery_partner_to_be_confirmed
+          end
+
+          scenario "A school chooses to deliver own programme" do
+            given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
+            and_cohort_for_next_academic_year_is_created
+            and_a_provider_relationship_exists_for_the_lp_and_dp
+            and_i_am_signed_in_as_an_induction_coordinator
+            then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
+            and_the_page_should_be_accessible
+
+            when_i_click_continue
+            then_i_am_taken_to_ects_expected_in_next_academic_year_page
+
+            when_i_choose_ects_expected
+            and_i_click_continue
+            then_i_am_taken_to_the_keep_providers_page
+            and_i_see_the_lead_provider
+            and_i_see_the_delivery_partner
+
+            when_i_choose_no
+            and_i_click_continue
+            then_i_am_taken_to_what_changes_page
+
+            when_i_choose_to_deliver_own_programme
+            and_i_click_continue
+            then_i_am_taken_to_the_change_to_design_own_programme_confirmation_page
+
+            when_i_click_the_confirm_button
+            then_i_am_taken_to_the_appropriate_body_appointed_page
+
+            when_i_choose_no
+            and_i_click_continue
+            then_i_am_taken_to_the_training_change_submitted_page
+            and_a_notification_email_is_sent_to_the_lead_provider
+
+            when_i_click_on_the_return_to_your_training_link
+            then_i_am_taken_to_the_manage_your_training_page
+            and_i_see_programme_to_dfe_accredited_materials
+          end
+
+          scenario "A school chooses to design and deliver own programme" do
+            given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
+            and_cohort_for_next_academic_year_is_created
+            and_a_provider_relationship_exists_for_the_lp_and_dp
+            and_i_am_signed_in_as_an_induction_coordinator
+            then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
+            and_the_page_should_be_accessible
+
+            when_i_click_continue
+            then_i_am_taken_to_ects_expected_in_next_academic_year_page
+
+            when_i_choose_ects_expected
+            and_i_click_continue
+            then_i_am_taken_to_the_keep_providers_page
+            and_i_see_the_lead_provider
+            and_i_see_the_delivery_partner
+
+            when_i_choose_no
+            and_i_click_continue
+            then_i_am_taken_to_what_changes_page
+
+            when_i_choose_to_design_and_deliver_own_programme
+            and_i_click_continue
+            then_i_am_taken_to_the_change_to_design_and_deliver_own_programme_confirmation_page
+
+            when_i_click_the_confirm_button
+            then_i_am_taken_to_the_appropriate_body_appointed_page
+
+            when_i_choose_no
+            and_i_click_continue
+            then_i_am_taken_to_the_training_change_submitted_page
+            and_a_notification_email_is_sent_to_the_lead_provider
+
+            when_i_click_on_the_return_to_your_training_link
+            then_i_am_taken_to_the_manage_your_training_page
+            and_i_see_programme_to_design_and_deliver_own_programme
+          end
+        end
       end
-    end
 
-    context "When is an independent school (GIAS 10)" do
-      before do
-        create(:appropriate_body_national_organisation, name: "Independent Schools Teacher Induction Panel (IStip)")
+      context "Appropriate body" do
+        before do
+          @local_authorities = create_list(:appropriate_body_local_authority, 5)
+          @teaching_school_hubs = create_list(:appropriate_body_teaching_school_hub, 5)
+          @national_organisations = create_list(:appropriate_body_national_organisation, 2)
+        end
+
+        scenario "A school does not appoint an appropriate body" do
+          given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
+          and_cohort_for_next_academic_year_is_created
+          and_a_provider_relationship_exists_for_the_lp_and_dp
+          and_i_am_signed_in_as_an_induction_coordinator
+          then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
+          and_the_page_should_be_accessible
+
+          when_i_click_continue
+          then_i_am_taken_to_ects_expected_in_next_academic_year_page
+
+          when_i_choose_ects_expected
+          and_i_click_continue
+          then_i_am_taken_to_the_keep_providers_page
+
+          when_i_choose_yes
+          and_i_click_continue
+          then_i_am_taken_to_the_appropriate_body_appointed_page
+
+          when_i_choose_no
+          and_i_click_continue
+          then_i_am_taken_to_the_complete_page
+          and_i_see_the_tell_us_appropriate_body_copy
+
+          when_i_click_on_the_return_to_your_training_link
+          then_i_am_taken_to_the_manage_your_training_page
+          and_i_see_no_appropriate_body
+        end
+
+        context "When is a British school overseas (GIAS 37)" do
+          before do
+            create(:appropriate_body_national_organisation, name: "Educational Success Partners (ESP)")
+          end
+
+          scenario "A school chooses to appoint an appropriate body" do
+            given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
+            and_school_type_is(37)
+            and_cohort_for_next_academic_year_is_created
+            and_a_provider_relationship_exists_for_the_lp_and_dp
+            and_i_am_signed_in_as_an_induction_coordinator
+            then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
+            and_the_page_should_be_accessible
+
+            when_i_click_continue
+            then_i_am_taken_to_ects_expected_in_next_academic_year_page
+
+            when_i_choose_ects_expected
+            and_i_click_continue
+            then_i_am_taken_to_the_how_will_you_run_training_page
+
+            when_i_choose_deliver_your_own_programme
+            and_i_click_continue
+            then_i_am_taken_to_the_training_confirmation_page
+
+            when_i_click_the_confirm_button
+            then_i_am_taken_to_the_appropriate_body_appointed_page
+
+            when_i_choose_yes
+            and_i_click_continue
+            then_i_am_taken_to_the_appropriate_body_type_page
+
+            choose "Teaching school hub"
+            when_i_fill_appropriate_body_with @teaching_school_hubs.first.name
+            and_i_click_continue
+            then_i_am_taken_to_the_complete_page
+            and_i_dont_see_the_tell_us_appropriate_body_copy
+
+            when_i_click_on_the_return_to_your_training_link
+            then_i_am_taken_to_the_manage_your_training_page
+            and_i_see_appropriate_body @teaching_school_hubs.first.name
+          end
+
+          scenario "A school chooses the default appropriate body" do
+            given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
+            and_school_type_is(37)
+            and_cohort_for_next_academic_year_is_created
+            and_a_provider_relationship_exists_for_the_lp_and_dp
+            and_i_am_signed_in_as_an_induction_coordinator
+            then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
+            and_the_page_should_be_accessible
+
+            when_i_click_continue
+            then_i_am_taken_to_ects_expected_in_next_academic_year_page
+
+            when_i_choose_ects_expected
+            and_i_click_continue
+            then_i_am_taken_to_the_how_will_you_run_training_page
+
+            when_i_choose_deliver_your_own_programme
+            and_i_click_continue
+            then_i_am_taken_to_the_training_confirmation_page
+
+            when_i_click_the_confirm_button
+            then_i_am_taken_to_the_appropriate_body_appointed_page
+
+            when_i_choose_yes
+            and_i_click_continue
+            then_i_am_taken_to_the_appropriate_body_type_page
+
+            choose "Educational Success Partners (ESP)"
+            and_i_click_continue
+            then_i_am_taken_to_the_complete_page
+            and_i_dont_see_the_tell_us_appropriate_body_copy
+
+            when_i_click_on_the_return_to_your_training_link
+            then_i_am_taken_to_the_manage_your_training_page
+            and_i_see_appropriate_body "Educational Success Partners (ESP)"
+          end
+
+          scenario "The appropriate body is not listed" do
+            given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
+            and_school_type_is(37)
+            and_cohort_for_next_academic_year_is_created
+            and_a_provider_relationship_exists_for_the_lp_and_dp
+            and_i_am_signed_in_as_an_induction_coordinator
+            then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
+            and_the_page_should_be_accessible
+
+            when_i_click_continue
+            then_i_am_taken_to_ects_expected_in_next_academic_year_page
+
+            when_i_choose_ects_expected
+            and_i_click_continue
+            then_i_am_taken_to_the_how_will_you_run_training_page
+
+            when_i_choose_deliver_your_own_programme
+            and_i_click_continue
+            then_i_am_taken_to_the_training_confirmation_page
+
+            when_i_click_the_confirm_button
+            then_i_am_taken_to_the_appropriate_body_appointed_page
+
+            when_i_choose_yes
+            and_i_click_continue
+            then_i_am_taken_to_the_appropriate_body_type_page
+
+            when_i_click_on_appropriate_body_not_listed
+            then_i_am_taken_to_the_complete_page
+            and_i_see_the_tell_us_appropriate_body_copy
+
+            when_i_click_on_the_return_to_your_training_link
+            then_i_am_taken_to_the_manage_your_training_page
+            and_i_see_no_appropriate_body
+          end
+        end
+
+        context "When is an independent school (GIAS 10)" do
+          before do
+            create(:appropriate_body_national_organisation, name: "Independent Schools Teacher Induction Panel (IStip)")
+          end
+
+          scenario "A school chooses to appoint an appropriate body" do
+            given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
+            and_school_type_is(10)
+            and_cohort_for_next_academic_year_is_created
+            and_a_provider_relationship_exists_for_the_lp_and_dp
+            and_i_am_signed_in_as_an_induction_coordinator
+            then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
+            and_the_page_should_be_accessible
+
+            when_i_click_continue
+            then_i_am_taken_to_ects_expected_in_next_academic_year_page
+
+            when_i_choose_ects_expected
+            and_i_click_continue
+            then_i_am_taken_to_the_how_will_you_run_training_page
+
+            when_i_choose_deliver_your_own_programme
+            and_i_click_continue
+            then_i_am_taken_to_the_training_confirmation_page
+
+            when_i_click_the_confirm_button
+            then_i_am_taken_to_the_appropriate_body_appointed_page
+
+            when_i_choose_yes
+            and_i_click_continue
+            then_i_am_taken_to_the_appropriate_body_type_page
+
+            choose "Teaching school hub"
+            when_i_fill_appropriate_body_with @teaching_school_hubs.first.name
+            and_i_click_continue
+            then_i_am_taken_to_the_complete_page
+            and_i_dont_see_the_tell_us_appropriate_body_copy
+
+            when_i_click_on_the_return_to_your_training_link
+            then_i_am_taken_to_the_manage_your_training_page
+            and_i_see_appropriate_body @teaching_school_hubs.first.name
+          end
+
+          scenario "A school chooses the default appropriate body" do
+            given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
+            and_school_type_is(10)
+            and_cohort_for_next_academic_year_is_created
+            and_a_provider_relationship_exists_for_the_lp_and_dp
+            and_i_am_signed_in_as_an_induction_coordinator
+            then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
+            and_the_page_should_be_accessible
+
+            when_i_click_continue
+            then_i_am_taken_to_ects_expected_in_next_academic_year_page
+
+            when_i_choose_ects_expected
+            and_i_click_continue
+            then_i_am_taken_to_the_how_will_you_run_training_page
+
+            when_i_choose_deliver_your_own_programme
+            and_i_click_continue
+            then_i_am_taken_to_the_training_confirmation_page
+
+            when_i_click_the_confirm_button
+            then_i_am_taken_to_the_appropriate_body_appointed_page
+
+            when_i_choose_yes
+            and_i_click_continue
+            then_i_am_taken_to_the_appropriate_body_type_page
+
+            choose "Independent Schools Teacher Induction Panel (IStip)"
+            and_i_click_continue
+            then_i_am_taken_to_the_complete_page
+            and_i_dont_see_the_tell_us_appropriate_body_copy
+
+            when_i_click_on_the_return_to_your_training_link
+            then_i_am_taken_to_the_manage_your_training_page
+            and_i_see_appropriate_body "Independent Schools Teacher Induction Panel (IStip)"
+          end
+        end
+
+        context "When is an independent school (GIAS 11)" do
+          before do
+            create(:appropriate_body_national_organisation, name: "Independent Schools Teacher Induction Panel (IStip)")
+          end
+
+          scenario "A school chooses to appoint an appropriate body" do
+            given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
+            and_school_type_is(11)
+            and_cohort_for_next_academic_year_is_created
+            and_a_provider_relationship_exists_for_the_lp_and_dp
+            and_i_am_signed_in_as_an_induction_coordinator
+            then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
+            and_the_page_should_be_accessible
+
+            when_i_click_continue
+            then_i_am_taken_to_ects_expected_in_next_academic_year_page
+
+            when_i_choose_ects_expected
+            and_i_click_continue
+            then_i_am_taken_to_the_how_will_you_run_training_page
+
+            when_i_choose_deliver_your_own_programme
+            and_i_click_continue
+            then_i_am_taken_to_the_training_confirmation_page
+
+            when_i_click_the_confirm_button
+            then_i_am_taken_to_the_appropriate_body_appointed_page
+
+            when_i_choose_yes
+            and_i_click_continue
+            then_i_am_taken_to_the_appropriate_body_type_page
+
+            choose "Teaching school hub"
+            when_i_fill_appropriate_body_with @teaching_school_hubs.first.name
+            and_i_click_continue
+            then_i_am_taken_to_the_complete_page
+            and_i_dont_see_the_tell_us_appropriate_body_copy
+
+            when_i_click_on_the_return_to_your_training_link
+            then_i_am_taken_to_the_manage_your_training_page
+            and_i_see_appropriate_body @teaching_school_hubs.first.name
+          end
+
+          scenario "A school chooses the default appropriate body" do
+            given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
+            and_school_type_is(11)
+            and_cohort_for_next_academic_year_is_created
+            and_a_provider_relationship_exists_for_the_lp_and_dp
+            and_i_am_signed_in_as_an_induction_coordinator
+            then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
+            and_the_page_should_be_accessible
+
+            when_i_click_continue
+            then_i_am_taken_to_ects_expected_in_next_academic_year_page
+
+            when_i_choose_ects_expected
+            and_i_click_continue
+            then_i_am_taken_to_the_how_will_you_run_training_page
+
+            when_i_choose_deliver_your_own_programme
+            and_i_click_continue
+            then_i_am_taken_to_the_training_confirmation_page
+
+            when_i_click_the_confirm_button
+            then_i_am_taken_to_the_appropriate_body_appointed_page
+
+            when_i_choose_yes
+            and_i_click_continue
+            then_i_am_taken_to_the_appropriate_body_type_page
+
+            choose "Independent Schools Teacher Induction Panel (IStip)"
+            and_i_click_continue
+            then_i_am_taken_to_the_complete_page
+            and_i_dont_see_the_tell_us_appropriate_body_copy
+
+            when_i_click_on_the_return_to_your_training_link
+            then_i_am_taken_to_the_manage_your_training_page
+            and_i_see_appropriate_body "Independent Schools Teacher Induction Panel (IStip)"
+          end
+        end
+
+        scenario "A school chooses to appoint a teaching school hub as appropriate body" do
+          given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
+          and_cohort_for_next_academic_year_is_created
+          and_a_provider_relationship_exists_for_the_lp_and_dp
+          and_i_am_signed_in_as_an_induction_coordinator
+          then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
+          and_the_page_should_be_accessible
+
+          when_i_click_continue
+          then_i_am_taken_to_ects_expected_in_next_academic_year_page
+
+          when_i_choose_ects_expected
+          and_i_click_continue
+          then_i_am_taken_to_the_keep_providers_page
+
+          when_i_choose_yes
+          and_i_click_continue
+          then_i_am_taken_to_the_appropriate_body_appointed_page
+
+          when_i_choose_yes
+          and_i_click_continue
+          then_i_am_taken_to_the_teaching_school_hubs_selection_page
+
+          when_i_fill_appropriate_body_with @teaching_school_hubs.first.name
+          and_i_click_continue
+          then_i_am_taken_to_the_complete_page
+          and_i_dont_see_the_tell_us_appropriate_body_copy
+
+          when_i_click_on_the_return_to_your_training_link
+          then_i_am_taken_to_the_manage_your_training_page
+          and_i_see_appropriate_body @teaching_school_hubs.first.name
+        end
       end
-
-      scenario "A school chooses to appoint an appropriate body" do
-        given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
-        and_school_type_is(10)
-        and_cohort_for_next_academic_year_is_created
-        and_a_provider_relationship_exists_for_the_lp_and_dp
-        and_i_am_signed_in_as_an_induction_coordinator
-        then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
-        and_the_page_should_be_accessible
-
-        when_i_click_continue
-        then_i_am_taken_to_ects_expected_in_next_academic_year_page
-
-        when_i_choose_ects_expected
-        and_i_click_continue
-        then_i_am_taken_to_the_how_will_you_run_training_page
-
-        when_i_choose_deliver_your_own_programme
-        and_i_click_continue
-        then_i_am_taken_to_the_training_confirmation_page
-
-        when_i_click_the_confirm_button
-        then_i_am_taken_to_the_appropriate_body_appointed_page
-
-        when_i_choose_yes
-        and_i_click_continue
-        then_i_am_taken_to_the_appropriate_body_type_page
-
-        choose "Teaching school hub"
-        when_i_fill_appropriate_body_with @teaching_school_hubs.first.name
-        and_i_click_continue
-        then_i_am_taken_to_the_complete_page
-        and_i_dont_see_the_tell_us_appropriate_body_copy
-
-        when_i_click_on_the_return_to_your_training_link
-        then_i_am_taken_to_the_manage_your_training_page
-        and_i_see_appropriate_body @teaching_school_hubs.first.name
-      end
-
-      scenario "A school chooses the default appropriate body" do
-        given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
-        and_school_type_is(10)
-        and_cohort_for_next_academic_year_is_created
-        and_a_provider_relationship_exists_for_the_lp_and_dp
-        and_i_am_signed_in_as_an_induction_coordinator
-        then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
-        and_the_page_should_be_accessible
-
-        when_i_click_continue
-        then_i_am_taken_to_ects_expected_in_next_academic_year_page
-
-        when_i_choose_ects_expected
-        and_i_click_continue
-        then_i_am_taken_to_the_how_will_you_run_training_page
-
-        when_i_choose_deliver_your_own_programme
-        and_i_click_continue
-        then_i_am_taken_to_the_training_confirmation_page
-
-        when_i_click_the_confirm_button
-        then_i_am_taken_to_the_appropriate_body_appointed_page
-
-        when_i_choose_yes
-        and_i_click_continue
-        then_i_am_taken_to_the_appropriate_body_type_page
-
-        choose "Independent Schools Teacher Induction Panel (IStip)"
-        and_i_click_continue
-        then_i_am_taken_to_the_complete_page
-        and_i_dont_see_the_tell_us_appropriate_body_copy
-
-        when_i_click_on_the_return_to_your_training_link
-        then_i_am_taken_to_the_manage_your_training_page
-        and_i_see_appropriate_body "Independent Schools Teacher Induction Panel (IStip)"
-      end
-    end
-
-    context "When is an independent school (GIAS 11)" do
-      before do
-        create(:appropriate_body_national_organisation, name: "Independent Schools Teacher Induction Panel (IStip)")
-      end
-
-      scenario "A school chooses to appoint an appropriate body" do
-        given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
-        and_school_type_is(11)
-        and_cohort_for_next_academic_year_is_created
-        and_a_provider_relationship_exists_for_the_lp_and_dp
-        and_i_am_signed_in_as_an_induction_coordinator
-        then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
-        and_the_page_should_be_accessible
-
-        when_i_click_continue
-        then_i_am_taken_to_ects_expected_in_next_academic_year_page
-
-        when_i_choose_ects_expected
-        and_i_click_continue
-        then_i_am_taken_to_the_how_will_you_run_training_page
-
-        when_i_choose_deliver_your_own_programme
-        and_i_click_continue
-        then_i_am_taken_to_the_training_confirmation_page
-
-        when_i_click_the_confirm_button
-        then_i_am_taken_to_the_appropriate_body_appointed_page
-
-        when_i_choose_yes
-        and_i_click_continue
-        then_i_am_taken_to_the_appropriate_body_type_page
-
-        choose "Teaching school hub"
-        when_i_fill_appropriate_body_with @teaching_school_hubs.first.name
-        and_i_click_continue
-        then_i_am_taken_to_the_complete_page
-        and_i_dont_see_the_tell_us_appropriate_body_copy
-
-        when_i_click_on_the_return_to_your_training_link
-        then_i_am_taken_to_the_manage_your_training_page
-        and_i_see_appropriate_body @teaching_school_hubs.first.name
-      end
-
-      scenario "A school chooses the default appropriate body" do
-        given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
-        and_school_type_is(11)
-        and_cohort_for_next_academic_year_is_created
-        and_a_provider_relationship_exists_for_the_lp_and_dp
-        and_i_am_signed_in_as_an_induction_coordinator
-        then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
-        and_the_page_should_be_accessible
-
-        when_i_click_continue
-        then_i_am_taken_to_ects_expected_in_next_academic_year_page
-
-        when_i_choose_ects_expected
-        and_i_click_continue
-        then_i_am_taken_to_the_how_will_you_run_training_page
-
-        when_i_choose_deliver_your_own_programme
-        and_i_click_continue
-        then_i_am_taken_to_the_training_confirmation_page
-
-        when_i_click_the_confirm_button
-        then_i_am_taken_to_the_appropriate_body_appointed_page
-
-        when_i_choose_yes
-        and_i_click_continue
-        then_i_am_taken_to_the_appropriate_body_type_page
-
-        choose "Independent Schools Teacher Induction Panel (IStip)"
-        and_i_click_continue
-        then_i_am_taken_to_the_complete_page
-        and_i_dont_see_the_tell_us_appropriate_body_copy
-
-        when_i_click_on_the_return_to_your_training_link
-        then_i_am_taken_to_the_manage_your_training_page
-        and_i_see_appropriate_body "Independent Schools Teacher Induction Panel (IStip)"
-      end
-    end
-
-    scenario "A school chooses to appoint a teaching school hub as appropriate body" do
-      given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
-      and_cohort_for_next_academic_year_is_created
-      and_a_provider_relationship_exists_for_the_lp_and_dp
-      and_i_am_signed_in_as_an_induction_coordinator
-      then_i_am_taken_to_what_we_need_to_know_to_setup_academic_year
-      and_the_page_should_be_accessible
-
-      when_i_click_continue
-      then_i_am_taken_to_ects_expected_in_next_academic_year_page
-
-      when_i_choose_ects_expected
-      and_i_click_continue
-      then_i_am_taken_to_the_keep_providers_page
-
-      when_i_choose_yes
-      and_i_click_continue
-      then_i_am_taken_to_the_appropriate_body_appointed_page
-
-      when_i_choose_yes
-      and_i_click_continue
-      then_i_am_taken_to_the_teaching_school_hubs_selection_page
-
-      when_i_fill_appropriate_body_with @teaching_school_hubs.first.name
-      and_i_click_continue
-      then_i_am_taken_to_the_complete_page
-      and_i_dont_see_the_tell_us_appropriate_body_copy
-
-      when_i_click_on_the_return_to_your_training_link
-      then_i_am_taken_to_the_manage_your_training_page
-      and_i_see_appropriate_body @teaching_school_hubs.first.name
     end
   end
 

--- a/spec/features/schools/choose_programme/choose_programme_steps.rb
+++ b/spec/features/schools/choose_programme/choose_programme_steps.rb
@@ -99,8 +99,12 @@ module ChooseProgrammeSteps
   end
 
   def then_i_am_taken_to_the_change_to_design_and_deliver_own_programme_confirmation_page
-    expect(page).to have_content("Are you sure you want to run your own training programme?")
-    expect(page).to have_content("You’re choosing to design and deliver your own programme based on the early career framework (ECF).")
+    if FeatureFlag.active?(:programme_type_changes_2025)
+      expect(page).to have_content("You‘ve chosen to deliver your own programme using DfE-accredited materials.")
+    else
+      expect(page).to have_content("Are you sure you want to run your own training programme?")
+      expect(page).to have_content("You’re choosing to design and deliver your own programme based on the early career framework (ECF).")
+    end
   end
 
   def then_i_am_taken_to_the_training_change_submitted_page
@@ -223,7 +227,11 @@ module ChooseProgrammeSteps
   end
 
   def and_i_see_programme_to_design_and_deliver_own_programme
-    expect(page).to have_summary_row("Programme", "Design and deliver your own programme based on the early career framework (ECF)")
+    if FeatureFlag.active?(:programme_type_changes_2025)
+      expect(page).to have_summary_row("Programme", "DfE-accredited materials")
+    else
+      expect(page).to have_summary_row("Programme", "Design and deliver your own programme based on the early career framework (ECF)")
+    end
   end
 
   def and_i_see_the_school_name
@@ -295,19 +303,35 @@ module ChooseProgrammeSteps
   end
 
   def when_i_choose_dfe_funded_training
-    choose("Use a training provider, funded by the DfE")
+    if FeatureFlag.active?(:programme_type_changes_2025)
+      choose("Provider-led")
+    else
+      choose("Use a training provider, funded by the DfE")
+    end
   end
 
   def when_i_choose_deliver_your_own_programme
-    choose("Deliver your own programme using DfE-accredited materials")
+    if FeatureFlag.active?(:programme_type_changes_2025)
+      choose("School-led")
+    else
+      choose("Deliver your own programme using DfE-accredited materials")
+    end
   end
 
   def when_i_choose_design_and_deliver_your_own_material
-    choose("Design and deliver your own programme based on the early career framework (ECF)")
+    if FeatureFlag.active?(:programme_type_changes_2025)
+      choose("School-led")
+    else
+      choose("Design and deliver your own programme based on the early career framework (ECF)")
+    end
   end
 
   def when_i_choose_use_a_training_provider_funded_by_your_school
-    choose("Use a training provider funded by your school")
+    if FeatureFlag.active?(:programme_type_changes_2025)
+      choose("Provider-led")
+    else
+      choose("Use a training provider funded by your school")
+    end
   end
 
   def when_i_choose_to_form_a_new_partnership
@@ -319,11 +343,19 @@ module ChooseProgrammeSteps
   end
 
   def when_i_choose_to_deliver_own_programme
-    choose("Deliver your own programme using DfE-accredited materials")
+    if FeatureFlag.active?(:programme_type_changes_2025)
+      choose("Deliver a school-led programme")
+    else
+      choose("Deliver your own programme using DfE-accredited materials")
+    end
   end
 
   def when_i_choose_to_design_and_deliver_own_programme
-    choose("Design and deliver your own programme based on the early career framework (ECF)")
+    if FeatureFlag.active?(:programme_type_changes_2025)
+      choose("Deliver a school-led programme")
+    else
+      choose("Design and deliver your own programme based on the early career framework (ECF)")
+    end
   end
 
   def when_i_challenge_the_new_cohort_partnership

--- a/spec/features/schools/choose_programme/new_schools_spec.rb
+++ b/spec/features/schools/choose_programme/new_schools_spec.rb
@@ -8,80 +8,84 @@ RSpec.feature "New schools should be able to choose their programme", type: :fea
   include NewSchoolsSteps
   include ChooseProgrammeSteps
 
-  context "when no ECTs expected" do
-    scenario "a new school chooses their programme and get confirmation" do
-      given_a_new_school
-      and_i_am_signed_in_as_an_induction_coordinator
-      then_i_am_on_the_how_you_run_your_training_page
+  %w[active inactive].each do |flag_state|
+    context "when programme type changes for 2025 are #{flag_state}", with_feature_flags: { programme_type_changes_2025: flag_state } do
+      context "when no ECTs expected" do
+        scenario "a new school chooses their programme and get confirmation" do
+          given_a_new_school
+          and_i_am_signed_in_as_an_induction_coordinator
+          then_i_am_on_the_how_you_run_your_training_page
 
-      when_i_choose_no_ects_expected
-      and_i_click_on_continue
-      then_i_am_on_the_confirm_your_training_page
+          when_i_choose_no_ects_expected
+          and_i_click_on_continue
+          then_i_am_on_the_confirm_your_training_page
 
-      when_i_click_on_confirm
+          when_i_click_on_confirm
 
-      then_i_am_on_the_training_submitted_page
-      and_i_dont_see_appropriate_body_reported_title
-      and_i_see_appropriate_body_reminder
+          then_i_am_on_the_training_submitted_page
+          and_i_dont_see_appropriate_body_reported_title
+          and_i_see_appropriate_body_reminder
 
-      when_i_go_to_manage_your_training_page
-      then_i_see_no_ects_expected_confirmation
-    end
-  end
+          when_i_go_to_manage_your_training_page
+          then_i_see_no_ects_expected_confirmation
+        end
+      end
 
-  context "when appropriate body appointed" do
-    before do
-      @appropriate_body = create(:appropriate_body_teaching_school_hub)
-    end
+      context "when appropriate body appointed" do
+        before do
+          @appropriate_body = create(:appropriate_body_teaching_school_hub)
+        end
 
-    scenario "a new school chooses their programme and get confirmarion" do
-      given_a_new_school
-      and_i_am_signed_in_as_an_induction_coordinator
-      then_i_am_on_the_how_you_run_your_training_page
+        scenario "a new school chooses their programme and get confirmarion" do
+          given_a_new_school
+          and_i_am_signed_in_as_an_induction_coordinator
+          then_i_am_on_the_how_you_run_your_training_page
 
-      when_i_choose_deliver_own_programme
-      and_i_click_on_continue
-      then_i_am_on_the_confirm_your_training_page
+          when_i_choose_deliver_own_programme
+          and_i_click_on_continue
+          then_i_am_on_the_confirm_your_training_page
 
-      when_i_click_on_confirm
-      then_i_see_appropriate_body_appointed_page
+          when_i_click_on_confirm
+          then_i_see_appropriate_body_appointed_page
 
-      when_i_choose_yes
-      and_i_click_on_continue
+          when_i_choose_yes
+          and_i_click_on_continue
 
-      when_i_fill_appropriate_body_with @appropriate_body.name
-      and_i_click_on_continue
+          when_i_fill_appropriate_body_with @appropriate_body.name
+          and_i_click_on_continue
 
-      then_i_see_appropriate_body_reported_confirmation
-      and_i_dont_see_appropriate_body_reminder
+          then_i_see_appropriate_body_reported_confirmation
+          and_i_dont_see_appropriate_body_reminder
 
-      when_i_go_to_manage_your_training_page
-      then_i_am_on_the_manage_your_training_page
-      and_i_see_appropriate_body_saved
-    end
-  end
+          when_i_go_to_manage_your_training_page
+          then_i_am_on_the_manage_your_training_page
+          and_i_see_appropriate_body_saved
+        end
+      end
 
-  context "when no appropriate body appointed" do
-    scenario "a new school chooses their programme and get a reminder to tell appropriate body" do
-      given_a_new_school
-      and_i_am_signed_in_as_an_induction_coordinator
-      then_i_am_on_the_how_you_run_your_training_page
+      context "when no appropriate body appointed" do
+        scenario "a new school chooses their programme and get a reminder to tell appropriate body" do
+          given_a_new_school
+          and_i_am_signed_in_as_an_induction_coordinator
+          then_i_am_on_the_how_you_run_your_training_page
 
-      when_i_choose_deliver_own_programme
-      and_i_click_on_continue
-      then_i_am_on_the_confirm_your_training_page
+          when_i_choose_deliver_own_programme
+          and_i_click_on_continue
+          then_i_am_on_the_confirm_your_training_page
 
-      when_i_click_on_confirm
-      then_i_see_appropriate_body_appointed_page
-      when_i_choose_no
-      and_i_click_on_continue
+          when_i_click_on_confirm
+          then_i_see_appropriate_body_appointed_page
+          when_i_choose_no
+          and_i_click_on_continue
 
-      then_i_am_on_the_training_submitted_page
-      and_i_dont_see_appropriate_body_reported_title
+          then_i_am_on_the_training_submitted_page
+          and_i_dont_see_appropriate_body_reported_title
 
-      when_i_go_to_manage_your_training_page
-      then_i_am_on_the_manage_your_training_page
-      and_i_see_no_appropriate_body_selected
+          when_i_go_to_manage_your_training_page
+          then_i_am_on_the_manage_your_training_page
+          and_i_see_no_appropriate_body_selected
+        end
+      end
     end
   end
 end

--- a/spec/features/schools/choose_programme/new_schools_steps.rb
+++ b/spec/features/schools/choose_programme/new_schools_steps.rb
@@ -53,7 +53,11 @@ module NewSchoolsSteps
   end
 
   def when_i_choose_deliver_own_programme
-    choose("Deliver your own programme using DfE-accredited materials")
+    if FeatureFlag.active?(:programme_type_changes_2025)
+      choose("School-led")
+    else
+      choose("Deliver your own programme using DfE-accredited materials")
+    end
   end
 
   def then_i_see_appropriate_body_appointed_page


### PR DESCRIPTION
### Context

- Ticket: [JIRA](https://dfedigital.atlassian.net/browse/CST-2849)

We need to update the UI for schools and Administrators to use the new Provider-led and School-led programme type names.  This involves "smooshing" together the current "Full induction programme" and "School-funded FIP" into "Provider-led" and "Core induction programme" and "Design our own" into "School-led"

We are using the `:programme_type_changes_2025` feature flag to keep the changes hidden until we are ready launch

This is part eight, split off from #5647 - refer to that PR for screen shots and more info.

There will be more PRs to follow, some that may refactor the work in this one.

These PRs will make changes to the programme type naming that are visible to School and Admin users in the UI.

### Changes proposed in this pull request

* Adding loops to specs to ensure coverage with and without the feature flag active - schools choosing programme