### PR TITLE
Added support script and specs

### DIFF
--- a/spec/factories/staged_school.rb
+++ b/spec/factories/staged_school.rb
@@ -17,5 +17,15 @@ FactoryBot.define do
       school_status_code { 2 }
       school_status_name { "Closed" }
     end
+
+    trait :proposed_to_close do
+      school_status_code { 3 }
+      school_status_name { "Open, but proposed to close" }
+    end
+
+    trait :proposed_to_open do
+      school_status_code { 4 }
+      school_status_name { "Proposed to open" }
+    end
   end
 end


### PR DESCRIPTION
### Context

Thought I would make an effort to put common GIAS support task type stuff into a file and have specs for it so that:
1. less potential for mistakes
2. people other than me can do stuff
3. others can check/comment on what and how things are done and change if necessary

**NOTE:** because it is sometimes difficult to ascertain whether one of these scripts should be run automatically, it is the responsibility of the user to check that the school has no successors or that the correct successor is selected before running these scripts.

### Changes proposed in this pull request

- Adds a new class `DataStage::SupportScripts`
- Adds the `close_school_with_no_successor` method to close a school and mark any participants as left. This is normally when the school has closed and does not have a successor to migrate things to.
- Adds the `migrate_school_to_successor` method to migrate participants and their training info etc. to a successor school

### Guidance to review

