### PR TITLE
Add Scripts to update mentor contracts and statements

### DIFF
--- a/app/models/finance/statement/ecf.rb
+++ b/app/models/finance/statement/ecf.rb
@@ -15,7 +15,7 @@ class Finance::Statement::ECF < Finance::Statement
 
   def mentor_contract
     MentorCallOffContract.find_by!(
-      version: contract_version,
+      version: mentor_contract_version,
       cohort:,
       lead_provider:,
     )

--- a/app/services/importers/create_statement.rb
+++ b/app/services/importers/create_statement.rb
@@ -46,8 +46,13 @@ module Importers
 
           next if statement
 
-          contract_version = Finance::Statement::ECF.where(cpd_lead_provider:, cohort: statement_data.cohort).order(payment_date: :desc).first&.contract_version
+          latest_statement = Finance::Statement::ECF.where(cpd_lead_provider:, cohort: statement_data.cohort).order(payment_date: :desc).first
+
+          contract_version = latest_statement&.contract_version
           contract_version ||= "0.0.1"
+
+          mentor_contract_version = latest_statement&.mentor_contract_version
+          mentor_contract_version ||= "0.0.1"
 
           Finance::Statement::ECF.create!(
             name: statement_data.name,
@@ -58,6 +63,7 @@ module Importers
             output_fee: statement_data.output_fee,
             type: class_for(statement_data, namespace: statement_data.type),
             contract_version:,
+            mentor_contract_version:,
           )
 
           logger.info "CreateStatement: #{statement_data.cohort.start_year} cohort ECF statements for #{cpd_lead_provider.name} successfully created!"

--- a/app/services/oneoffs/update_mentor_contracts.rb
+++ b/app/services/oneoffs/update_mentor_contracts.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "csv"
+
+module Oneoffs
+  class UpdateMentorContracts
+    include HasRecordableInformation
+
+    def initialize(path_to_csv:)
+      @path_to_csv = path_to_csv
+    end
+
+    def perform_change(dry_run: true)
+      reset_recorded_info
+
+      check_headers!
+
+      record_info("~~~ DRY RUN ~~~") if dry_run
+
+      ActiveRecord::Base.transaction do
+        rows.each do |row|
+          record_info("Looking at provider '#{row['lead-provider-name']}' for cohort '#{row['cohort-start-year']}'")
+
+          cohort = Cohort.find_by!(start_year: row["cohort-start-year"].to_i)
+          lead_provider = LeadProvider.joins(:cohorts).find_by!(name: row["lead-provider-name"], cohorts: { start_year: row["cohort-start-year"].to_i })
+
+          contract_data = build_contract_data(row)
+          create_mentor_call_off_contract(lead_provider:, cohort:, contract_data:)
+        end
+
+        raise ActiveRecord::Rollback if dry_run
+      end
+
+      recorded_info
+    end
+
+  private
+
+    def latest_existing_mentor_contract(lead_provider:, cohort:)
+      mentor_call_off_contracts = MentorCallOffContract.where(
+        lead_provider:,
+        cohort:,
+      ).all
+      mentor_call_off_contracts.max_by { |contract| Finance::ECF::ContractVersion.new(contract.version).numerical_value }
+    end
+
+    def statements(lead_provider:, cohort:)
+      Finance::Statement::ECF.where(
+        cohort:,
+        cpd_lead_provider: lead_provider.cpd_lead_provider,
+      )
+    end
+
+    def create_mentor_call_off_contract(lead_provider:, cohort:, contract_data:)
+      existing_mentor_contract = latest_existing_mentor_contract(lead_provider:, cohort:)
+      record_info "Found existing contract with version '#{existing_mentor_contract.version}'" if existing_mentor_contract
+
+      if existing_contract_matches_contract_data?(existing_mentor_contract:, contract_data:)
+        record_info "Existing contract matches contract data, no need to update"
+        return
+      end
+
+      version = Finance::ECF::ContractVersion.new(existing_mentor_contract&.version || "0.0.0").increment!
+      record_info "Creating new mentor contract with version '#{version}'"
+      MentorCallOffContract.create!(
+        lead_provider:,
+        cohort:,
+        version:,
+        recruitment_target: contract_data[:recruitment_target],
+        payment_per_participant: contract_data[:payment_per_participant],
+      )
+
+      record_info "Updating ECF statements with new version '#{version}'"
+      statements(lead_provider:, cohort:).update!(mentor_contract_version: version)
+
+      record_info "Done"
+    end
+
+    def check_headers!
+      unless %w[lead-provider-name cohort-start-year recruitment-target payment-per-participant].all? { |header| rows.headers.include?(header) }
+        raise NameError, "Invalid CSV headers"
+      end
+    end
+
+    def existing_contract_matches_contract_data?(existing_mentor_contract:, contract_data:)
+      return false unless existing_mentor_contract
+
+      existing_mentor_contract.recruitment_target.to_s == contract_data[:recruitment_target].to_s &&
+        existing_mentor_contract.payment_per_participant.to_s == contract_data[:payment_per_participant].to_f.to_s
+    end
+
+    def rows
+      @rows ||= CSV.read(@path_to_csv, headers: true)
+    end
+
+    def build_contract_data(row)
+      {
+        recruitment_target: row["recruitment-target"],
+        payment_per_participant: row["payment-per-participant"],
+      }
+    end
+  end
+end

