### PR TITLE
Fix rollover to 2025

### DIFF
--- a/spec/factories/cohorts.rb
+++ b/spec/factories/cohorts.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
   factory :cohort do
     start_year { Faker::Number.unique.between(from: 2022, to: 2100) }
     registration_start_date { Date.new(start_year.to_i, 6, 5) }
-    academic_year_start_date { Date.new(start_year.to_i, 10, 1) }
+    academic_year_start_date { Date.new(start_year.to_i, 9, 1) }
     automatic_assignment_period_end_date { Date.new(start_year.to_i + 1, 3, 31) }
     mentor_funding { false }
     detailed_evidence_types { false }
@@ -18,15 +18,15 @@ FactoryBot.define do
     end
 
     trait :previous do
-      start_year { Date.current.year - (Date.current.month < 10 ? 2 : 1) }
+      start_year { Date.current.year - (Date.current.month < 9 ? 2 : 1) }
     end
 
     trait :current do
-      start_year { Date.current.year - (Date.current.month < 10 ? 1 : 0) }
+      start_year { Date.current.year - (Date.current.month < 9 ? 1 : 0) }
     end
 
     trait :next do
-      start_year { Date.current.year + (Date.current.month < 10 ? 0 : 1) }
+      start_year { Date.current.year + (Date.current.month < 9 ? 0 : 1) }
     end
 
     trait :payments_frozen do

