### PR TITLE
2234 ecf plan for dr test may 2025

### DIFF
--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -47,6 +47,7 @@ jobs:
     name: Deploy review
     concurrency: deploy_review_${{ github.event.pull_request.number }}
     runs-on: ubuntu-latest
+    needs: docker
     environment:
       name: review
     steps:

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -48,6 +48,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: setup envt variables
+        run: |
+          echo "PULL_REQUEST_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+
       - uses: ./.github/actions/deploy-environment-to-aks
         id: deploy
         with:
@@ -59,4 +63,3 @@ jobs:
           pull-request-number: ${{ github.event.pull_request.number }}
           current-commit-sha: ${{ github.event.pull_request.head.sha }}
           statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}
-          pull-request-number: ${{ github.event.inputs.pull_request_number }}

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -60,6 +60,7 @@ jobs:
           ref: ${{ github.event.inputs.sha }}
 
       - name: setup environment variables
+        id: setup-env
         run: |
           if [ ${{ github.event.inputs.build != 'false' }} ]
           then
@@ -71,7 +72,7 @@ jobs:
       - uses: ./.github/actions/deploy-environment-to-aks
         id: deploy
         with:
-          docker-image: ${{ env.IMAGE_TAG }}
+          docker-image: ${{ needs.step.setup-env.outputs.IMAGE_TAG }}
           environment: ${{ github.event.inputs.environment }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -47,7 +47,6 @@ jobs:
   deploy_review:
     name: Deploy review
     concurrency: deploy_review_${{ github.event.pull_request.number }}
-    needs: docker
     if: ${{ github.job.docker.status != 'skipped' }}
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -47,8 +47,9 @@ jobs:
   deploy_review:
     name: Deploy review
     concurrency: deploy_review_${{ github.event.pull_request.number }}
-    if: ${{ github.job.docker.status == 'skipped' || github.job.docker.status == 'success' }}
-    needs: docker
+    if: |
+      always() && 
+      (needs.docker.result == 'skipped' || needs.docker.result == 'success' }}
     runs-on: ubuntu-latest
     environment:
       name: review

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -62,11 +62,11 @@ jobs:
       - name: setup environment variables
         id: setup-env
         run: |
-          if [ ${{ github.event.inputs.build != 'false' }} ]
+          if [ ${{ github.event.inputs.build == 'false' }} ]
           then
-            echo "IMAGE_TAG=${{ needs.docker.outputs.docker-image }}" >> $GITHUB_ENV
-          else
             echo "IMAGE_TAG=${{ inputs.sha }}" >> $GITHUB_ENV
+          else
+            echo "IMAGE_TAG=${{ needs.docker.outputs.docker-image }}" >> $GITHUB_ENV
           fi
 
       - uses: ./.github/actions/deploy-environment-to-aks

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -48,7 +48,7 @@ jobs:
     name: Deploy review
     concurrency: deploy_review_${{ github.event.pull_request.number }}
     needs: docker
-    if: ${{ github.event.inputs.build != 'false'}}
+    if: ${{ github.job.docker.status != 'running' }}
     runs-on: ubuntu-latest
     environment:
       name: review

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -66,15 +66,15 @@ jobs:
             echo "IMAGE_TAG=${{ inputs.sha }}" >> $GITHUB_ENV
           fi
 
