### PR TITLE
DfE Analytics does not get TRN when participant added

### DIFF
--- a/app/forms/schools/add_participants/add_wizard.rb
+++ b/app/forms/schools/add_participants/add_wizard.rb
@@ -132,6 +132,9 @@ module Schools
 
         send_added_and_validated_email(profile) if profile && profile.ecf_participant_validation_data.present? && !sit_mentor?
 
+        # trigger an update to analytics so they receive the populated TRN
+        profile.teacher_profile.reload.touch if profile.present?
+
         profile
       end
 


### PR DESCRIPTION
### Context

Due to the nature/architecture of the code that validates and checks eligibility when the TRN is added to the `TeacherProfile` record it is not picked up by the analytics.  The reason is because this is in nested transactions and the `object_id` of the profile changes during a query in one of the services involved.

We can fix this by `touch`ing the record after it has been successfully created which will send an update event to analytics that contains the record with the TRN present.

### Changes proposed in this pull request

Touch the newly created `TeacherProfile` once the creation has successfully completed

### Guidance to review