--- a/spec/factories/finance/schedules.rb
+++ b/spec/factories/finance/schedules.rb
@@ -8,9 +8,9 @@ FactoryBot.define do
         [
           {
             name: "Output 1 - Participant Start",
-            start_date: Date.new(start_year, 10, 1),
-            milestone_date: Date.new(start_year, 12, 30),
-            payment_date: Date.new(start_year, 12, 30),
+            start_date: Date.new(start_year, 9, 1),
+            milestone_date: Date.new(start_year, 11, 30),
+            payment_date: Date.new(start_year, 11, 30),
             declaration_type: "started",
           },
           {
@@ -66,20 +66,20 @@ FactoryBot.define do
         [
           {
             name: "Output 7 - Extended Point 1",
-            start_date: Date.new(start_year, 10, 1),
-            payment_date: Date.new(start_year, 10, 1),
+            start_date: Date.new(start_year, 9, 1),
+            payment_date: Date.new(start_year, 9, 1),
             declaration_type: "extended-1",
           },
           {
             name: "Output 8 - Extended Point 2",
-            start_date: Date.new(start_year, 10, 1),
-            payment_date: Date.new(start_year, 10, 1),
+            start_date: Date.new(start_year, 9, 1),
+            payment_date: Date.new(start_year, 9, 1),
             declaration_type: "extended-2",
           },
           {
             name: "Output 9 - Extended Point 3",
-            start_date: Date.new(start_year, 10, 1),
-            payment_date: Date.new(start_year, 10, 1),
+            start_date: Date.new(start_year, 9, 1),
+            payment_date: Date.new(start_year, 9, 1),
             declaration_type: "extended-3",
           },
         ].each do |hash|

--- a/spec/features/scenarios/onboarding_a_deferred_participant/cip_to_fip_spec.rb
+++ b/spec/features/scenarios/onboarding_a_deferred_participant/cip_to_fip_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature "CIP to FIP - Onboard a deferred participant",
           create :milestone,
                  schedule:,
                  name: "Output 1 - Participant Start",
-                 start_date: Date.new(2021, 10, 1),
+                 start_date: Date.new(2021, 9, 1),
                  milestone_date: Date.new(2021, 11, 30),
                  payment_date: Date.new(2021, 11, 30),
                  declaration_type: "started"

--- a/spec/features/scenarios/onboarding_a_deferred_participant/fip_to_cip_spec.rb
+++ b/spec/features/scenarios/onboarding_a_deferred_participant/fip_to_cip_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature "FIP to CIP - Onboard a deferred participant",
           create :milestone,
                  schedule:,
                  name: "Output 1 - Participant Start",
-                 start_date: Date.new(2021, 10, 1),
+                 start_date: Date.new(2021, 9, 1),
                  milestone_date: Date.new(2021, 11, 30),
                  payment_date: Date.new(2021, 11, 30),
                  declaration_type: "started"

--- a/spec/features/scenarios/onboarding_a_deferred_participant/fip_to_fip_with_different_provider_spec.rb
+++ b/spec/features/scenarios/onboarding_a_deferred_participant/fip_to_fip_with_different_provider_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature "FIP to FIP with different provider - Onboard a deferred participa
           create :milestone,
                  schedule:,
                  name: "Output 1 - Participant Start",
-                 start_date: Date.new(2021, 10, 1),
+                 start_date: Date.new(2021, 9, 1),
                  milestone_date: Date.new(2021, 11, 30),
                  payment_date: Date.new(2021, 11, 30),
                  declaration_type: "started"

--- a/spec/features/scenarios/onboarding_a_deferred_participant/fip_to_fip_with_same_provider_spec.rb
+++ b/spec/features/scenarios/onboarding_a_deferred_participant/fip_to_fip_with_same_provider_spec.rb
@@ -57,7 +57,7 @@ RSpec.feature "FIP to FIP with same provider - Onboard a deferred participant",
           create :milestone,
                  schedule:,
                  name: "Output 1 - Participant Start",
-                 start_date: Date.new(2021, 10, 1),
+                 start_date: Date.new(2021, 9, 1),
                  milestone_date: Date.new(2021, 11, 30),
                  payment_date: Date.new(2021, 11, 30),
                  declaration_type: "started"

--- a/spec/features/scenarios/onboarding_a_withdrawn_participant/cip_to_fip_spec.rb
+++ b/spec/features/scenarios/onboarding_a_withdrawn_participant/cip_to_fip_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature "CIP to FIP - Onboarding a withdrawn participant",
           create :milestone,
                  schedule:,
                  name: "Output 1 - Participant Start",
-                 start_date: Date.new(2021, 10, 1),
+                 start_date: Date.new(2021, 9, 1),
                  milestone_date: Date.new(2021, 11, 30),
                  payment_date: Date.new(2021, 11, 30),
                  declaration_type: "started"

--- a/spec/features/scenarios/onboarding_a_withdrawn_participant/fip_to_fip_with_different_provider_spec.rb
+++ b/spec/features/scenarios/onboarding_a_withdrawn_participant/fip_to_fip_with_different_provider_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature "FIP to FIP with different provider - Onboarding a withdrawn parti
           create :milestone,
                  schedule:,
                  name: "Output 1 - Participant Start",
-                 start_date: Date.new(2021, 10, 1),
+                 start_date: Date.new(2021, 9, 1),
                  milestone_date: Date.new(2021, 11, 30),
                  payment_date: Date.new(2021, 11, 30),
                  declaration_type: "started"

--- a/spec/features/scenarios/onboarding_a_withdrawn_participant/fip_to_fip_with_same_provider_spec.rb
+++ b/spec/features/scenarios/onboarding_a_withdrawn_participant/fip_to_fip_with_same_provider_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature "FIP to FIP with same provider - Onboarding a withdrawn participan
           create :milestone,
                  schedule:,
                  name: "Output 1 - Participant Start",
-                 start_date: Date.new(2021, 10, 1),
+                 start_date: Date.new(2021, 9, 1),
                  milestone_date: Date.new(2021, 11, 30),
                  payment_date: Date.new(2021, 11, 30),
                  declaration_type: "started"

--- a/spec/features/scenarios/participants/ect_doing_fip/after_cohort_transfer_spec.rb
+++ b/spec/features/scenarios/participants/ect_doing_fip/after_cohort_transfer_spec.rb
@@ -174,21 +174,24 @@ RSpec.feature "ECT doing FIP: after cohort transfer", type: :feature do
         expect(participant_endpoint).to have_schedule_identifier schedule_identifier
       end
 
-      scenario "The current delivery partner can locate a record for the ECT" do
-        given_i_sign_in_as_the_user_with_the_full_name delivery_partner_name
+      context "within latest delivery partner participant cohort" do
+        let(:start_year) { DeliveryPartners::ParticipantsFilter::LATEST_COHORT_TO_RETURN }
+        scenario "The current delivery partner can locate a record for the ECT" do
+          given_i_sign_in_as_the_user_with_the_full_name delivery_partner_name
 
-        delivery_partner_portal = Pages::DeliveryPartnerPortal.loaded
-        delivery_partner_portal.get_participant(participant_full_name)
+          delivery_partner_portal = Pages::DeliveryPartnerPortal.loaded
+          delivery_partner_portal.get_participant(participant_full_name)
 
-        expect(delivery_partner_portal).to have_full_name participant_full_name
-        expect(delivery_partner_portal).to have_email_address participant_email
-        expect(delivery_partner_portal).to have_teacher_reference_number teacher_reference_number
-        expect(delivery_partner_portal).to have_participant_type long_participant_type
-        expect(delivery_partner_portal).to have_lead_provider_name lead_provider_name
-        expect(delivery_partner_portal).to have_school_name school_name
-        expect(delivery_partner_portal).to have_school_urn school.urn
-        expect(delivery_partner_portal).to have_academic_year new_school_cohort.start_year
-        expect(delivery_partner_portal).to have_training_record_status delivery_partner_record_state
+          expect(delivery_partner_portal).to have_full_name participant_full_name
+          expect(delivery_partner_portal).to have_email_address participant_email
+          expect(delivery_partner_portal).to have_teacher_reference_number teacher_reference_number
+          expect(delivery_partner_portal).to have_participant_type long_participant_type
+          expect(delivery_partner_portal).to have_lead_provider_name lead_provider_name
+          expect(delivery_partner_portal).to have_school_name school_name
+          expect(delivery_partner_portal).to have_school_urn school.urn
+          expect(delivery_partner_portal).to have_academic_year new_school_cohort.start_year
+          expect(delivery_partner_portal).to have_training_record_status delivery_partner_record_state
+        end
       end
 
       scenario "The Support for ECTs service can locate a record for the CIP ECT" do

--- a/spec/features/scenarios/transfering_a_participant/cip_to_cip_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/cip_to_cip_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature "CIP to CIP - Transfer a participant",
           create :milestone,
                  schedule:,
                  name: "Output 1 - Participant Start",
-                 start_date: Date.new(2021, 10, 1),
+                 start_date: Date.new(2021, 9, 1),
                  milestone_date: Date.new(2021, 11, 30),
                  payment_date: Date.new(2021, 11, 30),
                  declaration_type: "started"

--- a/spec/features/scenarios/transfering_a_participant/cip_to_fip_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/cip_to_fip_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature "CIP to FIP - Transfer a participant",
           create :milestone,
                  schedule:,
                  name: "Output 1 - Participant Start",
-                 start_date: Date.new(2021, 10, 1),
+                 start_date: Date.new(2021, 9, 1),
                  milestone_date: Date.new(2021, 11, 30),
                  payment_date: Date.new(2021, 11, 30),
                  declaration_type: "started"

--- a/spec/features/scenarios/transfering_a_participant/fip_to_fip_with_different_provider_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/fip_to_fip_with_different_provider_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature "FIP to FIP with different provider - Transfer a participant",
           create :milestone,
                  schedule:,
                  name: "Output 1 - Participant Start",
-                 start_date: Date.new(2021, 10, 1),
+                 start_date: Date.new(2021, 9, 1),
                  milestone_date: Date.new(2021, 11, 30),
                  payment_date: Date.new(2021, 11, 30),
                  declaration_type: "started"

--- a/spec/features/scenarios/transfering_a_participant/fip_to_fip_with_same_provider_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/fip_to_fip_with_same_provider_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature "FIP to FIP with same provider - Transfer a participant",
           create :milestone,
                  schedule:,
                  name: "Output 1 - Participant Start",
-                 start_date: Date.new(2021, 10, 1),
+                 start_date: Date.new(2021, 9, 1),
                  milestone_date: Date.new(2021, 11, 30),
                  payment_date: Date.new(2021, 11, 30),
                  declaration_type: "started"

--- a/spec/features/schools/participants/add_participants/payments_frozen/assign_ect_to_mentor_spec.rb
+++ b/spec/features/schools/participants/add_participants/payments_frozen/assign_ect_to_mentor_spec.rb
@@ -8,18 +8,20 @@ RSpec.describe "SIT assigns a mentor to an ECT", js: true, early_in_cohort: true
   include ManageTrainingSteps
 
   scenario "when payments are frozen for cohort" do
-    given_there_is_a_school_that_has_chosen_fip_for_four_cohorts_and_partnered
-    and_the_earliest_cohort_has_payments_frozen
-    and_there_is_an_ect_in_the_active_registration_cohort
-    and_there_is_a_mentor_in_the_earliest_cohort
-    and_i_am_signed_in_as_an_induction_coordinator
-    and_i_click_on(Cohort.current.description)
+    inside_auto_assignment_window(cohort: Cohort.find_by(start_year: Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT)) do
+      given_there_is_a_school_that_has_chosen_fip_for_four_cohorts_and_partnered
+      and_the_earliest_cohort_has_payments_frozen
+      and_there_is_an_ect_in_the_active_registration_cohort
+      and_there_is_a_mentor_in_the_earliest_cohort
+      and_i_am_signed_in_as_an_induction_coordinator
+      and_i_click_on(Cohort.current.description)
 
-    when_i_navigate_to_ect_dashboard
-    and_i_assign_the_ect_a_mentor
-    then_i_see_confirmation_that_the_mentor_has_been_assigned
+      when_i_navigate_to_ect_dashboard
+      and_i_assign_the_ect_a_mentor
+      then_i_see_confirmation_that_the_mentor_has_been_assigned
 
-    and_the_mentor_has_been_assigned_to_the_active_registration_cohort
+      and_the_mentor_has_been_assigned_to_the_active_registration_cohort
+    end
   end
 
   def and_there_is_an_ect_in_the_active_registration_cohort

--- a/spec/features/schools/participants/add_participants/payments_frozen/common_steps.rb
+++ b/spec/features/schools/participants/add_participants/payments_frozen/common_steps.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 def given_there_is_a_school_that_has_chosen_fip_for_four_cohorts_and_partnered
-  (2021..2024).each do |year|
+  (2021..Cohort.current.start_year).each do |year|
     cohort = Cohort.find_or_create_by!(start_year: year)
     school_cohort = SchoolCohort.create!(cohort:, school:, induction_programme_choice: "full_induction_programme")
     induction_programme = create(:induction_programme, :fip, school_cohort:, partnership: nil)

--- a/spec/features/schools/participants/add_participants/payments_frozen/sit_adds_ect_spec.rb
+++ b/spec/features/schools/participants/add_participants/payments_frozen/sit_adds_ect_spec.rb
@@ -96,50 +96,52 @@ RSpec.describe "SIT adding an ECT", js: true, early_in_cohort: true do
   end
 
   scenario "when target cohort payments are not frozen and unfinished 2021 mentor is assigned" do
-    given_there_is_a_school_that_has_chosen_fip_for_four_cohorts_and_partnered
-    and_the_earliest_cohort_has_payments_frozen
-    and_i_am_signed_in_as_an_induction_coordinator
+    inside_auto_assignment_window(cohort: Cohort.find_by(start_year: Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT)) do
+      given_there_is_a_school_that_has_chosen_fip_for_four_cohorts_and_partnered
+      and_the_earliest_cohort_has_payments_frozen
+      and_i_am_signed_in_as_an_induction_coordinator
 
-    and_i_have_added_a_mentor_in_cohort(earliest_cohort)
-    and_i_am_adding_a_participant_with_an_induction_start_date_in_the_cohort_with_payments_frozen
-    and_i_click_on(Cohort.current.description)
-    then_i_am_taken_to_fip_induction_dashboard
+      and_i_have_added_a_mentor_in_cohort(earliest_cohort)
+      and_i_am_adding_a_participant_with_an_induction_start_date_in_the_cohort_with_payments_frozen
+      and_i_click_on(Cohort.current.description)
+      then_i_am_taken_to_fip_induction_dashboard
 
-    when_i_navigate_to_ect_dashboard
-    when_i_click_to_add_a_new_ect
-    then_i_should_be_on_the_who_to_add_page
+      when_i_navigate_to_ect_dashboard
+      when_i_click_to_add_a_new_ect
+      then_i_should_be_on_the_who_to_add_page
 
-    when_i_select_to_add_a "ECT"
-    when_i_click_on_continue
+      when_i_select_to_add_a "ECT"
+      when_i_click_on_continue
 
-    then_i_am_taken_to_the_what_we_need_from_you_page
+      then_i_am_taken_to_the_what_we_need_from_you_page
 
-    when_i_click_on_continue
-    then_i_am_taken_to_add_ect_name_page
+      when_i_click_on_continue
+      then_i_am_taken_to_add_ect_name_page
 
-    when_i_add_ect_name
-    when_i_click_on_continue
-    then_i_am_taken_to_add_teachers_trn_page
+      when_i_add_ect_name
+      when_i_click_on_continue
+      then_i_am_taken_to_add_teachers_trn_page
 
-    when_i_add_the_trn
-    when_i_click_on_continue
-    then_i_am_taken_to_add_date_of_birth_page
+      when_i_add_the_trn
+      when_i_click_on_continue
+      then_i_am_taken_to_add_date_of_birth_page
 
-    when_i_add_a_date_of_birth
-    when_i_click_on_continue
-    then_i_am_taken_to_add_ect_or_mentor_email_page
+      when_i_add_a_date_of_birth
+      when_i_click_on_continue
+      then_i_am_taken_to_add_ect_or_mentor_email_page
 
-    when_i_add_ect_or_mentor_email(email: @participant_data[:email])
-    when_i_click_on_continue
-    then_i_am_taken_to_choose_mentor_page
+      when_i_add_ect_or_mentor_email(email: @participant_data[:email])
+      when_i_click_on_continue
+      then_i_am_taken_to_choose_mentor_page
 
-    when_i_select("Cohort Mentor")
-    when_i_click_on_continue
-    then_i_am_taken_to_check_details_page
+      when_i_select("Cohort Mentor")
+      when_i_click_on_continue
+      then_i_am_taken_to_check_details_page
 
-    when_i_click_confirm_and_add
-    then_i_see_confirmation_that_the_participant_has_been_added
-    and_the_participant_has_been_added_to_the_active_registration_cohort
-    and_the_mentor_has_been_added_to_the_active_registration_cohort
+      when_i_click_confirm_and_add
+      then_i_see_confirmation_that_the_participant_has_been_added
+      and_the_participant_has_been_added_to_the_active_registration_cohort
+      and_the_mentor_has_been_added_to_the_active_registration_cohort
+    end
   end
 end

--- a/spec/features/schools/participants/add_participants/payments_frozen/transfer_ect_to_another_school_spec.rb
+++ b/spec/features/schools/participants/add_participants/payments_frozen/transfer_ect_to_another_school_spec.rb
@@ -8,162 +8,168 @@ RSpec.describe "SIT transfers ECT to another school", js: true, early_in_cohort:
   include ManageTrainingSteps
 
   scenario "when target cohort payments are frozen" do
-    given_there_is_a_school_that_has_chosen_fip_for_four_cohorts_and_partnered
-    and_there_is_another_school_that_has_chosen_fip_in_the_payments_frozen_cohort_and_partnered
-    and_the_earliest_cohort_has_payments_frozen
-    and_i_am_signed_in_as_an_induction_coordinator_for_the_transfer_school
-    and_i_am_transfering_an_ect_in_a_cohort_with_payments_frozen_between_schools
-    and_i_click_on(Cohort.current.description)
+    inside_auto_assignment_window(cohort: Cohort.find_by(start_year: Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT)) do
+      given_there_is_a_school_that_has_chosen_fip_for_four_cohorts_and_partnered
+      and_there_is_another_school_that_has_chosen_fip_in_the_payments_frozen_cohort_and_partnered
+      and_the_earliest_cohort_has_payments_frozen
+      and_i_am_signed_in_as_an_induction_coordinator_for_the_transfer_school
+      and_i_am_transfering_an_ect_in_a_cohort_with_payments_frozen_between_schools
+      and_i_click_on(Cohort.current.description)
 
-    when_i_navigate_to_ect_dashboard
-    when_i_click_to_add_a_new_ect
-    then_i_should_be_on_the_who_to_add_page
+      when_i_navigate_to_ect_dashboard
+      when_i_click_to_add_a_new_ect
+      then_i_should_be_on_the_who_to_add_page
 
-    when_i_select_to_add_a "ECT"
-    when_i_click_on_continue
+      when_i_select_to_add_a "ECT"
+      when_i_click_on_continue
 
-    then_i_am_taken_to_the_what_we_need_from_you_page
+      then_i_am_taken_to_the_what_we_need_from_you_page
 
-    when_i_click_on_continue
-    then_i_am_taken_to_add_ect_name_page
+      when_i_click_on_continue
+      then_i_am_taken_to_add_ect_name_page
 
-    when_i_add_ect_name
-    when_i_click_on_continue
-    then_i_am_taken_to_add_teachers_trn_page
+      when_i_add_ect_name
+      when_i_click_on_continue
+      then_i_am_taken_to_add_teachers_trn_page
 
-    when_i_add_the_trn
-    when_i_click_on_continue
-    then_i_am_taken_to_add_date_of_birth_page
+      when_i_add_the_trn
+      when_i_click_on_continue
+      then_i_am_taken_to_add_date_of_birth_page
 
-    when_i_add_a_date_of_birth
-    when_i_click_on_continue
+      when_i_add_a_date_of_birth
+      when_i_click_on_continue
 
-    then_i_should_be_on_the_confirm_transfer_page
-    when_i_complete_transfer_steps
+      then_i_should_be_on_the_confirm_transfer_page
+      when_i_complete_transfer_steps
 
-    when_i_click_confirm_and_add
-    then_i_see_confirmation_that_the_participant_has_been_added
+      when_i_click_confirm_and_add
+      then_i_see_confirmation_that_the_participant_has_been_added
 
-    and_the_participant_has_been_transfered_to_another_school
-    and_the_participant_has_been_added_to_the_active_registration_cohort
+      and_the_participant_has_been_transfered_to_another_school
+      and_the_participant_has_been_added_to_the_active_registration_cohort
+    end
   end
 
   scenario "when an unfinished mentor is assigned" do
-    given_there_is_a_school_that_has_chosen_fip_for_four_cohorts_and_partnered
-    and_there_is_another_school_that_has_chosen_fip_in_the_payments_frozen_cohort_and_partnered
-    and_the_earliest_cohort_has_payments_frozen
-    and_i_am_signed_in_as_an_induction_coordinator_for_the_transfer_school
+    inside_auto_assignment_window(cohort: Cohort.find_by(start_year: Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT)) do
+      given_there_is_a_school_that_has_chosen_fip_for_four_cohorts_and_partnered
+      and_there_is_another_school_that_has_chosen_fip_in_the_payments_frozen_cohort_and_partnered
+      and_the_earliest_cohort_has_payments_frozen
+      and_i_am_signed_in_as_an_induction_coordinator_for_the_transfer_school
 
-    and_i_have_added_a_mentor_in_cohort(earliest_cohort, school: target_school)
-    and_i_am_transfering_an_ect_in_a_cohort_with_payments_frozen_between_schools
-    and_i_click_on(Cohort.current.description)
+      and_i_have_added_a_mentor_in_cohort(earliest_cohort, school: target_school)
+      and_i_am_transfering_an_ect_in_a_cohort_with_payments_frozen_between_schools
+      and_i_click_on(Cohort.current.description)
 
-    when_i_navigate_to_ect_dashboard
-    when_i_click_to_add_a_new_ect
-    then_i_should_be_on_the_who_to_add_page
+      when_i_navigate_to_ect_dashboard
+      when_i_click_to_add_a_new_ect
+      then_i_should_be_on_the_who_to_add_page
 
-    when_i_select_to_add_a "ECT"
-    when_i_click_on_continue
+      when_i_select_to_add_a "ECT"
+      when_i_click_on_continue
 
-    then_i_am_taken_to_the_what_we_need_from_you_page
+      then_i_am_taken_to_the_what_we_need_from_you_page
 
-    when_i_click_on_continue
-    then_i_am_taken_to_add_ect_name_page
+      when_i_click_on_continue
+      then_i_am_taken_to_add_ect_name_page
 
-    when_i_add_ect_name
-    when_i_click_on_continue
-    then_i_am_taken_to_add_teachers_trn_page
+      when_i_add_ect_name
+      when_i_click_on_continue
+      then_i_am_taken_to_add_teachers_trn_page
 
-    when_i_add_the_trn
-    when_i_click_on_continue
-    then_i_am_taken_to_add_date_of_birth_page
+      when_i_add_the_trn
+      when_i_click_on_continue
+      then_i_am_taken_to_add_date_of_birth_page
 
-    when_i_add_a_date_of_birth
-    when_i_click_on_continue
+      when_i_add_a_date_of_birth
+      when_i_click_on_continue
 
-    then_i_should_be_on_the_confirm_transfer_page
-    when_i_click_on_confirm
-    then_i_should_be_on_the_teacher_start_date_page
+      then_i_should_be_on_the_confirm_transfer_page
+      when_i_click_on_confirm
+      then_i_should_be_on_the_teacher_start_date_page
 
-    when_i_add_a_valid_start_date
-    when_i_click_on_continue
-    then_i_am_taken_to_add_ect_or_mentor_email_page
+      when_i_add_a_valid_start_date
+      when_i_click_on_continue
+      then_i_am_taken_to_add_ect_or_mentor_email_page
 
-    when_i_add_ect_or_mentor_email(email: @participant_data[:email])
-    when_i_click_on_continue
-    then_i_am_taken_to_choose_mentor_page
+      when_i_add_ect_or_mentor_email(email: @participant_data[:email])
+      when_i_click_on_continue
+      then_i_am_taken_to_choose_mentor_page
 
-    when_i_select("Cohort Mentor")
-    when_i_click_on_continue
-    when_i_choose_yes
-    when_i_click_on_continue
-    then_i_am_taken_to_check_details_page
+      when_i_select("Cohort Mentor")
+      when_i_click_on_continue
+      when_i_choose_yes
+      when_i_click_on_continue
+      then_i_am_taken_to_check_details_page
 
-    when_i_click_confirm_and_add
-    then_i_see_confirmation_that_the_participant_has_been_added
+      when_i_click_confirm_and_add
+      then_i_see_confirmation_that_the_participant_has_been_added
 
-    and_the_participant_has_been_transfered_to_another_school
-    and_the_participant_has_been_added_to_the_active_registration_cohort
-    and_the_mentor_has_been_added_to_the_active_registration_cohort
+      and_the_participant_has_been_transfered_to_another_school
+      and_the_participant_has_been_added_to_the_active_registration_cohort
+      and_the_mentor_has_been_added_to_the_active_registration_cohort
+    end
   end
 
   scenario "when an unfinished mentor is assigned", with_feature_flags: { closing_2022: "active" } do
-    given_there_is_a_school_that_has_chosen_fip_for_four_cohorts_and_partnered
-    and_there_is_another_school_that_has_chosen_fip_in_the_payments_frozen_cohort_and_partnered
-    and_the_earliest_cohort_has_payments_frozen
-    and_i_am_signed_in_as_an_induction_coordinator_for_the_transfer_school
+    inside_auto_assignment_window(cohort: Cohort.find_by(start_year: Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT)) do
+      given_there_is_a_school_that_has_chosen_fip_for_four_cohorts_and_partnered
+      and_there_is_another_school_that_has_chosen_fip_in_the_payments_frozen_cohort_and_partnered
+      and_the_earliest_cohort_has_payments_frozen
+      and_i_am_signed_in_as_an_induction_coordinator_for_the_transfer_school
 
-    and_i_have_added_a_mentor_in_cohort(earliest_cohort, school: target_school)
-    and_i_am_transfering_an_ect_in_a_cohort_with_payments_frozen_between_schools
-    and_i_click_on(Cohort.current.description)
+      and_i_have_added_a_mentor_in_cohort(earliest_cohort, school: target_school)
+      and_i_am_transfering_an_ect_in_a_cohort_with_payments_frozen_between_schools
+      and_i_click_on(Cohort.current.description)
 
-    when_i_navigate_to_ect_dashboard
-    when_i_click_to_add_a_new_ect
-    then_i_should_be_on_the_who_to_add_page
+      when_i_navigate_to_ect_dashboard
+      when_i_click_to_add_a_new_ect
+      then_i_should_be_on_the_who_to_add_page
 
-    when_i_select_to_add_a "ECT"
-    when_i_click_on_continue
+      when_i_select_to_add_a "ECT"
+      when_i_click_on_continue
 
-    then_i_am_taken_to_the_what_we_need_from_you_page
+      then_i_am_taken_to_the_what_we_need_from_you_page
 
-    when_i_click_on_continue
-    then_i_am_taken_to_add_ect_name_page
+      when_i_click_on_continue
+      then_i_am_taken_to_add_ect_name_page
 
-    when_i_add_ect_name
-    when_i_click_on_continue
-    then_i_am_taken_to_add_teachers_trn_page
+      when_i_add_ect_name
+      when_i_click_on_continue
+      then_i_am_taken_to_add_teachers_trn_page
 
-    when_i_add_the_trn
-    when_i_click_on_continue
-    then_i_am_taken_to_add_date_of_birth_page
+      when_i_add_the_trn
+      when_i_click_on_continue
+      then_i_am_taken_to_add_date_of_birth_page
 
-    when_i_add_a_date_of_birth
-    when_i_click_on_continue
+      when_i_add_a_date_of_birth
+      when_i_click_on_continue
 
-    then_i_should_be_on_the_confirm_transfer_page
-    when_i_click_on_confirm
-    then_i_should_be_on_the_teacher_start_date_page
+      then_i_should_be_on_the_confirm_transfer_page
+      when_i_click_on_confirm
+      then_i_should_be_on_the_teacher_start_date_page
 
-    when_i_add_a_valid_start_date
-    when_i_click_on_continue
-    then_i_am_taken_to_add_ect_or_mentor_email_page
+      when_i_add_a_valid_start_date
+      when_i_click_on_continue
+      then_i_am_taken_to_add_ect_or_mentor_email_page
 
-    when_i_add_ect_or_mentor_email(email: @participant_data[:email])
-    when_i_click_on_continue
-    then_i_am_taken_to_choose_mentor_page
+      when_i_add_ect_or_mentor_email(email: @participant_data[:email])
+      when_i_click_on_continue
+      then_i_am_taken_to_choose_mentor_page
 
-    when_i_select("Cohort Mentor")
-    when_i_click_on_continue
-    when_i_choose_yes
-    when_i_click_on_continue
-    then_i_am_taken_to_check_details_page
+      when_i_select("Cohort Mentor")
+      when_i_click_on_continue
+      when_i_choose_yes
+      when_i_click_on_continue
+      then_i_am_taken_to_check_details_page
 
-    when_i_click_confirm_and_add
-    then_i_see_confirmation_that_the_participant_has_been_added
+      when_i_click_confirm_and_add
+      then_i_see_confirmation_that_the_participant_has_been_added
 
-    and_the_participant_has_been_transfered_to_another_school
-    and_the_participant_has_been_added_to_the_active_registration_cohort
-    and_the_mentor_stays_in_their_current_cohort(@mentor_school_cohort.cohort)
+      and_the_participant_has_been_transfered_to_another_school
+      and_the_participant_has_been_added_to_the_active_registration_cohort
+      and_the_mentor_stays_in_their_current_cohort(@mentor_school_cohort.cohort)
+    end
   end
 
   def and_i_am_transfering_an_ect_in_a_cohort_with_payments_frozen_between_schools

--- a/spec/features/schools/participants/add_participants/payments_frozen/transfer_mentor_to_another_school_spec.rb
+++ b/spec/features/schools/participants/add_participants/payments_frozen/transfer_mentor_to_another_school_spec.rb
@@ -8,44 +8,46 @@ RSpec.describe "SIT transfers mentor to another school", js: true, early_in_coho
   include ManageTrainingSteps
 
   scenario "when target cohort payments are frozen" do
-    given_there_is_a_school_that_has_chosen_fip_for_four_cohorts_and_partnered
-    and_there_is_another_school_that_has_chosen_fip_in_the_payments_frozen_cohort_and_partnered
-    and_the_earliest_cohort_has_payments_frozen
-    and_i_am_signed_in_as_an_induction_coordinator_for_the_transfer_school
-    and_i_am_transfering_a_mentor_in_a_cohort_with_payments_frozen_between_schools
-    and_i_click_on(Cohort.current.description)
+    inside_auto_assignment_window(cohort: Cohort.find_by(start_year: Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT)) do
+      given_there_is_a_school_that_has_chosen_fip_for_four_cohorts_and_partnered
+      and_there_is_another_school_that_has_chosen_fip_in_the_payments_frozen_cohort_and_partnered
+      and_the_earliest_cohort_has_payments_frozen
+      and_i_am_signed_in_as_an_induction_coordinator_for_the_transfer_school
+      and_i_am_transfering_a_mentor_in_a_cohort_with_payments_frozen_between_schools
+      and_i_click_on(Cohort.current.description)
 
-    when_i_navigate_to_ect_dashboard
-    when_i_click_to_add_a_new_ect
-    then_i_should_be_on_the_who_to_add_page
+      when_i_navigate_to_ect_dashboard
+      when_i_click_to_add_a_new_ect
+      then_i_should_be_on_the_who_to_add_page
 
-    when_i_select_to_add_a "Mentor"
-    when_i_click_on_continue
+      when_i_select_to_add_a "Mentor"
+      when_i_click_on_continue
 
-    then_i_am_taken_to_the_what_we_need_from_mentor_page
+      then_i_am_taken_to_the_what_we_need_from_mentor_page
 
-    when_i_click_on_continue
-    then_i_am_taken_to_add_mentor_full_name_page
+      when_i_click_on_continue
+      then_i_am_taken_to_add_mentor_full_name_page
 
-    when_i_add_mentor_name
-    when_i_click_on_continue
-    then_i_am_taken_to_add_teachers_trn_page
+      when_i_add_mentor_name
+      when_i_click_on_continue
+      then_i_am_taken_to_add_teachers_trn_page
 
-    when_i_add_the_trn
-    when_i_click_on_continue
-    then_i_am_taken_to_add_date_of_birth_page
+      when_i_add_the_trn
+      when_i_click_on_continue
+      then_i_am_taken_to_add_date_of_birth_page
 
-    when_i_add_a_date_of_birth
-    when_i_click_on_continue
+      when_i_add_a_date_of_birth
+      when_i_click_on_continue
 
-    when_i_complete_transfer_steps
+      when_i_complete_transfer_steps
 
-    when_i_click_confirm_and_add
+      when_i_click_confirm_and_add
 
-    then_i_am_taken_to_mentor_added_confirmation_page
+      then_i_am_taken_to_mentor_added_confirmation_page
 
-    and_the_mentor_has_been_transfered_to_another_school
-    and_the_mentor_has_been_added_to_the_active_registration_cohort
+      and_the_mentor_has_been_transfered_to_another_school
+      and_the_mentor_has_been_added_to_the_active_registration_cohort
+    end
   end
 
   scenario "when target cohort payments are frozen", with_feature_flags: { closing_2022: "active" } do

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -1522,7 +1522,7 @@ module ManageTrainingSteps
       date_of_birth: Date.new(1998, 3, 22),
       email: "sally@school.com",
       nino: "AB123456A",
-      start_date: Date.new(Cohort.current.start_year, 10, 1),
+      start_date: Date.new(Cohort.current.start_year, 9, 1),
       start_term: "summer",
     }
   end

--- a/spec/fixtures/files/importers/cohort_csv_data.csv
+++ b/spec/fixtures/files/importers/cohort_csv_data.csv
@@ -1,2 +1,2 @@
 start-year,registration-start-date,academic-year-start-date,automatic-assignment-period-end-date,payments-frozen-at,mentor-funding,detailed-evidence-types
-2026,2026/05/10,2026/09/01,2026/03/31,,true,true
+2027,2027/05/10,2027/09/01,2027/03/31,,true,true

--- a/spec/fixtures/files/importers/cohort_lead_provider_csv_data.csv
+++ b/spec/fixtures/files/importers/cohort_lead_provider_csv_data.csv
@@ -1,2 +1,2 @@
 lead-provider-name,cohort-start-year
-Ambition Institute,2026
+Ambition Institute,2027

--- a/spec/fixtures/files/importers/contract_csv_data.csv
+++ b/spec/fixtures/files/importers/contract_csv_data.csv
@@ -1,2 +1,2 @@
 lead-provider-name,cohort-start-year,uplift-target,uplift-amount,recruitment-target,revised-target,set-up-fee,monthly-service-fee,band-a-min,band-a-max,band-a-per-participant,band-b-min,band-b-max,band-b-per-participant,band-c-min,band-c-max,band-c-per-participant,band-d-min,band-d-max,band-d-per-participant
-Ambition Institute,2026,0.44,200,4600,4790,0,0,90,895,91,199,700,200,299,600,300,400,500,400
+Ambition Institute,2027,0.44,200,4600,4790,0,0,90,895,91,199,700,200,299,600,300,400,500,400

--- a/spec/fixtures/files/importers/mentor_contract_csv_data.csv
+++ b/spec/fixtures/files/importers/mentor_contract_csv_data.csv
@@ -1,2 +1,2 @@
 lead-provider-name,cohort-start-year,recruitment-target,payment-per-participant
-Ambition Institute,2026,4600,1000.0
+Ambition Institute,2027,4600,1000.0

--- a/spec/fixtures/files/importers/schedule_csv_data.csv
+++ b/spec/fixtures/files/importers/schedule_csv_data.csv
@@ -1,2 +1,2 @@
 type,schedule-identifier,schedule-name,schedule-cohort-year,milestone-name,milestone-declaration-type,milestone-start-date,milestone-date,milestone-payment-date
-ecf_standard,ecf-standard-september,ECF Standard September,2026,Output 1 - Participant Start,started,2024/09/01,2024/11/30,2024/11/30
+ecf_standard,ecf-standard-september,ECF Standard September,2027,Output 1 - Participant Start,started,2024/09/01,2024/11/30,2024/11/30

--- a/spec/fixtures/files/importers/statement_csv_data.csv
+++ b/spec/fixtures/files/importers/statement_csv_data.csv
@@ -1,2 +1,2 @@
 type,name,cohort,deadline_date,payment_date,output_fee
-ecf,September 2026,2026,2026-09-01,2026-11-25,true
+ecf,September 2027,2027,2027-09-01,2027-11-25,true

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Cohort, type: :model do
     describe ".ordered_by_start_year" do
       it "orders the cohorts by year ascending" do
         expect(Cohort.ordered_by_start_year.to_sql).to include(%(ORDER BY "cohorts"."start_year" ASC))
-        expect(Cohort.ordered_by_start_year.map(&:start_year)).to eql([2020, 2021, 2022, 2023, 2024, 2025])
+        expect(Cohort.ordered_by_start_year.map(&:start_year)).to eql([2020, 2021, 2022, 2023, 2024, 2025, 2026])
       end
     end
   end

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Cohort, type: :model do
   describe ".current" do
     describe "when the current date matches the academic year start date" do
       it "returns the cohort with start_year the current year" do
-        Timecop.freeze(Date.new(2021, 10, 1)) do
+        Timecop.freeze(Date.new(2021, 9, 1)) do
           expect(Cohort.current.start_year).to eq 2021
         end
       end
@@ -70,7 +70,7 @@ RSpec.describe Cohort, type: :model do
     end
 
     context "when the provided date is in 2021 since September" do
-      let(:induction_start_date) { Date.new(2021, 10, 1) }
+      let(:induction_start_date) { Date.new(2021, 9, 1) }
 
       it { is_expected.to eq(Cohort.find_by_start_year(2021)) }
     end
@@ -91,7 +91,7 @@ RSpec.describe Cohort, type: :model do
   describe ".next" do
     describe "when the current date matches the academic year start date" do
       it "returns the cohort with start_year the next year" do
-        Timecop.freeze(Date.new(2021, 10, 1)) do
+        Timecop.freeze(Date.new(2021, 9, 1)) do
           expect(Cohort.next.start_year).to eq 2022
         end
       end
@@ -109,7 +109,7 @@ RSpec.describe Cohort, type: :model do
   describe ".previous" do
     describe "when exactly 1 year ago matches the academic year start date" do
       it "returns the cohort with start_year the previous year" do
-        Timecop.freeze(Date.new(2021, 10, 10)) do
+        Timecop.freeze(Date.new(2021, 9, 10)) do
           expect(Cohort.previous.start_year).to eq 2020
         end
       end
@@ -126,14 +126,14 @@ RSpec.describe Cohort, type: :model do
 
   describe ".containing_date" do
     it "returns the cohort which contains the given date" do
-      expect(Cohort.containing_date(Date.new(2021, 10, 1)).start_year).to eq 2021
-      expect(Cohort.containing_date(Date.new(2022, 10, 10)).start_year).to eq 2022
+      expect(Cohort.containing_date(Date.new(2021, 9, 1)).start_year).to eq 2021
+      expect(Cohort.containing_date(Date.new(2022, 9, 10)).start_year).to eq 2022
       expect(Cohort.containing_date(Date.new(2023, 1, 10)).start_year).to eq 2022
       expect(Cohort.containing_date(Date.new(2024, 3, 22)).start_year).to eq 2023
     end
 
     context "when outside the currently added cohorts" do
-      let(:oob_date) { Date.new(Cohort.maximum(:start_year) + 1, 10, 1) }
+      let(:oob_date) { Date.new(Cohort.maximum(:start_year) + 1, 9, 1) }
 
       it "returns nil" do
         expect(Cohort.containing_date(oob_date)).to be_nil
@@ -143,7 +143,7 @@ RSpec.describe Cohort, type: :model do
 
   describe ".within_next_registration_period?" do
     before do
-      Cohort.find_by(start_year: 2023).update!(registration_start_date: Date.new(2023, 6, 1), academic_year_start_date: Date.new(2023, 10, 1))
+      Cohort.find_by(start_year: 2023).update!(registration_start_date: Date.new(2023, 6, 1), academic_year_start_date: Date.new(2023, 9, 1))
     end
 
     context "when the current time is after the registration start date for then next cohort" do
@@ -156,7 +156,7 @@ RSpec.describe Cohort, type: :model do
 
     context "when the active_registration_cohort and the current cohort are the same" do
       it "returns false" do
-        Timecop.freeze(Date.new(2023, 10, 1)) do
+        Timecop.freeze(Date.new(2023, 9, 1)) do
           expect(Cohort).not_to be_within_next_registration_period
         end
       end

--- a/spec/requests/schools/dashboard_spec.rb
+++ b/spec/requests/schools/dashboard_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Schools::Dashboard", type: :request do
   let(:school) { user.schools.first }
 
   before do
-    travel_to Date.new(2022, 10, 1)
+    travel_to Date.new(2022, 9, 1)
     sign_in user
   end
 

--- a/spec/services/delivery_partners/participants_filter_spec.rb
+++ b/spec/services/delivery_partners/participants_filter_spec.rb
@@ -150,11 +150,11 @@ RSpec.describe DeliveryPartners::ParticipantsFilter do
   end
 
   describe "#academic_year_options" do
-    before { expect(Cohort.where(start_year: excluded_start_year)).to be_exists }
+    before { expect(Cohort.where("start_year >= ?", excluded_start_year)).to be_exists }
 
     subject(:options) { instance.academic_year_options }
 
-    let(:expected_values) { [""] + Cohort.order(:start_year).pluck(:start_year).excluding(excluded_start_year) }
+    let(:expected_values) { [""] + Cohort.order(:start_year).pluck(:start_year).excluding(Cohort.where("start_year >= ?", excluded_start_year).pluck(:start_year)) }
 
     it { expect(options.map(&:id)).to eq(expected_values) }
     it { expect(options.map(&:name)).to eq(expected_values) }

--- a/spec/services/finance/ecf/banding_calculator_spec.rb
+++ b/spec/services/finance/ecf/banding_calculator_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Finance::ECF::BandingCalculator do
+RSpec.describe Finance::ECF::BandingCalculator, mid_cohort: true do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
   let(:lead_provider) { cpd_lead_provider.lead_provider }
   let!(:call_off_contract) { create(:call_off_contract, :with_minimal_bands, lead_provider:) }

--- a/spec/services/finance/ecf/ect/banding_calculator_spec.rb
+++ b/spec/services/finance/ecf/ect/banding_calculator_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Finance::ECF::ECT::BandingCalculator do
+RSpec.describe Finance::ECF::ECT::BandingCalculator, mid_cohort: true do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
   let(:lead_provider) { cpd_lead_provider.lead_provider }
   let!(:call_off_contract) { create(:call_off_contract, :with_minimal_bands, lead_provider:) }

--- a/spec/services/finance/ecf/ect/uplift_calculator_spec.rb
+++ b/spec/services/finance/ecf/ect/uplift_calculator_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Finance::ECF::ECT::UpliftCalculator do
+RSpec.describe Finance::ECF::ECT::UpliftCalculator, mid_cohort: true do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
   let(:lead_provider) { cpd_lead_provider.lead_provider }
   let!(:call_off_contract) { create(:call_off_contract, :with_minimal_bands, lead_provider:) }

--- a/spec/services/finance/ecf/uplift_calculator_spec.rb
+++ b/spec/services/finance/ecf/uplift_calculator_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Finance::ECF::UpliftCalculator do
+RSpec.describe Finance::ECF::UpliftCalculator, mid_cohort: true do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
   let(:lead_provider) { cpd_lead_provider.lead_provider }
   let!(:call_off_contract) { create(:call_off_contract, :with_minimal_bands, lead_provider:) }

--- a/spec/services/importers/create_new_ecf_cohort_spec.rb
+++ b/spec/services/importers/create_new_ecf_cohort_spec.rb
@@ -5,7 +5,7 @@ require "tempfile"
 RSpec.describe Importers::CreateNewECFCohort do
   describe "#call" do
     # TODO: hard coding year for now here and in csvs due to flaky tests but those need to be dynamic
-    let(:start_year) { "2026" }
+    let(:start_year) { "2027" }
 
     let(:cohort_csv) { "spec/fixtures/files/importers/cohort_csv_data.csv" }
     let(:cohort_lead_provider_csv) { "spec/fixtures/files/importers/cohort_lead_provider_csv_data.csv" }

--- a/spec/services/induction/amend_cohort_after_eligibility_checks_spec.rb
+++ b/spec/services/induction/amend_cohort_after_eligibility_checks_spec.rb
@@ -47,9 +47,13 @@ RSpec.describe Induction::AmendCohortAfterEligibilityChecks, mid_cohort: true do
       let(:target_cohort_start_year) { Cohort.active_registration_cohort.start_year }
 
       before do
-        participant_profile.schedule.cohort.update!(payments_frozen_at: Date.yesterday)
-        allow(Induction::AmendParticipantCohort).to receive(:new).and_return(double(save: true))
-        subject.call
+        inside_auto_assignment_window(cohort: Cohort.find_by(start_year: Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT)) do
+          source_cohort_start_year
+          target_cohort_start_year
+          participant_profile.schedule.cohort.update!(payments_frozen_at: Date.yesterday)
+          allow(Induction::AmendParticipantCohort).to receive(:new).and_return(double(save: true))
+          subject.call
+        end
       end
 
       it "try and place them in the currently active registration cohort" do

--- a/spec/services/induction/amend_participant_cohort_spec.rb
+++ b/spec/services/induction/amend_participant_cohort_spec.rb
@@ -3,8 +3,8 @@
 RSpec.describe Induction::AmendParticipantCohort, mid_cohort: true do
   describe "#save" do
     let(:participant_profile) {}
-    let(:source_cohort_start_year) { Cohort.previous.start_year }
-    let(:target_cohort_start_year) { Cohort.current.start_year }
+    let(:source_cohort_start_year) { Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT - 1 }
+    let(:target_cohort_start_year) { Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT }
     let(:force_from_frozen_cohort) { false }
 
     subject(:form) do
@@ -19,7 +19,7 @@ RSpec.describe Induction::AmendParticipantCohort, mid_cohort: true do
 
       it "returns false and set errors" do
         expect(form.save).to be_falsey
-        expect(form.errors[:source_cohort_start_year]).to include("Invalid value. Must be an integer between 2020 and #{Date.current.year}")
+        expect(form.errors[:source_cohort_start_year]).to include("Invalid value. Must be an integer between 2020 and #{Cohort.current.start_year}")
       end
     end
 
@@ -28,7 +28,7 @@ RSpec.describe Induction::AmendParticipantCohort, mid_cohort: true do
 
       it "returns false and set errors" do
         expect(form.save).to be_falsey
-        expect(form.errors[:source_cohort_start_year]).to include("Invalid value. Must be an integer between 2020 and #{Date.current.year}")
+        expect(form.errors[:source_cohort_start_year]).to include("Invalid value. Must be an integer between 2020 and #{Cohort.current.start_year}")
       end
     end
 
@@ -37,7 +37,7 @@ RSpec.describe Induction::AmendParticipantCohort, mid_cohort: true do
 
       it "returns false and set errors" do
         expect(form.save).to be_falsey
-        expect(form.errors[:source_cohort_start_year]).to include("Invalid value. Must be an integer between 2020 and #{Date.current.year}")
+        expect(form.errors[:source_cohort_start_year]).to include("Invalid value. Must be an integer between 2020 and #{Cohort.current.start_year}")
       end
     end
 
@@ -46,7 +46,7 @@ RSpec.describe Induction::AmendParticipantCohort, mid_cohort: true do
 
       it "returns false and set errors" do
         expect(form.save).to be_falsey
-        expect(form.errors[:target_cohort_start_year]).to include("Invalid value. Must be an integer between 2020 and #{Date.current.year}")
+        expect(form.errors[:target_cohort_start_year]).to include("Invalid value. Must be an integer between 2020 and #{Cohort.current.start_year}")
       end
     end
 
@@ -55,7 +55,7 @@ RSpec.describe Induction::AmendParticipantCohort, mid_cohort: true do
 
       it "returns false and set errors" do
         expect(form.save).to be_falsey
-        expect(form.errors[:target_cohort_start_year]).to include("Invalid value. Must be an integer between 2020 and #{Date.current.year}")
+        expect(form.errors[:target_cohort_start_year]).to include("Invalid value. Must be an integer between 2020 and #{Cohort.current.start_year}")
       end
     end
 
@@ -64,7 +64,7 @@ RSpec.describe Induction::AmendParticipantCohort, mid_cohort: true do
 
       it "returns false and set errors" do
         expect(form.save).to be_falsey
-        expect(form.errors[:target_cohort_start_year]).to include("Invalid value. Must be an integer between 2020 and #{Date.current.year}")
+        expect(form.errors[:target_cohort_start_year]).to include("Invalid value. Must be an integer between 2020 and #{Cohort.current.start_year}")
       end
     end
 
@@ -85,7 +85,7 @@ RSpec.describe Induction::AmendParticipantCohort, mid_cohort: true do
       end
 
       context "when the target_cohort_start_year is not matching that of the schedule" do
-        let(:schedule) { Finance::Schedule::ECF.default_for(cohort: Cohort.previous) }
+        let(:schedule) { Finance::Schedule::ECF.default_for(cohort: Cohort.find_by(start_year: Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT - 1)) }
 
         subject(:form) do
           described_class.new(participant_profile:, source_cohort_start_year:, target_cohort_start_year:, schedule:)
@@ -128,7 +128,7 @@ RSpec.describe Induction::AmendParticipantCohort, mid_cohort: true do
       end
 
       context "when the participant is transferred from their payments-frozen cohort to the currently one open for registration" do
-        let(:target_cohort_start_year) { Cohort.active_registration_cohort.start_year }
+        let(:target_cohort_start_year) { Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT }
 
         before do
           source_cohort.update!(payments_frozen_at: Time.current)

--- a/spec/services/induction/change_mentor_spec.rb
+++ b/spec/services/induction/change_mentor_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Induction::ChangeMentor do
       end
 
       context "when the mentor is unfinished and the mentee in a non-frozen for payments cohort" do
-        let(:declaration) { create(:mentor_participant_declaration, :paid, declaration_type: :started, cohort: Cohort.previous) }
+        let(:declaration) { create(:mentor_participant_declaration, :paid, declaration_type: :started, cohort: Cohort.find_by(start_year: Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT - 1)) }
         let(:mentor_profile) { declaration.participant_profile }
         let(:current_cohort) { mentor_profile.schedule.cohort }
         let(:cohort) { Cohort.destination_from_frozen_cohort }
@@ -96,7 +96,7 @@ RSpec.describe Induction::ChangeMentor do
 
       context "when the mentor is not unfinished, in a payments-frozen cohort and the mentee not in a payments-frozen one" do
         let(:mentor_school_cohort) do
-          NewSeeds::Scenarios::SchoolCohorts::Fip.new(cohort: Cohort.previous).build.with_programme.school_cohort
+          NewSeeds::Scenarios::SchoolCohorts::Fip.new(cohort: Cohort.find_by(start_year: Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT - 1)).build.with_programme.school_cohort
         end
 
         let!(:mentor_profile) do
@@ -108,7 +108,7 @@ RSpec.describe Induction::ChangeMentor do
         end
 
         let(:mentor_cohort) { mentor_profile.schedule.cohort }
-        let(:cohort) { Cohort.active_registration_cohort }
+        let(:cohort) { Cohort.find_by(start_year: Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT) }
         let!(:school_cohort) { create(:school_cohort, :fip, :with_induction_programme, cohort:, school: mentor_profile.school) }
 
         before do

--- a/spec/services/induction/transfer_and_continue_existing_fip_spec.rb
+++ b/spec/services/induction/transfer_and_continue_existing_fip_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe Induction::TransferAndContinueExistingFip do
         expect { service_call }
           .to change { mentor_profile_2.reload.schedule.cohort.start_year }
                 .from(2021)
-                .to(Cohort.active_registration_cohort.start_year)
+                .to(Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT)
       end
     end
 

--- a/spec/services/induction/transfer_to_schools_programme_spec.rb
+++ b/spec/services/induction/transfer_to_schools_programme_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe Induction::TransferToSchoolsProgramme do
         expect { service_call }
           .to change { mentor_profile_2.reload.schedule.cohort.start_year }
                 .from(2021)
-                .to(Cohort.active_registration_cohort.start_year)
+                .to(Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT)
       end
     end
 

--- a/spec/services/partnerships/report_spec.rb
+++ b/spec/services/partnerships/report_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe Partnerships::Report do
   end
 
   context "challenge deadline to 31st October from 2023" do
-    let(:cohort) { create(:cohort, start_year: 2023, academic_year_start_date: Date.new(2023, 9, 1)) }
+    let(:cohort) { create(:cohort, start_year: 2023) }
 
     it "sets the challenge deadline to 31st October when the partnership is created before the 17th October", travel_to: Date.new(2023, 5, 1) do
       expect(result.challenge_deadline).to eq(Date.new(2023, 10, 31))

--- a/spec/services/record_declaration_spec.rb
+++ b/spec/services/record_declaration_spec.rb
@@ -485,7 +485,7 @@ RSpec.shared_examples "creates participant declaration attempt" do
   end
 end
 
-RSpec.describe RecordDeclaration do
+RSpec.describe RecordDeclaration, mid_cohort: true do
   let(:cpd_lead_provider)     { create(:cpd_lead_provider, :with_lead_provider) }
   let(:another_lead_provider) { create(:cpd_lead_provider, :with_lead_provider, name: "Unknown") }
   let(:declaration_type)      { "started" }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -109,7 +109,7 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     # create cohorts since 2020 with default schedule
-    end_year = Date.current.month < 10 ? Date.current.year : Date.current.year + 1
+    end_year = Date.current.month < 9 ? Date.current.year : Date.current.year + 1
     (2020..end_year).each do |start_year|
       cohort = Cohort.find_by(start_year:) || FactoryBot.create(:cohort, start_year:)
       Finance::Schedule::ECF.default_for(cohort:) || FactoryBot.create(:ecf_schedule, cohort:)

--- a/spec/support/shared_examples/change_cohort_and_continue_training_support.rb
+++ b/spec/support/shared_examples/change_cohort_and_continue_training_support.rb
@@ -7,7 +7,7 @@ RSpec.shared_examples "can change cohort and continue training" do |participant_
     let(:current_cohort) { eligible_participant.schedule.cohort }
     let(:restrict_to_participant_ids) { [] }
     let(:cpd_lead_provider) { eligible_participant.lead_provider.cpd_lead_provider }
-    let(:eligible_participants) { create_list(declaration_type, 3, :payable, declaration_type: :started, cohort: Cohort.previous).map(&:participant_profile) }
+    let(:eligible_participants) { create_list(declaration_type, 3, :payable, declaration_type: :started, cohort: create(:cohort, start_year: 2023)).map(&:participant_profile) }
     let(:eligible_participant) { eligible_participants.first }
     let(:cohort) { create(:cohort, start_year: 2024) }
 
@@ -58,7 +58,7 @@ RSpec.shared_examples "can change cohort and continue training" do |participant_
   end
 
   describe "#unfinished_with_billable_declaration?" do
-    let(:declaration) { create(declaration_type, :paid, declaration_type: :started, cohort: Cohort.previous) }
+    let(:declaration) { create(declaration_type, :paid, declaration_type: :started, cohort: create(:cohort, start_year: 2023)) }
     let(:participant_profile) { declaration.participant_profile }
     let(:current_cohort) { participant_profile.schedule.cohort }
     let(:cohort) { create(:cohort, start_year: 2024) }
@@ -198,7 +198,7 @@ RSpec.shared_examples "can't change cohort and continue training" do |participan
     let(:current_cohort) { eligible_participant.schedule.cohort }
     let(:restrict_to_participant_ids) { [] }
     let(:cpd_lead_provider) { eligible_participant.lead_provider.cpd_lead_provider }
-    let(:eligible_participants) { create_list(declaration_type, 3, :payable, declaration_type: :started, cohort: Cohort.previous).map(&:participant_profile) }
+    let(:eligible_participants) { create_list(declaration_type, 3, :payable, declaration_type: :started, cohort: create(:cohort, start_year: 2023)).map(&:participant_profile) }
     let(:eligible_participant) { eligible_participants.first }
     let(:cohort) { create(:cohort, start_year: 2024) }
 
@@ -249,7 +249,7 @@ RSpec.shared_examples "can't change cohort and continue training" do |participan
   end
 
   describe "#unfinished_with_billable_declaration?" do
-    let(:declaration) { create(declaration_type, :paid, declaration_type: :started, cohort: Cohort.previous) }
+    let(:declaration) { create(declaration_type, :paid, declaration_type: :started, cohort: create(:cohort, start_year: 2023)) }
     let(:participant_profile) { declaration.participant_profile }
     let(:current_cohort) { participant_profile.schedule.cohort }
     let(:cohort) { create(:cohort, start_year: 2024) }

--- a/spec/support/shared_examples/participant_actions_change_schedule_support.rb
+++ b/spec/support/shared_examples/participant_actions_change_schedule_support.rb
@@ -55,7 +55,7 @@ RSpec.shared_examples "JSON Participant Change schedule endpoint" do
     let(:parsed_response) { JSON.parse(response.body) }
 
     let!(:schedule) { early_career_teacher_profile.schedule }
-    let(:new_cohort) { Cohort.active_registration_cohort }
+    let(:new_cohort) { Cohort.find_by(start_year: Cohort::DESTINATION_START_YEAR_FROM_A_FROZEN_COHORT) }
     let!(:new_schedule) { create(:ecf_schedule, schedule_identifier: "ecf-replacement-april", cohort: new_cohort) }
     let!(:new_school_cohort) { create(:school_cohort, :fip, :with_induction_programme, cohort: new_cohort, lead_provider: cpd_lead_provider.lead_provider, school: early_career_teacher_profile.school) }
 

--- a/spec/validators/evidence_held_validator_spec.rb
+++ b/spec/validators/evidence_held_validator_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe EvidenceHeldValidator do
+RSpec.describe EvidenceHeldValidator, mid_cohort: true do
   let(:klass) do
     Class.new do
       include ActiveModel::Model


### PR DESCRIPTION
## Context

The cohort rolls over in the 1st of September in the specs. This means `Cohort.current` moves to 2025. However specs seem to fail especially around frozen cohorts, and hardcoded cohorts.

## Changes proposed in this pull request
- Revert DFE-Digital/early-careers-framework#5966
- Hardcode frozen payment specs to cohort 2024 as that was the current previous cohort, and we aren't moving participants to 2025 
- Add new cohort to specs where we need to for cohort creation, as the pre-generated spec cohorts are up to 2026
- Set mid cohort flags on specs that require it
- Excluded cohort is no longer the latest cohort, include all later excluded cohorts in specs as the excluded one was 2024
- Hard code cohort to avoid cohort previous being similar to 2024 cohort

## Guidance to review
commit by commit