### PR TITLE
Update content in the Transfer Support form

### DIFF
--- a/app/components/support_form_component.html.erb
+++ b/app/components/support_form_component.html.erb
@@ -10,7 +10,11 @@
         <%= t("support_form.introduction.#{subject}_html", **i18n_params) %>
       </p>
 
-      <p class="govuk-body">We’ll automatically include these details for you: </p>
+      <p class="govuk-body">
+        <%= t("support_form.instructions.#{subject}_html", **i18n_params) %>
+      </p>
+
+      <p class="govuk-body">We’ll automatically include the following in your message:</p>
 
       <dl class="govuk-summary-list">
         <div class="govuk-summary-list__row">
@@ -78,10 +82,6 @@
         <% end %>
       </dl>
 
-      <p class="govuk-body">
-        <%= t("support_form.instructions.#{subject}_html", **i18n_params) %>
-      </p>
-
       <%= f.hidden_field :subject %>
       <%= f.hidden_field :participant_profile_id %>
       <%= f.hidden_field :school_id %>
@@ -91,7 +91,7 @@
             :message,
             rows: 5,
             width: "three-quarters",
-            label: { text: "Your message", size: "s" },
+            label: { text: t("support_form.message_field.#{subject}", **i18n_params, default: t("support_form.message_field.unspecified")), size: "s" },
           ) %>
 
       <%= f.govuk_submit "Send message to support" %>

--- a/app/components/support_form_component.rb
+++ b/app/components/support_form_component.rb
@@ -28,6 +28,7 @@ class SupportFormComponent < BaseComponent
       support_email: Rails.application.config.support_email,
       school_name:,
       teacher_name:,
+      possesive_teacher_name:,
     }
   end
 
@@ -37,5 +38,9 @@ private
 
   def cohort_year_range
     Cohort.new(start_year: cohort_year)&.description if cohort_year.present?
+  end
+
+  def possesive_teacher_name
+    ApplicationController.helpers.possessive_name(teacher_name)
   end
 end

--- a/app/components/support_form_component.rb
+++ b/app/components/support_form_component.rb
@@ -28,7 +28,7 @@ class SupportFormComponent < BaseComponent
       support_email: Rails.application.config.support_email,
       school_name:,
       teacher_name:,
-      possesive_teacher_name:,
+      possessive_teacher_name:,
     }
   end
 
@@ -40,7 +40,7 @@ private
     Cohort.new(start_year: cohort_year)&.description if cohort_year.present?
   end
 
-  def possesive_teacher_name
+  def possessive_teacher_name
     ApplicationController.helpers.possessive_name(teacher_name)
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -765,7 +765,7 @@ en:
       add-participant-dqt-mismatch-mentor: "Contact Support: You cannot add %{teacher_name}"
     message_field:
       unspecified: Your message
-      add-participant-requires-manual-transfer-ect: "Your message and %{possesive_teacher_name} details"
+      add-participant-requires-manual-transfer-ect: "Your message and %{possessive_teacher_name} details"
 
     introduction:
       unspecified_html: "If you have a question about the Manage training for early career teachers service, you can contact the DfE using this form."
@@ -822,7 +822,7 @@ en:
         </ul>
       add-participant-requires-manual-transfer-ect_html: |
         <p class="govuk-body">Make sure you include all the details we need. Registration might take longer if we don’t have them:</p>
-        <p class="govuk-body">Include %{possesive_teacher_name}:</p>
+        <p class="govuk-body">Include %{possessive_teacher_name}:</p>
         <ul class="govuk-list govuk-list--bullet">
           <li>full name</li>
           <li>date of birth</li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -763,6 +763,10 @@ en:
       add-participant-requires-manual-transfer: "Contact Support: You cannot add %{teacher_name}"
       add-participant-dqt-mismatch-ect: "Contact Support: You cannot add %{teacher_name}"
       add-participant-dqt-mismatch-mentor: "Contact Support: You cannot add %{teacher_name}"
+    message_field:
+      unspecified: Your message
+      add-participant-requires-manual-transfer-ect: "Your message and %{possesive_teacher_name} details"
+
     introduction:
       unspecified_html: "If you have a question about the Manage training for early career teachers service, you can contact the DfE using this form."
       trouble-nominating-induction-coordinator_html: "Complete this form to request a change to %{school_name}’s induction coordinator."
@@ -776,7 +780,7 @@ en:
         <br><br>
         You can view your options here: <a class="govuk-link" target="_blank" rel="noopener noreferrer" href="https://www.gov.uk/guidance/how-to-set-up-training-for-early-career-teachers#choose-a-training-option">https://www.gov.uk/guidance/how-to-set-up-training-for-early-career-teachers#choose-a-training-option</a>.
 
-      add-participant-requires-manual-transfer-ect_html: "Complete this request form to register %{teacher_name} as an ECT at your school."
+      add-participant-requires-manual-transfer-ect_html: "Send us a message to register %{teacher_name} as an ECT at your school."
       add-participant-requires-manual-transfer-mentor_html: "Complete this request form to register %{teacher_name} as a mentor at your school."
       add-participant-dqt-mismatch-ect_html: "Complete this request form to register %{teacher_name} as an ECT at your school."
       add-participant-dqt-mismatch-mentor_html:  "Complete this request form to register %{teacher_name} as a mentor at your school."
@@ -817,19 +821,20 @@ en:
           <li>the years you want to apply the change to (year 1, year 2, or both years)</li>
         </ul>
       add-participant-requires-manual-transfer-ect_html: |
-        <p class="govuk-body">Include their:</p>
+        <p class="govuk-body">Make sure you include all the details we need. Registration might take longer if we don’t have them:</p>
+        <p class="govuk-body">Include %{possesive_teacher_name}:</p>
         <ul class="govuk-list govuk-list--bullet">
           <li>full name</li>
-          <li>teacher reference number (TRN)</li>
           <li>date of birth</li>
+          <li>teacher reference number (TRN)</li>
           <li>email address (personal or school)</li>
           <li>start date at your school</li>
-          <li>previous school’s name</li>
+          <li>previous school</li>
         </ul>
 
-        <p class="govuk-body">Tell us:
-          <li>how they’ll continue their ECF-based training at your school (for example, with a DfE-funded training provider)</li>
-          <li>which lead provider and delivery partner you’ve chosen for their training, if applicable</li>
+        <p class="govuk-body">You also need to tell us:
+          <li>how they’ll continue their early career training programme at your school, for example, with a DfE-funded training provider</li>
+          <li>which lead provider and delivery partner you’ve chosen for their training if they’re on provider-led training</li>
         </ul>
       add-participant-requires-manual-transfer-mentor_html: |
         <p class="govuk-body">Include their:</p>


### PR DESCRIPTION
### Context

- Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/1724

This PR revisits the content on the support form page that a SIT sees whenever the transfer needs done manually.

### Changes proposed in this pull request
- Add method in the SupportFormComponent to convert the teacher's name to possesive
- Update i18n file with the new content
- Update the support form component html

### Guidance to review
|before|after|
|-|-|
|![before](https://github.com/user-attachments/assets/1a4d4b75-9ff2-4889-a459-b0cd3c7fff8c)|![after](https://github.com/user-attachments/assets/11d718a6-302c-4159-b7e9-2688d3cec0bb)|