-#      - uses: ./.github/actions/deploy-environment-to-aks
-#        id: deploy
-#        with:
-#          docker-image: ${{ env.IMAGE_TAG }}
-#          environment: ${{ github.event.inputs.environment }}
-#          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
-#          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-#          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-#          pull-request-number: ${{ inputs.pr-number }}
-#          #OVERRIDE CURRENT-COMMIT WITH ANY COMMIT OFF A BRANCH
-#          current-commit-sha: ${{ inputs.sha }}
-#          statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}
+      - uses: ./.github/actions/deploy-environment-to-aks
+        id: deploy
+        with:
+          docker-image: ${{ env.IMAGE_TAG }}
+          environment: ${{ github.event.inputs.environment }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          pull-request-number: ${{ inputs.pr-number }}
+          #OVERRIDE CURRENT-COMMIT WITH ANY COMMIT OFF A BRANCH
+          current-commit-sha: ${{ inputs.sha }}
+          statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: setup envt variables
         run: |
-          export PULL_REQUEST_NUMBER=${{ github.event.pull_request.number }} >> $GITHUB_ENV
+          echo "export PULL_REQUEST_NUMBER=${{ github.event.pull_request.number }} >> $GITHUB_ENV
 
       - uses: ./.github/actions/deploy-environment-to-aks
         id: deploy

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -47,6 +47,8 @@ jobs:
   deploy_review:
     name: Deploy review
     concurrency: deploy_review_${{ github.event.pull_request.number }}
+    needs: docker
+    if: ${{ github.event.inputs.build != 'false'}}
     runs-on: ubuntu-latest
     environment:
       name: review

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -64,9 +64,9 @@ jobs:
         run: |
           if [ ${{ github.event.inputs.build != 'false' }} ]
           then
-            echo "IMAGE_TAG=${{ needs.docker.outputs.docker-image }}" >> $GITHUB_ENV
+            echo export "IMAGE_TAG=${{ needs.docker.outputs.docker-image }}" >> $GITHUB_ENV
           else
-            echo "IMAGE_TAG=${{ inputs.sha }}" >> $GITHUB_ENV
+            echo export "IMAGE_TAG=${{ inputs.sha }}" >> $GITHUB_ENV
           fi
 
       - uses: ./.github/actions/deploy-environment-to-aks

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -51,6 +51,8 @@ jobs:
       name: review
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.sha }}
 
       - uses: ./.github/actions/deploy-environment-to-aks
         id: deploy

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -79,5 +79,5 @@ jobs:
           azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           pull-request-number: ${{ inputs.pr-number }}
           #OVERRIDE CURRENT-COMMIT WITH ANY COMMIT OFF A BRANCH
-          current-commit-sha: ${{ inputs.sha }}
+          current-commit-sha: ${{ env.IMAGE_TAG }}
           statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -49,7 +49,7 @@ jobs:
     concurrency: deploy_review_${{ github.event.pull_request.number }}
     if: |
       always() && 
-      (needs.docker.result == 'skipped' || needs.docker.result == 'success' ))
+      (needs.docker.result == 'skipped' || needs.docker.result == 'success' )
     runs-on: ubuntu-latest
     environment:
       name: review

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -57,6 +57,12 @@ jobs:
         with:
           ref: ${{ github.event.inputs.sha }}
 
+      - name: Set Environment variables
+        id: set_env_var
+        shell: bash
+        run: |
+          echo "PULL_REQUEST_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+
       - uses: ./.github/actions/deploy-environment-to-aks
         id: deploy
         with:

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -30,7 +30,7 @@ jobs:
   docker:
     name: Build and push Docker image
     runs-on: ubuntu-latest
-    if: ${{ github.event.inputs.build != 'false' }}
+    if: ${{ github.event.inputs.build = 'true' }}
     outputs:
       docker-image: ${{ steps.build-docker-image.outputs.image }}
     steps:
@@ -58,7 +58,7 @@ jobs:
 
       - name: setup environment variables
         run: |
-          if [ ${{ inputs.build }} == 'true' ]
+          if [ ${{ inputs.build == 'true' }}]
           then
             echo "IMAGE_TAG=${{ steps.docker.outputs.docker-image }}" >> $GITHUB_ENV
           else

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -11,7 +11,7 @@ on:
         description: "Build the Docker image"
         required: true
         type: boolean
-        default: false
+        default: "false"
       sha:
         description: Commit sha to be deployed (deploy only)
         required: false
@@ -63,7 +63,7 @@ jobs:
       - name: setup environment variables
         id: setup-env
         run: |
-          if [[ ${{ github.event.inputs.build != 'false' }} ]]; then
+          if [[ -n ${{ github.event.inputs.build }} ]]; then
             echo "IMAGE_TAG=${{ needs.docker.outputs.docker-image }}" >> $GITHUB_ENV
           else
             echo "IMAGE_TAG=${{ inputs.sha }}" >> $GITHUB_ENV

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: setup envt variables
         run: |
-          echo "PULL_REQUEST_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+          export PULL_REQUEST_NUMBER=${{ github.event.pull_request.number }} >> $GITHUB_ENV
 
       - uses: ./.github/actions/deploy-environment-to-aks
         id: deploy

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -3,6 +3,7 @@ name: "Manually deploy to an environment"
 on:
   workflow_dispatch:
     inputs:
+      environment: review
       build:
         description: "Build the Docker image"
         required: true
@@ -49,7 +50,8 @@ jobs:
       - uses: ./.github/actions/deploy-environment-to-aks
         id: deploy
         with:
-          docker-image: ${{ needs.docker.outputs.docker-image }}
+          docker-image: ${{ inputs.sha || needs.docker.outputs.docker-image }}
+          environment: ${{ github.event.inputs.environment }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: ./.github/actions/deploy-environment-to-aks
         id: deploy
         with:
-          docker-image: ${{ inputs.sha || needs.docker.outputs.docker-image }}
+          docker-image: ${{ inputs.sha }}
           environment: ${{ github.event.inputs.environment }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -59,3 +59,4 @@ jobs:
           pull-request-number: ${{ github.event.pull_request.number }}
           current-commit-sha: ${{ github.event.pull_request.head.sha }}
           statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}
+          pull-request-number: ${{ github.event.inputs.pull_request_number }}

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -31,7 +31,7 @@ jobs:
   docker:
     name: Build and push Docker image
     runs-on: ubuntu-latest
-    if: ${{ github.event.inputs.build != "false" }}
+    if: ${{ github.event.inputs.build != 'false' }}
     outputs:
       docker-image: ${{ steps.build-docker-image.outputs.image }}
     steps:
@@ -63,7 +63,7 @@ jobs:
       - name: setup environment variables
         id: setup-env
         run: |
-          if [[ ${{ github.event.inputs.build != "false" }} ]]; then
+          if [[ ${{ github.event.inputs.build != 'false' }} ]]; then
             echo "IMAGE_TAG=${{ needs.docker.outputs.docker-image }}" >> $GITHUB_ENV
           else
             echo "IMAGE_TAG=${{ inputs.sha }}" >> $GITHUB_ENV

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -51,10 +51,8 @@ jobs:
     name: Deploy review
     concurrency: deploy_review_${{ github.event.pull_request.number }}
     if: github.actor != 'dependabot[bot]' && github.event_name == 'pull_request'
-    needs: [docker, brakeman]
+    needs: [docker]
     runs-on: ubuntu-latest
-    environment:
-      name: review
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -11,6 +11,7 @@ on:
         description: "Build the Docker image"
         required: true
         type: boolean
+        default: false
       sha:
         description: Commit sha to be deployed
         required: true

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -30,7 +30,7 @@ jobs:
   docker:
     name: Build and push Docker image
     runs-on: ubuntu-latest
-    if: ${{ github.event.inputs.build == 'true' }}
+    if: ${{ github.event.inputs.build != 'false' }}
     outputs:
       docker-image: ${{ steps.build-docker-image.outputs.image }}
     steps:

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -64,9 +64,9 @@ jobs:
         run: |
           if [ ${{ github.event.inputs.build != 'false' }} ]
           then
-            echo export "IMAGE_TAG=${{ needs.docker.outputs.docker-image }}" >> $GITHUB_ENV
+            echo "IMAGE_TAG=${{ needs.docker.outputs.docker-image }}" >> $GITHUB_ENV
           else
-            echo export "IMAGE_TAG=${{ inputs.sha }}" >> $GITHUB_ENV
+            echo "IMAGE_TAG=${{ inputs.sha }}" >> $GITHUB_ENV
           fi
 
       - uses: ./.github/actions/deploy-environment-to-aks

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -30,7 +30,7 @@ jobs:
   docker:
     name: Build and push Docker image
     runs-on: ubuntu-latest
-    if: ${{ github.event.inputs.build = 'true' }}
+    if: ${{ github.event.inputs.build == 'true' }}
     outputs:
       docker-image: ${{ steps.build-docker-image.outputs.image }}
     steps:
@@ -58,7 +58,7 @@ jobs:
 
       - name: setup environment variables
         run: |
-          if [ ${{ inputs.build == 'true' }}]
+          if [ ${{ inputs.build == 'true' }} ]
           then
             echo "IMAGE_TAG=${{ steps.docker.outputs.docker-image }}" >> $GITHUB_ENV
           else

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -66,15 +66,15 @@ jobs:
             echo "IMAGE_TAG=${{ inputs.sha }}" >> $GITHUB_ENV
           fi
 
-      - uses: ./.github/actions/deploy-environment-to-aks
-        id: deploy
-        with:
-          docker-image: ${{ env.IMAGE_TAG }}
-          environment: ${{ github.event.inputs.environment }}
-          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          pull-request-number: ${{ inputs.pr-number }}
-          #OVERRIDE CURRENT-COMMIT WITH ANY COMMIT OFF A BRANCH
-          current-commit-sha: ${{ inputs.sha }}
-          statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}
+#      - uses: ./.github/actions/deploy-environment-to-aks
+#        id: deploy
+#        with:
+#          docker-image: ${{ env.IMAGE_TAG }}
+#          environment: ${{ github.event.inputs.environment }}
+#          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+#          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+#          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+#          pull-request-number: ${{ inputs.pr-number }}
+#          #OVERRIDE CURRENT-COMMIT WITH ANY COMMIT OFF A BRANCH
+#          current-commit-sha: ${{ inputs.sha }}
+#          statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -36,12 +36,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-#      - uses: DFE-Digital/github-actions/build-docker-image@master
-#        id: build-docker-image
-#        with:
-#          docker-repository: ghcr.io/dfe-digital/early-careers-framework
-#          github-token: ${{ secrets.GITHUB_TOKEN }}
-#          snyk-token: ${{ secrets.SNYK_TOKEN }}
+      - uses: DFE-Digital/github-actions/build-docker-image@master
+        id: build-docker-image
+        with:
+          docker-repository: ghcr.io/dfe-digital/early-careers-framework
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          snyk-token: ${{ secrets.SNYK_TOKEN }}
 
 
   deploy_review:
@@ -68,15 +68,15 @@ jobs:
             echo "IMAGE_TAG=${{ inputs.sha }}" >> $GITHUB_ENV
           fi
 
-#      - uses: ./.github/actions/deploy-environment-to-aks
-#        id: deploy
-#        with:
-#          docker-image: ${{ env.IMAGE_TAG }}
-#          environment: ${{ github.event.inputs.environment }}
-#          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
-#          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-#          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-#          pull-request-number: ${{ inputs.pr-number }}
-#          #OVERRIDE CURRENT-COMMIT WITH ANY COMMIT OFF A BRANCH
-#          current-commit-sha: ${{ inputs.sha }}
-#          statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}
+      - uses: ./.github/actions/deploy-environment-to-aks
+        id: deploy
+        with:
+          docker-image: ${{ env.IMAGE_TAG }}
+          environment: ${{ github.event.inputs.environment }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          pull-request-number: ${{ inputs.pr-number }}
+          #OVERRIDE CURRENT-COMMIT WITH ANY COMMIT OFF A BRANCH
+          current-commit-sha: ${{ inputs.sha }}
+          statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -3,7 +3,10 @@ name: "Manually deploy to an environment"
 on:
   workflow_dispatch:
     inputs:
-      environment: review
+      environment:
+        description: "environment"
+        required: true
+        default: "review"
       build:
         description: "Build the Docker image"
         required: true

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -36,12 +36,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-#      - uses: DFE-Digital/github-actions/build-docker-image@master
-#        id: build-docker-image
-#        with:
-#          docker-repository: ghcr.io/dfe-digital/early-careers-framework
-#          github-token: ${{ secrets.GITHUB_TOKEN }}
-#          snyk-token: ${{ secrets.SNYK_TOKEN }}
+      - uses: DFE-Digital/github-actions/build-docker-image@master
+        id: build-docker-image
+        with:
+          docker-repository: ghcr.io/dfe-digital/early-careers-framework
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          snyk-token: ${{ secrets.SNYK_TOKEN }}
 
 
   deploy_review:

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -56,13 +56,13 @@ jobs:
           ref: ${{ github.event.inputs.sha }}
 
       - name: setup environment variables
-        if: ${{ github.event.inputs.build != 'false' }}
-        run: echo "IMAGE_TAG=${{ needs.docker.outputs.docker-image }}" >> $GITHUB_ENV
-
-      - name: setup environment variables2
-        if: ${{ github.event.inputs.build == 'false' }}
-        run: echo "IMAGE_TAG=${{ inputs.sha }}" >> $GITHUB_ENV
-
+        run: |
+          if [ ${{ github.event.inputs.build != 'false' }} ]
+          then
+            echo "IMAGE_TAG=${{ needs.docker.outputs.docker-image }}" >> $GITHUB_ENV
+          else
+            echo "IMAGE_TAG=${{ inputs.sha }}" >> $GITHUB_ENV
+          fi
 
       - uses: ./.github/actions/deploy-environment-to-aks
         id: deploy

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -14,6 +14,10 @@ on:
       sha:
         description: Commit sha to be deployed
         required: true
+      pr-number:
+        description: "Pull request number"
+        required: true
+        type: number
 
 permissions:
   id-token: write
@@ -56,6 +60,6 @@ jobs:
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          pull-request-number: ${{ github.event.pull_request.number }}
+          pull-request-number: ${{ inputs.pr-number }}
           current-commit-sha: ${{ github.event.pull_request.head.sha }}
           statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -42,7 +42,6 @@ jobs:
   deploy_review:
     name: Deploy review
     concurrency: deploy_review_${{ github.event.pull_request.number }}
-    needs: [docker]
     runs-on: ubuntu-latest
     environment:
       name: review

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -14,7 +14,8 @@ on:
         default: "false"
       sha:
         description: Commit sha to be deployed
-        required: true
+        required: false
+        
       pr-number:
         description: "Pull request number"
         required: true

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -47,6 +47,7 @@ jobs:
   deploy_review:
     name: Deploy review
     concurrency: deploy_review_${{ github.event.pull_request.number }}
+    needs: docker
     if: |
       always() && 
       (needs.docker.result == 'skipped' || needs.docker.result == 'success' )

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -47,6 +47,8 @@ jobs:
     name: Deploy review
     concurrency: deploy_review_${{ github.event.pull_request.number }}
     runs-on: ubuntu-latest
+    needs: docker
+    if: ${{ inputs.build == 'true' }}
     environment:
       name: review
     steps:

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: setup envt variables
         run: |
-          echo "export PULL_REQUEST_NUMBER=${{ github.event.pull_request.number }} >> $GITHUB_ENV
+          echo "export PULL_REQUEST_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
 
       - uses: ./.github/actions/deploy-environment-to-aks
         id: deploy

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -47,8 +47,8 @@ jobs:
     name: Deploy review
     concurrency: deploy_review_${{ github.event.pull_request.number }}
     runs-on: ubuntu-latest
-    needs: docker
     if: ${{ inputs.build == 'true' }}
+    needs: docker
     environment:
       name: review
     steps:

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -63,7 +63,7 @@ jobs:
       - name: setup environment variables
         id: setup-env
         run: |
-          if [[ -n ${{ github.event.inputs.build }} ]]; then
+          if [[ "${{ github.event.inputs.build }}" != "false" ]]; then
             echo "IMAGE_TAG=${{ needs.docker.outputs.docker-image }}" >> $GITHUB_ENV
           else
             echo "IMAGE_TAG=${{ inputs.sha }}" >> $GITHUB_ENV

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -49,7 +49,7 @@ jobs:
     concurrency: deploy_review_${{ github.event.pull_request.number }}
     if: |
       always() && 
-      (needs.docker.result == 'skipped' || needs.docker.result == 'success' }}
+      (needs.docker.result == 'skipped' || needs.docker.result == 'success' ))
     runs-on: ubuntu-latest
     environment:
       name: review

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -57,12 +57,6 @@ jobs:
         with:
           ref: ${{ github.event.inputs.sha }}
 
