### PR TITLE
Add mid cohort tag to all failing cohort tests

### DIFF
--- a/spec/services/appropriate_bodies/induction_records_query_spec.rb
+++ b/spec/services/appropriate_bodies/induction_records_query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe AppropriateBodies::InductionRecordsQuery do
+RSpec.describe AppropriateBodies::InductionRecordsQuery, mid_cohort: true do
   let(:appropriate_body_user) { create(:user, :appropriate_body) }
   let(:appropriate_body) { appropriate_body_user.appropriate_bodies.first }
   let(:participant_profile) { create(:ect_participant_profile) }
@@ -43,7 +43,11 @@ RSpec.describe AppropriateBodies::InductionRecordsQuery do
     end
 
     context "when there are more induction records for the same appropriate body" do
-      let!(:latest_induction_record) { create(:induction_record, participant_profile:, appropriate_body:, induction_programme:) }
+      let!(:latest_induction_record) do
+        travel_to(1.day.from_now) do
+          create(:induction_record, participant_profile:, appropriate_body:, induction_programme:)
+        end
+      end
 
       it "returns latest induction record for appropriate body" do
         expect(subject.induction_records).to match_array([latest_induction_record])

--- a/spec/services/induction/amend_cohort_after_eligibility_checks_spec.rb
+++ b/spec/services/induction/amend_cohort_after_eligibility_checks_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Induction::AmendCohortAfterEligibilityChecks do
+RSpec.describe Induction::AmendCohortAfterEligibilityChecks, mid_cohort: true do
   describe "#call" do
     let(:participant_profile) { create(:ect, status, cohort: Cohort.previous) }
 

--- a/spec/services/induction/amend_participant_cohort_spec.rb
+++ b/spec/services/induction/amend_participant_cohort_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Induction::AmendParticipantCohort do
+RSpec.describe Induction::AmendParticipantCohort, mid_cohort: true do
   describe "#save" do
     let(:participant_profile) {}
     let(:source_cohort_start_year) { Cohort.previous.start_year }

--- a/spec/services/induction/change_mentor_spec.rb
+++ b/spec/services/induction/change_mentor_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Induction::ChangeMentor do
       expect(MentorMailer).not_to have_received(:with)
     end
 
-    context "with CIP induction programme" do
+    context "with CIP induction programme", mid_cohort: true do
       let!(:sit) { create(:induction_coordinator_profile, schools: [induction_record.school]).user }
 
       context "with SIT" do

--- a/spec/services/induction/transfer_and_continue_existing_fip_spec.rb
+++ b/spec/services/induction/transfer_and_continue_existing_fip_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Induction::TransferAndContinueExistingFip do
           .not_to change { mentor_profile_2.reload.schedule.cohort.start_year }
       end
 
-      it "moves the mentor to the currently active registration cohort" do
+      it "moves the mentor to the currently active registration cohort", mid_cohort: true do
         expect { service_call }
           .to change { mentor_profile_2.reload.schedule.cohort.start_year }
                 .from(2021)

--- a/spec/services/induction/transfer_to_schools_programme_spec.rb
+++ b/spec/services/induction/transfer_to_schools_programme_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe Induction::TransferToSchoolsProgramme do
           .not_to change { mentor_profile_2.reload.schedule.cohort.start_year }
       end
 
-      it "moves the mentor to the currently active registration cohort" do
+      it "moves the mentor to the currently active registration cohort", mid_cohort: true do
         expect { service_call }
           .to change { mentor_profile_2.reload.schedule.cohort.start_year }
                 .from(2021)

--- a/spec/support/shared_examples/participant_actions_change_schedule_support.rb
+++ b/spec/support/shared_examples/participant_actions_change_schedule_support.rb
@@ -71,7 +71,7 @@ RSpec.shared_examples "JSON Participant Change schedule endpoint" do
       )
     end
 
-    it "changes participant schedule" do
+    it "changes participant schedule", mid_cohort: true do
       expect {
         put "/api/v1/participants/#{early_career_teacher_profile.user.id}/change-schedule", params: {
           data: {
@@ -102,7 +102,7 @@ RSpec.shared_examples "JSON Participant Change schedule endpoint" do
         }
       end
 
-      it "allows them to change back to their original cohort" do
+      it "allows them to change back to their original cohort", mid_cohort: true do
         expect {
           put "/api/v1/participants/#{early_career_teacher_profile.user.id}/change-schedule", params: {
             data: {


### PR DESCRIPTION
### Context

Tests tend to fail around the time when new cohorts end/start. We have a support tag to set tests to mid cohort. We need to use that on those failing tests

### Changes proposed in this pull request

We need to ensure those tests run whilst travelling to mid cohort, otherwise they start failing towards the end of the cohort.

For the AB spec, ensure not all induction records have the same date, travel to date in the future to ensure appropriate body checks pick the latest induction record

### Guidance to review
We will keep getting failures it seems on those tests, something to watch out when writing them
