### PR TITLE
[CST-2857] Final tweaks for programme type changes

### DIFF
--- a/app/forms/induction_choice_form.rb
+++ b/app/forms/induction_choice_form.rb
@@ -28,6 +28,10 @@ class InductionChoiceForm
                             exclude: [school_cohort.induction_programme_choice].compact)
   end
 
+  def programme_confirmation_description
+    confirmation_description(training_programme: programme_choice)
+  end
+
   def opt_out_choice_selected?
     programme_choice&.in? %i[school_funded_fip design_our_own no_early_career_teachers]
   end

--- a/app/models/concerns/training_programme_options.rb
+++ b/app/models/concerns/training_programme_options.rb
@@ -83,6 +83,21 @@ module TrainingProgrammeOptions
     not_yet_known: "Not yet decided",
   }.freeze
 
+  CONFIRMATION_DESCRIPTION = {
+    core_induction_programme: "deliver your own programme using DfE-accredited materials",
+    full_induction_programme: "use a training provider, funded by the DfE",
+    design_our_own: "design and deliver your own programme based on the early career framework (ECF)",
+    school_funded_fip: "use a training provider funded by your school",
+    no_early_career_teachers: "opt out of notifications, because you do not expect any early career teachers to join this academic year",
+  }.freeze
+
+  CONFIRMATION_DESCRIPTION_2025 = {
+    core_induction_programme: "design and deliver your own training programme",
+    full_induction_programme: "use provider-led training, funded by the DfE",
+    school_funded_fip: "use provider-led training, funded by your school",
+    no_early_career_teachers: "opt out of notifications, because you do not expect any early career teachers to join this academic year",
+  }.freeze
+
   def school_training_options(state_funded: true, exclude: [])
     choices = possible_programmes(state_funded:, exclude:)
 
@@ -103,5 +118,13 @@ module TrainingProgrammeOptions
               end
 
     choices.reject { |choice| choice.in? exclude.map(&:to_sym) }
+  end
+
+  def confirmation_description(training_programme:)
+    if FeatureFlag.active?(:programme_type_changes_2025)
+      CONFIRMATION_DESCRIPTION_2025[training_programme.to_sym]
+    else
+      CONFIRMATION_DESCRIPTION[training_programme.to_sym]
+    end
   end
 end

--- a/app/views/schools/choose_programme/confirm_programme.html.erb
+++ b/app/views/schools/choose_programme/confirm_programme.html.erb
@@ -8,7 +8,7 @@
 
         <span class="govuk-caption-l"><%= @school.name %></span>
         <h1 class="govuk-heading-l">Confirm your training programme</h1>
-        <p class="govuk-body govuk-!-margin-bottom-7">You’ve chosen to <%= t @induction_choice_form.programme_choice, scope: "schools.induction_choice_form.confirmation_options", cohort: @induction_choice_form.cohort.display_name %>.</p>
+        <p class="govuk-body govuk-!-margin-bottom-7">You’ve chosen to <%= @induction_choice_form.programme_confirmation_description %>.</p>
 
     <%= form_for @induction_choice_form, url: choose_appropriate_body_schools_choose_programme_path do |f| %>
       <%= f.hidden_field :programme_choice %>

--- a/app/views/schools/choose_programme/success.html.erb
+++ b/app/views/schools/choose_programme/success.html.erb
@@ -27,7 +27,11 @@
           <% unless appropriate_body_form.body_appointed? %>
             <li>tell us which appropriate body you’ve appointed for your ECTs</li>
           <% end %>
-          <li>add the new ECTs and mentors to this service so we can check their eligibility for DfE funding</li>
+          <% if @school_cohort.school.cip_only? %>
+            <li>add the new ECTs and mentors to this service</li>
+          <% else %>
+            <li>add the new ECTs and mentors to this service so we can check their eligibility for DfE funding</li>
+          <% end %>
           <li>use this service to tell us which mentor has been assigned to each ECT</li>
         </ul>
       <% end %>

--- a/app/views/schools/cohort_setup/_training_confirmation_cip.html.erb
+++ b/app/views/schools/cohort_setup/_training_confirmation_cip.html.erb
@@ -1,12 +1,14 @@
 <h2 class="govuk-heading-m">What to do next</h2>
 <p>As soon as possible:</p>
 <ol class="govuk-list govuk-list--bullet govuk-list--spaced">