-      - name: Set Environment variables
-        id: set_env_var
-        shell: bash
-        run: |
-          echo "PULL_REQUEST_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
-
       - uses: ./.github/actions/deploy-environment-to-aks
         id: deploy
         with:
@@ -73,5 +67,5 @@ jobs:
           azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           current-commit-sha: ${{ github.sha }}
           statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}
-          pr-number: ${{ github.event.pull_request.number }}
           sha: ${{ inputs.sha }}
+          pull-request-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -54,14 +54,23 @@ jobs:
         with:
           ref: ${{ github.event.inputs.sha }}
 
+      - name: setup environment variables
+        run: |
+          if [ ${{ inputs.build }} == 'true' ] then
+            echo "IMAGE_TAG=$${{ steps.docker.outputs.docker-image }}" >> $GITHUB_ENV
+          else
+            echo "IMAGE_TAG=${{ inputs.sha }}" >> $GITHUB_ENV
+          fi
+
       - uses: ./.github/actions/deploy-environment-to-aks
         id: deploy
         with:
-          docker-image: ${{ inputs.sha }}
+          docker-image: ${{ env.IMAGE_TAG }}
           environment: ${{ github.event.inputs.environment }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           pull-request-number: ${{ inputs.pr-number }}
-          current-commit-sha: ${{ github.event.pull_request.head.sha }}
+          #OVERRIDE CURRENT-COMMIT WITH ANY COMMIT OFF A BRANCH
+          current-commit-sha: ${{ inputs.sha }}
           statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -47,8 +47,6 @@ jobs:
     name: Deploy review
     concurrency: deploy_review_${{ github.event.pull_request.number }}
     runs-on: ubuntu-latest
-    if: ${{ inputs.build == 'true' }}
-    needs: docker
     environment:
       name: review
     steps:

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -11,7 +11,7 @@ on:
         description: "Build the Docker image"
         required: true
         type: boolean
-        default: false
+        default: "false"
       sha:
         description: Commit sha to be deployed
         required: true
@@ -30,7 +30,7 @@ jobs:
   docker:
     name: Build and push Docker image
     runs-on: ubuntu-latest
-    if: ${{ github.event.inputs.build == 'true' }}
+    if: ${{ github.event.inputs.build != 'false' }}
     outputs:
       docker-image: ${{ steps.build-docker-image.outputs.image }}
     steps:
@@ -56,11 +56,11 @@ jobs:
           ref: ${{ github.event.inputs.sha }}
 
       - name: setup environment variables
-        if: ${{ inputs.build == 'true' }}
+        if: ${{ github.event.inputs.build != 'false' }}
         run: echo "IMAGE_TAG=${{ needs.docker.outputs.docker-image }}" >> $GITHUB_ENV
 
       - name: setup environment variables2
-        if: ${{ inputs.build == 'false' }}
+        if: ${{ github.event.inputs.build == 'false' }}
         run: echo "IMAGE_TAG=${{ inputs.sha }}" >> $GITHUB_ENV
 
 

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -36,12 +36,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: DFE-Digital/github-actions/build-docker-image@master
-        id: build-docker-image
-        with:
-          docker-repository: ghcr.io/dfe-digital/early-careers-framework
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          snyk-token: ${{ secrets.SNYK_TOKEN }}
+#      - uses: DFE-Digital/github-actions/build-docker-image@master
+#        id: build-docker-image
+#        with:
+#          docker-repository: ghcr.io/dfe-digital/early-careers-framework
+#          github-token: ${{ secrets.GITHUB_TOKEN }}
+#          snyk-token: ${{ secrets.SNYK_TOKEN }}
 
 
   deploy_review:

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -48,6 +48,7 @@ jobs:
     name: Deploy review
     concurrency: deploy_review_${{ github.event.pull_request.number }}
     if: ${{ github.job.docker.status == 'skipped' || github.job.docker.status == 'success' }}
+    needs: docker
     runs-on: ubuntu-latest
     environment:
       name: review

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -56,7 +56,8 @@ jobs:
 
       - name: setup environment variables
         run: |
-          if [ ${{ inputs.build }} == 'true' ] then
+          if [ ${{ inputs.build }} == 'true' ]
+          then
             echo "IMAGE_TAG=$${{ steps.docker.outputs.docker-image }}" >> $GITHUB_ENV
           else
             echo "IMAGE_TAG=${{ inputs.sha }}" >> $GITHUB_ENV

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -50,7 +50,6 @@ jobs:
   deploy_review:
     name: Deploy review
     concurrency: deploy_review_${{ github.event.pull_request.number }}
-    if: github.actor != 'dependabot[bot]' && github.event_name == 'pull_request'
     needs: [docker]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -46,16 +46,17 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           snyk-token: ${{ secrets.SNYK_TOKEN }}
 
-  deploy:
-    name: Deploy to environment
+
+  deploy_review:
+    name: Deploy review
+    concurrency: deploy_review_${{ github.event.pull_request.number }}
+    if: github.actor != 'dependabot[bot]' && github.event_name == 'pull_request'
+    needs: [docker, brakeman]
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
-    outputs:
-      docker-image: ${{ needs.docker.outputs.docker-image }}
+    environment:
+      name: review
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.sha }}
+      - uses: actions/checkout@v3
 
       - uses: ./.github/actions/deploy-environment-to-aks
         id: deploy
