### PR TITLE
Sort cohort field in delivery partners in ascending order

### DIFF
--- a/app/serializers/api/v3/delivery_partner_serializer.rb
+++ b/app/serializers/api/v3/delivery_partner_serializer.rb
@@ -21,7 +21,7 @@ module Api
       end
 
       attribute :cohort do |delivery_partner, params|
-        delivery_partner.cohorts_with_provider(params[:lead_provider]).map(&:display_name)
+        delivery_partner.cohorts_with_provider(params[:lead_provider]).map(&:display_name).sort
       end
     end
   end

--- a/spec/serializers/api/v3/delivery_partner_serializer_spec.rb
+++ b/spec/serializers/api/v3/delivery_partner_serializer_spec.rb
@@ -8,7 +8,7 @@ module Api
       describe "serialization" do
         let(:lead_provider) { create(:cpd_lead_provider, :with_lead_provider).lead_provider }
         let(:delivery_partner) { create(:delivery_partner) }
-        let(:cohort) { create(:cohort) }
+        let(:cohort) { create(:cohort, start_year: 2027) }
         let!(:provider_relationship) { create(:provider_relationship, cohort:, delivery_partner:, lead_provider:) }
 
         subject { described_class.new([delivery_partner], params: { lead_provider: }) }
@@ -26,6 +26,18 @@ module Api
               cohort: [cohort.display_name],
             },
           ])
+        end
+
+        context "with multiple provider relationships" do
+          before do
+            create(:provider_relationship, cohort: create(:cohort, start_year: 2024), delivery_partner:, lead_provider:)
+            create(:provider_relationship, cohort: create(:cohort, start_year: 2020), delivery_partner:, lead_provider:)
+          end
+
+          it "sorts cohorts in ascending order" do
+            result = subject.serializable_hash[:data].first
+            expect(result[:attributes][:cohort]).to eq(%w[2020 2024 2027])
+          end
         end
       end
     end


### PR DESCRIPTION
### Context

In the parity  check between RECT and ECF we are getting different cohort orders, making it harder to compare results.

### Changes proposed in this pull request

Sort cohort field in delivery partners in ascending order to ensure parity in RECT is respected when comparing endpoints

### Guidance to review
This should not affect providers as they are the same results just different order, I'll mention it to Andy/Colin however before merging to ensure all is well
