### PR TITLE
Redirect to ec2 domains

### DIFF
--- a/terraform/domains/environment_domains/main.tf
+++ b/terraform/domains/environment_domains/main.tf
@@ -12,6 +12,7 @@ module "domains" {
   null_host_header      = try(each.value.null_host_header, false)
   cached_paths          = try(each.value.cached_paths, [])
   rate_limit            = try(var.rate_limit, null)
+  redirect_rules        = try(each.value.redirect_rules, null)
 }
 
 # Takes values from hosted_zone.domain_name.cnames (or txt_records, a-records). Use for domains which are not associated with front door.

--- a/terraform/domains/environment_domains/workspace_variables/cpd_ecf_production.tfvars.json
+++ b/terraform/domains/environment_domains/workspace_variables/cpd_ecf_production.tfvars.json
@@ -13,7 +13,13 @@
           "target": "_973d1fa4805e3e29efa0dab7d8c759cc.zjfbrrwmzc.acm-validations.aws",
           "ttl": 86400
         }
-      }
+      },
+      "redirect_rules": [
+        {
+          "from-domain": "apex",
+          "to-domain": "register-early-career-teachers.education.gov.uk"
+        }
+      ]
     }
   },
     "rate_limit": [

--- a/terraform/domains/environment_domains/workspace_variables/cpd_ecf_sandbox.tfvars.json
+++ b/terraform/domains/environment_domains/workspace_variables/cpd_ecf_sandbox.tfvars.json
@@ -7,7 +7,13 @@
         "sb"
       ],
       "environment_short": "sb",
-      "origin_hostname": "cpd-ecf-sandbox-web.teacherservices.cloud"
+      "origin_hostname": "cpd-ecf-sandbox-web.teacherservices.cloud",
+      "redirect_rules": [
+        {
+          "from-domain": "sb",
+          "to-domain": "sandbox.register-early-career-teachers.education.gov.uk"
+        }
+      ]
     }
   },
     "rate_limit": [

--- a/terraform/domains/environment_domains/workspace_variables/cpd_ecf_staging.tfvars.json
+++ b/terraform/domains/environment_domains/workspace_variables/cpd_ecf_staging.tfvars.json
@@ -7,7 +7,13 @@
         "st"
       ],
       "environment_short": "st",
-      "origin_hostname": "cpd-ecf-staging-web.test.teacherservices.cloud"
+      "origin_hostname": "cpd-ecf-staging-web.test.teacherservices.cloud",
+      "redirect_rules": [
+        {
+          "from-domain": "st",
+          "to-domain": "staging.register-early-career-teachers.education.gov.uk"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
### Context

- Ticket: https://trello.com/c/hxE1u5fL/2754-setup-ecf-to-ec2-redirect

### Changes proposed in this pull request

Add redirect rule for ecf after migration to ec2 is complete

I've added rules for production, staging and sandbox although the non prod can be removed if not required.
It might be a good idea to test this against one of the non-prod envs beforehand to confirm it behaves as expected?

Also note;
AFD configuration updates take up to 20 minutes to take effect. Back to Back changes may take up to 40 minutes. More details in [Azure Front Door Frequently Asked Questions (FAQ)](https://learn.microsoft.com/azure/frontdoor/front-door-faq?WT.mc_id=Portal-Microsoft_Azure_AFDX#what-is-the-estimated-time-for-deploying-an-azure-front-door--does-my-front-door-remain-operational-during-the-update-process-).

### Guidance to review

make env domains-plan
