### PR TITLE
Add comms for SITs from BPN partnered schools to report training details

### DIFF
--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -29,6 +29,7 @@ class SchoolMailer < ApplicationMailer
   REMIND_SIT_TO_APPOINT_AB_FOR_UNREGISTERED_ECT = "e697e076-a0f6-4738-a421-ae507d804499"
   SIT_PRE_TERM_REMINDER_TO_REPORT_ANY_CHANGES = "59983db6-678f-4a7d-9a3b-80bed4f6ef17"
   REMIND_SIT_TO_REPORT_SCHOOL_TRAINING_DETAILS = "38e2e143-2b11-4acf-b305-26185f28d58c"
+  BPN_SIT_SCHOOL_TRAINING_DETAILS_TEMPLATE = "e7d9149b-0522-46c5-83b5-42e3d7c7338f"
 
   def remind_sit_that_ab_has_not_registered_ect
     school = params[:school]
@@ -589,5 +590,23 @@ class SchoolMailer < ApplicationMailer
         school_name:,
       },
     ).tag(:remind_sit_to_report_school_training_details).associate_with(induction_coordinator, as: :induction_coordinator_profile)
+  end
+
+  # Mailer to contact SITs from Best Practice Network partnered schools
+  def ask_bpn_school_sit_to_report_school_training_details
+    sit_user = params[:sit_user]
+    nomination_link = params[:nomination_link]
+
+    template_mail(
+      BPN_SIT_SCHOOL_TRAINING_DETAILS_TEMPLATE,
+      to: sit_user.email,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        name: sit_user.full_name,
+        email_address: sit_user.email,
+        nomination_link:,
+      },
+    ).tag(:ask_bpn_school_sit_to_report_school_training_details).associate_with(sit_user)
   end
 end

--- a/spec/mailers/school_mailer_spec.rb
+++ b/spec/mailers/school_mailer_spec.rb
@@ -606,4 +606,26 @@ RSpec.describe SchoolMailer, type: :mailer do
       mailer
     end
   end
+
+  describe "#ask_bpn_school_sit_to_report_school_training_details" do
+    let(:sit_user) { create(:user, :induction_coordinator) }
+    let(:nomination_link) { "https://ecf-dev.london.cloudapps/nominations/start?token=123" }
+
+    let(:ask_bpn_school_sit_to_report_school_training_details) do
+      SchoolMailer.with(
+        sit_user:,
+        nomination_link:,
+        email_address: sit_user.email,
+      ).ask_bpn_school_sit_to_report_school_training_details.deliver_now
+    end
+
+    it "renders the right headers" do
+      expect(ask_bpn_school_sit_to_report_school_training_details.to).to eq([sit_user.email])
+      expect(ask_bpn_school_sit_to_report_school_training_details.from).to eq(["mail@example.com"])
+    end
+
+    it "uses the correct Notify template" do
+      expect(SchoolMailer::BPN_SIT_SCHOOL_TRAINING_DETAILS_TEMPLATE).to eq("e7d9149b-0522-46c5-83b5-42e3d7c7338f")
+    end
+  end
 end


### PR DESCRIPTION
### Context

- Ticket: [#1725](https://github.com/DFE-Digital/register-ects-project-board/issues/1725)

As part of our soft launch we want to send emails to schools that were partnered with BPN in academic year 24/25 to allow them more time to register participants and for providers to submit partnerships for them.

A bespoke urn list will be feeded to the task that will trigger the emails.

### Changes proposed in this pull request
- Add new mair
- Add rake task to trigger the comms

### Guidance to review
- The mailer is using the correct email template and placeholders
- The rake task is triggering the correct mailer with the required params