@@ -65,7 +66,6 @@ jobs:
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          current-commit-sha: ${{ github.sha }}
-          statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}
-          sha: ${{ inputs.sha }}
           pull-request-number: ${{ github.event.pull_request.number }}
+          current-commit-sha: ${{ github.event.pull_request.head.sha }}
+          statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -48,7 +48,6 @@ jobs:
     name: Deploy review
     concurrency: deploy_review_${{ github.event.pull_request.number }}
     runs-on: ubuntu-latest
-    needs: docker
     environment:
       name: review
     steps:
@@ -57,13 +56,13 @@ jobs:
           ref: ${{ github.event.inputs.sha }}
 
       - name: setup environment variables
-        run: |
-          if [ ${{ inputs.build == 'true' }} ]
-          then
-            echo "IMAGE_TAG=${{ steps.docker.outputs.docker-image }}" >> $GITHUB_ENV
-          else
-            echo "IMAGE_TAG=${{ inputs.sha }}" >> $GITHUB_ENV
-          fi
+        if: ${{ inputs.build == 'true' }}
+        run: echo "IMAGE_TAG=${{ needs.docker.outputs.docker-image }}" >> $GITHUB_ENV
+
+      - name: setup environment variables2
+        if: ${{ inputs.build == 'false' }}
+        run: echo "IMAGE_TAG=${{ inputs.sha }}" >> $GITHUB_ENV
+
 
       - uses: ./.github/actions/deploy-environment-to-aks
         id: deploy

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -48,7 +48,7 @@ jobs:
     name: Deploy review
     concurrency: deploy_review_${{ github.event.pull_request.number }}
     needs: docker