-  <li>
-    choose the DfE-accredited materials you want to use
-  </li>
+  <% unless FeatureFlag.active?(:programme_type_changes_2025) %>
+    <li>choose the DfE-accredited materials you want to use</li>
+  <% end %>
+
   <% unless @wizard.appropriate_body_appointed? %>
     <li>tell us which appropriate body you’ve appointed for your ECTs</li>
   <% end %>
+
   <li>add the new ECTs and mentors to this service so we can check their eligibility for DfE funding</li>
   <li>use this service to tell us which mentor has been assigned to each ECT</li>
 </ol>

--- a/app/views/schools/cohort_setup/_training_confirmation_cip.html.erb
+++ b/app/views/schools/cohort_setup/_training_confirmation_cip.html.erb
@@ -9,6 +9,10 @@
     <li>tell us which appropriate body you’ve appointed for your ECTs</li>
   <% end %>
 
-  <li>add the new ECTs and mentors to this service so we can check their eligibility for DfE funding</li>
+  <% if @wizard.cip_only_school? %>
+    <li>add the new ECTs and mentors to this service</li>
+  <% else %>
+    <li>add the new ECTs and mentors to this service so we can check their eligibility for DfE funding</li>
+  <% end %>
   <li>use this service to tell us which mentor has been assigned to each ECT</li>
 </ol>

--- a/app/views/schools/cohort_setup/programme_confirmation.html.erb
+++ b/app/views/schools/cohort_setup/programme_confirmation.html.erb
@@ -8,24 +8,31 @@
         <h1 class="govuk-heading-l">Are you sure this is how you want to run your training?</h1>
 
         <% if @wizard.how_will_you_run_training == 'full_induction_programme' %>
-            <p class="govuk-body">You‘ve chosen to use a training provider, funded by DfE.</p>
+            <p class="govuk-body">You’ve chosen to use a training provider, funded by DfE.</p>
             <p class="govuk-body">You’ll need to:</p>
             <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-7">
               <li>choose a training provider</li>
               <li>add your ECTs and mentors</li>
             </ul>
         <% elsif @wizard.how_will_you_run_training == 'core_induction_programme' %>
+          <% if FeatureFlag.active?(:programme_type_changes_2025) %>
+            <p class="govuk-body">You’ve chosen to design and deliver your own training programme.</p>
+            <p class="govuk-body">You’ll need to:</p>
+            <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-7">
+              <li>add your ECTs and mentors</li>
+            </ul>
+          <% else %>
             <p class="govuk-body">You‘ve chosen to deliver your own programme using DfE-accredited materials.</p>
             <p class="govuk-body">You’ll need to:</p>
             <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-7">
-              <% unless FeatureFlag.active?(:programme_type_changes_2025) %>
-                <li>choose your training materials</li>
-              <% end %>
+              <li>choose your training materials</li>
               <li>add your ECTs and mentors</li>
             </ul>
+          <% end %>
         <% elsif @wizard.how_will_you_run_training == 'school_funded_fip' %>
             <p class="govuk-body">You‘ve chosen to use a training provider funded by your school.</p>
             <% if FeatureFlag.active?(:programme_type_changes_2025) %>
+              <p class="govuk-body">You’ll need to:</p>
               <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-7">
                 <li>choose a training provider</li>
                 <li>add your ECTs and mentors</li>

--- a/spec/forms/induction_choice_form_spec.rb
+++ b/spec/forms/induction_choice_form_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe InductionChoiceForm, type: :model do
-  let(:school) { build :school }
+  let(:school) { build :school, school_type_code: 1 }
   let(:school_cohort) { build :school_cohort, school: }
   subject(:form) { described_class.new(school_cohort:) }
 
@@ -12,33 +12,67 @@ RSpec.describe InductionChoiceForm, type: :model do
   end
 
   describe "#programme_choices" do
-    context "when the school has not yet made the choice" do
-      let(:school_cohort) { build :school_cohort, school:, induction_programme_choice: nil }
+    context "when programme_type_changes_2025 feature is inactive", with_feature_flags: { programme_type_changes_2025: "inactive" } do
+      context "when the school has not yet made the choice" do
+        let(:school_cohort) { build :school_cohort, school:, induction_programme_choice: nil }
 
