### PR TITLE
Update maintenance banner for April service migration window

### DIFF
--- a/app/components/banners/maintenance_component.rb
+++ b/app/components/banners/maintenance_component.rb
@@ -4,7 +4,7 @@ module Banners
   class MaintenanceComponent < ApplicationComponent
     HOUR_FORMAT = "%-l%P"
     DAY_FORMAT = "%-d %B"
-    MAINTENANCE_WINDOW = Time.zone.local(2024, 11, 27, 19)..Time.zone.local(2024, 11, 27, 22)
+    MAINTENANCE_WINDOW = Time.zone.local(2026, 4, 27, 12)..Time.zone.local(2026, 4, 28, 9)
 
     def render?
       FeatureFlag.active?(:maintenance_banner) && maintenance_window_ends_in_future?

--- a/spec/components/banners/maintenance_component_spec.rb
+++ b/spec/components/banners/maintenance_component_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Banners::MaintenanceComponent, type: :component do
-  let(:maintenance_window) { Time.zone.local(2050, 11, 27, 19)..Time.zone.local(2050, 11, 27, 21) }
+  let(:maintenance_window) { Time.zone.local(2050, 4, 27, 12)..Time.zone.local(2050, 4, 27, 21) }
   let(:component) { described_class.new }
 
   before do
@@ -18,13 +18,13 @@ RSpec.describe Banners::MaintenanceComponent, type: :component do
 
   it { is_expected.to have_css(".govuk-width-container") }
   it { is_expected.to have_css("h2", text: "Important") }
-  it { is_expected.to have_css(".govuk-notification-banner__heading", text: "This service will be unavailable from 7pm to 9pm on 27 November.") }
+  it { is_expected.to have_css(".govuk-notification-banner__heading", text: "This service will be unavailable from 12pm to 9pm on 27 April.") }
   it { is_expected.to have_link("Dismiss", href: maintenance_banner_dismiss_path) }
 
   context "when the maintenance window spans multiple days" do
-    let(:maintenance_window) { Time.zone.local(2050, 11, 27, 19)..Time.zone.local(2050, 11, 28, 21) }
+    let(:maintenance_window) { Time.zone.local(2050, 4, 27, 12)..Time.zone.local(2050, 4, 28, 9) }
 
-    it { is_expected.to have_css(".govuk-notification-banner__heading", text: "This service will be unavailable from 7pm on 27 November to 9pm on 28 November.") }
+    it { is_expected.to have_css(".govuk-notification-banner__heading", text: "This service will be unavailable from 12pm on 27 April to 9am on 28 April.") }
   end
 
   describe "#render?" do


### PR DESCRIPTION
### Context

- Ticket: https://github.com/DFE-Digital/register-ects-project-board/issues/3676

### Changes proposed in this pull request
- update the maintenance banner window

### Guidance to review
  - enable the `maintenance_banner` feature flag in the target environment
  - verify the banner shows: `This service will be unavailable from 12pm on 27 April to 9am on 28 April.`
