### PR TITLE
Rebrand Gov UK

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ gem "mail-notify", "~> 1.2"
 # do not rely on host's timezone data, which can be inconsistent
 gem "tzinfo-data"
 
-gem "govuk-components", "~> 5.10.1"
+gem "govuk-components", "~> 5.11.1"
 gem "govuk_design_system_formbuilder", "~> 5.11.0"
 
 # Fetching from APIs

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,7 +276,7 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
-    govuk-components (5.10.1)
+    govuk-components (5.11.1)
       html-attributes-utils (~> 1.0.0, >= 1.0.0)
       pagy (>= 6, < 10)
       view_component (>= 3.18, < 3.24)
@@ -776,7 +776,7 @@ DEPENDENCIES
   faker
   foreman
   friendly_id (~> 5.5)
-  govuk-components (~> 5.10.1)
+  govuk-components (~> 5.11.1)
   govuk_design_system_formbuilder (~> 5.11.0)
   httpclient (~> 2.9)
   jsbundling-rails

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,4 +1,5 @@
 //= link_tree ../images
+//= link_tree ../../../node_modules/govuk-frontend/dist/govuk/assets/rebrand/images
 //= link_directory ../../../node_modules/govuk-frontend/dist/govuk/assets/images
 //= link_directory ../../../node_modules/govuk-frontend/dist/govuk/assets/fonts
 //= link application.css

--- a/app/views/layouts/_application.html.erb
+++ b/app/views/layouts/_application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="govuk-template">
+<html lang="en" class="govuk-template govuk-template--rebranded">
   <head>
     <% javascript_tag_args = ['application'] %>
 
@@ -16,12 +16,12 @@
     <%= csp_meta_tag %>
     <%= canonical_tag %>
     <%= tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1' %>
-    <%= tag :meta, property: 'og:image', content: image_path('govuk-opengraph-image.png') %>
-    <%= tag :meta, name: 'theme-color', content: '#0b0c0c' %>
-    <%= favicon_link_tag image_path('favicon.ico'), type: nil, sizes: "48x48" %>
-    <%= favicon_link_tag image_path('favicon.svg'), type: 'image/svg+xml', sizes: "any" %>
-    <%= favicon_link_tag image_path('govuk-icon-mask.svg'), rel: 'mask-icon', color: "#0b0c0c", type: nil %>
-    <%= favicon_link_tag image_path('govuk-icon-180.png'), rel: 'apple-touch-icon', type: nil %>
+    <%= tag :meta, property: 'og:image', content: asset_path('/rebrand/images/govuk-opengraph-image.png') %>
+    <%= tag :meta, name: 'theme-color', content: '#1d70b8' %>
+    <%= favicon_link_tag asset_path('/rebrand/images/favicon.ico'), type: nil, sizes: "48x48" %>
+    <%= favicon_link_tag asset_path('/rebrand/images/favicon.svg'), type: 'image/svg+xml', sizes: "any" %>
+    <%= favicon_link_tag asset_path('/rebrand/images/govuk-icon-mask.svg'), rel: 'mask-icon', color: "#0b0c0c", type: nil %>
+    <%= favicon_link_tag asset_path('/rebrand/images/govuk-icon-180.png'), rel: 'apple-touch-icon', type: nil %>
     <%= stylesheet_link_tag 'application', nonce: true, media: 'all' %>
     <script nonce="<%= content_security_policy_nonce %>">
       dataLayer = <%= data_layer.to_json.html_safe %>;

--- a/app/views/layouts/_application.html.erb
+++ b/app/views/layouts/_application.html.erb
@@ -16,12 +16,12 @@
     <%= csp_meta_tag %>
     <%= canonical_tag %>
     <%= tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1' %>
-    <%= tag :meta, property: 'og:image', content: asset_path('/rebrand/images/govuk-opengraph-image.png') %>
+    <%= tag :meta, property: 'og:image', content: asset_path('rebrand/images/govuk-opengraph-image.png') %>
     <%= tag :meta, name: 'theme-color', content: '#1d70b8' %>
