### PR TITLE
[1754] Tweak TrainingRecordState service class

### DIFF
--- a/app/services/training_record_state.rb
+++ b/app/services/training_record_state.rb
@@ -44,6 +44,7 @@
 # mentoring_state:
 #   active_mentoring
 #   active_mentoring_ero
+#   left
 #   not_a_mentor
 #   not_yet_mentoring
 #   not_yet_mentoring_ero
@@ -299,6 +300,9 @@ class TrainingRecordState
     in { mentoring: false, previous_participation_reason: true }
       :not_yet_mentoring_ero
 
+    in { mentoring: false, transferred: true }
+      :left
+
     else
       :not_yet_mentoring
     end
@@ -520,6 +524,7 @@ private
       mentor: mentor?,
       mentoring: mentoring?,
       previous_participation_reason: previous_participation_reason?,
+      transferred: left_school?,
     }
   end
 
@@ -549,6 +554,7 @@ private
 
   def mentoring?
     return false unless mentor?
+    return false if left_school?
     return induction_record.transient_current_mentees if induction_record.respond_to?(:transient_current_mentees)
 
     @mentoring ||= InductionRecord.current.where(mentor_profile_id: participant_profile.id).exists?

--- a/spec/services/training_record_state_spec.rb
+++ b/spec/services/training_record_state_spec.rb
@@ -1227,9 +1227,9 @@ RSpec.describe TrainingRecordState do
                          :valid,
                          :eligible_for_mentor_training,
                          :eligible_for_mentor_funding,
-                         :active_mentoring,
                          :left,
-                         :active_mentoring
+                         :left,
+                         :left
       end
 
       context "and they are transferring from their current school" do
@@ -1251,9 +1251,9 @@ RSpec.describe TrainingRecordState do
                          :valid,
                          :eligible_for_mentor_training,
                          :eligible_for_mentor_funding,
-                         :active_mentoring,
                          :left,
-                         :active_mentoring
+                         :left,
+                         :left
       end
 
       context "and they are joining their current school" do
@@ -1617,9 +1617,9 @@ RSpec.describe TrainingRecordState do
                          :valid,
                          :eligible_for_mentor_training,
                          :eligible_for_mentor_funding,
-                         :active_mentoring,
                          :left,
-                         :active_mentoring
+                         :left,
+                         :left
       end
 
       context "and they are transferring from their current school" do
@@ -1641,9 +1641,9 @@ RSpec.describe TrainingRecordState do
                          :valid,
                          :eligible_for_mentor_training,
                          :eligible_for_mentor_funding,
-                         :active_mentoring,
                          :left,
-                         :active_mentoring
+                         :left,
+                         :left
       end
 
       context "and they are joining their current school" do


### PR DESCRIPTION
### Context

- Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/1754

Mentor left school but is being displayed as `Training or eligible for training` on the old delivery partner dashboard.
The logic determining the displayed status appears to not considering the induction status (in this case, "leaving"). As a result, it mistakenly attributes the new school's mentee record to the previous school and returns `:active_mentoring` as the participant's status. We need to incorporate induction status more accurately.

### Changes proposed in this pull request

When a `InductionRecord` has induction status = `leaving` for a delivery partner:
- Take in consideration in the logic when a mentor left a school -> `mentoring?` method will return false instead.
- Then return `:left` on `mentoring_state` when mentor is not mentoring and has been transferred.

### Guidance to review

- Snapshot db.
- Same participant can be seen in the old and new delivery partner dashboard.

Logged in as old delivery partner:
![image](https://github.com/user-attachments/assets/80d38573-346c-45a8-81e4-b9e9bf500bbc)

Logged in as new delivery partner:
![image](https://github.com/user-attachments/assets/518ffc33-07ca-461e-91c8-4ca6d556975b)

