### PR TITLE
Update the school sit comms tag to 2025

### DIFF
--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -451,7 +451,7 @@ class SchoolMailer < ApplicationMailer
         email_address: sit_user.email,
         nomination_link:,
       },
-    ).tag(:launch_ask_sit_to_report_school_training_details_for_2024).associate_with(sit_user.school, sit_user)
+    ).tag(:launch_ask_sit_to_report_school_training_details_for_2025).associate_with(sit_user.school, sit_user)
   end
 
   def launch_ask_gias_contact_to_report_school_training_details

--- a/lib/tasks/comms.rake
+++ b/lib/tasks/comms.rake
@@ -144,7 +144,7 @@ namespace :comms do
       end
 
       school.induction_coordinators.each do |sit_user|
-        if Email.tagged_with(:launch_ask_sit_to_report_school_training_details_for_2024).associated_with(sit_user).where.not(status: Email::FAILED_STATUSES).any?
+        if Email.tagged_with(:launch_ask_sit_to_report_school_training_details_for_2025).associated_with(sit_user).where.not(status: Email::FAILED_STATUSES).any?
           logger.info "The SIT has been already contacted"
           next
         end


### PR DESCRIPTION
### Context

- Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/1760

Update email tag to ensure school SITs receive only one copy of the upcoming 2025 training comms.