--- a/app/services/oneoffs/update_statements.rb
+++ b/app/services/oneoffs/update_statements.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "csv"
+
+module Oneoffs
+  class UpdateStatements
+    include HasRecordableInformation
+
+    def initialize(path_to_csv:)
+      @path_to_csv = path_to_csv
+    end
+
+    def perform_change(dry_run: true)
+      reset_recorded_info
+
+      check_headers!
+
+      record_info("~~~ DRY RUN ~~~") if dry_run
+
+      ActiveRecord::Base.transaction do
+        rows.each do |row|
+          record_info("Looking at statements for cohort: #{row['cohort']} and name: #{row['name']}")
+
+          statement_data = build_statement_data(row)
+          update_statements(statement_data:)
+        end
+
+        raise ActiveRecord::Rollback if dry_run
+      end
+
+      recorded_info
+    end
+
+  private
+
+    def update_statements(statement_data:)
+      cohort = statement_data[:cohort]
+      name = statement_data[:name]
+
+      statements = Finance::Statement::ECF.where(
+        cohort:,
+        name:,
+      )
+
+      if statements.none?
+        record_info "No statements found for cohort: #{cohort.start_year} with name: #{name}"
+        return
+      end
+
+      statements.each do |statement|
+        update_statement!(statement:, statement_data:)
+      end
+    end
+
+    def update_statement!(statement:, statement_data:)
+      statement.deadline_date = statement_data[:deadline_date]
+      statement.payment_date = statement_data[:payment_date]
+      statement.output_fee = statement_data[:output_fee]
+
+      if statement.has_changes_to_save?
+        record_info "Updating statement: '#{statement.id}' with changes: #{statement.changes_to_save.inspect}"
+        statement.save!
+      else
+        record_info "No updates made to statement: '#{statement.id}' with cohort: #{statement.cohort.start_year} and name: #{statement.name}"
+      end
+    end
+
+    def check_headers!
+      unless %w[type name cohort deadline_date payment_date output_fee].all? { |header| rows.headers.include?(header) }
+        raise NameError, "Invalid CSV headers"
+      end
+    end
+
+    def rows
+      @rows ||= CSV.read(@path_to_csv, headers: true)
+    end
+
+    def build_statement_data(row)
+      {
+        name: row["name"],
+        cohort: Cohort.find_by!(start_year: row["cohort"]),
+        deadline_date: Date.parse(row["deadline_date"]),
+        payment_date: Date.parse(row["payment_date"]),
+        output_fee: ActiveModel::Type::Boolean.new.cast(row["output_fee"]),
+      }
+    end
+  end
+end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -50,6 +50,7 @@
   :statements:
   - original_value
   - contract_version
+  - mentor_contract_version
   - reconcile_amount
   - marked_as_paid_at
   :schedule_milestones:

--- a/db/migrate/20250828003324_add_mentor_contract_version_to_statements.rb
+++ b/db/migrate/20250828003324_add_mentor_contract_version_to_statements.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMentorContractVersionToStatements < ActiveRecord::Migration[7.1]
+  def change
+    add_column :statements, :mentor_contract_version, :string, default: "0.0.1"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_02_28_135429) do
+ActiveRecord::Schema[7.1].define(version: 2025_08_28_003324) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -1113,6 +1113,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_28_135429) do
     t.string "contract_version", default: "0.0.1"
     t.decimal "reconcile_amount", default: "0.0", null: false
     t.datetime "marked_as_paid_at"
+    t.string "mentor_contract_version", default: "0.0.1"
     t.index ["cohort_id"], name: "index_statements_on_cohort_id"
     t.index ["cpd_lead_provider_id"], name: "index_statements_on_cpd_lead_provider_id"
   end

--- a/spec/factories/finance/statements.rb
+++ b/spec/factories/finance/statements.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     payment_date  { Time.zone.today.end_of_month }
     cohort        { Cohort.current || create(:cohort, :current) }
     contract_version { "1.0" }
+    mentor_contract_version { "1.0" }
 
     factory :ecf_statement, class: "Finance::Statement::ECF" do
       cpd_lead_provider { association :cpd_lead_provider, :with_lead_provider }

--- a/spec/features/finance/payment_breakdown_spec.rb
+++ b/spec/features/finance/payment_breakdown_spec.rb
@@ -15,8 +15,8 @@ RSpec.feature "Finance users payment breakdowns", type: :feature, js: true do
   let(:voided_declarations) { create_list(:ect_participant_declaration, 2, :eligible, :voided, cpd_lead_provider:) }
   let(:clawed_back_declarations) { create_list(:ect_participant_declaration, 3, :eligible, cpd_lead_provider:).each(&:clawed_back!) }
 
-  let!(:january_statement) { create(:ecf_statement, name: "January #{next_start_year}", deadline_date: Date.new(next_start_year, 1, 31), cpd_lead_provider:, contract_version: contract.version) }
-  let!(:november_statement) { create(:ecf_statement, name: "November #{current_start_year}", deadline_date: Date.new(current_start_year, 11, 30), cpd_lead_provider:, contract_version: contract.version) }
+  let!(:january_statement) { create(:ecf_statement, name: "January #{next_start_year}", deadline_date: Date.new(next_start_year, 1, 31), cpd_lead_provider:, contract_version: contract.version, mentor_contract_version: mentor_contract.version) }
+  let!(:november_statement) { create(:ecf_statement, name: "November #{current_start_year}", deadline_date: Date.new(current_start_year, 11, 30), cpd_lead_provider:, contract_version: contract.version, mentor_contract_version: mentor_contract.version) }
 
   let(:jan_statement_calculator) { Finance::ECF::StatementCalculator.new(statement: january_statement) }
   let(:nov_statement_ect_calculator) { Finance::ECF::ECT::StatementCalculator.new(statement: november_statement) }

--- a/spec/models/finance/statement/ecf_spec.rb
+++ b/spec/models/finance/statement/ecf_spec.rb
@@ -8,11 +8,12 @@ RSpec.describe Finance::Statement::ECF do
   let(:lead_provider) { cpd_lead_provider.lead_provider }
 
   let(:contract_version) { "0.0.2" }
-
   let!(:call_off_contract) { create(:call_off_contract, cohort:, lead_provider:, version: contract_version) }
-  let!(:mentor_call_off_contract) { create(:mentor_call_off_contract, cohort:, lead_provider:, version: contract_version) }
 
-  subject { create(:ecf_statement, cpd_lead_provider:, cohort:, contract_version:) }
+  let(:mentor_contract_version) { "0.0.3" }
+  let!(:mentor_call_off_contract) { create(:mentor_call_off_contract, cohort:, lead_provider:, version: mentor_contract_version) }
+
+  subject { create(:ecf_statement, cpd_lead_provider:, cohort:, contract_version:, mentor_contract_version:) }
 
   describe "#payable!" do
     it "transitions the statement to payable" do

--- a/spec/services/importers/create_statement_spec.rb
+++ b/spec/services/importers/create_statement_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Importers::CreateStatement do
 
     context "when contracts for the cohort exists" do
       let!(:ecf_contract) { create(:call_off_contract, lead_provider:, version: "0.0.1", cohort: cohort_2023) }