-      context "the school is eligible for the full induction programme" do
-        it "provides options for the all programme choices except school_funded_fip" do
-          options = SchoolCohort.induction_programme_choices.except("not_yet_known", "school_funded_fip").keys
-          expect(form.programme_choices.map(&:id)).to match_array options.map(&:to_sym)
+        context "the school is eligible for the full induction programme" do
+          it "provides options for the all programme choices except school_funded_fip" do
+            options = SchoolCohort.induction_programme_choices.except("not_yet_known", "school_funded_fip").keys
+            expect(form.programme_choices.map(&:id)).to match_array options.map(&:to_sym)
+          end
+        end
+
+        context "the school is cip only" do
+          let(:school) { build(:school, :cip_only) }
+
+          it "doesn't show the full induction programme as an option" do
+            options = SchoolCohort.induction_programme_choices.except("not_yet_known", "full_induction_programme").keys
+            expect(form.programme_choices.map(&:id)).to match_array options.map(&:to_sym)
+          end
         end
       end
 
-      context "the school is cip only" do
-        let(:school) { build(:school, :cip_only) }
+      context "when the school has already made the choice for given cohort" do
+        let(:previous_choice) { SchoolCohort.induction_programme_choices.except("not_yet_known", "school_funded_fip").keys.sample }
+        let(:school_cohort) { build :school_cohort, school:, induction_programme_choice: previous_choice }
 
-        it "doesn't show the full induction programme as an option" do
-          options = SchoolCohort.induction_programme_choices.except("not_yet_known", "full_induction_programme").keys
+        it "does not show previous selection as an option" do
+          options = SchoolCohort.induction_programme_choices.except("not_yet_known", "school_funded_fip", previous_choice).keys
           expect(form.programme_choices.map(&:id)).to match_array options.map(&:to_sym)
         end
       end
     end
 
-    context "when the school has already made the choice for given cohort" do
-      let(:previous_choice) { SchoolCohort.induction_programme_choices.except("not_yet_known", "school_funded_fip").keys.sample }
-      let(:school_cohort) { build :school_cohort, school:, induction_programme_choice: previous_choice }
+    context "when programme_type_changes_2025 feature is active", with_feature_flags: { programme_type_changes_2025: "active" } do
+      context "when the school has not yet made the choice" do
+        let(:school_cohort) { build :school_cohort, school:, induction_programme_choice: nil }
 
-      it "does not show previous selection as an option" do
-        options = SchoolCohort.induction_programme_choices.except("not_yet_known", "school_funded_fip", previous_choice).keys
-        expect(form.programme_choices.map(&:id)).to match_array options.map(&:to_sym)
+        context "the school is eligible for the full induction programme" do
+          it "provides options for the all programme choices except school_funded_fip and design_our_own" do
+            options = SchoolCohort.induction_programme_choices.except("not_yet_known", "school_funded_fip", "design_our_own").keys
+            expect(form.programme_choices.map(&:id)).to match_array options.map(&:to_sym)
+          end
+        end
+
+        context "the school is cip only" do
+          let(:school) { build(:school, :cip_only) }
+
+          it "doesn't show the full induction programme as an option" do
+            options = SchoolCohort.induction_programme_choices.except("not_yet_known", "full_induction_programme", "design_our_own").keys
+            expect(form.programme_choices.map(&:id)).to match_array options.map(&:to_sym)
+          end
+        end
+      end
+
+      context "when the school has already made the choice for given cohort" do
+        let(:previous_choice) { SchoolCohort.induction_programme_choices.except("not_yet_known", "school_funded_fip", "design_our_own").keys.sample }
+        let(:school_cohort) { build :school_cohort, school:, induction_programme_choice: previous_choice }
+
+        it "does not show previous selection as an option" do
+          options = SchoolCohort.induction_programme_choices.except("not_yet_known", "school_funded_fip", "design_our_own", previous_choice).keys
+          expect(form.programme_choices.map(&:id)).to match_array options.map(&:to_sym)
+        end
       end
     end
   end
@@ -77,6 +111,26 @@ RSpec.describe InductionChoiceForm, type: :model do
 
       it "returns true" do
         expect(form.opt_out_choice_selected?).to eq true
