### PR TITLE
Update CSP to fix violations

### DIFF
--- a/app/assets/javascripts/print.js
+++ b/app/assets/javascripts/print.js
@@ -37,12 +37,14 @@ const restoreSummaryDetails = () => {
   });
 };
 
-window.formattedPrint = (target) => {
-  formatSummaryDetails();
-  setPageTitle(target);
+document.querySelectorAll(".print-link").forEach((link) => {
+  link.onclick = () => {
+    formatSummaryDetails();
+    setPageTitle(link);
 
-  window.print();
+    window.print();
 
-  restorePageTitle(target);
-  restoreSummaryDetails();
-};
+    restorePageTitle(link);
+    restoreSummaryDetails();
+  };
+});

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -94,7 +94,7 @@ module ApplicationHelper
   end
 
   def print_link(title, filename:)
-    govuk_link_to title, "javascript:void(0)", onclick: "window.formattedPrint(this)", data: { filename: }
+    govuk_link_to title, "javascript:void(0)", class: "print-link", data: { filename: }
   end
 
 private

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -12,10 +12,10 @@ Rails.application.configure do
   self_base          = %i[self]
   data               = %i[data]
   blob               = %i[blob]
-  gtm_src            = %w[*.googletagmanager.com]
+  gtm_src            = %w[*.googletagmanager.com www.googletagmanager.com]
   ga_connect_src     = %w[*.google-analytics.com]
   zd_script_src      = %w[*.zdassets.com]
-  gfonts_src         = %w[*.fonts.gstatic.com]
+  gfonts_src         = %w[fonts.gstatic.com *.fonts.gstatic.com]
   sentry_connect_src = %w[*.ingest.sentry.io]
 
   config.content_security_policy do |policy|
@@ -28,6 +28,7 @@ Rails.application.configure do
     policy.connect_src(*self_base.concat(ga_connect_src, zd_script_src, sentry_connect_src))
     policy.frame_src(*self_base.concat(gtm_src))
     policy.style_src_elem(*self_base.concat(["'unsafe-inline'"]))
+    policy.style_src_attr(*self_base.concat(["'unsafe-inline'"]))
 
     # The report-uri seems to make the feature specs flakey when ran in
     # CI. I'm not sure why - disabling for now.

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe ApplicationHelper, type: :helper do
     it "renders a HTML link to print/save via the built-in browser functionality" do
       is_expected.to eq(
         <<~HTML.chomp,
-          <a class="govuk-link" onclick="window.formattedPrint(this)" data-filename="My Document" href="javascript:void(0)">Save as PDF</a>
+          <a class="govuk-link print-link" data-filename="My Document" href="javascript:void(0)">Save as PDF</a>
         HTML
       )
     end


### PR DESCRIPTION
### Context

We are seeing a number of CSP violations in our [logs](https://kibana-uk1.logit.io/s/e9b9162d-0b5e-4362-bed0-8e577f88d06e/app/visualize#/edit/e1734f20-f874-11ef-8ed9-6f343317b3e8?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2025-09-23T14:00:00.000Z',to:'2025-09-24T17:00:00.000Z'))&_a=(filters:!(),linked:!t,query:(language:kuery,query:''),uiState:(vis:(columnsWidth:!((colIndex:0,width:431.3333333333333)))),vis:(aggs:!((enabled:!t,id:'1',params:(),schema:metric,type:count),(enabled:!t,id:'2',params:(field:app.payload.csp-report.blocked-uri,size:200),schema:bucket,type:significant_terms),(enabled:!t,id:'3',params:(field:app.payload.csp-report.violated-directive,size:200),schema:bucket,type:significant_terms)),params:(perPage:10,percentageCol:'',showMetricsAtAllLevels:!f,showPartialRows:!f,showTotal:!f,totalFunc:sum),title:'ECF%20CSP%20violations',type:table))) - we want to allow these where appropriate before enforcing the CSP in production

### Changes proposed in this pull request

- Add domains to CSP directives

Looking at the reports in Kibana we need to add these exceptions:

- `fonts.gstatic.com` (as `*.fonts.gstatic.com` requires a subdomain so doesn't match this).
- `unsafe-inline` for `style_src_attr` as we have a number of inline styles e.g. <elem style="inline">.
- `www.googletagmanager.com` for `script_src` -- we get a violation for this even though we allow `*.googletagmanager.com`; adding it explicitly to see if it resolves it.

- Remove onclick from print link

If we have inline handlers like this we would have to allow `script-src-attr: unsafe-inline` in the CSP -- better to avoid them.

### Guidance to review

There is an `inline` violation on the `script-src-elem` directive that I can't explain; it happens on the homepage and I've checked the rendered source and all `<script>` elements (without a `src`) have a `nonce` set. It could be something injected from a client's browser that's causing the violation.
