### PR TITLE
Bug: fix participants listings for delivery partners and appropriate body users

### DIFF
--- a/app/services/delivery_partners/induction_records_query.rb
+++ b/app/services/delivery_partners/induction_records_query.rb
@@ -15,16 +15,6 @@ module DeliveryPartners
         .select(Arel.sql("DISTINCT FIRST_VALUE(induction_records.id) OVER (#{latest_induction_record_order}) AS latest_id"))
         .includes(induction_programme: :partnership)
         .joins(:participant_profile)
-        .where(
-          induction_programme: {
-            partnerships: {
-              delivery_partner:,
-              challenged_at: nil,
-              challenge_reason: nil,
-              pending: false,
-            },
-          },
-        )
 
       InductionRecord.distinct
         .joins("JOIN (#{join.to_sql}) AS latest_induction_records ON latest_induction_records.latest_id = induction_records.id")
@@ -42,6 +32,16 @@ module DeliveryPartners
           latest_email_status_per_participant,
           mentees_count,
           current_mentees_count,
+        )
+        .where(
+          induction_programmes: {
+            partnerships: {
+              delivery_partner:,
+              challenged_at: nil,
+              challenge_reason: nil,
+              pending: false,
+            },
+          },
         )
     end
 

--- a/app/services/delivery_partners/participants_filter.rb
+++ b/app/services/delivery_partners/participants_filter.rb
@@ -40,12 +40,7 @@ module DeliveryPartners
         school_cohort_school_urn
       ].join("_or_")
 
-      scoped.includes(
-        user: [
-          :teacher_profile,
-        ],
-        induction_programme: { partnership: [:lead_provider] },
-      ).ransack("#{fields}_cont": query).result.distinct
+      scoped.ransack("#{fields}_cont": query).result.distinct
     end
 
     def filter_role(scoped, role)

--- a/spec/services/delivery_partners/induction_records_query_spec.rb
+++ b/spec/services/delivery_partners/induction_records_query_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe DeliveryPartners::InductionRecordsQuery do
     )
   end
   let(:induction_programme) { create(:induction_programme, partnership:) }
-  let!(:another_induction_record) { create(:induction_record, participant_profile:) }
+  let!(:another_induction_record) { create(:induction_record, :with_end_date, participant_profile:) }
   let!(:induction_record) { create(:induction_record, participant_profile:, induction_programme:) }
 
   subject { described_class.new(delivery_partner:) }
@@ -38,8 +38,8 @@ RSpec.describe DeliveryPartners::InductionRecordsQuery do
     context "when there are newer induction records for a different delivery partner" do
       let!(:latest_induction_record) { create(:induction_record, participant_profile:, training_status: "deferred") }
 
-      it "returns correct induction record for the delivery partner" do
-        expect(subject.induction_records).to match_array([induction_record])
+      it "returns no induction record for the delivery partner" do
+        expect(subject.induction_records).to be_empty
       end
     end
   end

--- a/spec/support/shared_examples/optimised_training_record_state_query_support.rb
+++ b/spec/support/shared_examples/optimised_training_record_state_query_support.rb
@@ -14,7 +14,7 @@ shared_examples "a query optimised for calculating training record states" do |e
 
     if mentor_optimization
       context "when there are historical mentees associated with the participant" do
-        let(:participant_profile) { create(:mentor) }
+        let(:participant_profile) { create(:mentor_participant_profile) }
         let!(:mentee) { create(:ect, mentor_profile: participant_profile) }
 
         before { mentee.latest_induction_record.update!(induction_status: "completed") }
@@ -26,7 +26,7 @@ shared_examples "a query optimised for calculating training record states" do |e
       end
 
       context "when there are mentees associated with the participant that are leaving" do
-        let(:participant_profile) { create(:mentor) }
+        let(:participant_profile) { create(:mentor_participant_profile) }
         let!(:mentee) { create(:ect, mentor_profile: participant_profile) }
 
         before { mentee.latest_induction_record.update!(induction_status: "leaving", end_date: 1.week.from_now) }
@@ -38,7 +38,7 @@ shared_examples "a query optimised for calculating training record states" do |e
       end
 
       context "when there are mentees associated with the participant that have left" do
-        let(:participant_profile) { create(:mentor) }
+        let(:participant_profile) { create(:mentor_participant_profile) }
         let!(:mentee) { create(:ect, mentor_profile: participant_profile) }
 
         before { mentee.latest_induction_record.update!(induction_status: "leaving", end_date: 1.week.ago) }
@@ -50,7 +50,7 @@ shared_examples "a query optimised for calculating training record states" do |e
       end
 
       context "when there are current mentees associated with the participant" do
-        let(:participant_profile) { create(:mentor) }
+        let(:participant_profile) { create(:mentor_participant_profile) }
         let!(:mentee) { create(:ect, mentor_profile: participant_profile) }
 
         it "populates transient_current_mentees with true" do


### PR DESCRIPTION
### Context
 
DP and AB users have a view listing their participants. 
These listings currently include all the participants that ever were linked to them, no matter if they have moved to another provider/AB.

- Ticket: 

### Changes proposed in this pull request

Make this listings include only participants currently associated to the DP/AB logged in.

### Guidance to review

