### PR TITLE
Spike into including leaving declarations

### DIFF
--- a/app/services/api/v3/participant_declarations_query.rb
+++ b/app/services/api/v3/participant_declarations_query.rb
@@ -16,7 +16,7 @@ module Api
       end
 
       def participant_declarations_for_pagination
-        filterable_attributes = %i[id created_at user_id updated_at delivery_partner_id type]
+        filterable_attributes = %i[id created_at user_id updated_at delivery_partner_id type declaration_type]
         scope = ParticipantDeclaration::ECF.union(
           declarations_scope.select(*filterable_attributes),
           ecf_previous_declarations_scope.select(*filterable_attributes),

--- a/app/services/api/v3/participant_declarations_query_new.rb
+++ b/app/services/api/v3/participant_declarations_query_new.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+module Api
+  module V3
+    class ParticipantDeclarationsQueryNew
+      include Api::Concerns::FilterCohorts
+      include Api::Concerns::FilterUpdatedSince
+
+      RELEVANT_INDUCTION_STATUS = %w[active completed leaving].freeze
+
+      attr_reader :cpd_lead_provider, :params
+
+      def initialize(cpd_lead_provider:, params:)
+        @cpd_lead_provider = cpd_lead_provider
+        @params = params
+      end
+
+      def participant_declarations_for_pagination
+        filterable_attributes = %i[id created_at user_id updated_at delivery_partner_id type]
+        scope = ParticipantDeclaration::ECF.union(
+          declarations_scope.select(*filterable_attributes),
+          ecf_previous_declarations_scope.select(*filterable_attributes),
+        )
+
+        if participant_ids.present?
+          scope = scope.where(user_id: participant_ids)
+        end
+
+        if updated_since_filter.present?
+          scope = scope.where(updated_at: updated_since..)
+        end
+
+        if delivery_partner_ids.present?
+          scope = scope.where(delivery_partner_id: delivery_partner_ids)
+        end
+
+        scope
+         .select(:id, :created_at)
+         .order(:created_at)
+      end
+
+      def participant_declarations_from(paginated_join)
+        ParticipantDeclaration::ECF
+          .includes(
+            :statement_line_items,
+            :declaration_states,
+            :participant_profile,
+            :cpd_lead_provider,
+          )
+          .where(participant_declarations: { id: paginated_join.map(&:id) })
+          .order(:created_at)
+          .distinct
+      end
+
+      def participant_declaration(id)
+        ParticipantDeclaration::ECF.union(
+          declarations_scope,
+          ecf_previous_declarations_scope,
+        ).find(id)
+      end
+
+    private
+
+      def lead_provider
+        cpd_lead_provider.lead_provider if cpd_lead_provider.respond_to?(:lead_provider)
+      end
+
+      def declarations_scope
+        scope = ParticipantDeclaration::ECF.for_lead_provider(cpd_lead_provider)
+          .left_outer_joins(:cohort)
+        filter_cohorts(scope)
+      end
+
+      def ecf_previous_declarations_scope
+        scope = ParticipantDeclaration::ECF
+          .left_outer_joins(
+            :cohort,
+            participant_profile: [
+              { induction_records: [
+                { induction_programme: :partnership },
+              ] },
+            ],
+          )
+          .where.not(participant_profile: { induction_records: { induction_programmes: { partnership_id: nil } } }) # Exclude any nil partnerships (eg: cip)
+          .where(participant_profile: { induction_records: { induction_programme: { partnerships: { lead_provider_id: lead_provider&.id } } } })
+          .where(participant_profile: { induction_records: { induction_status: RELEVANT_INDUCTION_STATUS } }) # only want induction records that are the winning latest ones
+          .where(state: %w[submitted eligible payable paid])
+          .where("induction_records.end_date IS NULL OR participant_declarations.declaration_date <= induction_records.end_date")
+
+        scope = filter_cohorts(scope) if lead_provider.present?
+
+        scope
+      end
+
+      def filter_cohorts(scope)
+        return scope if cohort_years.blank?
+
+        scope.where(cohort: { start_year: cohort_years })
+      end
+
+      def participant_ids
+        filter[:participant_id]&.split(",")
+      end
+
+      def delivery_partner_ids
+        filter[:delivery_partner_id]&.split(",")
+      end
+    end
+  end
+end

--- a/app/services/api/v3/participant_declarations_query_new.rb
+++ b/app/services/api/v3/participant_declarations_query_new.rb
@@ -6,7 +6,7 @@ module Api
       include Api::Concerns::FilterCohorts
       include Api::Concerns::FilterUpdatedSince
 
-      RELEVANT_INDUCTION_STATUS = %w[active completed leaving].freeze
+      RELEVANT_INDUCTION_STATUS = %w[active completed].freeze
 
       attr_reader :cpd_lead_provider, :params
 
@@ -20,6 +20,7 @@ module Api
         scope = ParticipantDeclaration::ECF.union(
           declarations_scope.select(*filterable_attributes),
           ecf_previous_declarations_scope.select(*filterable_attributes),
+          ecf_previous_declarations_leaving_scope.select(*filterable_attributes),
         )
 
         if participant_ids.present?
@@ -85,7 +86,27 @@ module Api
           .where(participant_profile: { induction_records: { induction_programme: { partnerships: { lead_provider_id: lead_provider&.id } } } })
           .where(participant_profile: { induction_records: { induction_status: RELEVANT_INDUCTION_STATUS } }) # only want induction records that are the winning latest ones
           .where(state: %w[submitted eligible payable paid])
-          .where("induction_records.end_date IS NULL OR participant_declarations.declaration_date <= induction_records.end_date")
+
+        scope = filter_cohorts(scope) if lead_provider.present?
+
+        scope
+      end
+
+      def ecf_previous_declarations_leaving_scope
+        scope = ParticipantDeclaration::ECF
+        .left_outer_joins(
+          :cohort,
+          participant_profile: [
+            { induction_records: [
+              { induction_programme: :partnership },
+            ] },
+          ],
+        )
+        .where.not(participant_profile: { induction_records: { induction_programmes: { partnership_id: nil } } }) # Exclude any nil partnerships (eg: cip)
+        .where(participant_profile: { induction_records: { induction_programme: { partnerships: { lead_provider_id: lead_provider&.id } } } })
+        .where(participant_profile: { induction_records: { induction_status: :leaving } }) # only want induction records that are the winning latest ones
+        .where(state: %w[submitted eligible payable paid])
+        .where("induction_records.end_date IS NULL OR participant_declarations.declaration_date <= induction_records.end_date")
 
         scope = filter_cohorts(scope) if lead_provider.present?
 

--- a/app/services/api/v3/participant_declarations_query_new_unchallenged.rb
+++ b/app/services/api/v3/participant_declarations_query_new_unchallenged.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+module Api
+  module V3
+    class ParticipantDeclarationsQueryNewUnchallenged
+      include Api::Concerns::FilterCohorts
+      include Api::Concerns::FilterUpdatedSince
+
+      RELEVANT_INDUCTION_STATUS = %w[active completed leaving].freeze
+
+      attr_reader :cpd_lead_provider, :params
+
+      def initialize(cpd_lead_provider:, params:)
+        @cpd_lead_provider = cpd_lead_provider
+        @params = params
+      end
+
+      def participant_declarations_for_pagination
+        filterable_attributes = %i[id created_at user_id updated_at delivery_partner_id type]
+        scope = ParticipantDeclaration::ECF.union(
+          declarations_scope.select(*filterable_attributes),
+          ecf_previous_declarations_scope.select(*filterable_attributes),
+        )
+
+        if participant_ids.present?
+          scope = scope.where(user_id: participant_ids)
+        end
+
+        if updated_since_filter.present?
+          scope = scope.where(updated_at: updated_since..)
+        end
+
+        if delivery_partner_ids.present?
+          scope = scope.where(delivery_partner_id: delivery_partner_ids)
+        end
+
+        scope
+         .select(:id, :created_at)
+         .order(:created_at)
+      end
+
+      def participant_declarations_from(paginated_join)
+        ParticipantDeclaration::ECF
+          .includes(
+            :statement_line_items,
+            :declaration_states,
+            :participant_profile,
+            :cpd_lead_provider,
+          )
+          .where(participant_declarations: { id: paginated_join.map(&:id) })
+          .order(:created_at)
+          .distinct
+      end
+
+      def participant_declaration(id)
+        ParticipantDeclaration::ECF.union(
+          declarations_scope,
+          ecf_previous_declarations_scope,
+        ).find(id)
+      end
+
+    private
+
+      def lead_provider
+        cpd_lead_provider.lead_provider if cpd_lead_provider.respond_to?(:lead_provider)
+      end
+
+      def declarations_scope
+        scope = ParticipantDeclaration::ECF.for_lead_provider(cpd_lead_provider)
+          .left_outer_joins(:cohort)
+        filter_cohorts(scope)
+      end
+
+      def ecf_previous_declarations_scope
+        scope = ParticipantDeclaration::ECF
+          .left_outer_joins(
+            :cohort,
+            participant_profile: [
+              { induction_records: [
+                { induction_programme: :partnership },
+              ] },
+            ],
+          )
+          .where.not(participant_profile: { induction_records: { induction_programmes: { partnership_id: nil } } }) # Exclude any nil partnerships (eg: cip)
+          .where(participant_profile: { induction_records: { induction_programme: { partnerships: { lead_provider_id: lead_provider&.id, challenge_reason: nil } } } })
+          .where(participant_profile: { induction_records: { induction_status: RELEVANT_INDUCTION_STATUS } }) # only want induction records that are the winning latest ones
+          .where(state: %w[submitted eligible payable paid])
+          .where("induction_records.end_date IS NULL OR participant_declarations.declaration_date <= induction_records.end_date")
+
+        scope = filter_cohorts(scope) if lead_provider.present?
+
+        scope
+      end
+
+      def filter_cohorts(scope)
+        return scope if cohort_years.blank?
+
+        scope.where(cohort: { start_year: cohort_years })
+      end
+
+      def participant_ids
+        filter[:participant_id]&.split(",")
+      end
+
+      def delivery_partner_ids
+        filter[:delivery_partner_id]&.split(",")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds two new declaration query services for including leaving declarations and only leaving declarations when unchallenged.

Script for analysis (run individually for each LP):

```
lead_provider = LeadProvider.find_by!(name: "Education Development Trust")
affected_user_ids = ParticipantDeclaration::ECF
  .left_outer_joins(
    :cohort,
    participant_profile: [
      { induction_records: [
        { induction_programme: :partnership },
      ] },
    ],
  )
  .where.not(participant_profile: { induction_records: { induction_programmes: { partnership_id: nil } } }) # Exclude any nil partnerships (eg: cip)
  .where(participant_profile: { induction_records: { induction_programme: { partnerships: { lead_provider_id: lead_provider&.id } } } })
  .where(participant_profile: { induction_records: { induction_status: "leaving" } })
  .where(state: %w[submitted eligible payable paid])
  .where("induction_records.end_date IS NULL OR participant_declarations.declaration_date <= induction_records.end_date" )
  .pluck(:user_id)
  .uniq

results = {}

cpd_lead_provider = lead_provider.cpd_lead_provider
results[lead_provider.name] = {}
all_user_ids = Api::V3::ParticipantDeclarationsQuery.new(cpd_lead_provider:, params: {}).participant_declarations_for_pagination.pluck(:user_id).uniq
all_user_ids &= affected_user_ids

progress = 0
total = all_user_ids.size.to_f

ActiveRecord::Base.logger.silence(Logger::FATAL) do
  all_user_ids.each do |participant_id|
    puts "Progress: #{((progress += 1) * 100 / total).round(1)}%"
    current_query = new_query = unchallenged_new_query = nil

    current_benchmark = Benchmark.measure do
      current_query = Api::V3::ParticipantDeclarationsQuery.new(cpd_lead_provider: lead_provider.cpd_lead_provider, params: { filter: { participant_id: } })
    end.real
    new_benchmark = Benchmark.measure do
      new_query = Api::V3::ParticipantDeclarationsQueryNew.new(cpd_lead_provider: lead_provider.cpd_lead_provider, params: { filter: { participant_id: } })
    end.real
    new_unchallenged_benchmark = Benchmark.measure do
      unchallenged_new_query = Api::V3::ParticipantDeclarationsQueryNewUnchallenged.new(cpd_lead_provider: lead_provider.cpd_lead_provider, params: { filter: { participant_id: } })
    end.real

    new_ids = new_query.participant_declarations_for_pagination.pluck(:id)
    new_types = ParticipantDeclaration.where(id: new_ids).pluck(:declaration_type)
    new_unchallenged_ids = unchallenged_new_query.participant_declarations_for_pagination.pluck(:id)
    new_unchallenged_types = ParticipantDeclaration.where(id: new_unchallenged_ids).pluck(:declaration_type)
    old_ids = current_query.participant_declarations_for_pagination.pluck(:id)

    only_in_new = new_ids - old_ids
    only_in_new_unchallenged = new_unchallenged_ids - old_ids
    only_in_current = old_ids - new_ids

    results[lead_provider.name][participant_id] = {
      only_in_current:,
      only_in_new:,
      only_in_new_types: new_types,
      only_in_new_unchallenged:,
      only_in_new_unchallenged_types: new_unchallenged_types,
      current_benchmark:,
      new_benchmark:,
      new_unchallenged_benchmark:,
    } if only_in_new.any? || only_in_current.any? || only_in_new_unchallenged.any?
  end
end

results.each do |lead_provider_name, participants_data|
  filename = "output/#{lead_provider_name.parameterize}_differences.csv"

  CSV.open(filename, "w") do |csv|
    csv << ["Participant ID", "Only in Current", "Only in New", "Only in New Types", "Only in New and Unchallenged", "Only in New and Unchallenged Types", "Current Benchmark", "New Benchmark", "New Unchallenged Benchmark"]

    participants_data.each do |participant_id, diffs|
      csv << [
        participant_id,
        diffs[:only_in_current].join(', '),
        diffs[:only_in_new].join(', '),
        diffs[:only_in_new_types].join(', '),
        diffs[:only_in_new_unchallenged].join(', '),
        diffs[:only_in_new_unchallenged_types].join(', '),
        diffs[:current_benchmark],
        diffs[:new_benchmark],
        diffs[:new_unchallenged_benchmark],
      ]
    end
  end

  puts "Saved CSV: #{filename}"
end
```
