### PR TITLE
delay refreshing migration db

### DIFF
--- a/.github/workflows/refresh_database.yml
+++ b/.github/workflows/refresh_database.yml
@@ -18,7 +18,7 @@ on:
           - paritycheck
         required: true
   schedule:
-    - cron: "0 0 * * *" # Run at midnight.
+    - cron: "0 3 * * *" # Run at midnight.
 
 jobs:
   refresh-db:


### PR DESCRIPTION
### Context

Delay refreshing migration db from production to allow ECF2 migration run to finish successfully.

### Changes proposed in this pull request

### Guidance to review

