### PR TITLE
Fix paritycheck env domains environment tfstate

### DIFF
--- a/terraform/domains/environment_domains/workspace_variables/cpd_ecf_paritycheck_backend.tfvars
+++ b/terraform/domains/environment_domains/workspace_variables/cpd_ecf_paritycheck_backend.tfvars
@@ -1,4 +1,4 @@
 resource_group_name  = "s189p01-cpdecfdomains-rg"
 storage_account_name = "s189p01cpdecfdomainstf"
 container_name       = "cpdecfdomains-tf"
-key                  = "cpdecfdomains_mig.tfstate"
+key                  = "cpdecfdomains_pc.tfstate"


### PR DESCRIPTION
### Context

Paritycheck env domains environment is pointing to the migration env statefile
This causes a conflict.

### Changes proposed in this pull request

Point paritycheck to its own statefile

### Guidance to review

make paritycheck domains-plan
make migration domains-plan