+      let!(:ecf_mentor_contract) { create(:mentor_call_off_contract, lead_provider:, version: "0.0.1", cohort: cohort_2023) }
 
       it "creates ECF statements idempotently" do
         expect {
@@ -42,6 +43,7 @@ RSpec.describe Importers::CreateStatement do
             deadline_date: Date.new(2023, 12, 31),
             payment_date: Date.new(2024, 1, 25),
             contract_version: "0.0.1",
+            mentor_contract_version: "0.0.1",
             output_fee: true,
           ),
         ).to be_present
@@ -53,6 +55,7 @@ RSpec.describe Importers::CreateStatement do
             deadline_date: Date.new(2024, 1, 31),
             payment_date: Date.new(2024, 2, 25),
             contract_version: "0.0.1",
+            mentor_contract_version: "0.0.1",
             output_fee: false,
           ),
         ).to be_present
@@ -78,6 +81,7 @@ RSpec.describe Importers::CreateStatement do
             statement_attributes.merge({
               cpd_lead_provider: create(:cpd_lead_provider, :with_lead_provider),
               contract_version: "0.0.8",
+              mentor_contract_version: "0.0.9",
             }),
           )
 
@@ -86,6 +90,7 @@ RSpec.describe Importers::CreateStatement do
             statement_attributes.merge({
               cohort: cohort_2023.previous,
               contract_version: "0.0.8",
+              mentor_contract_version: "0.0.9",
             }),
           )
 
@@ -93,6 +98,7 @@ RSpec.describe Importers::CreateStatement do
           statement_type.create!(
             statement_attributes.merge({
               contract_version: "0.0.8",
+              mentor_contract_version: "0.0.9",
               payment_date: "2023-12-24",
             }),
           )
@@ -102,6 +108,7 @@ RSpec.describe Importers::CreateStatement do
         Finance::Statement::ECF.create!(
           statement_attributes.merge({
             contract_version: "0.0.5",
+            mentor_contract_version: "0.0.4",
           }),
         )
       end
@@ -117,6 +124,7 @@ RSpec.describe Importers::CreateStatement do
         )
 
         expect(st.contract_version).to eql("0.0.5")
+        expect(st.mentor_contract_version).to eql("0.0.4")
       end
     end
 