+      end
+    end
+  end
+
+  describe "#programme_confirmation_description" do
+    context "when programme_type_changes_2025 flag is inactive", with_feature_flags: { programme_type_changes_2025: "inactive" } do
+      %w[full_induction_programme core_induction_programme design_our_own school_funded_fip no_early_career_teachers].each do |programme_choice|
+        it "returns the correct description for the confirmation page" do
+          form.programme_choice = programme_choice
+          expect(form.programme_confirmation_description).to eq TrainingProgrammeOptions::CONFIRMATION_DESCRIPTION[programme_choice.to_sym]
+        end
+      end
+    end
+
+    context "when programme_type_changes_2025 flag is active", with_feature_flags: { programme_type_changes_2025: "active" } do
+      %w[full_induction_programme core_induction_programme school_funded_fip no_early_career_teachers].each do |programme_choice|
+        it "returns the correct description for the confirmation page" do
+          form.programme_choice = programme_choice
+          expect(form.programme_confirmation_description).to eq TrainingProgrammeOptions::CONFIRMATION_DESCRIPTION_2025[programme_choice.to_sym]
+        end
       end
     end
   end


### PR DESCRIPTION
### Context
Final tweaks for programme type changes for 2025

On the registration journey when a SIT has picked school-led the text needs revised in certain steps as still refers to DfE-accredited materials etc

- [x] On the 'Are you sure this is how you want to run your training?' page
- Not a requirement that they use DfE materials so needs to be removed
- Propose that is says something like 'You've chosen to design and deliver your own training programme.'

- [x] Confirmation page, next steps need revised
- ‘Choose the DfE-accredited materials you want to use’ - Schools don't need to tell us this anymore so can be removed

- [x] On the registration journey for School funded provider-led; 
- On the 'Are you sure this is how you want to run your training' page
- Need 'You'll need to' text 

Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-2857)


### Changes proposed in this pull request

### Guidance to review

| current | 2025 onwards |
| ---- | ---- |
| ![image](https://github.com/user-attachments/assets/fad979b1-c24b-4df5-8d66-4c276838b296) | ![image](https://github.com/user-attachments/assets/2eb6feb0-b7a3-40fd-a28a-6fb1d55a1e16) |
| ![image](https://github.com/user-attachments/assets/467b3152-e033-442a-95ae-f8ea5f42edaa) | ![image](https://github.com/user-attachments/assets/42b69e96-7885-4bee-af32-49c0c1a12ba8) |
| ![image](https://github.com/user-attachments/assets/5e451389-2def-43bf-a4ca-b80fa00209fc) | ![image](https://github.com/user-attachments/assets/8b74fbe4-df0e-416a-92fa-64226361a035) |
| ![image](https://github.com/user-attachments/assets/0c3ac2dd-c099-499c-b0ef-ccac22df3131) | ![image](https://github.com/user-attachments/assets/7b139487-e191-4c23-8cb7-50ac53f734f3) |
| ![image](https://github.com/user-attachments/assets/ccccf86b-5eba-4157-8c90-91facf5a978a) | N/A |
| ![image](https://github.com/user-attachments/assets/e673e346-665e-4962-8666-df76b19776ef) | N/A |
| ![image](https://github.com/user-attachments/assets/7b16ca52-6470-4f6d-b339-680f510448b2) | ![image](https://github.com/user-attachments/assets/ce88fea8-c56c-49f3-824a-6b7298d679b6) |
| ![image](https://github.com/user-attachments/assets/57746f0e-9158-4882-a5a3-12558c345442) | ![image](https://github.com/user-attachments/assets/27263602-83c6-4409-bdc7-a89157dd9af9) |


### Non-state funded school selecting provider-led confirmation (post 2025)
![image](https://github.com/user-attachments/assets/346688eb-1474-4a92-a8d0-c4cc30284da3)

### School-led confirmation and completion (post 2025)
![image](https://github.com/user-attachments/assets/a635d45b-7da6-4753-9039-f604b842803a)

### Non-state funded chosen CIP/School-led journey completion

| current | 2025 onwards |
| ---- | ---- |
| ![image](https://github.com/user-attachments/assets/83968eb3-87cd-4117-8f3f-ba06e9915f6c) | ![image](https://github.com/user-attachments/assets/95945a24-40e2-491a-97b5-12229dfe0a4d) |




