### PR TITLE
[2064] Fix declarations api v3 query bug

### DIFF
--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -5,6 +5,18 @@ weight: 8
 
 # Release notes
 
+## 8 September 2025
+
+[#bug-fix #data-update]
+
+### Declarations query bug fixed
+
+We’ve fixed a bug in the declarations query affecting some participants who transferred to a new lead provider.
+
+Due to a data issue, the new provider couldn’t see all declarations made by the previous provider. This prevented them from viewing the participant’s full training engagement.
+
+As a result of this fix, lead providers might notice additional declarations in their next sync.
+
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
 
 ## 24 June 2025


### PR DESCRIPTION
### Context

- Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/2064

A LP that a ppt has transferred to or trained with should be able to see historical decs made by another lead provider. This is so they can see how much engagement has taken place. 

We have identified a bug where participants with leaving and withdrawn inductions result in providers missing out declarations. Where IR are active these can be found but there's a bug in the service that does not permit this.

### Changes proposed in this pull request

- Fix the bug described above.
- Add release note on the bug fix

### Guidance to review

Snapshot db api calls before/after using declaration id examples added to the ticket.
