### PR TITLE
Lower rate limit on sandbox to 1500

### DIFF
--- a/terraform/domains/environment_domains/workspace_variables/cpd_ecf_sandbox.tfvars.json
+++ b/terraform/domains/environment_domains/workspace_variables/cpd_ecf_sandbox.tfvars.json
@@ -15,7 +15,7 @@
         "agent": "all",
         "priority": 100,
         "duration": 5,
-        "limit": 2000,
+        "limit": 1500,
         "selector": "Host",
         "operator": "GreaterThanOrEqual",
         "match_values": "0"


### PR DESCRIPTION
Pods are restarting as we're being scanned and going to keep lowering/monitoring

