### PR TITLE
Enforce content security policy

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
   config.content_security_policy_nonce_directives = %w[script-src style-src]
 
   # Report violations without enforcing the policy.
-  config.content_security_policy_report_only = true
+  config.content_security_policy_report_only = false
 
   # Security-related HTTP headers.
   config.action_dispatch.default_headers = {


### PR DESCRIPTION
We've addressed the outstanding violations that we think are legitimate/warrant allowing.

Switch over the config to enforce the CSP.

Outstanding violations over the last couple of days are below; the `inline` violations I expect are bots/various browser extensions. The GTM exceptions I'm not sure how are arising; I don't see them when I access the website and they appear to be correctly whitelisted in the CSP under the correct directive.

<img width="864" height="301" alt="Screenshot 2025-09-29 at 11 52 45" src="https://github.com/user-attachments/assets/3ca63d40-f206-462a-9b27-d2289c331091" />