-    if: ${{ github.job.docker.status != 'running' }}
+    if: ${{ github.job.docker.status != 'skipped' }}
     runs-on: ubuntu-latest
     environment:
       name: review

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -11,7 +11,7 @@ on:
         description: "Build the Docker image"
         required: true
         type: boolean
-        default: "false"
+        default: false
       sha:
         description: Commit sha to be deployed (deploy only)
         required: false

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -7,11 +7,10 @@ on:
       build:
         description: "Build the Docker image"
         required: true
-        default: false
         type: boolean
       sha:
         description: Commit sha to be deployed
-        required: false
+        required: true
 
 permissions:
   id-token: write

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -13,9 +13,9 @@ on:
         type: boolean
         default: "false"
       sha:
-        description: Commit sha to be deployed
+        description: Commit sha to be deployed (deploy only)
         required: false
-        
+
       pr-number:
         description: "Pull request number"
         required: true
@@ -63,8 +63,7 @@ jobs:
       - name: setup environment variables
         id: setup-env
         run: |
-          if [ ${{ github.event.inputs.build == 'false' }} ]
-          then
+          if [[ ${{ github.event.inputs.build == 'false' }} ]]; then
             echo "IMAGE_TAG=${{ inputs.sha }}" >> $GITHUB_ENV
           else
             echo "IMAGE_TAG=${{ needs.docker.outputs.docker-image }}" >> $GITHUB_ENV

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -46,7 +46,6 @@ jobs:
   deploy_review:
     name: Deploy review
     concurrency: deploy_review_${{ github.event.pull_request.number }}
-    needs: [docker]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -22,14 +22,6 @@ on:
       sha:
         description: Commit sha to be deployed
         required: false
-      pr:number:
-        description: PR number for the review app
-        required: false
-        default: 0
-        type: number
-
-env:
-  PULL_REQUEST_NUMBER: 5840
 
 permissions:
   id-token: write
@@ -75,5 +67,5 @@ jobs:
           azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           current-commit-sha: ${{ github.sha }}
           statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}
-          pr-number: ${{ github.event.inputs.pr-number }}
+          pr-number: ${{ github.event.pull_request.number }}
           sha: ${{ inputs.sha }}

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -72,7 +72,7 @@ jobs:
       - uses: ./.github/actions/deploy-environment-to-aks
         id: deploy
         with:
