### PR TITLE
move time of backup from 3am to 5am UTC to test if backup will pass

### DIFF
--- a/.github/workflows/backup_nightly_database.yml
+++ b/.github/workflows/backup_nightly_database.yml
@@ -23,7 +23,7 @@ on:
           Name of the database server. Default is the live server. When backing up a point-in-time (PTR) server, use the full name of the PTR server. (Optional)
 
   schedule:
-    - cron: "0 3 * * *" # 03:00 UTC
+    - cron: "0 5 * * *" # 05:00 UTC
 
 env:
   SERVICE_NAME: cpd-ecf


### PR DESCRIPTION
Backups are failing consistently on the versions table, as it's quite sizeable. However they pass when triggered manually. First pass is to change the time of the backup before we investigate further