### PR TITLE
Remove cancel-in-progress from deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,6 @@ name: "Deploy"
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
his has been added for concurrency however causes issues with when the job is on the terraform apply step and then the job is cancelled.

Opt to have current jobs complete before kicking off the next job to avoid getting into strange states where resources created are not confirmed in state.