-    <%= favicon_link_tag asset_path('/rebrand/images/favicon.ico'), type: nil, sizes: "48x48" %>
-    <%= favicon_link_tag asset_path('/rebrand/images/favicon.svg'), type: 'image/svg+xml', sizes: "any" %>
-    <%= favicon_link_tag asset_path('/rebrand/images/govuk-icon-mask.svg'), rel: 'mask-icon', color: "#0b0c0c", type: nil %>
-    <%= favicon_link_tag asset_path('/rebrand/images/govuk-icon-180.png'), rel: 'apple-touch-icon', type: nil %>
+    <%= favicon_link_tag asset_path('rebrand/images/favicon.ico'), type: nil, sizes: "48x48" %>
+    <%= favicon_link_tag asset_path('rebrand/images/favicon.svg'), type: 'image/svg+xml', sizes: "any" %>
+    <%= favicon_link_tag asset_path('rebrand/images/govuk-icon-mask.svg'), rel: 'mask-icon', color: "#0b0c0c", type: nil %>
+    <%= favicon_link_tag asset_path('rebrand/images/govuk-icon-180.png'), rel: 'apple-touch-icon', type: nil %>
     <%= stylesheet_link_tag 'application', nonce: true, media: 'all' %>
     <script nonce="<%= content_security_policy_nonce %>">
       dataLayer = <%= data_layer.to_json.html_safe %>;

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,20 +1,5 @@
-<footer class="govuk-footer" role="contentinfo">
-  <%= tag.div(class: class_names("govuk-width-container", "govuk-width-container__wide" => wide_container_view?)) do %>
-    <div class="govuk-footer__meta">
-      <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-        <%= render 'layouts/support_links' %>
-        <svg role="presentation" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
-          <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
-          />
-        </svg>
-        <span class="govuk-footer__licence-description">
-          All content is available under the
-          <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
-        </span>
-      </div>
-      <div class="govuk-footer__meta-item">
-        <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
-      </div>
-    </div>
+<%= render GovukComponent::FooterComponent.new do |footer| %>
+  <% footer.with_meta_html do %>
+    <%= render 'layouts/support_links' %>
   <% end %>
-</footer>
+<% end %>

--- a/app/views/layouts/_support_links.html.erb
+++ b/app/views/layouts/_support_links.html.erb
@@ -9,12 +9,12 @@
 </p>
 <ul class="govuk-footer__inline-list">
   <li class="govuk-footer__inline-list-item">
-    <%= link_to "Privacy", privacy_policy_path, class: "govuk-footer__link" %>
+    <%= govuk_footer_link_to("Privacy", privacy_policy_path) %>
   </li>
   <li class="govuk-footer__inline-list-item">
-    <%= link_to "Cookies", cookies_path, class: "govuk-footer__link" %>
+    <%= govuk_footer_link_to("Cookies", cookies_path) %>
   </li>
   <li class="govuk-footer__inline-list-item">
-    <%= link_to "Accessibility", accessibility_statement_path, class: "govuk-footer__link" %>
+    <%= govuk_footer_link_to("Accessibility", accessibility_statement_path) %>
   </li>
 </ul>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -4,6 +4,8 @@
 
 # Because these paths are searched in order, we want the assets to come first
 # Add the GOVUK Frontend images path
+Rails.application.config.assets.paths << Rails.root.join("node_modules/govuk-frontend/dist/govuk/assets")
+
 Rails.application.config.assets.paths << Rails.root.join("node_modules/govuk-frontend/dist/govuk/assets/images")
 
 # Add the GOVUK Frontend fonts path

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "compression-webpack-plugin": "^9.2.0",
     "es6-promise": "^4.2.8",
     "file-loader": "^6.2.0",
-    "govuk-frontend": "^5.10.2",
+    "govuk-frontend": "^5.11.2",
     "nunjucks": "^3.2.4",
     "sass": "^1.91.0",
     "terser-webpack-plugin": "^5.3.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3834,7 +3834,7 @@ __metadata:
     eslint-plugin-import: "npm:^2.32.0"
     eslint-plugin-no-only-tests: "npm:^2.6.0"
     file-loader: "npm:^6.2.0"
-    govuk-frontend: "npm:^5.10.2"
+    govuk-frontend: "npm:^5.11.2"
     nunjucks: "npm:^3.2.4"
     prettier: "npm:^2.8.8"
     sass: "npm:^1.91.0"
@@ -5064,10 +5064,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"govuk-frontend@npm:^5.10.2":
-  version: 5.10.2
-  resolution: "govuk-frontend@npm:5.10.2"
-  checksum: d18d5f101072f63ce18183e2ded89da7fa255596de18cc43a8845a9f2dcb2e583ba36181119a1ba9fec456db09c0d1921a734d030f75c4befd7bffef2ba94909
+"govuk-frontend@npm:^5.11.2":
+  version: 5.11.2
+  resolution: "govuk-frontend@npm:5.11.2"
+  checksum: 54993df0537ddde1e14a5219bc88ce0ba71f79157ba685b58234843cda8f95b8432f8de4047273670e402479cc3a3654056438d260879f5a433d8d1747922a03
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Context

Rebrand GovUK  https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.0

### Changes proposed in this pull request

- Add rebrand class to layout
- use component for footer to avoid having to change svgs,
- fix footer links to use existing components
- update image assets and theme colour
- details found here https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.0

### Guidance to review
I tried doing the api-reference middleman implementation, but upgrading `govuk_tech_docs` caused quite a few issues so abandoned that for now
