### PR TITLE
Set `voided_by_user` as event actor on voided declarations

### DIFF
--- a/app/services/participants/history_builder.rb
+++ b/app/services/participants/history_builder.rb
@@ -125,7 +125,7 @@ private
       declaration.declaration_states.each do |declaration_state|
         type = "#{declaration.declaration_type.capitalize}Declaration"
 
-        actor = declaration.voided_by_user if declaration.voided? || declaration.awaiting_clawback?
+        actor = declaration.voided_by_user if declaration_state.voided? || declaration_state.awaiting_clawback?
         actor ||= declaration.cpd_lead_provider.name
 
         value = declaration_state.state

--- a/spec/services/participants/history_builder_spec.rb
+++ b/spec/services/participants/history_builder_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe Participants::HistoryBuilder, :with_support_for_ect_examples do
       expect(reporters).to include console_user_name
     end
 
-    it "users the lead provider as the user when a provider has voided a declaration" do
+    it "uses the lead provider as the user when a provider has voided a declaration" do
       voided_declaration = create(:ect_participant_declaration, :voided)
 
       event_list = described_class.from_participant_profile(voided_declaration.participant_profile).events
@@ -179,21 +179,25 @@ RSpec.describe Participants::HistoryBuilder, :with_support_for_ect_examples do
       expect(voided_event.user).to eq(voided_declaration.cpd_lead_provider.name)
     end
 
-    it "users the voided_by_user as the user when a user has voided a declaration" do
+    it "uses the voided_by_user as the user when a user has a declaration with a voided declaration state" do
       voided_by_user = create(:user, full_name: "User Name")
-      voided_declaration = create(:ect_participant_declaration, :voided, voided_by_user:, voided_at: Time.zone.now)
+      participant_declaration = create(:ect_participant_declaration, voided_by_user:, voided_at: Time.zone.now)
 
-      event_list = described_class.from_participant_profile(voided_declaration.participant_profile).events
+      create(:declaration_state, :voided, participant_declaration:)
+
+      event_list = described_class.from_participant_profile(participant_declaration.participant_profile).events
       voided_event = event_list.select { |event| event.value == "voided" }.sole
 
       expect(voided_event.user).to eq(voided_by_user)
     end
 
-    it "users the voided_by_user as the user when a user has declaration awaiting clawback" do
+    it "uses the voided_by_user as the user when a user has declaration with an awaiting clawback declaration state" do
       voided_by_user = create(:user, full_name: "User Name")
-      declaration_awaiting_clawback = create(:ect_participant_declaration, :awaiting_clawback, voided_by_user:, voided_at: Time.zone.now)
+      participant_declaration = create(:ect_participant_declaration, voided_by_user:, voided_at: Time.zone.now)
 
-      event_list = described_class.from_participant_profile(declaration_awaiting_clawback.participant_profile).events
+      create(:declaration_state, :awaiting_clawback, participant_declaration:)
+
+      event_list = described_class.from_participant_profile(participant_declaration.participant_profile).events
       voided_event = event_list.select { |event| event.value == "awaiting_clawback" }.sole
 
       expect(voided_event.user).to eq(voided_by_user)


### PR DESCRIPTION
### Context

Currently, declarations that have been voided by a user in the finance dashboard still show up as voided by a lead provider in the audit trail. We want to show the user that voided the declaration here instead.

### Changes proposed in this pull request

- Set `voided_by_user` as event actor on voided declarations

Update the `HistoryBuilder` to set the `voided_by_user` as the `ParticipantEvent#user` when building the audit trail.

### Guidance to review

Find a voidable declaration:

```
ParticipantDeclaration.all.find(&:voidable?).id
ParticipantDeclaration.all.find(&:voidable?).email
```

Search for it in the finance dashboard and void it.

Go to the user's audit log in the admin dashboard.

| Before | After |
| -- | -- |
| <img width="960" height="182" alt="Screenshot 2025-09-24 at 11 08 35" src="https://github.com/user-attachments/assets/bbf70a80-94cb-4686-866c-a4eaf9ccba57" /> | <img width="967" height="187" alt="Screenshot 2025-09-24 at 11 08 24" src="https://github.com/user-attachments/assets/2438bc94-4461-4f00-9479-2aa747fcaa6b" /> |

