### PR TITLE
Remove extra `<h1>` elements from change training status page

### DIFF
--- a/app/views/finance/ecf/change_training_statuses/new.html.erb
+++ b/app/views/finance/ecf/change_training_statuses/new.html.erb
@@ -25,13 +25,13 @@
     <%= form_for @change_training_status_form, url: create_finance_participant_profile_ecf_induction_records_path(@participant_profile, @induction_record) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset :training_status, legend: { text: "Choose a different training status", tag: 'h1', size: 'm' } do %>
+      <%= f.govuk_radio_buttons_fieldset :training_status, legend: { text: "Choose a different training status", size: 'm' } do %>
         <% @change_training_status_form.training_status_options.values.each_with_index do |val, n| %>
           <%= f.govuk_radio_button :training_status, val, label: { text: val }, link_errors: n.zero? %>
         <% end %>
       <% end %>
 
-      <%= f.govuk_select(:reason, label: { text: "Reason for change", tag: 'h1', size: 'm' }, hint: { text: "Required for deferred or withdrawn" }, options: { include_blank: true }) do %>
+      <%= f.govuk_select(:reason, label: { text: "Reason for change", size: 'm' }, hint: { text: "Required for deferred or withdrawn" }, options: { include_blank: true }) do %>
         <%= grouped_options_for_select @change_training_status_form.reason_options %>
       <% end %>
 


### PR DESCRIPTION
There are three here, there should only be one.