--- a/spec/services/oneoffs/update_mentor_contracts_spec.rb
+++ b/spec/services/oneoffs/update_mentor_contracts_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+RSpec.describe Oneoffs::UpdateMentorContracts do
+  let!(:cohort) { create(:cohort, start_year: 2025) }
+  let!(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider, name: "Great Provider") }
+  let(:lead_provider) { cpd_lead_provider.lead_provider }
+  let(:statement) { create(:ecf_statement, cohort:, cpd_lead_provider:, contract_version: "0.0.7") }
+
+  let(:dry_run) { false }
+
+  let(:csv_content) do
+    <<~CSV
+      lead-provider-name,cohort-start-year,recruitment-target,payment-per-participant
+      Great Provider,2025,100,11500
+    CSV
+  end
+
+  let(:instance) { described_class.new(path_to_csv:) }
+  subject(:perform_change) { instance.perform_change(dry_run:) }
+
+  let(:csv) { Tempfile.new("mentor_contracts.csv") }
+  let(:path_to_csv) { csv.path }
+
+  before do
+    allow(Rails.logger).to receive(:info)
+
+    csv.write(csv_content)
+    csv.rewind
+  end
+
+  after do
+    csv.close
+    csv.unlink
+  end
+
+  describe "#perform_change" do
+    context "when dry run is false" do
+      it { is_expected.to eq(instance.recorded_info) }
+
+      context "when there are no existing mentor contracts" do
+        it "creates a new mentor call off contract with correct values " do
+          expect { perform_change }.to change { MentorCallOffContract.count }.by(1)
+
+          new_mentor_contract = MentorCallOffContract.first
+          expect(new_mentor_contract.recruitment_target).to eq(100)
+          expect(new_mentor_contract.payment_per_participant).to eq(11_500)
+        end
+
+        it "updates existing statements with the new mentor contract version" do
+          expect { perform_change }.to change { statement.reload.mentor_contract_version }.to("0.0.1")
+        end
+      end
+
+      context "when a mentor contract already exists and matches data" do
+        let!(:existing_mentor_contract) do
+          create(
+            :mentor_call_off_contract,
+            lead_provider:,
+            cohort:,
+            recruitment_target: 100,
+            payment_per_participant: 11_500,
+            version: "0.0.7",
+          )
+        end
+
+        it "does not create a new mentor contract" do
+          expect { perform_change }.not_to change { MentorCallOffContract.count }
+        end
+
+        it "records that the existing contract matches" do
+          expect(perform_change).to include("Existing contract matches contract data, no need to update")
+        end
+      end
+
+      context "when the contract exists but does not match data" do
+        let!(:older_mentor_contract) do
+          create(
+            :mentor_call_off_contract,
+            lead_provider:,
+            cohort:,
+            recruitment_target: 10,
+            payment_per_participant: 500,
+            version: "0.0.6",
+          )
+        end
+
+        let!(:existing_mentor_contract) do
+          create(
+            :mentor_call_off_contract,
+            lead_provider:,
+            cohort:,
+            recruitment_target: 50,
+            payment_per_participant: 1000,
+            version: "0.0.7",
+          )
+        end
+        let(:new_mentor_contract) { MentorCallOffContract.where.not(id: [existing_mentor_contract, older_mentor_contract]).first }
+
+        it "creates mentor contract with correct values" do
+          expect { perform_change }.to change { MentorCallOffContract.count }.by(1)
+
+          expect(new_mentor_contract.recruitment_target).to eq(100)
+          expect(new_mentor_contract.payment_per_participant).to eq(11_500)
+        end
+
+        it "creates a new mentor contract version" do
+          perform_change
+
+          expect(new_mentor_contract.version).to eq("0.0.8")
+        end
+
+        it "updates the statements with the new version" do
+          expect { perform_change }.to change { statement.reload.mentor_contract_version }.to("0.0.8")
+        end
+      end
+
+      context "when headers are invalid" do
+        let(:csv_content) do
+          <<~CSV
+            invalid-header-name,cohort-start-year,recruitment-target,payment-per-participant
+          CSV
+        end
+
+        it "raises a NameError" do
+          expect { perform_change }.to raise_error(NameError, "Invalid CSV headers")
+        end
+      end
+
+      context "when dry run is true" do
+        let(:dry_run) { true }
+
+        it "does not persist any changes" do
+          expect { perform_change }.not_to change { MentorCallOffContract.count }
+        end
+
+        it "records information about the dry run" do
+          expect(perform_change).to include("~~~ DRY RUN ~~~")
+        end
+      end
+    end
+  end
+end