-          docker-image: ${{ needs.step.setup-env.outputs.IMAGE_TAG }}
+          docker-image: ${{ env.IMAGE_TAG }}
           environment: ${{ github.event.inputs.environment }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -10,10 +10,6 @@ on:
         type: choice
         options:
           - review
-          - staging
-          - migration
-          - sandbox
-          - production
       build:
         description: "Build the Docker image"
         required: true

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -31,7 +31,7 @@ jobs:
   docker:
     name: Build and push Docker image
     runs-on: ubuntu-latest
-    if: ${{ github.event.inputs.build != 'false' }}
+    if: ${{ github.event.inputs.build != "false" }}
     outputs:
       docker-image: ${{ steps.build-docker-image.outputs.image }}
     steps:
@@ -63,10 +63,10 @@ jobs:
       - name: setup environment variables
         id: setup-env
         run: |
-          if [[ ${{ github.event.inputs.build == 'false' }} ]]; then
-            echo "IMAGE_TAG=${{ inputs.sha }}" >> $GITHUB_ENV
-          else
+          if [[ ${{ github.event.inputs.build != "false" }} ]]; then
             echo "IMAGE_TAG=${{ needs.docker.outputs.docker-image }}" >> $GITHUB_ENV
+          else
+            echo "IMAGE_TAG=${{ inputs.sha }}" >> $GITHUB_ENV
           fi
 
       - uses: ./.github/actions/deploy-environment-to-aks

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -47,7 +47,7 @@ jobs:
   deploy_review:
     name: Deploy review
     concurrency: deploy_review_${{ github.event.pull_request.number }}
-    if: ${{ github.job.docker.status != 'skipped' }}
+    if: ${{ github.job.docker.status == 'skipped' || github.job.docker.status == 'success' }}
     runs-on: ubuntu-latest
     environment:
       name: review

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -48,10 +48,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: setup envt variables
-        run: |
-          echo "export PULL_REQUEST_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
-
       - uses: ./.github/actions/deploy-environment-to-aks
         id: deploy
         with:

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -36,12 +36,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: DFE-Digital/github-actions/build-docker-image@master
-        id: build-docker-image
-        with:
-          docker-repository: ghcr.io/dfe-digital/early-careers-framework
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          snyk-token: ${{ secrets.SNYK_TOKEN }}
+#      - uses: DFE-Digital/github-actions/build-docker-image@master
+#        id: build-docker-image
+#        with:
+#          docker-repository: ghcr.io/dfe-digital/early-careers-framework
+#          github-token: ${{ secrets.GITHUB_TOKEN }}
+#          snyk-token: ${{ secrets.SNYK_TOKEN }}
 
 
   deploy_review:
@@ -64,15 +64,15 @@ jobs:
             echo "IMAGE_TAG=${{ inputs.sha }}" >> $GITHUB_ENV
           fi
 
-      - uses: ./.github/actions/deploy-environment-to-aks
-        id: deploy
-        with:
-          docker-image: ${{ env.IMAGE_TAG }}
-          environment: ${{ github.event.inputs.environment }}
-          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          pull-request-number: ${{ inputs.pr-number }}
-          #OVERRIDE CURRENT-COMMIT WITH ANY COMMIT OFF A BRANCH
-          current-commit-sha: ${{ inputs.sha }}
-          statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}
+#      - uses: ./.github/actions/deploy-environment-to-aks
+#        id: deploy
+#        with:
+#          docker-image: ${{ env.IMAGE_TAG }}
+#          environment: ${{ github.event.inputs.environment }}
+#          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+#          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+#          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+#          pull-request-number: ${{ inputs.pr-number }}
+#          #OVERRIDE CURRENT-COMMIT WITH ANY COMMIT OFF A BRANCH
+#          current-commit-sha: ${{ inputs.sha }}
+#          statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -3,13 +3,6 @@ name: "Manually deploy to an environment"
 on:
   workflow_dispatch:
     inputs:
-      environment:
-        description: "Deploy environment"
-        required: true
-        default: migration
-        type: choice
-        options:
-          - review
       build:
         description: "Build the Docker image"
         required: true
@@ -46,14 +39,16 @@ jobs:
   deploy_review:
     name: Deploy review
     concurrency: deploy_review_${{ github.event.pull_request.number }}
+    needs: [docker]
     runs-on: ubuntu-latest
+    environment:
+      name: review
     steps:
       - uses: actions/checkout@v3
 
       - uses: ./.github/actions/deploy-environment-to-aks
         id: deploy
         with:
-          environment: ${{ inputs.environment }}
           docker-image: ${{ needs.docker.outputs.docker-image }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           if [ ${{ inputs.build }} == 'true' ]
           then
-            echo "IMAGE_TAG=$${{ steps.docker.outputs.docker-image }}" >> $GITHUB_ENV
+            echo "IMAGE_TAG=${{ steps.docker.outputs.docker-image }}" >> $GITHUB_ENV
           else
             echo "IMAGE_TAG=${{ inputs.sha }}" >> $GITHUB_ENV
           fi


### PR DESCRIPTION
### Context

- Ticket: https://trello.com/c/QJnC0E8h/2324-ecf-dr-test?filter=member:paulsenior26

### Changes proposed in this pull request

- allow manual build of an environment with either a fresh image build or a commit-sha of a previous image

### Guidance to review

valid tests:-
- run workflow-dispatch scheduled build via github UI, enabling docker build via toggle (review envt 5840)

- run workflow-dispatch scheduled build via github UI, leaving docker build toggle blank, but specifying a commit-sha on branch 2234-ecf-plan-for-dr-test-may-2025 (review envt 5840)
(check commit-sha is valid first - i.e. the image is currently in ghcr.io registry:-
docker pull ghcr.io/dfe-digital/early-careers-framework:78cb4eebd98c33973ebdb0f4b0ad573a99d43cf0
