### PR TITLE
Switch back to the normal terraform-modules tags

### DIFF
--- a/terraform/application/application.tf
+++ b/terraform/application/application.tf
@@ -5,7 +5,7 @@ locals {
 }
 
 module "application_configuration" {
-  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/application_configuration?ref=testing-azurerm-v4"
+  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/application_configuration?ref=testing"
 
   namespace             = var.namespace
   environment           = local.environment
@@ -45,7 +45,7 @@ module "application_configuration" {
 }
 
 module "web_application" {
-  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/application?ref=testing-azurerm-v4"
+  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/application?ref=testing"
 
   name   = "web"
   is_web = true
@@ -70,7 +70,7 @@ module "web_application" {
 }
 
 module "worker_application" {
-  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/application?ref=testing-azurerm-v4"
+  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/application?ref=testing"
 
   name   = "worker"
   is_web = false

--- a/terraform/application/cluster_data.tf
+++ b/terraform/application/cluster_data.tf
@@ -1,4 +1,4 @@
 module "cluster_data" {
-  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/cluster_data?ref=testing-azurerm-v4"
+  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/cluster_data?ref=testing"
   name   = var.cluster
 }

--- a/terraform/application/databases.tf
+++ b/terraform/application/databases.tf
@@ -1,5 +1,5 @@
 module "redis-cache" {
-  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/redis?ref=testing-azurerm-v4"
+  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/redis?ref=testing"
 
   namespace                 = var.namespace
   environment               = local.environment
@@ -21,7 +21,7 @@ module "redis-cache" {
 }
 
 module "redis" {
-  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/redis?ref=testing-azurerm-v4"
+  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/redis?ref=testing"
 
   namespace             = var.namespace
   environment           = local.environment
@@ -40,7 +40,7 @@ module "redis" {
 }
 
 module "postgres" {
-  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/postgres?ref=testing-azurerm-v4"
+  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/postgres?ref=testing"
 
   namespace             = var.namespace
   environment           = local.environment
@@ -65,7 +65,7 @@ module "postgres" {
 }
 
 module "postgres-snapshot" {
-  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/postgres?ref=testing-azurerm-v4"
+  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/postgres?ref=testing"
 
   count                 = var.deploy_snapshot_database ? 1 : 0
   name                  = "snapshot"

--- a/terraform/application/dfe_analytics.tf
+++ b/terraform/application/dfe_analytics.tf
@@ -4,7 +4,7 @@ provider "google" {
 
 module "dfe_analytics" {
   count  = var.enable_dfe_analytics_federated_auth ? 1 : 0
-  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/dfe_analytics?ref=stable-azurerm-v4"
+  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/dfe_analytics?ref=stable"
 
   azure_resource_prefix = var.azure_resource_prefix
   cluster               = var.cluster

--- a/terraform/application/monitoring.tf
+++ b/terraform/application/monitoring.tf
@@ -5,7 +5,7 @@ locals {
 module "statuscake" {
   count = var.enable_monitoring ? 1 : 0
 
-  source = "git::https://github.com/DFE-Digital/terraform-modules.git//monitoring/statuscake?ref=stable-azurerm-v4"
+  source = "git::https://github.com/DFE-Digital/terraform-modules.git//monitoring/statuscake?ref=stable"
 
   uptime_urls = compact([module.web_application.probe_url, local.external_url])
   ssl_urls    = compact([local.external_url])

--- a/terraform/application/secrets.tf
+++ b/terraform/application/secrets.tf
@@ -1,5 +1,5 @@
 module "infrastructure_secrets" {
-  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/secrets?ref=testing-azurerm-v4"
+  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/secrets?ref=testing"
 
   azure_resource_prefix = var.azure_resource_prefix
   service_short         = var.service_short

--- a/terraform/domains/environment_domains/main.tf
+++ b/terraform/domains/environment_domains/main.tf
@@ -1,7 +1,7 @@
 # Used to create domains to be managed by front door.
 module "domains" {
   for_each              = var.hosted_zone
-  source                = "git::https://github.com/DFE-Digital/terraform-modules.git//domains/environment_domains?ref=main-azurerm-v4"
+  source                = "git::https://github.com/DFE-Digital/terraform-modules.git//domains/environment_domains?ref=main"
   zone                  = each.key
   front_door_name       = each.value.front_door_name
   resource_group_name   = each.value.resource_group_name
@@ -16,6 +16,6 @@ module "domains" {
 
 # Takes values from hosted_zone.domain_name.cnames (or txt_records, a-records). Use for domains which are not associated with front door.
 module "dns_records" {
-  source      = "git::https://github.com/DFE-Digital/terraform-modules.git//dns/records?ref=main-azurerm-v4"
+  source      = "git::https://github.com/DFE-Digital/terraform-modules.git//dns/records?ref=main"
   hosted_zone = var.hosted_zone
 }

--- a/terraform/domains/infrastructure/main.tf
+++ b/terraform/domains/infrastructure/main.tf
@@ -1,5 +1,5 @@
 module "domains_infrastructure" {
-  source                 = "git::https://github.com/DFE-Digital/terraform-modules.git//domains/infrastructure?ref=main-azurerm-v4"
+  source                 = "git::https://github.com/DFE-Digital/terraform-modules.git//domains/infrastructure?ref=main"
   hosted_zone            = var.hosted_zone
   tags                   = var.tags
   deploy_default_records = var.deploy_default_records


### PR DESCRIPTION
### Context

The terraform-modules repo has been updated to azurerm 4.61.0 so this repository can be repointed to the main, testing and stable modules branches.

### Changes proposed in this pull request

Update TERRAFORM_MODULES_TAG in each environment

### Guidance to review

make staging terraform-plan
make production terraform-plan
make domains-infra-plan
make production domains-plan

All the above have been run and return

<img width="897" height="87" alt="image" src="https://github.com/user-attachments/assets/a724a557-3269-4077-ad22-5acde45cf033" />