--- a/spec/services/oneoffs/update_statements_spec.rb
+++ b/spec/services/oneoffs/update_statements_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+describe Oneoffs::UpdateStatements do
+  let(:cohort) { create(:cohort, start_year: 2025) }
+
+  let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
+  let!(:statement_with_no_updates) { create(:ecf_statement, cohort:, name: "July 2025", deadline_date: Date.new(2025, 6, 30), payment_date: Date.new(2025, 7, 28), cpd_lead_provider:, output_fee: false) }
+
+  let(:other_cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
+  let!(:statement_with_updates) { create(:ecf_statement, cohort:, name: "August 2025", deadline_date: Date.new(2025, 7, 29), payment_date: Date.new(2025, 8, 28), cpd_lead_provider: other_cpd_lead_provider, output_fee: false) }
+
+  let(:csv_content) do
+    <<~CSV
+      type,name,cohort,deadline_date,payment_date,output_fee
+      ecf,July 2025,2025,2025-06-30,2025-07-28,false
+      ecf,August 2025,2025,2025-07-31,2025-08-29,true
+    CSV
+  end
+
+  let(:instance) { described_class.new(path_to_csv:) }
+  subject(:perform_change) { instance.perform_change(dry_run:) }
+
+  let(:csv) { Tempfile.new("statements.csv") }
+  let(:path_to_csv) { csv.path }
+  before do
+    allow(Rails.logger).to receive(:info)
+
+    csv.write(csv_content)
+    csv.rewind
+  end
+
+  after do
+    csv.close
+    csv.unlink
+  end
+
+  describe "#perform_change" do
+    let(:dry_run) { false }
+
+    it { is_expected.to eq(instance.recorded_info) }
+
+    it "updates the statement with different values to csv" do
+      expect { perform_change }.to change { statement_with_updates.reload.deadline_date }.to(Date.new(2025, 7, 31))
+      .and change { statement_with_updates.reload.payment_date }.to(Date.new(2025, 8, 29))
+      .and change { statement_with_updates.reload.output_fee }.to(true)
+    end
+
+    it "does not update statement with equal values to csv" do
+      expect { perform_change }.not_to change { statement_with_no_updates.reload.attributes }
+    end
+
+    it "logs out information" do
+      perform_change
+      expect(instance).to have_recorded_info([
+        "Looking at statements for cohort: 2025 and name: July 2025",
+        "No updates made to statement: '#{statement_with_no_updates.id}' with cohort: 2025 and name: July 2025",
+        "Looking at statements for cohort: 2025 and name: August 2025",
+        "Updating statement: '#{statement_with_updates.id}' with changes: {\"deadline_date\"=>[Tue, 29 Jul 2025, Thu, 31 Jul 2025], \"payment_date\"=>[Thu, 28 Aug 2025, Fri, 29 Aug 2025], \"output_fee\"=>[false, true]}",
+      ])
+    end
+
+    it "does not change statements that belong to other cohorts" do
+      other_cohort = create(:cohort, start_year: 2023)
+      statement_other_cohort = create(:ecf_statement, cohort: other_cohort, cpd_lead_provider:)
+
+      expect { perform_change }.not_to change { statement_other_cohort.reload.attributes }
+    end
+
+    context "when statements in csv do not exist" do
+      let(:csv_content) do
+        <<~CSV
+          type,name,cohort,deadline_date,payment_date,output_fee
+          ecf,July 2028,2025,2025-06-30,2025-07-28,false
+        CSV
+      end
+
+      it "does not change statements" do
+        expect { perform_change }.not_to change { Finance::Statement::ECF.all.reload.pluck(:deadline_date, :payment_date, :output_fee) }
+      end
+
+      it "logs out information" do
+        perform_change
+        expect(instance).to have_recorded_info([
+          "Looking at statements for cohort: 2025 and name: July 2028",
+          "No statements found for cohort: 2025 with name: July 2028",
+        ])
+      end
+    end
+
+    context "when headers are invalid" do
+      let(:csv_content) do
+        <<~CSV
+          invalid-header-name,type,name,cohort,deadline_date,payment_date
+        CSV
+      end
+
+      it "raises a NameError" do
+        expect { perform_change }.to raise_error(NameError, "Invalid CSV headers")
+      end
+    end
+
+    context "when dry_run is true" do
+      let(:dry_run) { true }
+
+      it "does not make any changes, but records the changes it would make" do
+        expect { perform_change }.not_to change { statement_with_updates.reload.attributes }
+
+        expect(instance).to have_recorded_info([
+          "~~~ DRY RUN ~~~",
+          "Looking at statements for cohort: 2025 and name: July 2025",
+          "No updates made to statement: '#{statement_with_no_updates.id}' with cohort: 2025 and name: July 2025",
+          "Looking at statements for cohort: 2025 and name: August 2025",
+          "Updating statement: '#{statement_with_updates.id}' with changes: {\"deadline_date\"=>[Tue, 29 Jul 2025, Thu, 31 Jul 2025], \"payment_date\"=>[Thu, 28 Aug 2025, Fri, 29 Aug 2025], \"output_fee\"=>[false, true]}",
+        ])
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

We need to update cohort 2025 statements, contracts and mentor contracts

- Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/1586

### Changes proposed in this pull request
- Add script to update statements in place, creation can be done via importers
- I realised we were missing the mentor contract version, we cannot reuse the contract version, especially if we update one and not the other it would break everything. I've added a. new mentor contract version and have linked it up
- Add script to create and update mentor contracts

### Guidance to review
I've run dry runs of this on the snapshot and all works as expected for the 2 scripts
