### PR TITLE
1712-update ECF1 terminology

### DIFF
--- a/app/models/concerns/training_programme_options.rb
+++ b/app/models/concerns/training_programme_options.rb
@@ -58,15 +58,15 @@ module TrainingProgrammeOptions
   PROGRAMME_CHOICES_2025 = {
     full_induction_programme: {
       name: "Provider-led",
-      description: "Your school will work with providers who will deliver early career framework based training funded by the Department for Education.",
+      description: "Your school will work with providers who will deliver initial teacher training and early career framework based training funded by the Department for Education.",
     },
     core_induction_programme: {
       name: "School-led",
-      description: "Your school will deliver training based on the early career framework.",
+      description: "Your school will deliver training based on the initial teacher training and early career framework.",
     },
     school_funded_fip: {
       name: "Provider-led",
-      description: "Your school will fund providers who will deliver early career framework based training.",
+      description: "Your school will fund providers who will deliver initial teacher training and early career framework based training.",
     },
     no_early_career_teachers: {
       name: "We do not expect any early career teachers to join",

--- a/app/views/finance/ecf/statements/show.html.erb
+++ b/app/views/finance/ecf/statements/show.html.erb
@@ -39,7 +39,7 @@
             <div class="govuk-grid-column-one-half govuk-!-text-align-right">
               <p class="govuk-body-s">
                 <%=
-                  print_link("Save as PDF", filename: "#{@ecf_lead_provider.name} #{@statement.name} ECF Statement (#{@statement.cohort.start_year} Cohort)")
+                  print_link("Save as PDF", filename: "#{@ecf_lead_provider.name} #{@statement.name} ECTE Statement (#{@statement.cohort.start_year} Cohort)")
                 %>
               </p>
               <% unless @mentor_funding_cohort %>

--- a/app/views/finance/landing_page/show.html.erb
+++ b/app/views/finance/landing_page/show.html.erb
@@ -12,7 +12,7 @@
     <p class="govuk-body">Search, view and edit participant records, training histories and funding eligibility.</p>
 
     <h2 class="govuk-heading-m"><%= govuk_link_to "Search duplicate records", finance_ecf_duplicates_path %></h2>
-    <p class="govuk-body">Search and compare participant records with any ECF duplicate errors.</p>
+    <p class="govuk-body">Search and compare participant records with any ECTE duplicate errors.</p>
 
   </div>
 </div>

--- a/app/views/lead_providers/content/index.html.erb
+++ b/app/views/lead_providers/content/index.html.erb
@@ -7,7 +7,7 @@
       <div class="govuk-grid-column-two-thirds">
         <h1 class="app-masthead__title govuk-heading-l">Manage data quickly and easily</h1>
         <div class="app-masthead__description">
-          <p class="govuk-body-l">Login to the service to manage or test ECF integrations and see school details</p>
+          <p class="govuk-body-l">Login to the service to manage or test ECTE integrations and see school details</p>
         </div>
         <%= govuk_start_button(
           text: 'Login',
@@ -28,12 +28,12 @@
   <section class="app-section">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half">
-        <h2 class="govuk-heading-m">Manage ECF partnerships with schools and delivery partners</h2>
+        <h2 class="govuk-heading-m">Manage ECTE partnerships with schools and delivery partners</h2>
         <p class="govuk-body">Providers with system integrations with API versions 1.0.0 or 2.0.0 can login to confirm partnerships with the schools and see school details including induction tutor contacts.</p>
 
 
         <%= govuk_start_button(
-          text: 'How to manage ECF partnerships',
+          text: 'How to manage ECTE partnerships',
           href: :lead_providers_partnership_guide,
           classes: 'govuk-!-margin-bottom-0',
         ) %>

--- a/app/views/nominations/nominate_induction_coordinator/nominate_school_lead_success.html.erb
+++ b/app/views/nominations/nominate_induction_coordinator/nominate_school_lead_success.html.erb
@@ -13,7 +13,7 @@
         <h2 class="govuk-heading-m">What happens next</h2>
         <p class="govuk-body">We've sent them an email to confirm you nominated them.</p>
 
-        <p class="govuk-body">This person is now our single point of contact for ECF-based training at your school.</p>
+        <p class="govuk-body">This person is now our single point of contact for early career teacher entitlement (ECTE) at your school.</p>
 
         <p class="govuk-body">They'll use our service to:</p>
 

--- a/app/views/nominations/nominate_induction_coordinator/start_nomination.html.erb
+++ b/app/views/nominations/nominate_induction_coordinator/start_nomination.html.erb
@@ -9,7 +9,7 @@
         <span class="govuk-caption-l"><%= @nominate_induction_tutor_form.school.name %></span>
         <h1 class="govuk-heading-x">Nominate an induction tutor for your school</h1>
 
-        <p class="govuk-body">Your induction tutor will be our single point of contact for ECF-based training at your school.</p>
+        <p class="govuk-body">Your induction tutor will be our single point of contact for early career teacher entitlement (ECTE) at your school.</p>
         <p>They’ll use our service to:</p>
         <ul class="govuk-list govuk-list--bullet">
             <li>report how your school will run training for early career teachers (ECTs)</li>

--- a/app/views/pages/change_ECF_training_provider.html.erb
+++ b/app/views/pages/change_ECF_training_provider.html.erb
@@ -1,9 +1,9 @@
-<% content_for :title, "Change ECF-based training provider for ECTs and their mentors" %>
+<% content_for :title, "Change early career teacher entitlement (ECTE) training provider for ECTs and their mentors" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <h1 class="govuk-heading-l">Change ECF-based training provider for ECTs and their mentors</h1>
+    <h1 class="govuk-heading-l">Change early career teacher entitlement (ECTE) training provider for ECTs and their mentors</h1>
 
     <p class="govuk-body-s govuk-!-margin-bottom-2 govuk-!-margin-top-7">Contents</p>
 
@@ -23,7 +23,7 @@
 
     <p>We recommend that ECTs and mentors complete their training with one provider to minimise disruption.</p>
 
-    <p>All training providers cover the same ECF-based content, but they deliver it in a different order. This means ECTs and mentors may repeat or miss content if they change provider during their training.</p>
+    <p>All training providers cover the same ITTECF-based content, but they deliver it in a different order. This means ECTs and mentors may repeat or miss content if they change provider during their training.</p>
 
     <p>We recognise that it’s not always feasible for your school, or a transferring ECT, to stay with an existing provider however.</p>
 
@@ -31,7 +31,7 @@
 
     <p>If you believe it’s in the best interests of your ECTs and mentors to make a change during their training, try to do this at the end of the academic year. Where that’s not possible, aim for the end of a term instead.</p>
 
-    <div class="govuk-inset-text">See guidance on <%= govuk_link_to "choosing a training option", "https://www.gov.uk/guidance/how-to-set-up-training-for-early-career-teachers#choose-a-training-option" %> to find out which lead providers offer DfE-funded training. </div>
+    <div class="govuk-inset-text">See guidance on <%= govuk_link_to "choosing a training option", "https://www.gov.uk/guidance/how-to-set-up-training-for-early-career-teachers#choose-your-schools-training-option" %> to find out which lead providers offer DfE-funded training. </div>
 
     <h2 class="govuk-heading-m" id="change-training-provider-for-ects-and-mentors-across-1-or-2-years">Change training provider for ECTs and mentors across 1 or 2 years</h2>
 
@@ -44,7 +44,7 @@
       <li>Check that they have the capacity to train ECTs, and mentors where relevant, in the new academic year.</li>
     </ol>
 
-    <p>Your school’s registered induction tutor is responsible for telling DfE how your school will deliver ECF-based training ahead of each academic year.</p>
+    <p>Your school’s registered induction tutor is responsible for telling DfE how your school will deliver ITTECF-based training ahead of each academic year.</p>
 
     <p>We’ll email your school’s registered induction tutor in the summer term when it’s time to sign in to the Manage training for early career teachers service and set up training for the new year.</p>
 

--- a/app/views/sandbox/show.html.erb
+++ b/app/views/sandbox/show.html.erb
@@ -9,7 +9,7 @@
       <p class="govuk-body">Login to sandbox to experience the service as a school induction tutor, lead provider and software vendor.</p>
 
       <h2 class="govuk-heading-m">Test API integrations with lead provider systems</h2>
-      <p class="govuk-body">Test provider system integrations in sandbox without affecting real ECF data.</p>
+      <p class="govuk-body">Test provider system integrations in sandbox without affecting real ECTE data.</p>
 
       <p class="govuk-body">Fake participants and IDs have been made available to use. </p>
 
@@ -26,8 +26,8 @@
             href: "/api-reference",
             ) %>
 
-      <h2 class="govuk-heading-m">Impersonate ECF school induction tutors </h2>
-      <p class="govuk-body">Impersonate a school induction tutor to see how they set up ECF-based training programmes and register Early Career Teachers (ECTs) and mentors to the service. </p>
+      <h2 class="govuk-heading-m">Impersonate ECTE school induction tutors </h2>
+      <p class="govuk-body">Impersonate a school induction tutor to see how they set up early career training programmes and register Early Career Teachers (ECTs) and mentors to the service. </p>
 
       <p class="govuk-body">Request induction tutor test access to the sandbox by emailing us on <%= render MailToSupportComponent.new %>.</p>
 

--- a/app/views/schools/add_participants/_no_eligibility_record.html.erb
+++ b/app/views/schools/add_participants/_no_eligibility_record.html.erb
@@ -1,10 +1,10 @@
 <h2 class="govuk-heading-m">What happens next</h2>
-<p class="govuk-body">We’ll let this person know you’ve registered them for ECF-based training at your school.</p>
+<p class="govuk-body">We’ll let this person know you’ve registered them for early career training at your school.</p>
 <p class="govuk-body">We’ll ask them to use this service to tell us their:</p>
 <ul class="govuk-list govuk-list--bullet">
   <li>full name</li>
   <li>date of birth</li>
   <li>teacher reference number (TRN) or National Insurance number</li>
 </ul>
-<p class="govuk-body">We can then confirm if they’re eligible for funded ECF-based training.</p>
+<p class="govuk-body">We can then confirm if they’re eligible for funded early career training.</p>
 <p class="govuk-body">We’ll also pass their information to your training provider.</p>

--- a/app/views/schools/add_participants/cannot_add.html.erb
+++ b/app/views/schools/add_participants/cannot_add.html.erb
@@ -8,7 +8,7 @@
     <span class="govuk-caption-l"><%= @school.name %></span>
     <h1 class="govuk-heading-l"><%= title %></h1>
 
-    <p class="govuk-body">Our records show this person is already registered on an ECTE training programme at a different school</p>
+    <p class="govuk-body">Our records show this person is already registered on an early career training programme at a different school</p>
     <p class="govuk-body">Contact us for help to register this person at your school: <%= render MailToSupportComponent.new %></p>
 
     <p class="govuk-body"><%= govuk_link_to "Return to your ECTs", school_early_career_teachers_path, no_visited_state: true %></p>

--- a/app/views/schools/add_participants/cannot_add.html.erb
+++ b/app/views/schools/add_participants/cannot_add.html.erb
@@ -8,7 +8,7 @@
     <span class="govuk-caption-l"><%= @school.name %></span>
     <h1 class="govuk-heading-l"><%= title %></h1>
 
-    <p class="govuk-body">Our records show this person is already registered on an ECF-based training programme at a different school</p>
+    <p class="govuk-body">Our records show this person is already registered on an ECTE training programme at a different school</p>
     <p class="govuk-body">Contact us for help to register this person at your school: <%= render MailToSupportComponent.new %></p>
 
     <p class="govuk-body"><%= govuk_link_to "Return to your ECTs", school_early_career_teachers_path, no_visited_state: true %></p>

--- a/app/views/schools/add_participants/cannot_add_already_enrolled_at_school.html.erb
+++ b/app/views/schools/add_participants/cannot_add_already_enrolled_at_school.html.erb
@@ -6,7 +6,7 @@
     <span class="govuk-caption-l"><%= @school.name %></span>
     <h1 class="govuk-heading-l"><%= title %></h1>
 
-    <p class="govuk-body">Our records show this person is already registered on an ECF-based training programme at your school</p>
+    <p class="govuk-body">Our records show this person is already registered on an early carrer training programme at your school</p>
 
     <% if @wizard.existing_lead_provider.present? %>
       <p class="govuk-body">If <%= @wizard.full_name %> has been withdrawn by <%= @wizard.existing_lead_provider.name %>, you should contact them to get <%= @wizard.full_name %> reinstated.</p>

--- a/app/views/schools/add_participants/cannot_add_already_enrolled_at_school.html.erb
+++ b/app/views/schools/add_participants/cannot_add_already_enrolled_at_school.html.erb
@@ -6,7 +6,7 @@
     <span class="govuk-caption-l"><%= @school.name %></span>
     <h1 class="govuk-heading-l"><%= title %></h1>
 
-    <p class="govuk-body">Our records show this person is already registered on an early carrer training programme at your school</p>
+    <p class="govuk-body">Our records show this person is already registered on an early career training programme at your school</p>
 
     <% if @wizard.existing_lead_provider.present? %>
       <p class="govuk-body">If <%= @wizard.full_name %> has been withdrawn by <%= @wizard.existing_lead_provider.name %>, you should contact them to get <%= @wizard.full_name %> reinstated.</p>

--- a/app/views/schools/add_participants/cannot_add_already_enrolled_at_school_but_withdrawn.html.erb
+++ b/app/views/schools/add_participants/cannot_add_already_enrolled_at_school_but_withdrawn.html.erb
@@ -7,14 +7,14 @@
     <h1 class="govuk-heading-xl"><%= title %></h1>
 
     <% if @wizard.existing_induction_record.enrolled_in_fip? %>
-      <p class="govuk-body">They've already been registered. You reported that they left your school, or are no longer taking part in ECF-based training.</p>
+      <p class="govuk-body">They've already been registered. You reported that they left your school, or are no longer taking part in early career training.</p>
 
       <% if @wizard.existing_lead_provider.present? %>
         <p class="govuk-body">If you reported this by mistake, contact your training provider (<%= @wizard.existing_lead_provider.name %>) and ask for them to be reinstated.</p>
         <p class="govuk-body">Once your provider confirms this with us, we'll update this person's training record for you.</p>
       <% end %>
     <% elsif @wizard.existing_induction_record.enrolled_in_cip? %>
-      <p class="govuk-body">They've already been registered. You reported that they left your school, or are no longer taking part in ECF-based training.</p>
+      <p class="govuk-body">They've already been registered. You reported that they left your school, or are no longer taking part in early career training.</p>
       <p class="govuk-body">If you reported this by mistake, email our support team for help: <%= govuk_mail_to "continuing-professional-development@digital.education.gov.uk" %></p>
     <% end %>
 

--- a/app/views/schools/add_participants/cannot_transfer_no_fip.html.erb
+++ b/app/views/schools/add_participants/cannot_transfer_no_fip.html.erb
@@ -20,7 +20,7 @@
 
     <p class="govuk-body">Tell us:</p>
     <ul class="govuk-list govuk-list--bullet">
-      <li>how <%= @wizard.full_name || "the ECT" %> will continue their ECF-based training at your school - for example, with a DfE-funded training provider
+      <li>how <%= @wizard.full_name || "the ECT" %> will continue their early career training at your school - for example, with a DfE-funded training provider
       </li>
       <li>the lead provider and delivery partner you’ve chosen for their training, if applicable</li>
     </ul>

--- a/app/views/schools/add_participants/complete.html.erb
+++ b/app/views/schools/add_participants/complete.html.erb
@@ -20,7 +20,7 @@
       <h2>What happens next</h2>
       <% if @wizard.transfer? %>
         <p class="govuk-body">
-          We’ll let this person know you’ve registered them for ECF-based training at your school.
+          We’ll let this person know you’ve registered them for early career training at your school.
         </p>
         <% if @wizard.same_provider? && !@wizard.was_withdrawn_participant? %>
           <p class="govuk-body">They’re already training with the same provider used by your school. We’ll let your provider know about the transfer.</p>
@@ -30,7 +30,7 @@
           <p class="govuk-body">We’ll contact your training lead provider, <%= @wizard.lead_provider&.name %>, to let them know that you’ve reported this transfer. We recommend you confirm this with them directly too.</p>
         <% end %>
         <% if @wizard.mentor_participant? %>
-          <h3 class="govuk-heading-s">Continuing induction and ECF-based training</h3>
+          <h3 class="govuk-heading-s">Continuing induction and early career training</h3>
           <p class="govuk-body">Ask <%= @wizard.full_name %> or their previous school to provide records of any assessments and progress reviews completed so far.</p>
           <% if @wizard.join_school_programme? || @wizard.was_withdrawn_participant? %>
             <p class="govuk-body"><%= @wizard.lead_provider&.name %> will advise how <%= @wizard.full_name %> should transfer onto their programme.</p>
@@ -39,7 +39,7 @@
         <% end %>
       <% else %>
         <p class="govuk-body">
-          We’ll let this person know you’ve registered them for ECF-based training at your school.
+          We’ll let this person know you’ve registered them for early career training at your school.
           They do not need to provide us with any more information.
         </p>
 

--- a/app/views/schools/add_participants/confirm_transfer.html.erb
+++ b/app/views/schools/add_participants/confirm_transfer.html.erb
@@ -11,7 +11,7 @@
     <h1 class="govuk-heading-l"><%= title %></h1>
 
     <p class="govuk-body govuk-!-margin-bottom-7">
-      Our records show this person is already registered on an ECF-based training programme at a different school.
+      Our records show this person is already registered on an early career training programme at a different school.
     </p>
 
     <%= form_with model: @wizard.form, url: url_for(action: :update), scope: @wizard.form_scope, method: :put do |f| %>

--- a/app/views/schools/add_participants/eligibility_confirmation/_exempt_from_induction.html.erb
+++ b/app/views/schools/add_participants/eligibility_confirmation/_exempt_from_induction.html.erb
@@ -1,6 +1,6 @@
 <%= govuk_panel title_text: "#{profile.user.full_name} does not need to serve statutory induction for early career teachers", text: nil, classes: "govuk-!-margin-bottom-8" %>
 
-<p>Their Teaching Regulation Agency record shows that they do not need to complete a statutory induction, or take part in ECF-based training.</p>
+<p>Their Teaching Regulation Agency record shows that they do not need to complete a statutory induction, or take part in early career training.</p>
 
 <p>This is likely to be because of the way in which DfE recognised their qualified teacher status (QTS).</p>
 

--- a/app/views/schools/add_participants/eligibility_confirmation/_post_transitional.html.erb
+++ b/app/views/schools/add_participants/eligibility_confirmation/_post_transitional.html.erb
@@ -6,7 +6,7 @@
 <%= render 'schools/add_participants/eligibility_confirmation/appropriate_body_guidance' %>
 
 <h2 class="govuk-heading-m">What happens next</h2>
-<p class="govuk-body">We’ll let this person know you’ve registered them for ECF-based training at your school. They do not need to provide us with any further information.</p>
+<p class="govuk-body">We’ll let this person know you’ve registered them for early career training at your school. They do not need to provide us with any further information.</p>
 <p class="govuk-body">We’ll let them know their statutory induction requirement has changed too.</p>
 
 <h2 class="govuk-heading-m">This person’s statutory induction requirement has changed from 1 year to 2 years</h2>
@@ -16,7 +16,7 @@
 <ul class="govuk-list govuk-list--bullet">
   <li>does not need to start induction again</li>
   <li>must complete what remains of their 2-year induction</li>
-  <li>should be given access to ECF-based training, mentor support and other statutory entitlements</li>
+  <li>should be given access to early career training, mentor support and other statutory entitlements</li>
 </ul>
 <div class="govuk-inset-text">Contact your appropriate body for more information, including how much of this ECT’s induction remains to be served.</div>
 

--- a/app/views/schools/add_participants/eligibility_confirmation/_previous_induction.html.erb
+++ b/app/views/schools/add_participants/eligibility_confirmation/_previous_induction.html.erb
@@ -2,4 +2,4 @@
 
 <p>Their Teaching Regulation Agency record shows they have completed their statutory induction.</p>
 
-<p>You do not need to arrange ECF-based early career teacher training for them.</p>
+<p>You do not need to arrange early career teacher training for them.</p>

--- a/app/views/schools/add_participants/need_training_setup.html.erb
+++ b/app/views/schools/add_participants/need_training_setup.html.erb
@@ -8,7 +8,7 @@
     <span class="govuk-caption-l"><%= @school.name %></span>
     <h1 class="govuk-heading-l"><%= title %></h1>
 
-    <p class="govuk-body">Before you can register <%= @wizard.full_name_or_yourself %> for ECF-based training at your school,
+    <p class="govuk-body">Before you can register <%= @wizard.full_name_or_yourself %> for an early career training programme at your school,
       you’ll need to set up training for the <%= @wizard.cohort_to_place_participant.description %> academic year.
       <% if @wizard.transfer? %>
         This is because they started training in that year at a previous school.

--- a/app/views/schools/add_participants/participant_type.html.erb
+++ b/app/views/schools/add_participants/participant_type.html.erb
@@ -11,7 +11,7 @@
       <%= f.govuk_error_summary %>
       <%= f.govuk_radio_buttons_fieldset :participant_type , legend: { text: "Who do you want to add?", tag: 'h1', size: 'l' } do %>
         <p class="govuk-body govuk-!-margin-top-4">
-          This could be a new teacher or a teacher transferring from another school where they’ve started ECF-based training or mentoring.
+          This could be a new teacher or a teacher transferring from another school where they’ve started their early career teacher entitlement (ECTE).
         </p>
         <%= f.govuk_radio_button :participant_type, :ect, label: { text: "ECT" }, link_errors: true %>
         <%= f.govuk_radio_button :participant_type, :mentor, label: { text: "Mentor" } %>

--- a/app/views/schools/add_participants/start_term.html.erb
+++ b/app/views/schools/add_participants/start_term.html.erb
@@ -1,10 +1,10 @@
 <%
     if @wizard.sit_mentor?
       title = "When will you start mentor training?"
-      hint = "This is when you’ll start ECF-based mentor training"
+      hint = "This is when you’ll start early career teacher entitlement (ECTE) mentor training"
     else
       title = "When will #{@wizard.full_name} start their #{@wizard.ect_participant? ? 'induction' : 'mentor training'}?"
-      hint = "This is when #{@wizard.full_name} will start their #{@wizard.ect_participant? ? 'induction and begin ECF-based training' : 'ECF-based mentor training'} at your school."
+      hint = "This is when #{@wizard.full_name} will start their #{@wizard.ect_participant? ? 'ECTE' : 'ECTE mentor training'} at your school."
     end
 %>
 

--- a/app/views/schools/add_participants/what_we_need.html.erb
+++ b/app/views/schools/add_participants/what_we_need.html.erb
@@ -36,7 +36,7 @@
       <p>You should let them know that we:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>use their personal data to arrange DfE funding</li>
-        <li>need to share this data with training providers and other organisations involved in ECT induction and ECF-based training</li>
+        <li>need to share this data with training providers and other organisations involved in early career teacher entitlement (ECTE).</li>
       </ul>
       <p class="govuk-body">
         <a class="govuk-link govuk-link--no-visited-state" href="/privacy-policy">Read our privacy policy</a></p>

--- a/app/views/schools/cohort_setup/_change_to_design_our_own_confirmation.html.erb
+++ b/app/views/schools/cohort_setup/_change_to_design_our_own_confirmation.html.erb
@@ -2,18 +2,17 @@
 <h1 class="govuk-heading-l">Are you sure you want to run your own training programme?</h1>
 
 <p class="govuk-body">
-  You’re choosing to design and deliver your own programme based on the early career
-  framework (ECF).
+  You’re choosing to design and deliver your own programme based on the initial teacher training and early career framework (ITTECF).
 </p>
 <p class="govuk-body">
   You’ll need to design a 2-year programme of support and training that covers every 'learn that' and
   'learn how to' statement in the
-  <%= govuk_link_to 'early career framework (ECF) (opens in new tab)', "https://www.gov.uk/government/publications/early-career-framework",
+  <%= govuk_link_to 'initial teacher training and early career framework (ITTECF) (opens in new tab)', "https://www.gov.uk/government/publications/initial-teacher-training-and-early-career-framework",
   target: :_blank,
   rel: "noopener noreferrer" %>
 </p>
 <p class="govuk-body govuk-!-margin-bottom-7">
-  <%= govuk_link_to 'See you statutory guidance (opens in new tab)', "https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#schools-designing-and-delivering-their-own-ecf-based-induction",
+  <%= govuk_link_to 'See our statutory guidance (opens in new tab)', "https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#schools-designing-and-delivering-their-own-ecf-based-induction",
   target: :_blank,
   rel: "noopener noreferrer" %>
   for information about funding, time off timetable, and roles.

--- a/app/views/schools/cohort_setup/_change_to_design_our_own_submitted.html.erb
+++ b/app/views/schools/cohort_setup/_change_to_design_our_own_submitted.html.erb
@@ -15,7 +15,7 @@
 <% if @wizard.appropriate_body_appointed? %>
   <p class="govuk-body">Contact your appropriate body to find out what evidence is needed to demonstrate that your programme:</p>
   <ul class="govuk-list govuk-list--bullet">
-    <li>is based on the ECF</li>
+    <li>is based on the ITTECF</li>
     <li>meets the statutory requirements</li>
   </ul>
 <% end %>

--- a/app/views/schools/cohort_setup/_training_confirmation_diy.html.erb
+++ b/app/views/schools/cohort_setup/_training_confirmation_diy.html.erb
@@ -2,8 +2,7 @@
 <p class="govuk-body">
   You need to design a 2-year programme of support and training that covers every ‘learn that’ and ‘learn how to’
   statement in the
-  <a href="https://www.gov.uk/government/publications/early-career-framework" class="govuk-link govuk-link--no-visited-state" rel="noreferrer noopener" target="_blank">Early
-    Career Framework (ECF) (opens in new tab)</a>.
+  <a href="https://www.gov.uk/government/publications/initial-teacher-training-and-early-career-framework" class="govuk-link govuk-link--no-visited-state" rel="noreferrer noopener" target="_blank"> initial teacher training and early career framework (ITTECF) (opens in new tab)</a>.
 </p>
 <p class="govuk-body">Contact your appropriate body to find out what evidence is needed to demonstrate that your
   programme:</p>

--- a/app/views/schools/cohort_setup/programme_confirmation.html.erb
+++ b/app/views/schools/cohort_setup/programme_confirmation.html.erb
@@ -39,12 +39,11 @@
               </ul>
             <% end %>
         <% elsif @wizard.how_will_you_run_training == 'design_our_own' %>
-            <p class="govuk-body">You’re choosing to design and deliver your own programme based on the early career
-                framework (ECF).</p>
+            <p class="govuk-body">You’re choosing to design and deliver your own programme based on the initial teacher training and early career framework (ITTECF).</p>
             <p class="govuk-body">You’ll need to design a 2-year programme of support and training that covers every
                 ‘learn that’ and ‘learn how to’ statement in the
-                <%= govuk_link_to 'early career framework (ECF) (opens in new tab)',
-                                  "https://www.gov.uk/government/publications/early-career-framework",
+                <%= govuk_link_to 'initial teacher training and early career framework (ITTECF)',
+                                  "https://www.gov.uk/government/publications/initial-teacher-training-and-early-career-framework",
                                   target: :_blank,
                                   rel: "noopener noreferrer" %>
             </p>

--- a/app/views/schools/cohort_setup/providers_relationship_has_changed.html.erb
+++ b/app/views/schools/cohort_setup/providers_relationship_has_changed.html.erb
@@ -10,7 +10,7 @@
         <h1 class="govuk-heading-l"><%= title %></h1>
 
         <p class="govuk-body">Your lead provider and delivery partner are no longer working together to
-            deliver ECF-based training.</p>
+            deliver early career training.</p>
 
         <p class="govuk-body">You can form a new partnership with a lead provider and delivery partner, or
             change the training programme.</p>

--- a/app/views/schools/cohort_setup/what_changes.html.erb
+++ b/app/views/schools/cohort_setup/what_changes.html.erb
@@ -21,7 +21,7 @@
             <% end %>
 
             <p class="govuk-body govuk-!-margin-top-4">If you’re not sure which option to choose, see
-                <%= govuk_link_to "delivery options for ECF-based training (opens in new tab)",
+                <%= govuk_link_to "delivery options for early career training (opens in new tab)",
                                   guidance_for_how_to_setup_training_url,
                                   target: :_blank,
                                   rel: "noopener noreferrer",

--- a/app/views/schools/cohorts/change_programme.html.erb
+++ b/app/views/schools/cohorts/change_programme.html.erb
@@ -35,7 +35,7 @@
 
     <% elsif @school_cohort.design_our_own? %>
 
-      <p class="govuk-body">Your school has chosen to design and deliver your own programme based on the early career framework (ECF).</p>
+      <p class="govuk-body">Your school has chosen to design and deliver your own programme based on the initial teacher training and early career framework (ITTECF).</p>
       <p class="govuk-body"><%= govuk_link_to "Check the other options available", schools_choose_programme_path %> for your school if this changes.</p>
 
     <% elsif @school_cohort.no_early_career_teachers? %>

--- a/app/views/schools/cohorts/programme_choice.html.erb
+++ b/app/views/schools/cohorts/programme_choice.html.erb
@@ -19,7 +19,7 @@
       </ul>
       <p class="govuk-body">Or</p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>design your own programme based on the Early Career Framework (ECF)</li>
+        <li>design your own programme based on the initial teacher training and early career framework (ITTECF)</li>
       </ul>
 
       <p class="govuk-body">You need to:</p>
@@ -43,7 +43,7 @@
       </p>
 
       <p class="govuk-body">
-      If your school has decided to design and deliver your own programme based on the Early Career Framework (ECF),
+      If your school has decided to design and deliver your own programme based on the initial teacher training and early career framework (ITTECF),
       you need to:
       </p>
       <ul class="govuk-list govuk-list--bullet">

--- a/app/views/schools/participants/replace_with_a_different_person.html.erb
+++ b/app/views/schools/participants/replace_with_a_different_person.html.erb
@@ -25,7 +25,7 @@
 
     <p class="govuk-body">You need to do this separately so that:</p>
     <ul class="govuk-list govuk-list--bullet">
-      <li>we can check their eligibility for DfE funding for ECF-based training, mentor support and time off timetable
+      <li>we can check their eligibility for DfE funding for early career training, mentor support and time off timetable
       </li>
       <li>their training can be recorded against the correct teacher reference number (TRN)</li>
     </ul>

--- a/app/views/schools/transfer_out/check_transfer.html.erb
+++ b/app/views/schools/transfer_out/check_transfer.html.erb
@@ -10,7 +10,7 @@
     <span class="govuk-caption-l"><%= @school.name %></span>
     <h1 class="govuk-heading-l"><%= title %></h1>
 
-    <p class="govuk-body">Confirm if this participant is moving to another school to continue their ECF-based training.</p>
+    <p class="govuk-body">Confirm if this participant is moving to another school to continue their early career training.</p>
 
     <p class="govuk-body">
       If they are leaving your school for any other reason, contact your training provider instead.

--- a/app/views/shared/_diy_what_you_can_do_now_info.html.erb
+++ b/app/views/shared/_diy_what_you_can_do_now_info.html.erb
@@ -8,7 +8,7 @@
 <p class="govuk-body">
   You must also ask your appropriate body what evidence you need to supply to demonstrate that your programme is:
   <ul class="govuk-list govuk-list--bullet">
-    <li>based on the ECF</li>
+    <li>based on the ITTECF</li>
     <li>meets the statutory requirements</li>
   </ul>
 </p>

--- a/app/views/start/delivery_partners.html.erb
+++ b/app/views/start/delivery_partners.html.erb
@@ -3,7 +3,7 @@
 
     <h1 class="govuk-heading-l">Check data about early career teachers and mentors</h1>
 
-    <p class="govuk-body">Use this service to find out what data the DfE has about participants and mentors that are doing an ECF-based training programme, including details provided by school induction tutors.</p>
+    <p class="govuk-body">Use this service to find out what data the DfE has about participants and mentors that are doing an early career training programm, including details provided by school induction tutors.</p>
     <p class="govuk-body">There may be differences between this data and what’s on your lead provider’s portal, including data that’s out of date.</p>
 
     <%= govuk_start_button text: "Start now", href: new_user_session_path %>

--- a/app/views/start/index.html.erb
+++ b/app/views/start/index.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Manage training for early career teachers</h1>
 
-    <p class="govuk-body">Set up and manage early career framework (ECF)-based training at your school.</p>
+    <p class="govuk-body">Set up and manage early career teacher entitlement (ECTE) at your school.</p>
 
     <p class="govuk-body">Use this service to report:</p>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -684,7 +684,7 @@ en:
       payment_breakdown: ECF Payment Breakdown
       statements:
         show:
-          title: Early career framework (ECF)
+          title: Initial teacher training and early career framework (ITTECF)
           title_ect_mentor: "Early career teacher programme: financial statements"
     service_fee:
       caption: Service fee

--- a/spec/features/finance/adjustments/create_adjustment_spec.rb
+++ b/spec/features/finance/adjustments/create_adjustment_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Create adjustment for statement", :js do
     given_i_am_logged_in_as_a_finance_user
     and_an_ecf_statement_exists
     when_i_visit_the_ecf_financial_statements_page
-    then_i_see("Early career framework (ECF)")
+    then_i_see("Initial teacher training and early career framework (ITTECF)")
     when_i_click_on_add_adjustment_link
 
     then_i_see("What is the name of the adjustment")
@@ -38,7 +38,7 @@ RSpec.describe "Create adjustment for statement", :js do
     and_a_closed_ecf_statement_exists
 
     when_i_visit_the_ecf_financial_statements_page
-    then_i_see("Early career framework (ECF)")
+    then_i_see("Initial teacher training and early career framework (ITTECF)")
     and_i_should_not_see_adjustment_links
 
     when_i_visit_new_adjustment_page_directly
@@ -50,7 +50,7 @@ RSpec.describe "Create adjustment for statement", :js do
     and_an_ecf_statement_with_false_output_fees_exists
 
     when_i_visit_the_ecf_financial_statements_page
-    then_i_see("Early career framework (ECF)")
+    then_i_see("Initial teacher training and early career framework (ITTECF)")
     and_i_should_not_see_adjustment_links
 
     when_i_visit_new_adjustment_page_directly
@@ -85,7 +85,7 @@ RSpec.describe "Create adjustment for statement", :js do
   end
 
   def then_i_am_redirected_back_to_financial_statements_page
-    then_i_see("Early career framework (ECF)")
+    then_i_see("Initial teacher training and early career framework (ITTECF)")
   end
 
   def and_an_adjustment_is_created

--- a/spec/features/finance/adjustments/delete_adjustment_spec.rb
+++ b/spec/features/finance/adjustments/delete_adjustment_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Delete adjustment from statement", :js do
     and_additional_adjustments_exist
 
     when_i_visit_the_ecf_financial_statements_page
-    then_i_see("Early career framework (ECF)")
+    then_i_see("Initial teacher training and early career framework (ITTECF)")
     when_i_click_on_change_or_remove_adjustment_link
 
     then_i_see("Change or remove an adjustment")

--- a/spec/features/finance/adjustments/update_adjustment_spec.rb
+++ b/spec/features/finance/adjustments/update_adjustment_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Update adjustment for statement", :js do
     and_additional_adjustments_exist
 
     when_i_visit_the_ecf_financial_statements_page
-    then_i_see("Early career framework (ECF)")
+    then_i_see("Initial teacher training and early career framework (ITTECF)")
     when_i_click_on_change_or_remove_adjustment_link
 
     then_i_see("Change or remove an adjustment")

--- a/spec/features/finance/ecf/statement_spec.rb
+++ b/spec/features/finance/ecf/statement_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Show ECF statement", :js do
 
     when_i_visit_the_ecf_financial_statements_page
 
-    then_i_see("Early career framework (ECF)")
+    then_i_see("Initial teacher training and early career framework (ITTECF)")
     and_i_see_additional_adjustments_table
     and_i_see_additional_adjustments_total
     and_i_see_save_as_pdf_link
@@ -40,7 +40,7 @@ RSpec.describe "Show ECF statement", :js do
 
       when_i_visit_the_ecf_financial_statements_page
 
-      then_i_see("Early career framework (ECF)")
+      then_i_see("Initial teacher training and early career framework (ITTECF)")
 
       and_i_see_authorise_for_payment_button
       when_i_click_the_authorise_for_payment_button
@@ -69,7 +69,7 @@ RSpec.describe "Show ECF statement", :js do
 
       when_i_visit_the_ecf_financial_statements_page
 
-      then_i_see("Early career framework (ECF)")
+      then_i_see("Initial teacher training and early career framework (ITTECF)")
 
       and_i_see_authorise_for_payment_button
       when_i_click_the_authorise_for_payment_button
@@ -92,7 +92,7 @@ RSpec.describe "Show ECF statement", :js do
 
       when_i_visit_the_ecf_financial_statements_page
 
-      then_i_see("Early career framework (ECF)")
+      then_i_see("Initial teacher training and early career framework (ITTECF)")
 
       and_i_see_authorise_for_payment_button
       when_i_click_the_authorise_for_payment_button

--- a/spec/features/finance/ecf/statement_spec.rb
+++ b/spec/features/finance/ecf/statement_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe "Show ECF statement", :js do
   end
 
   def and_i_see_save_as_pdf_link
-    expected_filename = "#{cpd_lead_provider.name} #{statement.name} ECF Statement (#{cohort.start_year} Cohort)"
+    expected_filename = "#{cpd_lead_provider.name} #{statement.name} ECTE Statement (#{cohort.start_year} Cohort)"
     expect(page).to have_css("a[data-filename='#{expected_filename}']", text: "Save as PDF")
   end
 

--- a/spec/features/nominations/nominate_induction_tutor_steps.rb
+++ b/spec/features/nominations/nominate_induction_tutor_steps.rb
@@ -71,7 +71,7 @@ module NominateInductionTutorSteps
 
   def then_i_should_be_on_the_start_nomination_page
     expect(page).to have_selector("h1", text: "Nominate an induction tutor for your school")
-    expect(page).to have_text("Your induction tutor will be our single point of contact for ECF-based training at your school.")
+    expect(page).to have_text("Your induction tutor will be our single point of contact for early career teacher entitlement (ECTE) at your school.")
     expect(page).to have_text("They’ll use our service to:")
     expect(page).to have_text("report how your school will run training for early career teachers (ECTs)")
   end
@@ -95,7 +95,7 @@ module NominateInductionTutorSteps
   def then_i_should_be_on_the_nominate_sit_success_page
     expect(page).to have_selector("h1", text: "Induction tutor nominated")
     expect(page).to have_selector("h2", text: "What happens next")
-    expect(page).to have_text("This person is now our single point of contact for ECF-based training at your school.")
+    expect(page).to have_text("This person is now our single point of contact for early career teacher entitlement (ECTE) at your school.")
     expect(page).to have_text("They'll use our service to:")
     expect(page).to have_text("We've sent them an email to confirm you nominated them.")
   end

--- a/spec/features/schools/choose_programme/choose_programme_steps.rb
+++ b/spec/features/schools/choose_programme/choose_programme_steps.rb
@@ -103,7 +103,7 @@ module ChooseProgrammeSteps
       expect(page).to have_content("You‘ve chosen to deliver your own programme using DfE-accredited materials.")
     else
       expect(page).to have_content("Are you sure you want to run your own training programme?")
-      expect(page).to have_content("You’re choosing to design and deliver your own programme based on the early career framework (ECF).")
+      expect(page).to have_content("You’re choosing to design and deliver your own programme based on the initial teacher training and early career framework (ITTECF).")
     end
   end
 

--- a/spec/features/schools/participants/transferring_participants/already_enrolled_at_school_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/already_enrolled_at_school_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe "Transferring participants", type: :feature, js: true, rutabaga: 
   end
 
   def then_i_should_be_on_the_already_enrolled_page
-    expect(page).to have_text("Our records show this person is already registered on an ECF-based training programme at your school")
+    expect(page).to have_text("Our records show this person is already registered on an early career training programme at your school")
   end
 
   # and

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_different_partner_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_different_partner_spec.rb
@@ -280,12 +280,12 @@ RSpec.describe "Transferring ECT is with a different lead provider", type: :feat
 
   def then_i_should_be_on_the_complete_page
     expect(page).to have_selector("h2", text: "What happens next")
-    expect(page).to have_text("We’ll let this person know you’ve registered them for ECF-based training at your school.")
+    expect(page).to have_text("We’ll let this person know you’ve registered them for early career training at your school.")
   end
 
   def then_i_should_be_on_the_complete_page_for_an_existing_induction
     expect(page).to have_selector("h2", text: "What happens next")
-    expect(page).to have_text("We’ll let this person know you’ve registered them for ECF-based training at your school.")
+    expect(page).to have_text("We’ll let this person know you’ve registered them for early career training at your school.")
     expect(page).to have_text("We’ll contact their training lead provider, #{@lead_provider_two.name}, to let them know that you’ve reported their transfer too.")
   end
 

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_different_partner_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_different_partner_spec.rb
@@ -274,12 +274,12 @@ RSpec.describe "Transferring a mentor with a different provider", type: :feature
 
   def then_i_should_be_on_the_complete_page
     expect(page).to have_selector("h2", text: "What happens next")
-    expect(page).to have_text("We’ll let this person know you’ve registered them for ECF-based training at your school")
+    expect(page).to have_text("We’ll let this person know you’ve registered them for early career training at your school")
   end
 
   def then_i_should_be_on_the_complete_page_for_an_existing_induction
     expect(page).to have_selector("h2", text: "What happens next")
-    expect(page).to have_text("We’ll let this person know you’ve registered them for ECF-based training at your school.")
+    expect(page).to have_text("We’ll let this person know you’ve registered them for early career training at your school.")
     expect(page).to have_text("We’ll contact their training lead provider, #{@lead_provider_two.name}, to let them know that you’ve reported their transfer too.")
   end
 

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_no_change_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_no_change_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe "Transferring a mentor weith matching lead provider and delivery 
 
   def then_i_should_be_on_the_complete_page
     expect(page).to have_selector("h2", text: "What happens next")
-    expect(page).to have_text("We’ll let this person know you’ve registered them for ECF-based training at your school")
+    expect(page).to have_text("We’ll let this person know you’ve registered them for early career training at your school")
   end
 
   def then_i_should_see_the_transferring_participant

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -1429,12 +1429,12 @@ module ManageTrainingSteps
 
   def then_i_am_taken_to_the_cannot_add_page_same_school
     expect(page).to have_selector("h1", text: "You cannot add Sally Teacher")
-    expect(page).to have_text("Our records show this person is already registered on an ECF-based training programme at your school")
+    expect(page).to have_text("Our records show this person is already registered on an early career training programme at your school")
   end
 
   def then_i_am_taken_to_the_cannot_add_page_different_school
     expect(page).to have_selector("h1", text: "You cannot add Sally Teacher")
-    expect(page).to have_text("Our records show this person is already registered on an ECF-based training programme at a different school")
+    expect(page).to have_text("Our records show this person is already registered on an early career training programme at a different school")
   end
 
   def then_i_see_i_cannot_add_participant_yet

--- a/spec/forms/schools/cohorts/wizard_steps/how_will_you_run_training_step_spec.rb
+++ b/spec/forms/schools/cohorts/wizard_steps/how_will_you_run_training_step_spec.rb
@@ -159,15 +159,15 @@ RSpec.describe Schools::Cohorts::WizardSteps::HowWillYouRunTrainingStep, type: :
         {
           full_induction_programme: {
             name: "Provider-led",
-            description: "Your school will work with providers who will deliver early career framework based training funded by the Department for Education.",
+            description: "Your school will work with providers who will deliver initial teacher training and early career framework based training funded by the Department for Education.",
           },
           school_funded_fip: {
             name: "Provider-led",
-            description: "Your school will fund providers who will deliver early career framework based training.",
+            description: "Your school will fund providers who will deliver initial teacher training and early career framework based training.",
           },
           core_induction_programme: {
             name: "School-led",
-            description: "Your school will deliver training based on the early career framework.",
+            description: "Your school will deliver training based on the initial teacher training and early career framework.",
           },
         }
       end

--- a/spec/requests/sandbox_spec.rb
+++ b/spec/requests/sandbox_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Sandbox landing page", type: :request do
     it "should explain how to get started as an ECF Lead Provider" do
       get sandbox_path
 
-      expect(response.body).to include "Impersonate ECF school induction tutors"
+      expect(response.body).to include "Impersonate ECTE school induction tutors"
     end
 
     it "should signpost visitors to the Lead Provider Guidance" do

--- a/spec/support/features/pages/finance/finance_payment_breakdown_report.rb
+++ b/spec/support/features/pages/finance/finance_payment_breakdown_report.rb
@@ -10,7 +10,7 @@ require_relative "../../sections/contract_information_finance_panel"
 module Pages
   class FinancePaymentBreakdownReport < Pages::BasePage
     set_url "/finance/ecf/payment_breakdowns/{lead_provider_id}/statements/{statement_name}"
-    set_primary_heading "Early career framework (ECF)"
+    set_primary_heading "Initial teacher training and early career framework (ITTECF)"
 
     section :statement_selector, Sections::StatementSelector
     section :summary_panel, Sections::SummaryFinancePanel

--- a/spec/support/features/pages/lead_provider/lead_provider_landing_page.rb
+++ b/spec/support/features/pages/lead_provider/lead_provider_landing_page.rb
@@ -14,7 +14,7 @@ module Pages
     end
 
     def learn_to_manage_ecf_partnerships
-      click_on "How to manage ECF partnerships"
+      click_on "How to manage ECTE partnerships"
 
       Pages::LeadProviderPartnershipGuidancePage.loaded
     end


### PR DESCRIPTION
### Context
update ECF1 terminology to reflect changes for 2025 cohorts

- Ticket: [1712](https://github.com/orgs/DFE-Digital/projects/48/views/1?filterQuery=1712&pane=issue&itemId=113833136&issue=DFE-Digital%7Cregister-ects-project-board%7C1712)

### Changes proposed in this pull request
Various terminology changes. These include where we refer to:

- the ECF (framework), update to ITTECF.
- 'ECF-based training and induction' update to early career teacher entitlement (ECTE)
- 'ECF-based training' update to 'early career training' or 'early career training programme' depending on context

Update links. Where linking to ECF guidance docs, update to link to ITTECF guidance docs.

### Guidance to review
List of files in [1712](https://github.com/orgs/DFE-Digital/projects/48/views/1?filterQuery=1712&pane=issue&itemId=113833136&issue=DFE-Digital%7Cregister-ects-project-board%7C1712).

A sanity/literal url check where links have been changed would be helpful.

Not all files originally identified needed change. This was where terminology was:
- in the context of early roll-out
- in existing code links
- referring to to legacy docs (provider PDFs for example) that used old terms  