### PR TITLE
Bump sandbox pods to avoid restarts due to being scanned

### DIFF
--- a/terraform/application/workspace_variables/sandbox.tfvars.json
+++ b/terraform/application/workspace_variables/sandbox.tfvars.json
@@ -9,5 +9,7 @@
   "external_hostname": "sb.manage-training-for-early-career-teachers.education.gov.uk/",
   "webapp_memory_max": "2Gi",
   "enable_dfe_analytics_federated_auth": true,
-  "dataset_name": "ecf_events_sandbox"
+  "dataset_name": "ecf_events_sandbox",
+  "webapp_replicas": 2,
+  "worker_replicas": 2
 }


### PR DESCRIPTION
### Context

We get restarts in sandbox since we're getting scanned. We lowered the rate limit but it seems we also need to bump the pods for contingency

### Changes proposed in this pull request
Bump sandbox web and worker pods to 2, to have a bit of contingency

### Guidance to review
Keep monitoring
